### PR TITLE
bug fix FCFJacobi

### DIFF
--- a/src/parcsr_ls/par_lr_restr.c
+++ b/src/parcsr_ls/par_lr_restr.c
@@ -35,20 +35,20 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
                                    HYPRE_Int             max_elmts,
                                    HYPRE_Int            *col_offd_S_to_A,
                                    hypre_ParCSRMatrix  **R_ptr) {
-   
+
    MPI_Comm                 comm     = hypre_ParCSRMatrixComm(A);
    hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
    hypre_ParCSRCommHandle  *comm_handle;
 
    hypre_ParCSRCommPkg     *comm_pkg_SF;
-   
+
    /* diag part of A */
    hypre_CSRMatrix *A_diag   = hypre_ParCSRMatrixDiag(A);
    HYPRE_Real      *A_diag_a = hypre_CSRMatrixData(A_diag);
    HYPRE_Int       *A_diag_i = hypre_CSRMatrixI(A_diag);
    HYPRE_Int       *A_diag_j = hypre_CSRMatrixJ(A_diag);
    /* off-diag part of A */
-   hypre_CSRMatrix *A_offd   = hypre_ParCSRMatrixOffd(A);   
+   hypre_CSRMatrix *A_offd   = hypre_ParCSRMatrixOffd(A);
    HYPRE_Real      *A_offd_a = hypre_CSRMatrixData(A_offd);
    HYPRE_Int       *A_offd_i = hypre_CSRMatrixI(A_offd);
    HYPRE_Int       *A_offd_j = hypre_CSRMatrixJ(A_offd);
@@ -61,7 +61,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    HYPRE_Int       *S_diag_i = hypre_CSRMatrixI(S_diag);
    HYPRE_Int       *S_diag_j = hypre_CSRMatrixJ(S_diag);
    /* off-diag part of S */
-   hypre_CSRMatrix *S_offd   = hypre_ParCSRMatrixOffd(S);   
+   hypre_CSRMatrix *S_offd   = hypre_ParCSRMatrixOffd(S);
    HYPRE_Int       *S_offd_i = hypre_CSRMatrixI(S_offd);
    HYPRE_Int       *S_offd_j = hypre_CSRMatrixJ(S_offd);
    /* Restriction matrix R */
@@ -82,9 +82,9 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    HYPRE_Int       *CF_marker_offd = NULL;
    /* func type off-diag part */
    HYPRE_Int       *dof_func_offd  = NULL;
-   
+
    HYPRE_BigInt     big_i1, big_j1, big_k1;
-   HYPRE_Int        i, j, j1, j2, k, i1, i2, k1, k2, k3, rr, cc, ic, index, start, end, 
+   HYPRE_Int        i, j, j1, j2, k, i1, i2, k1, k2, k3, rr, cc, ic, index, start, end,
                     local_max_size, local_size, num_cols_offd_R;
    /*HYPRE_Int        i6;*/
    HYPRE_BigInt     *FF2_offd;
@@ -116,7 +116,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    HYPRE_BigInt col_end   = col_start + (HYPRE_BigInt)n_fine;
 
    HYPRE_Int  *send_buf_i;
-   
+
    /* recv_SF means the Strong F-neighbors of offd elements in col_map_offd */
    HYPRE_Int *send_SF_i, send_SF_jlen;
    HYPRE_BigInt *send_SF_j;
@@ -139,9 +139,9 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
 
    /* ghost rows: offd F and F2-pts */
    hypre_CSRMatrix *A_offd_FF2   = NULL;
-   
+
    /* MPI size and rank*/
-   hypre_MPI_Comm_size(comm, &num_procs);   
+   hypre_MPI_Comm_size(comm, &num_procs);
    hypre_MPI_Comm_rank(comm, &my_id);
 
    /*-------------- global number of C points and my start position */
@@ -156,7 +156,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    /*my_first_cpt = num_cpts_global[my_id];*/
    total_global_cpts = num_cpts_global[num_procs];
 #endif
- 
+
    /*-------------------------------------------------------------------
     * Get the CF_marker data for the off-processor columns
     *-------------------------------------------------------------------*/
@@ -174,7 +174,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    if (!comm_pkg)
    {
       hypre_MatvecCommPkgCreate(A);
-      comm_pkg = hypre_ParCSRMatrixCommPkg(A); 
+      comm_pkg = hypre_ParCSRMatrixCommPkg(A);
    }
 
    /* init markers to zeros */
@@ -186,15 +186,15 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
 
    /* number of recvs (number of procs) */
    num_recvs = hypre_ParCSRCommPkgNumRecvs(comm_pkg);
- 
+
    /* number of elements to send */
    num_elems_send = hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends);
 
-   /* send buffer, of size send_map_starts[num_sends]), 
+   /* send buffer, of size send_map_starts[num_sends]),
     * i.e., number of entries to send */
    send_buf_i = hypre_CTAlloc(HYPRE_Int , num_elems_send, HYPRE_MEMORY_HOST);
-   
-   /* copy CF markers of elements to send to buffer 
+
+   /* copy CF markers of elements to send to buffer
     * RL: why copy them with two for loops? Why not just loop through all in one */
    for (i = 0, index = 0; i < num_sends; i++)
    {
@@ -224,7 +224,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
          }
       }
       comm_handle = hypre_ParCSRCommHandleCreate(11, comm_pkg, send_buf_i, dof_func_offd);
-      hypre_ParCSRCommHandleDestroy(comm_handle);   
+      hypre_ParCSRCommHandleDestroy(comm_handle);
    }
 
    /*- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -233,7 +233,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
     *- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -*/
    send_SF_i = hypre_CTAlloc(HYPRE_Int, num_elems_send, HYPRE_MEMORY_HOST);
    recv_SF_i = hypre_CTAlloc(HYPRE_Int, num_cols_A_offd + 1, HYPRE_MEMORY_HOST);
-   
+
    /* for each F-elem to send, find the number of strong F-neighbors */
    for (i = 0, send_SF_jlen = 0; i < num_elems_send; i++)
    {
@@ -272,7 +272,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    comm_handle = hypre_ParCSRCommHandleCreate(11, comm_pkg, send_SF_i, recv_SF_i+1);
    /* ... */
    hypre_ParCSRCommHandleDestroy(comm_handle);
-   
+
    send_SF_j = hypre_CTAlloc(HYPRE_BigInt, send_SF_jlen, HYPRE_MEMORY_HOST);
    send_SF_jstarts = hypre_CTAlloc(HYPRE_Int, num_sends + 1, HYPRE_MEMORY_HOST);
 
@@ -348,7 +348,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    hypre_ParCSRCommHandleDestroy(comm_handle);
 
    /*- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    * recv_SF_offd_list: a sorted list of offd elems in recv_SF_j 
+    * recv_SF_offd_list: a sorted list of offd elems in recv_SF_j
     *- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
    recv_SF_offd_list = hypre_CTAlloc(HYPRE_BigInt, recv_SF_jlen, HYPRE_MEMORY_HOST);
    for (i = 0, j = 0; i < recv_SF_jlen; i++)
@@ -393,7 +393,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    /* mapping to col_map_offd_A */
    Mapper_recv_SF_offd_list = hypre_CTAlloc(HYPRE_Int, recv_SF_offd_list_len, HYPRE_MEMORY_HOST);
    Marker_recv_SF_offd_list = hypre_CTAlloc(HYPRE_Int, recv_SF_offd_list_len, HYPRE_MEMORY_HOST);
-   
+
    /* create a mapping from recv_SF_offd_list to col_map_offd_A for their intersections */
    for (i = 0; i < recv_SF_offd_list_len; i++)
    {
@@ -401,7 +401,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
       hypre_assert(big_i1 < col_start || big_i1 >= col_end);
       j = hypre_BigBinarySearch(col_map_offd_A, big_i1, num_cols_A_offd);
       /* mapping to col_map_offd_A, if not found equal to -1 */
-      Mapper_recv_SF_offd_list[i] = j;      
+      Mapper_recv_SF_offd_list[i] = j;
    }
 
    /*- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -439,7 +439,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
          }
       }
 
-      /* offd(F) and offd(F)-offd(F) 
+      /* offd(F) and offd(F)-offd(F)
        * NOTE: we are working with two marker arrays here: Marker_offd and Marker_recv_SF_offd_list
        * which may have overlap.
        * So, we always check the first marker array */
@@ -465,8 +465,8 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
                   /* index in recv_SF_offd_list */
                   k2 = recv_SF_j2[k];
 
-                  hypre_assert(recv_SF_offd_list[k2] == k1);
-                  
+                  hypre_assert(recv_SF_offd_list[k2] == big_k1);
+
                   /* map to offd_A */
                   k3 = Mapper_recv_SF_offd_list[k2];
                   if (k3 >= 0)
@@ -555,7 +555,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
       send_FF2_i[i] = A_diag_i[j+1] - A_diag_i[j] + A_offd_i[j+1] - A_offd_i[j];
       send_FF2_jlen += send_FF2_i[i];
    }
- 
+
    /* do communication */
    comm_handle = hypre_ParCSRCommHandleCreate(11, comm_pkg_FF2_i, send_FF2_i, recv_FF2_i+1);
    /* ... */
@@ -564,7 +564,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    send_FF2_j = hypre_CTAlloc(HYPRE_BigInt, send_FF2_jlen, HYPRE_MEMORY_HOST);
    send_FF2_a = hypre_CTAlloc(HYPRE_Complex, send_FF2_jlen, HYPRE_MEMORY_HOST);
    send_FF2_jstarts = hypre_CTAlloc(HYPRE_Int, num_sends_FF2 + 1, HYPRE_MEMORY_HOST);
-   
+
    for (i = 0, i1 = 0; i < num_sends_FF2; i++)
    {
       start = hypre_ParCSRCommPkgSendMapStart(comm_pkg_FF2_i, i);
@@ -593,7 +593,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
       send_FF2_jstarts[i+1] = i1;
    }
    hypre_assert(i1 == send_FF2_jlen);
-   
+
    /* adjust recv_FF2_i to ptrs */
    for (i = 1; i <= recv_FF2_ilen; i++)
    {
@@ -620,13 +620,13 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    hypre_ParCSRCommPkgNumRecvs     (comm_pkg_FF2_j) = num_recvs_FF2;
    hypre_ParCSRCommPkgRecvProcs    (comm_pkg_FF2_j) = hypre_ParCSRCommPkgRecvProcs(comm_pkg_FF2_i);
    hypre_ParCSRCommPkgRecvVecStarts(comm_pkg_FF2_j) = recv_FF2_jstarts;
-   
+
    /* do communication */
    /* ja */
    comm_handle = hypre_ParCSRCommHandleCreate(21, comm_pkg_FF2_j, send_FF2_j, recv_FF2_j);
    /* ... */
    hypre_ParCSRCommHandleDestroy(comm_handle);
-  
+
    /* a */
    comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg_FF2_j, send_FF2_a, recv_FF2_a);
    /* ... */
@@ -683,7 +683,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    {
       Mapper_offd_A[i] = hypre_BigBinarySearch(FF2_offd, col_map_offd_A[i], FF2_offd_len);
    }
-   
+
    /* Mapping from recv_SF_offd_list, overwrite the old one*/
    for (i = 0; i < recv_SF_offd_list_len; i++)
    {
@@ -701,7 +701,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    cnt_offd = 0;
    /* maximum size of local system: will allocate space of this size */
    local_max_size = 0;
-      
+
    for (i = 0; i < n_fine; i++)
    {
       HYPRE_Int MARK = i + 1;
@@ -711,7 +711,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
       {
          continue;
       }
-      
+
       /* size of the local dense problem */
       local_size = 0;
 
@@ -749,7 +749,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
          for (k = S_offd_i[j1]; k < S_offd_i[j1+1]; k++)
          {
             k1 = col_offd_S_to_A ? col_offd_S_to_A[S_offd_j[k]] : S_offd_j[k];
-            
+
             if (CF_marker_offd[k1] < 0)
             {
                /* map to FF2_offd */
@@ -778,7 +778,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
          {
             continue;
          }
-      
+
          /* map to FF2_offd */
          j2 = Mapper_offd_A[j1];
 
@@ -820,10 +820,10 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
 
                /* map to FF2_offd */
                k3 = Mapper_recv_SF_offd_list[k2];
-          
+
                /* this mapping must be successful */
                hypre_assert(k3 >= 0 && k3 < FF2_offd_len);
-               
+
                if (Marker_FF2_offd[k3] != MARK)
                {
                   Marker_FF2_offd[k3] = MARK;
@@ -837,20 +837,20 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
       /* keep ths max size */
       local_max_size = hypre_max(local_max_size, local_size);
    } /* for (i=0,...) */
- 
+
    /* this is because of the indentity matrix in C part
     * each C-pt has an entry 1.0 */
    cnt_diag += n_cpts;
- 
+
    nnz_diag = cnt_diag;
    nnz_offd = cnt_offd;
- 
+
    /*------------- allocate arrays */
    R_diag_i    = hypre_CTAlloc(HYPRE_Int,  n_cpts+1, HYPRE_MEMORY_HOST);
    R_diag_j    = hypre_CTAlloc(HYPRE_Int,  nnz_diag, HYPRE_MEMORY_HOST);
    R_diag_data = hypre_CTAlloc(HYPRE_Real, nnz_diag, HYPRE_MEMORY_HOST);
 
-   /* not in ``if num_procs > 1'', 
+   /* not in ``if num_procs > 1'',
     * allocation needed even for empty CSR */
    R_offd_i    = hypre_CTAlloc(HYPRE_Int,  n_cpts+1, HYPRE_MEMORY_HOST);
    R_offd_j    = hypre_CTAlloc(HYPRE_Int,  nnz_offd, HYPRE_MEMORY_HOST);
@@ -886,7 +886,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    //   Marker_recv_SF_list[i] = -1;
    //}
 
-   /* the local matrix and rhs (dense) 
+   /* the local matrix and rhs (dense)
     * column-major as always by BLAS/LAPACK */
    /* matrix */
    DAi = hypre_CTAlloc(HYPRE_Real, local_max_size * local_max_size, HYPRE_MEMORY_HOST);
@@ -900,10 +900,10 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    TMPb = hypre_CTAlloc(HYPRE_Real, local_max_size, HYPRE_MEMORY_HOST);
    TMPd = hypre_CTAlloc(HYPRE_Real, local_max_size, HYPRE_MEMORY_HOST);
 #endif
-   /*- - - - - - - - - - - - - - - - - - - - - - - - - 
+   /*- - - - - - - - - - - - - - - - - - - - - - - - -
     * space to save row indices of the local problem,
     * if diag, save the local indices,
-    * if offd, save the indices in FF2_offd, 
+    * if offd, save the indices in FF2_offd,
     *          since we will use it to access A_offd_FF2
     *- - - - - - - - - - - - - - - - - - - - - - - - - */
    RRi = hypre_CTAlloc(HYPRE_Int, local_max_size, HYPRE_MEMORY_HOST);
@@ -926,7 +926,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
 
       /* size of Ai, bi */
       local_size = 0;
-       
+
       /* Access matrices for the First time, mark the points we want */
       /* diag part of row i */
 //HYPRE_Real t1 = hypre_MPI_Wtime();
@@ -967,10 +967,10 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
             {
                /* map to FF2_offd */
                k2 = Mapper_offd_A[k1];
-               
+
                /* this mapping must be successful */
                hypre_assert(k2 >= 0 && k2 < FF2_offd_len);
-               
+
                /* an F-pt and never seen before */
                if (Marker_FF2_offd[k2] == -1)
                {
@@ -1065,7 +1065,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
       hypre_assert(local_size <= local_max_size);
 
       /* Second, copy values to local system: Ai and bi from A */
-      /* now we have marked all rows/cols we want. next we extract the entries 
+      /* now we have marked all rows/cols we want. next we extract the entries
        * we need from these rows and put them in Ai and bi*/
 
 //HYPRE_Real t2 = hypre_MPI_Wtime();
@@ -1131,7 +1131,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
                if ((cc = Marker_diag[j1]) >= 0)
                {
                   hypre_assert(CF_marker[j1] < 0);
-                  
+
                   /* copy the value */
                   /* rr and cc: local dense ids */
                   DAi[rr + cc * local_size] = A_diag_a[j];
@@ -1240,14 +1240,14 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
       if (local_size > 0)
       {
          /*- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-          * we have Ai and bi build 
+          * we have Ai and bi build
           * Solve the linear system by LAPACK : LU factorization
           *- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -*/
 #if AIR_DEBUG
          memcpy(TMPA, DAi, local_size*local_size*sizeof(HYPRE_Real));
          memcpy(TMPb, Dbi, local_size*sizeof(HYPRE_Real));
 #endif
-         
+
          hypre_dgetrf(&local_size, &local_size, DAi, &local_size, Ipi,
                &lapack_info);
 
@@ -1259,7 +1259,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
              * solution is saved in b_i on return */
             hypre_dgetrs(&charT, &local_size, &ione, DAi, &local_size,
                   Ipi, Dbi, &local_size, &lapack_info);
-            
+
             hypre_assert(lapack_info == 0);
          }
 
@@ -1267,7 +1267,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
 #if AIR_DEBUG
          HYPRE_Int one = 1;
          HYPRE_Real alp = 1.0, bet = 0.0;
-         hypre_dgemv(&charT, &local_size, &local_size, &alp, TMPA, &local_size, Dbi, 
+         hypre_dgemv(&charT, &local_size, &local_size, &alp, TMPA, &local_size, Dbi,
                &one, &bet, TMPd, &one);
          alp = -1.0;
          hypre_daxpy(&local_size, &alp, TMPb, &one, TMPd, &one);
@@ -1356,7 +1356,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    hypre_assert(ic == n_cpts)
    hypre_assert(cnt_diag == nnz_diag)
    hypre_assert(cnt_offd == nnz_offd)
-   
+
    /* num of cols in the offd part of R */
    num_cols_offd_R = 0;
    /* to this point, Marker_FF2_offd should be all -1 */
@@ -1431,7 +1431,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
    hypre_CSRMatrixJ(R_offd)    = R_offd_j;
    /* R does not own ColStarts, since A does */
    hypre_ParCSRMatrixOwnsColStarts(R) = 0;
-   
+
    hypre_ParCSRMatrixColMapOffd(R) = col_map_offd_R;
 
    /* create CommPkg of R */

--- a/src/parcsr_ls/par_relax.c
+++ b/src/parcsr_ls/par_relax.c
@@ -37,7 +37,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                                  hypre_ParVector    *Vtemp,
                                  hypre_ParVector    *Ztemp )
 {
-   MPI_Comm	   comm = hypre_ParCSRMatrixComm(A);
+   MPI_Comm         comm = hypre_ParCSRMatrixComm(A);
    hypre_CSRMatrix *A_diag = hypre_ParCSRMatrixDiag(A);
    HYPRE_Real      *A_diag_data  = hypre_CSRMatrixData(A_diag);
    HYPRE_Int       *A_diag_i     = hypre_CSRMatrixI(A_diag);
@@ -52,8 +52,8 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
    HYPRE_BigInt     global_num_rows = hypre_ParCSRMatrixGlobalNumRows(A);
    HYPRE_Int        n       = hypre_CSRMatrixNumRows(A_diag);
    HYPRE_Int        num_cols_offd = hypre_CSRMatrixNumCols(A_offd);
-   HYPRE_BigInt	    first_ind = hypre_ParVectorFirstIndex(u);
-   
+   HYPRE_BigInt     first_ind = hypre_ParVectorFirstIndex(u);
+
    hypre_Vector   *u_local = hypre_ParVectorLocalVector(u);
    HYPRE_Real     *u_data  = hypre_VectorData(u_local);
 
@@ -62,31 +62,31 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
 
    hypre_Vector   *Vtemp_local = hypre_ParVectorLocalVector(Vtemp);
    HYPRE_Real     *Vtemp_data = hypre_VectorData(Vtemp_local);
-   HYPRE_Real 	  *Vext_data = NULL;
-   HYPRE_Real 	  *v_buf_data;
-   HYPRE_Real 	  *tmp_data;
+   HYPRE_Real     *Vext_data = NULL;
+   HYPRE_Real     *v_buf_data = NULL;
+   HYPRE_Real     *tmp_data;
 
    hypre_Vector   *Ztemp_local;
    HYPRE_Real     *Ztemp_data;
 
    hypre_CSRMatrix *A_CSR;
-   HYPRE_Int	   *A_CSR_i;   
-   HYPRE_Int	   *A_CSR_j;
-   HYPRE_Real	   *A_CSR_data;
-   
+   HYPRE_Int       *A_CSR_i;
+   HYPRE_Int       *A_CSR_j;
+   HYPRE_Real      *A_CSR_data;
+
    hypre_Vector    *f_vector;
-   HYPRE_Real	   *f_vector_data;
+   HYPRE_Real      *f_vector_data;
 
    HYPRE_Int        i, j, jr;
    HYPRE_Int        ii, jj;
    HYPRE_Int        ns, ne, size, rest;
    HYPRE_Int        column;
    HYPRE_Int        relax_error = 0;
-   HYPRE_Int	    num_sends;
-   HYPRE_Int	    num_recvs;
-   HYPRE_Int	    index, start;
-   HYPRE_Int	    num_procs, num_threads, my_id, ip, p;
-   HYPRE_Int	    vec_start, vec_len;
+   HYPRE_Int        num_sends;
+   HYPRE_Int        num_recvs;
+   HYPRE_Int        index, start;
+   HYPRE_Int        num_procs, num_threads, my_id, ip, p;
+   HYPRE_Int        vec_start, vec_len;
    hypre_MPI_Status     *status;
    hypre_MPI_Request    *requests;
 
@@ -94,69 +94,70 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
    HYPRE_Real     *b_vec;
 
    HYPRE_Real      zero = 0.0;
-   HYPRE_Real	   res, res0, res2;
+   HYPRE_Real      res, res0, res2;
    HYPRE_Real      one_minus_weight;
    HYPRE_Real      one_minus_omega;
    HYPRE_Real      prod;
 
    one_minus_weight = 1.0 - relax_weight;
    one_minus_omega = 1.0 - omega;
-   hypre_MPI_Comm_size(comm,&num_procs);  
-   hypre_MPI_Comm_rank(comm,&my_id);  
+   hypre_MPI_Comm_size(comm,&num_procs);
+   hypre_MPI_Comm_rank(comm,&my_id);
    num_threads = hypre_NumThreads();
    /*-----------------------------------------------------------------------
     * Switch statement to direct control based on relax_type:
     *     relax_type = 0 -> Jacobi or CF-Jacobi
     *     relax_type = 1 -> Gauss-Seidel <--- very slow, sequential
     *     relax_type = 2 -> Gauss_Seidel: interior points in parallel ,
-    *			 	   	  boundary sequential 
+    *                                     boundary sequential
     *     relax_type = 3 -> hybrid: SOR-J mix off-processor, SOR on-processor
-    *     		    with outer relaxation parameters (forward solve)
+    *                               with outer relaxation parameters (forward solve)
     *     relax_type = 4 -> hybrid: SOR-J mix off-processor, SOR on-processor
-    *     		    with outer relaxation parameters (backward solve)
+    *                               with outer relaxation parameters (backward solve)
     *     relax_type = 5 -> hybrid: GS-J mix off-processor, chaotic GS on-node
     *     relax_type = 6 -> hybrid: SSOR-J mix off-processor, SSOR on-processor
-    *     		    with outer relaxation parameters 
+    *                               with outer relaxation parameters
     *     relax_type = 7 -> Jacobi (uses Matvec), only needed in CGNR
     *     relax_type = 19-> Direct Solve, (old version)
-    *     relax_type = 29-> Direct solve: use gaussian elimination & BLAS 
-    *			    (with pivoting) (old version)
+    *     relax_type = 29-> Direct solve: use gaussian elimination & BLAS
+    *                       (with pivoting) (old version)
     *-----------------------------------------------------------------------*/
    switch (relax_type)
    {
       case 0: /* Weighted Jacobi */
       {
-	if (num_procs > 1)
-	{
-   	   num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+         if (num_procs > 1)
+         {
+            num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
 
-   	   v_buf_data = hypre_CTAlloc(HYPRE_Real,  
-			hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
+            /* printf("!! Proc %d: n %d,  num_sends %d, num_cols_offd %d\n", my_id, n, num_sends, num_cols_offd); */
 
-	   Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
-        
-	   if (num_cols_offd)
-	   {
-		A_offd_j = hypre_CSRMatrixJ(A_offd);
-		A_offd_data = hypre_CSRMatrixData(A_offd);
-	   }
- 
-   	   index = 0;
-   	   for (i = 0; i < num_sends; i++)
-   	   {
-        	start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
-        	for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg, i+1); j++)
-                	v_buf_data[index++] 
-                 	= u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
-   	   }
- 
-   	   comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data, 
-        	Vext_data);
-	}
+            v_buf_data = hypre_CTAlloc(HYPRE_Real, hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
+
+            Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
+
+            if (num_cols_offd)
+            {
+               A_offd_j = hypre_CSRMatrixJ(A_offd);
+               A_offd_data = hypre_CSRMatrixData(A_offd);
+            }
+
+            index = 0;
+            for (i = 0; i < num_sends; i++)
+            {
+               start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+               for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg, i+1); j++)
+               {
+                  v_buf_data[index++] = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+               }
+            }
+
+            comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data, Vext_data);
+         }
          /*-----------------------------------------------------------------
           * Copy current approximation into temporary vector.
           *-----------------------------------------------------------------*/
-         
+
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
@@ -164,11 +165,11 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
          {
             Vtemp_data[i] = u_data[i];
          }
-	 if (num_procs > 1)
-	 { 
-   	    hypre_ParCSRCommHandleDestroy(comm_handle);
+         if (num_procs > 1)
+         {
+            hypre_ParCSRCommHandleDestroy(comm_handle);
             comm_handle = NULL;
-	 } 
+         }
 
          /*-----------------------------------------------------------------
           * Relax all points.
@@ -185,7 +186,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                /*-----------------------------------------------------------
                 * If diagonal is nonzero, relax point i; otherwise, skip it.
                 *-----------------------------------------------------------*/
-             
+
                if (A_diag_data[A_diag_i[i]] != zero)
                {
                   res = f_data[i];
@@ -199,16 +200,14 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                      ii = A_offd_j[jj];
                      res -= A_offd_data[jj] * Vext_data[ii];
                   }
-                  u_data[i] *= one_minus_weight; 
+                  u_data[i] *= one_minus_weight;
                   u_data[i] += relax_weight * res / A_diag_data[A_diag_i[i]];
                }
             }
          }
-
          /*-----------------------------------------------------------------
           * Relax only C or F points as determined by relax_points.
           *-----------------------------------------------------------------*/
-
          else
          {
 #ifdef HYPRE_USING_OPENMP
@@ -221,9 +220,8 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                 * If i is of the right type ( C or F ) and diagonal is
                 * nonzero, relax point i; otherwise, skip it.
                 *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
+
+               if (cf_marker[i] == relax_points && A_diag_data[A_diag_i[i]] != zero)
                {
                   res = f_data[i];
                   for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
@@ -236,55 +234,54 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                      ii = A_offd_j[jj];
                      res -= A_offd_data[jj] * Vext_data[ii];
                   }
-                  u_data[i] *= one_minus_weight; 
+                  u_data[i] *= one_minus_weight;
                   u_data[i] += relax_weight * res / A_diag_data[A_diag_i[i]];
                }
-            }     
+            }
          }
-	 if (num_procs > 1)
+         if (num_procs > 1)
          {
-	 hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
-	 hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
          }
       }
       break;
 
-      case 5: /* Hybrid: Jacobi off-processor, 
+      case 5: /* Hybrid: Jacobi off-processor,
                          chaotic Gauss-Seidel on-processor       */
       {
-	if (num_procs > 1)
-	{
-   	num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+         if (num_procs > 1)
+         {
+            num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
 
-   	v_buf_data = hypre_CTAlloc(HYPRE_Real,  
-			hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
+            v_buf_data = hypre_CTAlloc(HYPRE_Real, hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
 
-	Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
-        
-	if (num_cols_offd)
-	{
-		A_offd_j = hypre_CSRMatrixJ(A_offd);
-		A_offd_data = hypre_CSRMatrixData(A_offd);
-	}
- 
-   	index = 0;
-   	for (i = 0; i < num_sends; i++)
-   	{
-        	start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
-        	for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg,i+1); j++)
-                	v_buf_data[index++] 
-                 	= u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
-   	}
- 
-   	comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data, 
-        	Vext_data);
+            Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
 
-         /*-----------------------------------------------------------------
-          * Copy current approximation into temporary vector.
-          *-----------------------------------------------------------------*/
-   	 hypre_ParCSRCommHandleDestroy(comm_handle);
-         comm_handle = NULL;
-	}
+            if (num_cols_offd)
+            {
+               A_offd_j = hypre_CSRMatrixJ(A_offd);
+               A_offd_data = hypre_CSRMatrixData(A_offd);
+            }
+
+            index = 0;
+            for (i = 0; i < num_sends; i++)
+            {
+               start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+               for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg,i+1); j++)
+               {
+                  v_buf_data[index++] = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+               }
+            }
+
+            comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data, Vext_data);
+
+            /*-----------------------------------------------------------------
+             * Copy current approximation into temporary vector.
+             *-----------------------------------------------------------------*/
+            hypre_ParCSRCommHandleDestroy(comm_handle);
+            comm_handle = NULL;
+         }
 
          /*-----------------------------------------------------------------
           * Relax all points.
@@ -295,13 +292,13 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,jj,res) HYPRE_SMP_SCHEDULE
 #endif
-            for (i = 0; i < n; i++)	/* interior points first */
+            for (i = 0; i < n; i++) /* interior points first */
             {
 
                /*-----------------------------------------------------------
                 * If diagonal is nonzero, relax point i; otherwise, skip it.
                 *-----------------------------------------------------------*/
-             
+
                if ( A_diag_data[A_diag_i[i]] != zero)
                {
                   res = f_data[i];
@@ -336,9 +333,8 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                 * If i is of the right type ( C or F ) and diagonal is
                 * nonzero, relax point i; otherwise, skip it.
                 *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
+
+               if (cf_marker[i] == relax_points && A_diag_data[A_diag_i[i]] != zero)
                {
                   res = f_data[i];
                   for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
@@ -353,18 +349,18 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                   }
                   u_data[i] = res / A_diag_data[A_diag_i[i]];
                }
-            }     
+            }
          }
          if (num_procs > 1)
          {
-	   hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
-	   hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
          }
       }
       break;
 
-      case 3: /* Hybrid: Jacobi off-processor, 
-                         Gauss-Seidel on-processor       
+      case 3: /* Hybrid: Jacobi off-processor,
+                         Gauss-Seidel on-processor
                          (forward loop) */
       {
 
@@ -373,12 +369,12 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
             Ztemp_local = hypre_ParVectorLocalVector(Ztemp);
             Ztemp_data = hypre_VectorData(Ztemp_local);
          }
-         
+
 #ifdef HYPRE_USING_PERSISTENT_COMM
          // JSP: persistent comm can be similarly used for other smoothers
          hypre_ParCSRPersistentCommHandle *persistent_comm_handle;
 #endif
-         
+
          if (num_procs > 1)
          {
 #ifdef HYPRE_PROFILE
@@ -386,18 +382,18 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
 #endif
 
             num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
-            
+
 #ifdef HYPRE_USING_PERSISTENT_COMM
             persistent_comm_handle = hypre_ParCSRCommPkgGetPersistentCommHandle(1, comm_pkg);
             v_buf_data = (HYPRE_Real *)persistent_comm_handle->send_data;
             Vext_data = (HYPRE_Real *)persistent_comm_handle->recv_data;
 #else
-            v_buf_data = hypre_CTAlloc(HYPRE_Real,  
+            v_buf_data = hypre_CTAlloc(HYPRE_Real,
                                        hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
-            
+
             Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
 #endif
-            
+
             if (num_cols_offd)
             {
                A_offd_j = hypre_CSRMatrixJ(A_offd);
@@ -414,7 +410,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                v_buf_data[i - begin]
                   = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,i)];
             }
-            
+
 #ifdef HYPRE_PROFILE
             hypre_profile_times[HYPRE_TIMER_ID_PACK_UNPACK] += hypre_MPI_Wtime();
             hypre_profile_times[HYPRE_TIMER_ID_HALO_EXCHANGE] -= hypre_MPI_Wtime();
@@ -423,10 +419,10 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
 #ifdef HYPRE_USING_PERSISTENT_COMM
             hypre_ParCSRPersistentCommHandleStart(persistent_comm_handle);
 #else
-            comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data, 
+            comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data,
                                                         Vext_data);
 #endif
-            
+
             /*-----------------------------------------------------------------
              * Copy current approximation into temporary vector.
              *-----------------------------------------------------------------*/
@@ -449,411 +445,407 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
         hypre_profile_times[HYPRE_TIMER_ID_RELAX] -= hypre_MPI_Wtime();
 #endif
 
-	if (relax_weight == 1 && omega == 1)
+        if (relax_weight == 1 && omega == 1)
         {
-         if (relax_points == 0)
-         {
-	  if (num_threads > 1)
-          {
-	   tmp_data = Ztemp_data;
+           if (relax_points == 0)
+           {
+              if (num_threads > 1)
+              {
+                 tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
+                 for (i = 0; i < n; i++)
+                    tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ns; i < ne; i++)	/* interior points first */
-            {
+                 for (j = 0; j < num_threads; j++)
+                 {
+                    size = n/num_threads;
+                    rest = n - size*num_threads;
+                    if (j < rest)
+                    {
+                       ns = j*size+j;
+                       ne = (j+1)*size+j+1;
+                    }
+                    else
+                    {
+                       ns = j*size+rest;
+                       ne = (j+1)*size+rest;
+                    }
+                    for (i = ns; i < ne; i++) /* interior points first */
+                    {
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-                        res -= A_diag_data[jj] * u_data[ii];
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }
+                       /*-----------------------------------------------------------
+                        * If diagonal is nonzero, relax point i; otherwise, skip it.
+                        *-----------------------------------------------------------*/
+
+                       if ( A_diag_data[A_diag_i[i]] != zero)
+                       {
+                          res = f_data[i];
+                          for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                          {
+                             ii = A_diag_j[jj];
+                             if (ii >= ns && ii < ne)
+                                res -= A_diag_data[jj] * u_data[ii];
+                             else
+                                res -= A_diag_data[jj] * tmp_data[ii];
+                          }
+                          for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                          {
+                             ii = A_offd_j[jj];
+                             res -= A_offd_data[jj] * Vext_data[ii];
+                          }
+                          u_data[i] = res / A_diag_data[A_diag_i[i]];
+                       }
+                    }
+                 }
+
+              }
+              else
+              {
+                 for (i = 0; i < n; i++) /* interior points first */
+                 {
+
+                    /*-----------------------------------------------------------
+                     * If diagonal is nonzero, relax point i; otherwise, skip it.
+                     *-----------------------------------------------------------*/
+
+                    if ( A_diag_data[A_diag_i[i]] != zero)
+                    {
+                       res = f_data[i];
+                       for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                       {
+                          ii = A_diag_j[jj];
+                          res -= A_diag_data[jj] * u_data[ii];
+                       }
+                       for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                       {
+                          ii = A_offd_j[jj];
+                          res -= A_offd_data[jj] * Vext_data[ii];
+                       }
+                       u_data[i] = res / A_diag_data[A_diag_i[i]];
+                    }
+                 }
+              }
            }
 
-          }
-	  else
-          {
-            for (i = 0; i < n; i++)	/* interior points first */
-            {
+           /*-----------------------------------------------------------------
+            * Relax only C or F points as determined by relax_points.
+            *-----------------------------------------------------------------*/
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }
-          }
-         }
-
-         /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
-          *-----------------------------------------------------------------*/
-
-         else
-         {
-	  if (num_threads > 1)
-	  {
-             tmp_data = Ztemp_data;
+           else
+           {
+              if (num_threads > 1)
+              {
+                 tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
+                 for (i = 0; i < n; i++)
+                    tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ns; i < ne; i++) /* relax interior points */
-            {
+                 for (j = 0; j < num_threads; j++)
+                 {
+                    size = n/num_threads;
+                    rest = n - size*num_threads;
+                    if (j < rest)
+                    {
+                       ns = j*size+j;
+                       ne = (j+1)*size+j+1;
+                    }
+                    else
+                    {
+                       ns = j*size+rest;
+                       ne = (j+1)*size+rest;
+                    }
+                    for (i = ns; i < ne; i++) /* relax interior points */
+                    {
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-                        res -= A_diag_data[jj] * u_data[ii];
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }     
-           }     
+                       /*-----------------------------------------------------------
+                        * If i is of the right type ( C or F ) and diagonal is
+                        * nonzero, relax point i; otherwise, skip it.
+                        *-----------------------------------------------------------*/
 
-	  }
-	  else
-	  {
-            for (i = 0; i < n; i++) /* relax interior points */
-            {
+                       if (cf_marker[i] == relax_points && A_diag_data[A_diag_i[i]] != zero)
+                       {
+                          res = f_data[i];
+                          for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                          {
+                             ii = A_diag_j[jj];
+                             if (ii >= ns && ii < ne)
+                                res -= A_diag_data[jj] * u_data[ii];
+                             else
+                                res -= A_diag_data[jj] * tmp_data[ii];
+                          }
+                          for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                          {
+                             ii = A_offd_j[jj];
+                             res -= A_offd_data[jj] * Vext_data[ii];
+                          }
+                          u_data[i] = res / A_diag_data[A_diag_i[i]];
+                       }
+                    }
+                 }
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-      
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }     
-	  }
-         }
+              }
+              else
+              {
+                 for (i = 0; i < n; i++) /* relax interior points */
+                 {
+
+                    /*-----------------------------------------------------------
+                     * If i is of the right type ( C or F ) and diagonal is
+
+                     * nonzero, relax point i; otherwise, skip it.
+                     *-----------------------------------------------------------*/
+
+                    if (cf_marker[i] == relax_points && A_diag_data[A_diag_i[i]] != zero)
+                    {
+                       res = f_data[i];
+                       for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                       {
+                          ii = A_diag_j[jj];
+                          res -= A_diag_data[jj] * u_data[ii];
+                       }
+                       for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                       {
+                          ii = A_offd_j[jj];
+                          res -= A_offd_data[jj] * Vext_data[ii];
+                       }
+                       u_data[i] = res / A_diag_data[A_diag_i[i]];
+                    }
+                 }
+              }
+           }
         }
-	else
+        else
         {
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-         for (i = 0; i < n; i++)
-         {
-            Vtemp_data[i] = u_data[i];
-         }
-         prod = (1.0-relax_weight*omega);
-         if (relax_points == 0)
-         {
-	  if (num_threads > 1)
-          {
-             tmp_data = Ztemp_data;
+           for (i = 0; i < n; i++)
+           {
+              Vtemp_data[i] = u_data[i];
+           }
+           prod = (1.0-relax_weight*omega);
+           if (relax_points == 0)
+           {
+              if (num_threads > 1)
+              {
+                 tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
+                 for (i = 0; i < n; i++)
+                    tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ns; i < ne; i++)	/* interior points first */
-            {
+                 for (j = 0; j < num_threads; j++)
+                 {
+                    size = n/num_threads;
+                    rest = n - size*num_threads;
+                    if (j < rest)
+                    {
+                       ns = j*size+j;
+                       ne = (j+1)*size+j+1;
+                    }
+                    else
+                    {
+                       ns = j*size+rest;
+                       ne = (j+1)*size+rest;
+                    }
+                    for (i = ns; i < ne; i++) /* interior points first */
+                    {
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
-               }
-            }
+                       /*-----------------------------------------------------------
+                        * If diagonal is nonzero, relax point i; otherwise, skip it.
+                        *-----------------------------------------------------------*/
+
+                       if ( A_diag_data[A_diag_i[i]] != zero)
+                       {
+                          res = f_data[i];
+                          res0 = 0.0;
+                          res2 = 0.0;
+                          for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                          {
+                             ii = A_diag_j[jj];
+                             if (ii >= ns && ii < ne)
+                             {
+                                res0 -= A_diag_data[jj] * u_data[ii];
+                                res2 += A_diag_data[jj] * Vtemp_data[ii];
+                             }
+                             else
+                                res -= A_diag_data[jj] * tmp_data[ii];
+                          }
+                          for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                          {
+                             ii = A_offd_j[jj];
+                             res -= A_offd_data[jj] * Vext_data[ii];
+                          }
+                          u_data[i] *= prod;
+                          u_data[i] += relax_weight*(omega*res + res0 + one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                          /*u_data[i] += omega*(relax_weight*res + res0 +
+                            one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                       }
+                    }
+                 }
+
+              }
+              else
+              {
+                 for (i = 0; i < n; i++) /* interior points first */
+                 {
+
+                    /*-----------------------------------------------------------
+                     * If diagonal is nonzero, relax point i; otherwise, skip it.
+                     *-----------------------------------------------------------*/
+
+                    if ( A_diag_data[A_diag_i[i]] != zero)
+                    {
+                       res0 = 0.0;
+                       res2 = 0.0;
+                       res = f_data[i];
+                       for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                       {
+                          ii = A_diag_j[jj];
+                          res0 -= A_diag_data[jj] * u_data[ii];
+                          res2 += A_diag_data[jj] * Vtemp_data[ii];
+                       }
+                       for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                       {
+                          ii = A_offd_j[jj];
+                          res -= A_offd_data[jj] * Vext_data[ii];
+                       }
+                       u_data[i] *= prod;
+                       u_data[i] += relax_weight*(omega*res + res0 +
+                             one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                       /*u_data[i] += omega*(relax_weight*res + res0 +
+                         one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                    }
+                 }
+              }
            }
 
-          }
-	  else
-          {
-            for (i = 0; i < n; i++)	/* interior points first */
-            {
+           /*-----------------------------------------------------------------
+            * Relax only C or F points as determined by relax_points.
+            *-----------------------------------------------------------------*/
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
-               }
-            }
-          }
-         }
-
-         /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
-          *-----------------------------------------------------------------*/
-
-         else
-         {
-	  if (num_threads > 1)
-	  {
-             tmp_data = Ztemp_data;
+           else
+           {
+              if (num_threads > 1)
+              {
+                 tmp_data = Ztemp_data;
 
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
+                 for (i = 0; i < n; i++)
+                    tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ns; i < ne; i++) /* relax interior points */
-            {
+                 for (j = 0; j < num_threads; j++)
+                 {
+                    size = n/num_threads;
+                    rest = n - size*num_threads;
+                    if (j < rest)
+                    {
+                       ns = j*size+j;
+                       ne = (j+1)*size+j+1;
+                    }
+                    else
+                    {
+                       ns = j*size+rest;
+                       ne = (j+1)*size+rest;
+                    }
+                    for (i = ns; i < ne; i++) /* relax interior points */
+                    {
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
-               }
-            }     
-           }     
+                       /*-----------------------------------------------------------
+                        * If i is of the right type ( C or F ) and diagonal is
+                        * nonzero, relax point i; otherwise, skip it.
+                        *-----------------------------------------------------------*/
 
-           
-	  }
-	  else
-	  {
-            for (i = 0; i < n; i++) /* relax interior points */
-            {
+                       if (cf_marker[i] == relax_points
+                             && A_diag_data[A_diag_i[i]] != zero)
+                       {
+                          res0 = 0.0;
+                          res2 = 0.0;
+                          res = f_data[i];
+                          for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                          {
+                             ii = A_diag_j[jj];
+                             if (ii >= ns && ii < ne)
+                             {
+                                res0 -= A_diag_data[jj] * u_data[ii];
+                                res2 += A_diag_data[jj] * Vtemp_data[ii];
+                             }
+                             else
+                                res -= A_diag_data[jj] * tmp_data[ii];
+                          }
+                          for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                          {
+                             ii = A_offd_j[jj];
+                             res -= A_offd_data[jj] * Vext_data[ii];
+                          }
+                          u_data[i] *= prod;
+                          u_data[i] += relax_weight*(omega*res + res0 + one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                          /*u_data[i] += omega*(relax_weight*res + res0 +
+                            one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                       }
+                    }
+                 }
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-      
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
-               }
-            }     
-	  }
-         }
+
+              }
+              else
+              {
+                 for (i = 0; i < n; i++) /* relax interior points */
+                 {
+
+                    /*-----------------------------------------------------------
+                     * If i is of the right type ( C or F ) and diagonal is
+
+                     * nonzero, relax point i; otherwise, skip it.
+                     *-----------------------------------------------------------*/
+
+                    if (cf_marker[i] == relax_points
+                          && A_diag_data[A_diag_i[i]] != zero)
+                    {
+                       res = f_data[i];
+                       res0 = 0.0;
+                       res2 = 0.0;
+                       for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                       {
+                          ii = A_diag_j[jj];
+                          res0 -= A_diag_data[jj] * u_data[ii];
+                          res2 += A_diag_data[jj] * Vtemp_data[ii];
+                       }
+                       for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                       {
+                          ii = A_offd_j[jj];
+                          res -= A_offd_data[jj] * Vext_data[ii];
+                       }
+                       u_data[i] *= prod;
+                       u_data[i] += relax_weight*(omega*res + res0 +
+                             one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                       /*u_data[i] += omega*(relax_weight*res + res0 +
+                         one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                    }
+                 }
+              }
+           }
         }
 #ifndef HYPRE_USING_PERSISTENT_COMM
         if (num_procs > 1)
         {
-	   hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
-	   hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
+           hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
+           hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
         }
 #endif
 #ifdef HYPRE_PROFILE
@@ -864,294 +856,203 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
 
       case 1: /* Gauss-Seidel VERY SLOW */
       {
-        if (num_procs > 1)
-        {
-   	num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
-   	num_recvs = hypre_ParCSRCommPkgNumRecvs(comm_pkg);
-
-   	v_buf_data = hypre_CTAlloc(HYPRE_Real,  
-			hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
-
-	Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
-        
-	status  = hypre_CTAlloc(hypre_MPI_Status, num_recvs+num_sends, HYPRE_MEMORY_HOST);
-	requests= hypre_CTAlloc(hypre_MPI_Request,  num_recvs+num_sends, HYPRE_MEMORY_HOST);
-
-	if (num_cols_offd)
-	{
-		A_offd_j = hypre_CSRMatrixJ(A_offd);
-		A_offd_data = hypre_CSRMatrixData(A_offd);
-	}
- 
-         /*-----------------------------------------------------------------
-          * Copy current approximation into temporary vector.
-          *-----------------------------------------------------------------*/
-        /* 
-         for (i = 0; i < n; i++)
+         if (num_procs > 1)
          {
-            Vtemp_data[i] = u_data[i];
-         } */
- 
-        } 
+            num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+            num_recvs = hypre_ParCSRCommPkgNumRecvs(comm_pkg);
+
+            v_buf_data = hypre_CTAlloc(HYPRE_Real,
+                  hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
+
+            Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
+
+            status  = hypre_CTAlloc(hypre_MPI_Status, num_recvs+num_sends, HYPRE_MEMORY_HOST);
+            requests= hypre_CTAlloc(hypre_MPI_Request,  num_recvs+num_sends, HYPRE_MEMORY_HOST);
+
+            if (num_cols_offd)
+            {
+               A_offd_j = hypre_CSRMatrixJ(A_offd);
+               A_offd_data = hypre_CSRMatrixData(A_offd);
+            }
+
+            /*-----------------------------------------------------------------
+             * Copy current approximation into temporary vector.
+             *-----------------------------------------------------------------*/
+            /*
+               for (i = 0; i < n; i++)
+               {
+               Vtemp_data[i] = u_data[i];
+               } */
+
+         }
          /*-----------------------------------------------------------------
           * Relax all points.
           *-----------------------------------------------------------------*/
-	for (p = 0; p < num_procs; p++)
-	{
-	jr = 0;
-	if (p != my_id)
-	{
-   	  for (i = 0; i < num_sends; i++)
-   	  {
-            ip = hypre_ParCSRCommPkgSendProc(comm_pkg, i);
-	    if (ip == p)
-	    {
-               vec_start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
-	       vec_len = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i+1)-vec_start;
-               for (j=vec_start; j < vec_start+vec_len; j++)
-                  v_buf_data[j] = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
-	       hypre_MPI_Isend(&v_buf_data[vec_start], vec_len, HYPRE_MPI_REAL,
-                        ip, 0, comm, &requests[jr++]);
-	    }
-   	  }
-	  hypre_MPI_Waitall(jr,requests,status);
-	  hypre_MPI_Barrier(comm);
-        }
-	else
-        {
-          if (num_procs > 1)
-	  {
-	  for (i = 0; i < num_recvs; i++)
-          {
-             ip = hypre_ParCSRCommPkgRecvProc(comm_pkg, i);
-             vec_start = hypre_ParCSRCommPkgRecvVecStart(comm_pkg,i);
-             vec_len = hypre_ParCSRCommPkgRecvVecStart(comm_pkg,i+1)-vec_start;
-             hypre_MPI_Irecv(&Vext_data[vec_start], vec_len, HYPRE_MPI_REAL,
-                        ip, 0, comm, &requests[jr++]);
-	  }
-	  hypre_MPI_Waitall(jr,requests,status);
-	  }
-          if (relax_points == 0)
-          {
-            for (i = 0; i < n; i++)	
+         for (p = 0; p < num_procs; p++)
+         {
+            jr = 0;
+            if (p != my_id)
             {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
+               for (i = 0; i < num_sends; i++)
                {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                  ip = hypre_ParCSRCommPkgSendProc(comm_pkg, i);
+                  if (ip == p)
                   {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
+                     vec_start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+                     vec_len = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i+1)-vec_start;
+                     for (j=vec_start; j < vec_start+vec_len; j++)
+                        v_buf_data[j] = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+                     hypre_MPI_Isend(&v_buf_data[vec_start], vec_len, HYPRE_MPI_REAL,
+                           ip, 0, comm, &requests[jr++]);
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
                }
+               hypre_MPI_Waitall(jr,requests,status);
+               hypre_MPI_Barrier(comm);
+            }
+            else
+            {
+               if (num_procs > 1)
+               {
+                  for (i = 0; i < num_recvs; i++)
+                  {
+                     ip = hypre_ParCSRCommPkgRecvProc(comm_pkg, i);
+                     vec_start = hypre_ParCSRCommPkgRecvVecStart(comm_pkg,i);
+                     vec_len = hypre_ParCSRCommPkgRecvVecStart(comm_pkg,i+1)-vec_start;
+                     hypre_MPI_Irecv(&Vext_data[vec_start], vec_len, HYPRE_MPI_REAL,
+                           ip, 0, comm, &requests[jr++]);
+                  }
+                  hypre_MPI_Waitall(jr,requests,status);
+               }
+               if (relax_points == 0)
+               {
+                  for (i = 0; i < n; i++)
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ( A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] = res / A_diag_data[A_diag_i[i]];
+                     }
+                  }
+               }
+
+               /*-----------------------------------------------------------------
+                * Relax only C or F points as determined by relax_points.
+                *-----------------------------------------------------------------*/
+
+               else
+               {
+                  for (i = 0; i < n; i++)
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] = res / A_diag_data[A_diag_i[i]];
+                     }
+                  }
+               }
+               if (num_procs > 1)
+                  hypre_MPI_Barrier(comm);
             }
          }
-
-         /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
-          *-----------------------------------------------------------------*/
-
-         else
+         if (num_procs > 1)
          {
-            for (i = 0; i < n; i++)
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }     
-          }
-	  if (num_procs > 1)
-	  hypre_MPI_Barrier(comm);
-	 }
-	}
-	if (num_procs > 1)
-	{
- hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
- hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
- hypre_TFree(status, HYPRE_MEMORY_HOST);
- hypre_TFree(requests, HYPRE_MEMORY_HOST);
-	}
+            hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(status, HYPRE_MEMORY_HOST);
+            hypre_TFree(requests, HYPRE_MEMORY_HOST);
+         }
       }
       break;
 
       case 2: /* Gauss-Seidel: relax interior points in parallel, boundary
-				sequentially */
+                 sequentially */
       {
-	if (num_procs > 1)
-	{
-   	num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
-   	num_recvs = hypre_ParCSRCommPkgNumRecvs(comm_pkg);
+         if (num_procs > 1)
+         {
+            num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+            num_recvs = hypre_ParCSRCommPkgNumRecvs(comm_pkg);
 
-   	v_buf_data = hypre_CTAlloc(HYPRE_Real,  
-			hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
+            v_buf_data = hypre_CTAlloc(HYPRE_Real,
+                  hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
 
-	Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
-        
-	status  = hypre_CTAlloc(hypre_MPI_Status, num_recvs+num_sends, HYPRE_MEMORY_HOST);
-	requests= hypre_CTAlloc(hypre_MPI_Request,  num_recvs+num_sends, HYPRE_MEMORY_HOST);
+            Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
 
-	if (num_cols_offd)
-	{
-		A_offd_j = hypre_CSRMatrixJ(A_offd);
-		A_offd_data = hypre_CSRMatrixData(A_offd);
-	}
-	}
- 
+            status  = hypre_CTAlloc(hypre_MPI_Status, num_recvs+num_sends, HYPRE_MEMORY_HOST);
+            requests= hypre_CTAlloc(hypre_MPI_Request,  num_recvs+num_sends, HYPRE_MEMORY_HOST);
+
+            if (num_cols_offd)
+            {
+               A_offd_j = hypre_CSRMatrixJ(A_offd);
+               A_offd_data = hypre_CSRMatrixData(A_offd);
+            }
+         }
+
          /*-----------------------------------------------------------------
           * Copy current approximation into temporary vector.
           *-----------------------------------------------------------------*/
-        /* 
-         for (i = 0; i < n; i++)
-         {
+         /*
+            for (i = 0; i < n; i++)
+            {
             Vtemp_data[i] = u_data[i];
-         } */
- 
+            } */
+
          /*-----------------------------------------------------------------
           * Relax interior points first
           *-----------------------------------------------------------------*/
-          if (relax_points == 0)
-          {
-            for (i = 0; i < n; i++)	
-            {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ((A_offd_i[i+1]-A_offd_i[i]) == zero &&
-               		A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }
-          }
-          else
-          {
+         if (relax_points == 0)
+         {
             for (i = 0; i < n; i++)
             {
 
                /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-               			&& (A_offd_i[i+1]-A_offd_i[i]) == zero 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }     
-          }
-	for (p = 0; p < num_procs; p++)
-	{
-	jr = 0;
-	if (p != my_id)
-	{
-   	  for (i = 0; i < num_sends; i++)
-   	  {
-            ip = hypre_ParCSRCommPkgSendProc(comm_pkg, i);
-	    if (ip == p)
-	    {
-               vec_start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
-	       vec_len = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i+1)-vec_start;
-               for (j=vec_start; j < vec_start+vec_len; j++)
-                  v_buf_data[j] = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
-	       hypre_MPI_Isend(&v_buf_data[vec_start], vec_len, HYPRE_MPI_REAL,
-                        ip, 0, comm, &requests[jr++]);
-	    }
-   	  }
-	  hypre_MPI_Waitall(jr,requests,status);
-	  hypre_MPI_Barrier(comm);
-        }
-	else
-        {
-	  if (num_procs > 1)
-  	  {
-          for (i = 0; i < num_recvs; i++)
-          {
-             ip = hypre_ParCSRCommPkgRecvProc(comm_pkg, i);
-             vec_start = hypre_ParCSRCommPkgRecvVecStart(comm_pkg,i);
-             vec_len = hypre_ParCSRCommPkgRecvVecStart(comm_pkg,i+1)-vec_start;
-             hypre_MPI_Irecv(&Vext_data[vec_start], vec_len, HYPRE_MPI_REAL,
-                        ip, 0, comm, &requests[jr++]);
-	  }
-	  hypre_MPI_Waitall(jr,requests,status);
-	  }
-          if (relax_points == 0)
-          {
-            for (i = 0; i < n; i++)	
-            {
-
-               /*-----------------------------------------------------------
                 * If diagonal is nonzero, relax point i; otherwise, skip it.
                 *-----------------------------------------------------------*/
-             
-               if ((A_offd_i[i+1]-A_offd_i[i]) != zero &&
-               		A_diag_data[A_diag_i[i]] != zero)
+
+               if ((A_offd_i[i+1]-A_offd_i[i]) == zero &&
+                     A_diag_data[A_diag_i[i]] != zero)
                {
                   res = f_data[i];
                   for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
                   {
                      ii = A_diag_j[jj];
                      res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
                   }
                   u_data[i] = res / A_diag_data[A_diag_i[i]];
                }
             }
          }
-
-         /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
-          *-----------------------------------------------------------------*/
-
          else
          {
             for (i = 0; i < n; i++)
@@ -1161,10 +1062,10 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                 * If i is of the right type ( C or F ) and diagonal is
                 * nonzero, relax point i; otherwise, skip it.
                 *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-               			&& (A_offd_i[i+1]-A_offd_i[i]) != zero 
-				&& A_diag_data[A_diag_i[i]] != zero)
+
+               if (cf_marker[i] == relax_points
+                     && (A_offd_i[i+1]-A_offd_i[i]) == zero
+                     && A_diag_data[A_diag_i[i]] != zero)
                {
                   res = f_data[i];
                   for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
@@ -1172,483 +1073,574 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                      ii = A_diag_j[jj];
                      res -= A_diag_data[jj] * u_data[ii];
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
                   u_data[i] = res / A_diag_data[A_diag_i[i]];
                }
-            }     
-          }
-	  if (num_procs > 1)
-	  hypre_MPI_Barrier(comm);
-	 }
-	}
-	if (num_procs > 1)
-	{
- hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
- hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
- hypre_TFree(status, HYPRE_MEMORY_HOST);
- hypre_TFree(requests, HYPRE_MEMORY_HOST);
-	}
+            }
+         }
+         for (p = 0; p < num_procs; p++)
+         {
+            jr = 0;
+            if (p != my_id)
+            {
+               for (i = 0; i < num_sends; i++)
+               {
+                  ip = hypre_ParCSRCommPkgSendProc(comm_pkg, i);
+                  if (ip == p)
+                  {
+                     vec_start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+                     vec_len = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i+1)-vec_start;
+                     for (j=vec_start; j < vec_start+vec_len; j++)
+                        v_buf_data[j] = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+                     hypre_MPI_Isend(&v_buf_data[vec_start], vec_len, HYPRE_MPI_REAL,
+                           ip, 0, comm, &requests[jr++]);
+                  }
+               }
+               hypre_MPI_Waitall(jr,requests,status);
+               hypre_MPI_Barrier(comm);
+            }
+            else
+            {
+               if (num_procs > 1)
+               {
+                  for (i = 0; i < num_recvs; i++)
+                  {
+                     ip = hypre_ParCSRCommPkgRecvProc(comm_pkg, i);
+                     vec_start = hypre_ParCSRCommPkgRecvVecStart(comm_pkg,i);
+                     vec_len = hypre_ParCSRCommPkgRecvVecStart(comm_pkg,i+1)-vec_start;
+                     hypre_MPI_Irecv(&Vext_data[vec_start], vec_len, HYPRE_MPI_REAL,
+                           ip, 0, comm, &requests[jr++]);
+                  }
+                  hypre_MPI_Waitall(jr,requests,status);
+               }
+               if (relax_points == 0)
+               {
+                  for (i = 0; i < n; i++)
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ((A_offd_i[i+1]-A_offd_i[i]) != zero &&
+                           A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] = res / A_diag_data[A_diag_i[i]];
+                     }
+                  }
+               }
+
+               /*-----------------------------------------------------------------
+                * Relax only C or F points as determined by relax_points.
+                *-----------------------------------------------------------------*/
+
+               else
+               {
+                  for (i = 0; i < n; i++)
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && (A_offd_i[i+1]-A_offd_i[i]) != zero
+                           && A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] = res / A_diag_data[A_diag_i[i]];
+                     }
+                  }
+               }
+               if (num_procs > 1)
+                  hypre_MPI_Barrier(comm);
+            }
+         }
+         if (num_procs > 1)
+         {
+            hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(status, HYPRE_MEMORY_HOST);
+            hypre_TFree(requests, HYPRE_MEMORY_HOST);
+         }
       }
       break;
 
-      case 4: /* Hybrid: Jacobi off-processor, 
-                         Gauss-Seidel/SOR on-processor 
-                         (backward loop) */
+      case 4: /* Hybrid: Jacobi off-processor,
+                 Gauss-Seidel/SOR on-processor
+                 (backward loop) */
       {
-	if (num_procs > 1)
-	{
-   	num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+         if (num_procs > 1)
+         {
+            num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
 
-   	v_buf_data = hypre_CTAlloc(HYPRE_Real,  
-			hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
+            v_buf_data = hypre_CTAlloc(HYPRE_Real,
+                  hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
 
-	Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
-        
-	if (num_cols_offd)
-	{
-		A_offd_j = hypre_CSRMatrixJ(A_offd);
-		A_offd_data = hypre_CSRMatrixData(A_offd);
-	}
- 
-   	index = 0;
-   	for (i = 0; i < num_sends; i++)
-   	{
-        	start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
-        	for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg,i+1); j++)
-                	v_buf_data[index++] 
-                 	= u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
-   	}
- 
-   	comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data, 
-        	Vext_data);
+            Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
 
-         /*-----------------------------------------------------------------
-          * Copy current approximation into temporary vector.
-          *-----------------------------------------------------------------*/
-   	 hypre_ParCSRCommHandleDestroy(comm_handle);
-         comm_handle = NULL;
-	}
+            if (num_cols_offd)
+            {
+               A_offd_j = hypre_CSRMatrixJ(A_offd);
+               A_offd_data = hypre_CSRMatrixData(A_offd);
+            }
+
+            index = 0;
+            for (i = 0; i < num_sends; i++)
+            {
+               start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+               for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg,i+1); j++)
+                  v_buf_data[index++]
+                     = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+            }
+
+            comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data,
+                  Vext_data);
+
+            /*-----------------------------------------------------------------
+             * Copy current approximation into temporary vector.
+             *-----------------------------------------------------------------*/
+            hypre_ParCSRCommHandleDestroy(comm_handle);
+            comm_handle = NULL;
+         }
 
          /*-----------------------------------------------------------------
           * Relax all points.
           *-----------------------------------------------------------------*/
 
-	 if (relax_weight == 1 && omega == 1)
+         if (relax_weight == 1 && omega == 1)
          {
-         if (relax_points == 0)
-         {
-	  if (num_threads > 1)
-          {
-	   tmp_data = hypre_CTAlloc(HYPRE_Real, n, HYPRE_MEMORY_HOST);
+            if (relax_points == 0)
+            {
+               if (num_threads > 1)
+               {
+                  tmp_data = hypre_CTAlloc(HYPRE_Real, n, HYPRE_MEMORY_HOST);
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ne-1; i > ns-1; i--)	/* interior points first */
-            {
+                  for (j = 0; j < num_threads; j++)
+                  {
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
+                     {
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
+                     }
+                     else
+                     {
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* interior points first */
+                     {
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
+                        /*-----------------------------------------------------------
+                         * If diagonal is nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if ( A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                                 res -= A_diag_data[jj] * u_data[ii];
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] = res / A_diag_data[A_diag_i[i]];
+                        }
+                     }
+                  }
+                  hypre_TFree(tmp_data, HYPRE_MEMORY_HOST);
+               }
+               else
                {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                  for (i = n-1; i > -1; i--) /* interior points first */
                   {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-                        res -= A_diag_data[jj] * u_data[ii];
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
+
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ( A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] = res / A_diag_data[A_diag_i[i]];
+                     }
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
+
                }
             }
-           }
-           hypre_TFree(tmp_data, HYPRE_MEMORY_HOST);
-          }
-	  else
-          {
-            for (i = n-1; i > -1; i--)	/* interior points first */
-            {
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
+            /*-----------------------------------------------------------------
+             * Relax only C or F points as determined by relax_points.
+             *-----------------------------------------------------------------*/
+
+            else
+            {
+               if (num_threads > 1)
                {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                  tmp_data = hypre_CTAlloc(HYPRE_Real, n, HYPRE_MEMORY_HOST);
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
+#endif
+                  for (j = 0; j < num_threads; j++)
                   {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
+                     {
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
+                     }
+                     else
+                     {
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* relax interior points */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If i is of the right type ( C or F ) and diagonal is
+                         * nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if (cf_marker[i] == relax_points
+                              && A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                                 res -= A_diag_data[jj] * u_data[ii];
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] = res / A_diag_data[A_diag_i[i]];
+                        }
+                     }
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                  hypre_TFree(tmp_data, HYPRE_MEMORY_HOST);
+
+               }
+               else
+               {
+                  for (i = n-1; i > -1; i--) /* relax interior points */
                   {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] = res / A_diag_data[A_diag_i[i]];
+                     }
                   }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
                }
             }
-          
-          }
          }
-
-         /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
-          *-----------------------------------------------------------------*/
-
          else
          {
-	  if (num_threads > 1)
-	  {
-	   tmp_data = hypre_CTAlloc(HYPRE_Real, n, HYPRE_MEMORY_HOST);
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
+            for (i = 0; i < n; i++)
+            {
+               Vtemp_data[i] = u_data[i];
+            }
+            prod = (1.0-relax_weight*omega);
+            if (relax_points == 0)
+            {
+               if (num_threads > 1)
+               {
+                  tmp_data = hypre_CTAlloc(HYPRE_Real, n, HYPRE_MEMORY_HOST);
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ne-1; i > ns-1; i--) /* relax interior points */
-            {
+                  for (j = 0; j < num_threads; j++)
+                  {
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
+                     {
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
+                     }
+                     else
+                     {
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* interior points first */
+                     {
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-                        res -= A_diag_data[jj] * u_data[ii];
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
+                        /*-----------------------------------------------------------
+                         * If diagonal is nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if ( A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res = f_data[i];
+                           res0 = 0.0;
+                           res2 = 0.0;
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res0 -= A_diag_data[jj] * u_data[ii];
+                                 res2 += A_diag_data[jj] * Vtemp_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] *= prod;
+                           u_data[i] += relax_weight*(omega*res + res0 +
+                                 one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                           /*u_data[i] += omega*(relax_weight*res + res0 +
+                             one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                        }
+                     }
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
+                  hypre_TFree(tmp_data, HYPRE_MEMORY_HOST);
+
                }
-            }     
-           }     
-           hypre_TFree(tmp_data, HYPRE_MEMORY_HOST);
-           
-	  }
-	  else
-	  {
-            for (i = n-1; i > -1; i--) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-      
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
+               else
                {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                  for (i = n-1; i > -1; i--) /* interior points first */
                   {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }     
-	  }
-         }
-         }
-	 else
-         {
-#ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
-#endif
-         for (i = 0; i < n; i++)
-         {
-            Vtemp_data[i] = u_data[i];
-         }
-         prod = (1.0-relax_weight*omega);
-         if (relax_points == 0)
-         {
-	  if (num_threads > 1)
-          {
-	   tmp_data = hypre_CTAlloc(HYPRE_Real, n, HYPRE_MEMORY_HOST);
-#ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
-#endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
-#ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
-#endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ne-1; i > ns-1; i--)	/* interior points first */
-            {
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ( A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res0 = 0.0;
+                        res2 = 0.0;
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res0 -= A_diag_data[jj] * u_data[ii];
+                           res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] *= prod;
+                        u_data[i] += relax_weight*(omega*res + res0 +
+                              one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                        /*u_data[i] += omega*(relax_weight*res + res0 +
+                          one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                     }
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
                }
             }
-           }
-           hypre_TFree(tmp_data, HYPRE_MEMORY_HOST);
-           
-          }
-	  else
-          {
-            for (i = n-1; i > -1; i--)	/* interior points first */
+
+            /*-----------------------------------------------------------------
+             * Relax only C or F points as determined by relax_points.
+             *-----------------------------------------------------------------*/
+
+            else
             {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
+               if (num_threads > 1)
                {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
-               }
-            }
-          }
-         }
-
-         /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
-          *-----------------------------------------------------------------*/
-
-         else
-         {
-	  if (num_threads > 1)
-	  {
-	   tmp_data = hypre_CTAlloc(HYPRE_Real, n, HYPRE_MEMORY_HOST);
+                  tmp_data = hypre_CTAlloc(HYPRE_Real, n, HYPRE_MEMORY_HOST);
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,res0,res2,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ne-1; i > ns-1; i--) /* relax interior points */
-            {
+                  for (j = 0; j < num_threads; j++)
+                  {
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
+                     {
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
+                     }
+                     else
+                     {
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* relax interior points */
+                     {
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
-               }
-            }     
-           }     
-           hypre_TFree(tmp_data, HYPRE_MEMORY_HOST);
-	  }
-	  else
-	  {
-            for (i = n-1; i > -1; i--) /* relax interior points */
-            {
+                        /*-----------------------------------------------------------
+                         * If i is of the right type ( C or F ) and diagonal is
+                         * nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-      
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        if (cf_marker[i] == relax_points
+                              && A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res0 = 0.0;
+                           res2 = 0.0;
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res0 -= A_diag_data[jj] * u_data[ii];
+                                 res2 += A_diag_data[jj] * Vtemp_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] *= prod;
+                           u_data[i] += relax_weight*(omega*res + res0 +
+                                 one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                           /*u_data[i] += omega*(relax_weight*res + res0 +
+                             one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                        }
+                     }
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                  hypre_TFree(tmp_data, HYPRE_MEMORY_HOST);
                }
-            }     
-	  }
-         }
+               else
+               {
+                  for (i = n-1; i > -1; i--) /* relax interior points */
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        res0 = 0.0;
+                        res2 = 0.0;
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res0 -= A_diag_data[jj] * u_data[ii];
+                           res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] *= prod;
+                        u_data[i] += relax_weight*(omega*res + res0 +
+                              one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                        /*u_data[i] += omega*(relax_weight*res + res0 +
+                          one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                     }
+                  }
+               }
+            }
          }
          if (num_procs > 1)
          {
-	   hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
-	   hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
          }
       }
       break;
 
-      case 6: /* Hybrid: Jacobi off-processor, 
-                         Symm. Gauss-Seidel/ SSOR on-processor
-			with outer relaxation parameter */
+      case 6: /* Hybrid: Jacobi off-processor,
+                 Symm. Gauss-Seidel/ SSOR on-processor
+                 with outer relaxation parameter */
       {
 
          if (num_threads > 1)
@@ -1656,697 +1648,697 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
             Ztemp_local = hypre_ParVectorLocalVector(Ztemp);
             Ztemp_data = hypre_VectorData(Ztemp_local);
          }
-         
-         /*-----------------------------------------------------------------
-          * Copy current approximation into temporary vector.
-          *-----------------------------------------------------------------*/
-	if (num_procs > 1)
-	{
-   	num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
-
-   	v_buf_data = hypre_CTAlloc(HYPRE_Real,  
-			hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
-
-	Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
-        
-	if (num_cols_offd)
-	{
-		A_offd_j = hypre_CSRMatrixJ(A_offd);
-		A_offd_data = hypre_CSRMatrixData(A_offd);
-	}
- 
-   	index = 0;
-   	for (i = 0; i < num_sends; i++)
-   	{
-        	start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
-        	for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg,i+1); j++)
-                	v_buf_data[index++] 
-                 	= u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
-   	}
- 
-   	comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data, 
-        	Vext_data);
 
          /*-----------------------------------------------------------------
           * Copy current approximation into temporary vector.
           *-----------------------------------------------------------------*/
-   	 hypre_ParCSRCommHandleDestroy(comm_handle);
-         comm_handle = NULL;
-	}
-
-        /*-----------------------------------------------------------------
-         * Relax all points.
-         *-----------------------------------------------------------------*/
-
-	if (relax_weight == 1 && omega == 1)
-        {
-         if (relax_points == 0)
+         if (num_procs > 1)
          {
-	  if (num_threads > 1)
-          {
-             tmp_data = Ztemp_data;
-#ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
-#endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
-#ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
-#endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ns; i < ne; i++)	/* interior points first */
+            num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+
+            v_buf_data = hypre_CTAlloc(HYPRE_Real,
+                  hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
+
+            Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
+
+            if (num_cols_offd)
             {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res -= A_diag_data[jj] * u_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
+               A_offd_j = hypre_CSRMatrixJ(A_offd);
+               A_offd_data = hypre_CSRMatrixData(A_offd);
             }
-            for (i = ne-1; i > ns-1; i--)	/* interior points first */
+
+            index = 0;
+            for (i = 0; i < num_sends; i++)
             {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res -= A_diag_data[jj] * u_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
+               start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+               for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg,i+1); j++)
+                  v_buf_data[index++]
+                     = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
             }
-           }
 
-          }
-	  else
-          {
-            for (i = 0; i < n; i++)	/* interior points first */
-            {
+            comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data,
+                  Vext_data);
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }
-            for (i = n-1; i > -1; i--)	/* interior points first */
-            {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }
-          }
+            /*-----------------------------------------------------------------
+             * Copy current approximation into temporary vector.
+             *-----------------------------------------------------------------*/
+            hypre_ParCSRCommHandleDestroy(comm_handle);
+            comm_handle = NULL;
          }
 
          /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
+          * Relax all points.
           *-----------------------------------------------------------------*/
 
-         else
+         if (relax_weight == 1 && omega == 1)
          {
-	  if (num_threads > 1)
-	  {
-             tmp_data = Ztemp_data;
+            if (relax_points == 0)
+            {
+               if (num_threads > 1)
+               {
+                  tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ns; i < ne; i++) /* relax interior points */
-            {
+                  for (j = 0; j < num_threads; j++)
+                  {
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
+                     {
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
+                     }
+                     else
+                     {
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
+                     }
+                     for (i = ns; i < ne; i++) /* interior points first */
+                     {
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res -= A_diag_data[jj] * u_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
+                        /*-----------------------------------------------------------
+                         * If diagonal is nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if ( A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] = res / A_diag_data[A_diag_i[i]];
+                        }
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* interior points first */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If diagonal is nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if ( A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] = res / A_diag_data[A_diag_i[i]];
+                        }
+                     }
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
+
                }
-            }     
-            for (i = ne-1; i > ns-1; i--) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
+               else
                {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                  for (i = 0; i < n; i++) /* interior points first */
                   {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res -= A_diag_data[jj] * u_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }     
-           }     
 
-	  }
-	  else
-	  {
-            for (i = 0; i < n; i++) /* relax interior points */
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ( A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] = res / A_diag_data[A_diag_i[i]];
+                     }
+                  }
+                  for (i = n-1; i > -1; i--) /* interior points first */
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ( A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] = res / A_diag_data[A_diag_i[i]];
+                     }
+                  }
+               }
+            }
+
+            /*-----------------------------------------------------------------
+             * Relax only C or F points as determined by relax_points.
+             *-----------------------------------------------------------------*/
+
+            else
             {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-      
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
+               if (num_threads > 1)
                {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }     
-            for (i = n-1; i > -1; i--) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-      
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] = res / A_diag_data[A_diag_i[i]];
-               }
-            }     
-	  }
-         }
-        }
-        else
-        {
+                  tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-         for (i = 0; i < n; i++)
-         {
-            Vtemp_data[i] = u_data[i];
-         }
-         prod = (1.0-relax_weight*omega);
-         if (relax_points == 0)
-         {
-	  if (num_threads > 1)
-          {
-             tmp_data = Ztemp_data;
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
-#ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i,ii,j,jj,ns,ne,res,res0,res2,rest,size) HYPRE_SMP_SCHEDULE
-#endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ns; i < ne; i++)	/* interior points first */
-            {
+                  for (j = 0; j < num_threads; j++)
+                  {
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
+                     {
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
+                     }
+                     else
+                     {
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
+                     }
+                     for (i = ns; i < ne; i++) /* relax interior points */
+                     {
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
+                        /*-----------------------------------------------------------
+                         * If i is of the right type ( C or F ) and diagonal is
+                         * nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if (cf_marker[i] == relax_points
+                              && A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] = res / A_diag_data[A_diag_i[i]];
+                        }
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* relax interior points */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If i is of the right type ( C or F ) and diagonal is
+                         * nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if (cf_marker[i] == relax_points
+                              && A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] = res / A_diag_data[A_diag_i[i]];
+                        }
+                     }
+                  }
+
+               }
+               else
                {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                  for (i = 0; i < n; i++) /* relax interior points */
                   {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] = res / A_diag_data[A_diag_i[i]];
+                     }
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                  for (i = n-1; i > -1; i--) /* relax interior points */
                   {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] = res / A_diag_data[A_diag_i[i]];
+                     }
                   }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
                }
             }
-            for (i = ne-1; i > ns-1; i--)	/* interior points first */
-            {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
-               }
-            }
-           }
-
-          }
-	  else
-          {
-            for (i = 0; i < n; i++)	/* interior points first */
-            {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res0 = 0.0;
-                  res = f_data[i];
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
-               }
-            }
-            for (i = n-1; i > -1; i--)	/* interior points first */
-            {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if ( A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res0 = 0.0;
-                  res = f_data[i];
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
-               }
-            }
-          }
          }
-
-         /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
-          *-----------------------------------------------------------------*/
-
          else
          {
-	  if (num_threads > 1)
-	  {
-             tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-	      tmp_data[i] = u_data[i];
+            for (i = 0; i < n; i++)
+            {
+               Vtemp_data[i] = u_data[i];
+            }
+            prod = (1.0-relax_weight*omega);
+            if (relax_points == 0)
+            {
+               if (num_threads > 1)
+               {
+                  tmp_data = Ztemp_data;
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,res0,res2,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-	   {
-	    size = n/num_threads;
-	    rest = n - size*num_threads;
-	    if (j < rest)
-	    {
-	       ns = j*size+j;
-	       ne = (j+1)*size+j+1;
-	    }
-	    else
-	    {
-	       ns = j*size+rest;
-	       ne = (j+1)*size+rest;
-	    }
-            for (i = ns; i < ne; i++) /* relax interior points */
-            {
+                  for (j = 0; j < num_threads; j++)
+                  {
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
+                     {
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
+                     }
+                     else
+                     {
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
+                     }
+                     for (i = ns; i < ne; i++) /* interior points first */
+                     {
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-                        res0 -= A_diag_data[jj] * u_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
+                        /*-----------------------------------------------------------
+                         * If diagonal is nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if ( A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res0 = 0.0;
+                           res2 = 0.0;
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res0 -= A_diag_data[jj] * u_data[ii];
+                                 res2 += A_diag_data[jj] * Vtemp_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] *= prod;
+                           u_data[i] += relax_weight*(omega*res + res0 +
+                                 one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                           /*u_data[i] += omega*(relax_weight*res + res0 +
+                             one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                        }
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* interior points first */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If diagonal is nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if ( A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res0 = 0.0;
+                           res2 = 0.0;
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res0 -= A_diag_data[jj] * u_data[ii];
+                                 res2 += A_diag_data[jj] * Vtemp_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] *= prod;
+                           u_data[i] += relax_weight*(omega*res + res0 +
+                                 one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                           /*u_data[i] += omega*(relax_weight*res + res0 +
+                             one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                        }
+                     }
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+
                }
-            }     
-            for (i = ne-1; i > ns-1; i--) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
+               else
                {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                  for (i = 0; i < n; i++) /* interior points first */
                   {
-                     ii = A_diag_j[jj];
-		     if (ii >= ns && ii < ne)
-		     {
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-                        res0 -= A_diag_data[jj] * u_data[ii];
-		     }
-		     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
-               }
-            }     
-           }     
 
-	  }
-	  else
-	  {
-            for (i = 0; i < n; i++) /* relax interior points */
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ( A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res0 = 0.0;
+                        res = f_data[i];
+                        res2 = 0.0;
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res0 -= A_diag_data[jj] * u_data[ii];
+                           res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] *= prod;
+                        u_data[i] += relax_weight*(omega*res + res0 +
+                              one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                        /*u_data[i] += omega*(relax_weight*res + res0 +
+                          one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                     }
+                  }
+                  for (i = n-1; i > -1; i--) /* interior points first */
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ( A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res0 = 0.0;
+                        res = f_data[i];
+                        res2 = 0.0;
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res0 -= A_diag_data[jj] * u_data[ii];
+                           res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] *= prod;
+                        u_data[i] += relax_weight*(omega*res + res0 +
+                              one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                        /*u_data[i] += omega*(relax_weight*res + res0 +
+                          one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                     }
+                  }
+               }
+            }
+
+            /*-----------------------------------------------------------------
+             * Relax only C or F points as determined by relax_points.
+             *-----------------------------------------------------------------*/
+
+            else
             {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-      
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
+               if (num_threads > 1)
                {
-                  res = f_data[i];
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                  tmp_data = Ztemp_data;
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i,ii,j,jj,ns,ne,res,res0,res2,rest,size) HYPRE_SMP_SCHEDULE
+#endif
+                  for (j = 0; j < num_threads; j++)
                   {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
-               }
-            }     
-            for (i = n-1; i > -1; i--) /* relax interior points */
-            {
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
+                     {
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
+                     }
+                     else
+                     {
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
+                     }
+                     for (i = ns; i < ne; i++) /* relax interior points */
+                     {
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-      
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-             
-               if (cf_marker[i] == relax_points 
-				&& A_diag_data[A_diag_i[i]] != zero)
-               {
-                  res = f_data[i];
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        /*-----------------------------------------------------------
+                         * If i is of the right type ( C or F ) and diagonal is
+                         * nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if (cf_marker[i] == relax_points
+                              && A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res0 = 0.0;
+                           res2 = 0.0;
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res2 += A_diag_data[jj] * Vtemp_data[ii];
+                                 res0 -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] *= prod;
+                           u_data[i] += relax_weight*(omega*res + res0 +
+                                 one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                           /*u_data[i] += omega*(relax_weight*res + res0 +
+                             one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                        }
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* relax interior points */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If i is of the right type ( C or F ) and diagonal is
+                         * nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if (cf_marker[i] == relax_points
+                              && A_diag_data[A_diag_i[i]] != zero)
+                        {
+                           res0 = 0.0;
+                           res2 = 0.0;
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res2 += A_diag_data[jj] * Vtemp_data[ii];
+                                 res0 -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] *= prod;
+                           u_data[i] += relax_weight*(omega*res + res0 +
+                                 one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                           /*u_data[i] += omega*(relax_weight*res + res0 +
+                             one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                        }
+                     }
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-			one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-			one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+
                }
-            }     
-	  }
+               else
+               {
+                  for (i = 0; i < n; i++) /* relax interior points */
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        res0 = 0.0;
+                        res2 = 0.0;
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res0 -= A_diag_data[jj] * u_data[ii];
+                           res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] *= prod;
+                        u_data[i] += relax_weight*(omega*res + res0 +
+                              one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                        /*u_data[i] += omega*(relax_weight*res + res0 +
+                          one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                     }
+                  }
+                  for (i = n-1; i > -1; i--) /* relax interior points */
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && A_diag_data[A_diag_i[i]] != zero)
+                     {
+                        res = f_data[i];
+                        res0 = 0.0;
+                        res2 = 0.0;
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res0 -= A_diag_data[jj] * u_data[ii];
+                           res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] *= prod;
+                        u_data[i] += relax_weight*(omega*res + res0 +
+                              one_minus_omega*res2) / A_diag_data[A_diag_i[i]];
+                        /*u_data[i] += omega*(relax_weight*res + res0 +
+                          one_minus_weight*res2) / A_diag_data[A_diag_i[i]];*/
+                     }
+                  }
+               }
+            }
          }
-        }
-        if (num_procs > 1)
-        {
-	   hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
-	   hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
-        }
+         if (num_procs > 1)
+         {
+            hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
+         }
       }
       break;
 
@@ -2363,7 +2355,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
          VecCopy(Vtemp_data,f_data,hypre_VectorSize(hypre_ParVectorLocalVector(Vtemp)),HYPRE_STREAM(4));
 #else
          hypre_ParVectorCopy(f,Vtemp);
-#endif 
+#endif
          /*-----------------------------------------------------------------
           * Perform Matvec Vtemp=f-Au
           *-----------------------------------------------------------------*/
@@ -2386,7 +2378,6 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
 
       case 8: /* hybrid L1 Symm. Gauss-Seidel */
       {
-
          if (num_threads > 1)
          {
             Ztemp_local = hypre_ParVectorLocalVector(Ztemp);
@@ -2396,699 +2387,695 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
          /*-----------------------------------------------------------------
           * Copy current approximation into temporary vector.
           *-----------------------------------------------------------------*/
-        if (num_procs > 1)
-        {
-        num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
-
-        v_buf_data = hypre_CTAlloc(HYPRE_Real, 
-                        hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
-
-        Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
-
-        if (num_cols_offd)
-        {
-                A_offd_j = hypre_CSRMatrixJ(A_offd);
-                A_offd_data = hypre_CSRMatrixData(A_offd);
-        }
-
-        index = 0;
-        for (i = 0; i < num_sends; i++)
-        {
-                start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
-                for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg,i+1); j++)
-                        v_buf_data[index++]
-                        = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
-        }
-
-        comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data,
-                Vext_data);
-
-         /*-----------------------------------------------------------------
-          * Copy current approximation into temporary vector.
-          *-----------------------------------------------------------------*/
-         hypre_ParCSRCommHandleDestroy(comm_handle);
-         comm_handle = NULL;
-        }
-
-        /*-----------------------------------------------------------------
-         * Relax all points.
-         *-----------------------------------------------------------------*/
-
-        if (relax_weight == 1 && omega == 1)
-        {
-         if (relax_points == 0)
+         if (num_procs > 1)
          {
-          if (num_threads > 1)
-          {
-             tmp_data = Ztemp_data;
-#ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
-#endif
-           for (i = 0; i < n; i++)
-              tmp_data[i] = u_data[i];
-#ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
-#endif
-           for (j = 0; j < num_threads; j++)
-           {
-            size = n/num_threads;
-            rest = n - size*num_threads;
-            if (j < rest)
-            {
-               ns = j*size+j;
-               ne = (j+1)*size+j+1;
-            }
-            else
-            {
-               ns = j*size+rest;
-               ne = (j+1)*size+rest;
-            }
-            for (i = ns; i < ne; i++)	/* interior points first */
-            {
+            num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
+            v_buf_data = hypre_CTAlloc(HYPRE_Real, hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
 
-               if ( l1_norms[i] != zero)
+            Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
+
+            if (num_cols_offd)
+            {
+               A_offd_j = hypre_CSRMatrixJ(A_offd);
+               A_offd_data = hypre_CSRMatrixData(A_offd);
+            }
+
+            index = 0;
+            for (i = 0; i < num_sends; i++)
+            {
+               start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+               for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg,i+1); j++)
                {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
-                     {
-                        res -= A_diag_data[jj] * u_data[ii];
-                     }
-                     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
+                  v_buf_data[index++] = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
                }
             }
-            for (i = ne-1; i > ns-1; i--)	/* interior points first */
-            {
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
+            comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data, Vext_data);
 
-               if ( l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
-                     {
-                        res -= A_diag_data[jj] * u_data[ii];
-                     }
-                     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
-               }
-            }
-           }
-
-          }
-          else
-          {
-            for (i = 0; i < n; i++)	/* interior points first */
-            {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if ( l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
-               }
-            }
-            for (i = n-1; i > -1; i--)	/* interior points first */
-            {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if ( l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
-               }
-            }
-          }
+            /*-----------------------------------------------------------------
+             * Copy current approximation into temporary vector.
+             *-----------------------------------------------------------------*/
+            hypre_ParCSRCommHandleDestroy(comm_handle);
+            comm_handle = NULL;
          }
 
          /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
+          * Relax all points.
           *-----------------------------------------------------------------*/
 
+         if (relax_weight == 1 && omega == 1)
+         {
+            if (relax_points == 0)
+            {
+               if (num_threads > 1)
+               {
+                  tmp_data = Ztemp_data;
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
+#endif
+                  for (j = 0; j < num_threads; j++)
+                  {
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
+                     {
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
+                     }
+                     else
+                     {
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
+                     }
+                     for (i = ns; i < ne; i++) /* interior points first */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If diagonal is nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if ( l1_norms[i] != zero)
+                        {
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                              {
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                              }
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] += res / l1_norms[i];
+                        }
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* interior points first */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If diagonal is nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if ( l1_norms[i] != zero)
+                        {
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                              {
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                              }
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] += res / l1_norms[i];
+                        }
+                     }
+                  }
+
+               }
+               else
+               {
+                  for (i = 0; i < n; i++) /* interior points first */
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ( l1_norms[i] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] += res / l1_norms[i];
+                     }
+                  }
+                  for (i = n-1; i > -1; i--) /* interior points first */
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ( l1_norms[i] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] += res / l1_norms[i];
+                     }
+                  }
+               }
+            }
+            /*-----------------------------------------------------------------
+             * Relax only C or F points as determined by relax_points.
+             *-----------------------------------------------------------------*/
+            else
+            {
+               if (num_threads > 1)
+               {
+                  tmp_data = Ztemp_data;
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
+#endif
+                  for (j = 0; j < num_threads; j++)
+                  {
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
+                     {
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
+                     }
+                     else
+                     {
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
+                     }
+                     for (i = ns; i < ne; i++) /* relax interior points */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If i is of the right type ( C or F ) and diagonal is
+                         * nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if (cf_marker[i] == relax_points
+                              && l1_norms[i] != zero)
+                        {
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                              {
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                              }
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] += res / l1_norms[i];
+                        }
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* relax interior points */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If i is of the right type ( C or F ) and diagonal is
+                         * nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if (cf_marker[i] == relax_points
+                              && l1_norms[i] != zero)
+                        {
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] += res / l1_norms[i];
+                        }
+                     }
+                  }
+               }
+               else
+               {
+                  for (i = 0; i < n; i++) /* relax interior points */
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && l1_norms[i] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] += res / l1_norms[i];
+                     }
+                  }
+                  for (i = n-1; i > -1; i--) /* relax interior points */
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && l1_norms[i] != zero)
+                     {
+                        res = f_data[i];
+                        for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res -= A_diag_data[jj] * u_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] += res / l1_norms[i];
+                     }
+                  }
+               }
+            }
+         }
          else
          {
-          if (num_threads > 1)
-          {
-             tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-              tmp_data[i] = u_data[i];
+            for (i = 0; i < n; i++)
+            {
+               Vtemp_data[i] = u_data[i];
+            }
+            prod = (1.0-relax_weight*omega);
+            if (relax_points == 0)
+            {
+               if (num_threads > 1)
+               {
+                  tmp_data = Ztemp_data;
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-           {
-            size = n/num_threads;
-            rest = n - size*num_threads;
-            if (j < rest)
-            {
-               ns = j*size+j;
-               ne = (j+1)*size+j+1;
+                  for (j = 0; j < num_threads; j++)
+                  {
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
+                     {
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
+                     }
+                     else
+                     {
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
+                     }
+                     for (i = ns; i < ne; i++) /* interior points first */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If diagonal is nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if ( l1_norms[i] != zero)
+                        {
+                           res0 = 0.0;
+                           res2 = 0.0;
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res0 -= A_diag_data[jj] * u_data[ii];
+                                 res2 += A_diag_data[jj] * Vtemp_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] *= prod;
+                           u_data[i] += relax_weight*(omega*res + res0 + one_minus_omega*res2) / l1_norms[i];
+                           /*u_data[i] += omega*(relax_weight*res + res0 +
+                             one_minus_weight*res2) / l1_norms[i];*/
+                        }
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* interior points first */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If diagonal is nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if ( l1_norms[i] != zero)
+                        {
+                           res0 = 0.0;
+                           res2 = 0.0;
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res0 -= A_diag_data[jj] * u_data[ii];
+                                 res2 += A_diag_data[jj] * Vtemp_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] *= prod;
+                           u_data[i] += relax_weight*(omega*res + res0 +
+                                 one_minus_omega*res2) / l1_norms[i];
+                           /*u_data[i] += omega*(relax_weight*res + res0 +
+                             one_minus_weight*res2) / l1_norms[i];*/
+                        }
+                     }
+                  }
+               }
+               else
+               {
+                  for (i = 0; i < n; i++) /* interior points first */
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ( l1_norms[i] != zero)
+                     {
+                        res0 = 0.0;
+                        res = f_data[i];
+                        res2 = 0.0;
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res0 -= A_diag_data[jj] * u_data[ii];
+                           res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] *= prod;
+                        u_data[i] += relax_weight*(omega*res + res0 +
+                              one_minus_omega*res2) / l1_norms[i];
+                        /*u_data[i] += omega*(relax_weight*res + res0 +
+                          one_minus_weight*res2) / l1_norms[i];*/
+                     }
+                  }
+                  for (i = n-1; i > -1; i--) /* interior points first */
+                  {
+
+                     /*-----------------------------------------------------------
+                      * If diagonal is nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if ( l1_norms[i] != zero)
+                     {
+                        res0 = 0.0;
+                        res = f_data[i];
+                        res2 = 0.0;
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res0 -= A_diag_data[jj] * u_data[ii];
+                           res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] *= prod;
+                        u_data[i] += relax_weight*(omega*res + res0 +
+                              one_minus_omega*res2) / l1_norms[i];
+                        /*u_data[i] += omega*(relax_weight*res + res0 +
+                          one_minus_weight*res2) / l1_norms[i];*/
+                     }
+                  }
+               }
             }
+            /*-----------------------------------------------------------------
+             * Relax only C or F points as determined by relax_points.
+             *-----------------------------------------------------------------*/
             else
             {
-               ns = j*size+rest;
-               ne = (j+1)*size+rest;
-            }
-            for (i = ns; i < ne; i++) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
+               if (num_threads > 1)
                {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
-                     {
-                        res -= A_diag_data[jj] * u_data[ii];
-                     }
-                     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
-               }
-            }
-            for (i = ne-1; i > ns-1; i--) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
-                     {
-                        res -= A_diag_data[jj] * u_data[ii];
-                     }
-                     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
-               }
-            }
-           }
-
-          }
-          else
-          {
-            for (i = 0; i < n; i++) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
-               }
-            }
-            for (i = n-1; i > -1; i--) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
-               }
-            }
-          }
-         }
-        }
-        else
-        {
+                  tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-         for (i = 0; i < n; i++)
-         {
-            Vtemp_data[i] = u_data[i];
-         }
-         prod = (1.0-relax_weight*omega);
-         if (relax_points == 0)
-         {
-          if (num_threads > 1)
-          {
-             tmp_data = Ztemp_data;
-#ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
-#endif
-           for (i = 0; i < n; i++)
-              tmp_data[i] = u_data[i];
+                  for (i = 0; i < n; i++)
+                     tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-           {
-            size = n/num_threads;
-            rest = n - size*num_threads;
-            if (j < rest)
-            {
-               ns = j*size+j;
-               ne = (j+1)*size+j+1;
-            }
-            else
-            {
-               ns = j*size+rest;
-               ne = (j+1)*size+rest;
-            }
-            for (i = ns; i < ne; i++)	/* interior points first */
-            {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if ( l1_norms[i] != zero)
-               {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                  for (j = 0; j < num_threads; j++)
                   {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
+                     size = n/num_threads;
+                     rest = n - size*num_threads;
+                     if (j < rest)
                      {
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        ns = j*size+j;
+                        ne = (j+1)*size+j+1;
                      }
                      else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
-               }
-            }
-            for (i = ne-1; i > ns-1; i--)	/* interior points first */
-            {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if ( l1_norms[i] != zero)
-               {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
                      {
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        ns = j*size+rest;
+                        ne = (j+1)*size+rest;
                      }
-                     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
+                     for (i = ns; i < ne; i++) /* relax interior points */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If i is of the right type ( C or F ) and diagonal is
+                         * nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if (cf_marker[i] == relax_points && l1_norms[i] != zero)
+                        {
+                           res0 = 0.0;
+                           res2 = 0.0;
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res2 += A_diag_data[jj] * Vtemp_data[ii];
+                                 res0 -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] *= prod;
+                           u_data[i] += relax_weight*(omega*res + res0 +
+                                 one_minus_omega*res2) / l1_norms[i];
+                           /*u_data[i] += omega*(relax_weight*res + res0 +
+                             one_minus_weight*res2) / l1_norms[i];*/
+                        }
+                     }
+                     for (i = ne-1; i > ns-1; i--) /* relax interior points */
+                     {
+
+                        /*-----------------------------------------------------------
+                         * If i is of the right type ( C or F ) and diagonal is
+                         * nonzero, relax point i; otherwise, skip it.
+                         *-----------------------------------------------------------*/
+
+                        if (cf_marker[i] == relax_points
+                              && l1_norms[i] != zero)
+                        {
+                           res0 = 0.0;
+                           res2 = 0.0;
+                           res = f_data[i];
+                           for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                           {
+                              ii = A_diag_j[jj];
+                              if (ii >= ns && ii < ne)
+                              {
+                                 res2 += A_diag_data[jj] * Vtemp_data[ii];
+                                 res0 -= A_diag_data[jj] * u_data[ii];
+                              }
+                              else
+                                 res -= A_diag_data[jj] * tmp_data[ii];
+                           }
+                           for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                           {
+                              ii = A_offd_j[jj];
+                              res -= A_offd_data[jj] * Vext_data[ii];
+                           }
+                           u_data[i] *= prod;
+                           u_data[i] += relax_weight*(omega*res + res0 +
+                                 one_minus_omega*res2) / l1_norms[i];
+                           /*u_data[i] += omega*(relax_weight*res + res0 +
+                             one_minus_weight*res2) / l1_norms[i];*/
+                        }
+                     }
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
+
                }
-            }
-           }
-
-          }
-          else
-          {
-            for (i = 0; i < n; i++)	/* interior points first */
-            {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if ( l1_norms[i] != zero)
+               else
                {
-                  res0 = 0.0;
-                  res = f_data[i];
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                  for (i = 0; i < n; i++) /* relax interior points */
                   {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && l1_norms[i] != zero)
+                     {
+                        res = f_data[i];
+                        res0 = 0.0;
+                        res2 = 0.0;
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res0 -= A_diag_data[jj] * u_data[ii];
+                           res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] *= prod;
+                        u_data[i] += relax_weight*(omega*res + res0 +
+                              one_minus_omega*res2) / l1_norms[i];
+                        /*u_data[i] += omega*(relax_weight*res + res0 +
+                          one_minus_weight*res2) / l1_norms[i];*/
+                     }
                   }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                  for (i = n-1; i > -1; i--) /* relax interior points */
                   {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
+
+                     /*-----------------------------------------------------------
+                      * If i is of the right type ( C or F ) and diagonal is
+
+                      * nonzero, relax point i; otherwise, skip it.
+                      *-----------------------------------------------------------*/
+
+                     if (cf_marker[i] == relax_points
+                           && l1_norms[i] != zero)
+                     {
+                        res = f_data[i];
+                        res0 = 0.0;
+                        res2 = 0.0;
+                        for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                        {
+                           ii = A_diag_j[jj];
+                           res0 -= A_diag_data[jj] * u_data[ii];
+                           res2 += A_diag_data[jj] * Vtemp_data[ii];
+                        }
+                        for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                        {
+                           ii = A_offd_j[jj];
+                           res -= A_offd_data[jj] * Vext_data[ii];
+                        }
+                        u_data[i] *= prod;
+                        u_data[i] += relax_weight*(omega*res + res0 +
+                              one_minus_omega*res2) / l1_norms[i];
+                        /*u_data[i] += omega*(relax_weight*res + res0 +
+                          one_minus_weight*res2) / l1_norms[i];*/
+                     }
                   }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
                }
             }
-            for (i = n-1; i > -1; i--)	/* interior points first */
-            {
-
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if ( l1_norms[i] != zero)
-               {
-                  res0 = 0.0;
-                  res = f_data[i];
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
-               }
-            }
-          }
          }
-
-         /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
-          *-----------------------------------------------------------------*/
-
-         else
+         if (num_procs > 1)
          {
-          if (num_threads > 1)
-          {
-             tmp_data = Ztemp_data;
-#ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
-#endif
-           for (i = 0; i < n; i++)
-              tmp_data[i] = u_data[i];
-#ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
-#endif
-           for (j = 0; j < num_threads; j++)
-           {
-            size = n/num_threads;
-            rest = n - size*num_threads;
-            if (j < rest)
-            {
-               ns = j*size+j;
-               ne = (j+1)*size+j+1;
-            }
-            else
-            {
-               ns = j*size+rest;
-               ne = (j+1)*size+rest;
-            }
-            for (i = ns; i < ne; i++) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
-               {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
-                     {
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                     }
-                     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
-               }
-            }
-            for (i = ne-1; i > ns-1; i--) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
-               {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
-                     {
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                     }
-                     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
-               }
-            }
-           }
-
-          }
-          else
-          {
-            for (i = 0; i < n; i++) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
-               }
-            }
-            for (i = n-1; i > -1; i--) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
-               }
-            }
-          }
+            hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
+            hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
          }
-        }
-        if (num_procs > 1)
-        {
-           hypre_TFree(Vext_data, HYPRE_MEMORY_HOST);
-           hypre_TFree(v_buf_data, HYPRE_MEMORY_HOST);
-        }
       }
       break;
 
       case 13: /* hybrid L1 Gauss-Seidel forward solve */
       {
-
          if (num_threads > 1)
          {
             Ztemp_local = hypre_ParVectorLocalVector(Ztemp);
@@ -3102,7 +3089,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
         {
          num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
 
-         v_buf_data = hypre_CTAlloc(HYPRE_Real, 
+         v_buf_data = hypre_CTAlloc(HYPRE_Real,
                         hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
 
          Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
@@ -3165,7 +3152,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                ns = j*size+rest;
                ne = (j+1)*size+rest;
             }
-            for (i = ns; i < ne; i++)	/* interior points first */
+            for (i = ns; i < ne; i++) /* interior points first */
             {
 
                /*-----------------------------------------------------------
@@ -3198,7 +3185,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
           }
           else
           {
-            for (i = 0; i < n; i++)	/* interior points first */
+            for (i = 0; i < n; i++) /* interior points first */
             {
 
                /*-----------------------------------------------------------
@@ -3356,7 +3343,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                ns = j*size+rest;
                ne = (j+1)*size+rest;
             }
-            for (i = ns; i < ne; i++)	/* interior points first */
+            for (i = ns; i < ne; i++) /* interior points first */
             {
 
                /*-----------------------------------------------------------
@@ -3396,7 +3383,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
           }
           else
           {
-            for (i = 0; i < n; i++)	/* interior points first */
+            for (i = 0; i < n; i++) /* interior points first */
             {
 
                /*-----------------------------------------------------------
@@ -3560,36 +3547,35 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
           *-----------------------------------------------------------------*/
         if (num_procs > 1)
         {
-        num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+           num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
 
-        v_buf_data = hypre_CTAlloc(HYPRE_Real, 
-                        hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
+           v_buf_data = hypre_CTAlloc(HYPRE_Real, hypre_ParCSRCommPkgSendMapStart(comm_pkg,  num_sends), HYPRE_MEMORY_HOST);
 
-        Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
+           Vext_data = hypre_CTAlloc(HYPRE_Real, num_cols_offd, HYPRE_MEMORY_HOST);
 
-        if (num_cols_offd)
-        {
-                A_offd_j = hypre_CSRMatrixJ(A_offd);
-                A_offd_data = hypre_CSRMatrixData(A_offd);
-        }
+           if (num_cols_offd)
+           {
+              A_offd_j = hypre_CSRMatrixJ(A_offd);
+              A_offd_data = hypre_CSRMatrixData(A_offd);
+           }
 
-        index = 0;
-        for (i = 0; i < num_sends; i++)
-        {
-                start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
-                for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg,i+1); j++)
-                        v_buf_data[index++]
-                        = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
-        }
+           index = 0;
+           for (i = 0; i < num_sends; i++)
+           {
+              start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+              for (j=start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg,i+1); j++)
+              {
+                 v_buf_data[index++] = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+              }
+           }
 
-        comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data,
-                Vext_data);
+           comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, v_buf_data, Vext_data);
 
-         /*-----------------------------------------------------------------
-          * Copy current approximation into temporary vector.
-          *-----------------------------------------------------------------*/
-         hypre_ParCSRCommHandleDestroy(comm_handle);
-         comm_handle = NULL;
+           /*-----------------------------------------------------------------
+            * Copy current approximation into temporary vector.
+            *-----------------------------------------------------------------*/
+           hypre_ParCSRCommHandleDestroy(comm_handle);
+           comm_handle = NULL;
         }
 
         /*-----------------------------------------------------------------
@@ -3598,405 +3584,405 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
 
         if (relax_weight == 1 && omega == 1)
         {
-         if (relax_points == 0)
-         {
-          if (num_threads > 1)
-          {
-             tmp_data = Ztemp_data;
+           if (relax_points == 0)
+           {
+              if (num_threads > 1)
+              {
+                 tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-              tmp_data[i] = u_data[i];
+                 for (i = 0; i < n; i++)
+                    tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-           {
-            size = n/num_threads;
-            rest = n - size*num_threads;
-            if (j < rest)
-            {
-               ns = j*size+j;
-               ne = (j+1)*size+j+1;
-            }
-            else
-            {
-               ns = j*size+rest;
-               ne = (j+1)*size+rest;
-            }
-            for (i = ne-1; i > ns-1; i--)	/* interior points first */
-            {
+                 for (j = 0; j < num_threads; j++)
+                 {
+                    size = n/num_threads;
+                    rest = n - size*num_threads;
+                    if (j < rest)
+                    {
+                       ns = j*size+j;
+                       ne = (j+1)*size+j+1;
+                    }
+                    else
+                    {
+                       ns = j*size+rest;
+                       ne = (j+1)*size+rest;
+                    }
+                    for (i = ne-1; i > ns-1; i--) /* interior points first */
+                    {
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
+                       /*-----------------------------------------------------------
+                        * If diagonal is nonzero, relax point i; otherwise, skip it.
+                        *-----------------------------------------------------------*/
 
-               if ( l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
-                     {
-                        res -= A_diag_data[jj] * u_data[ii];
-                     }
-                     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
-               }
-            }
+                       if ( l1_norms[i] != zero)
+                       {
+                          res = f_data[i];
+                          for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                          {
+                             ii = A_diag_j[jj];
+                             if (ii >= ns && ii < ne)
+                             {
+                                res -= A_diag_data[jj] * u_data[ii];
+                             }
+                             else
+                                res -= A_diag_data[jj] * tmp_data[ii];
+                          }
+                          for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                          {
+                             ii = A_offd_j[jj];
+                             res -= A_offd_data[jj] * Vext_data[ii];
+                          }
+                          u_data[i] += res / l1_norms[i];
+                       }
+                    }
+                 }
+
+              }
+              else
+              {
+                 for (i = n-1; i > -1; i--) /* interior points first */
+                 {
+
+                    /*-----------------------------------------------------------
+                     * If diagonal is nonzero, relax point i; otherwise, skip it.
+                     *-----------------------------------------------------------*/
+
+                    if ( l1_norms[i] != zero)
+                    {
+                       res = f_data[i];
+                       for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                       {
+                          ii = A_diag_j[jj];
+                          res -= A_diag_data[jj] * u_data[ii];
+                       }
+                       for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                       {
+                          ii = A_offd_j[jj];
+                          res -= A_offd_data[jj] * Vext_data[ii];
+                       }
+                       u_data[i] += res / l1_norms[i];
+                    }
+                 }
+              }
            }
 
-          }
-          else
-          {
-            for (i = n-1; i > -1; i--)	/* interior points first */
-            {
+           /*-----------------------------------------------------------------
+            * Relax only C or F points as determined by relax_points.
+            *-----------------------------------------------------------------*/
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if ( l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
-               }
-            }
-          }
-         }
-
-         /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
-          *-----------------------------------------------------------------*/
-
-         else
-         {
-          if (num_threads > 1)
-          {
-             tmp_data = Ztemp_data;
+           else
+           {
+              if (num_threads > 1)
+              {
+                 tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-              tmp_data[i] = u_data[i];
+                 for (i = 0; i < n; i++)
+                    tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-           {
-            size = n/num_threads;
-            rest = n - size*num_threads;
-            if (j < rest)
-            {
-               ns = j*size+j;
-               ne = (j+1)*size+j+1;
-            }
-            else
-            {
-               ns = j*size+rest;
-               ne = (j+1)*size+rest;
-            }
-            for (i = ne-1; i > ns-1; i--) /* relax interior points */
-            {
+                 for (j = 0; j < num_threads; j++)
+                 {
+                    size = n/num_threads;
+                    rest = n - size*num_threads;
+                    if (j < rest)
+                    {
+                       ns = j*size+j;
+                       ne = (j+1)*size+j+1;
+                    }
+                    else
+                    {
+                       ns = j*size+rest;
+                       ne = (j+1)*size+rest;
+                    }
+                    for (i = ne-1; i > ns-1; i--) /* relax interior points */
+                    {
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
+                       /*-----------------------------------------------------------
+                        * If i is of the right type ( C or F ) and diagonal is
+                        * nonzero, relax point i; otherwise, skip it.
+                        *-----------------------------------------------------------*/
 
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
-                     {
-                        res -= A_diag_data[jj] * u_data[ii];
-                     }
-                     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
-               }
-            }
+                       if (cf_marker[i] == relax_points
+                             && l1_norms[i] != zero)
+                       {
+                          res = f_data[i];
+                          for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                          {
+                             ii = A_diag_j[jj];
+                             if (ii >= ns && ii < ne)
+                             {
+                                res -= A_diag_data[jj] * u_data[ii];
+                             }
+                             else
+                                res -= A_diag_data[jj] * tmp_data[ii];
+                          }
+                          for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                          {
+                             ii = A_offd_j[jj];
+                             res -= A_offd_data[jj] * Vext_data[ii];
+                          }
+                          u_data[i] += res / l1_norms[i];
+                       }
+                    }
+                 }
+
+              }
+              else
+              {
+                 for (i = n-1; i > -1; i--) /* relax interior points */
+                 {
+
+                    /*-----------------------------------------------------------
+                     * If i is of the right type ( C or F ) and diagonal is
+
+                     * nonzero, relax point i; otherwise, skip it.
+                     *-----------------------------------------------------------*/
+
+                    if (cf_marker[i] == relax_points
+                          && l1_norms[i] != zero)
+                    {
+                       res = f_data[i];
+                       for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
+                       {
+                          ii = A_diag_j[jj];
+                          res -= A_diag_data[jj] * u_data[ii];
+                       }
+                       for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                       {
+                          ii = A_offd_j[jj];
+                          res -= A_offd_data[jj] * Vext_data[ii];
+                       }
+                       u_data[i] += res / l1_norms[i];
+                    }
+                 }
+              }
            }
-
-          }
-          else
-          {
-            for (i = n-1; i > -1; i--) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res -= A_diag_data[jj] * u_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] += res / l1_norms[i];
-               }
-            }
-          }
-         }
         }
         else
         {
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-         for (i = 0; i < n; i++)
-         {
-            Vtemp_data[i] = u_data[i];
-         }
-         prod = (1.0-relax_weight*omega);
-         if (relax_points == 0)
-         {
-          if (num_threads > 1)
-          {
-             tmp_data = Ztemp_data;
+           for (i = 0; i < n; i++)
+           {
+              Vtemp_data[i] = u_data[i];
+           }
+           prod = (1.0-relax_weight*omega);
+           if (relax_points == 0)
+           {
+              if (num_threads > 1)
+              {
+                 tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-              tmp_data[i] = u_data[i];
+                 for (i = 0; i < n; i++)
+                    tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-           {
-            size = n/num_threads;
-            rest = n - size*num_threads;
-            if (j < rest)
-            {
-               ns = j*size+j;
-               ne = (j+1)*size+j+1;
-            }
-            else
-            {
-               ns = j*size+rest;
-               ne = (j+1)*size+rest;
-            }
-            for (i = ne-1; i > ns-1; i--)	/* interior points first */
-            {
+                 for (j = 0; j < num_threads; j++)
+                 {
+                    size = n/num_threads;
+                    rest = n - size*num_threads;
+                    if (j < rest)
+                    {
+                       ns = j*size+j;
+                       ne = (j+1)*size+j+1;
+                    }
+                    else
+                    {
+                       ns = j*size+rest;
+                       ne = (j+1)*size+rest;
+                    }
+                    for (i = ne-1; i > ns-1; i--) /* interior points first */
+                    {
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
+                       /*-----------------------------------------------------------
+                        * If diagonal is nonzero, relax point i; otherwise, skip it.
+                        *-----------------------------------------------------------*/
 
-               if ( l1_norms[i] != zero)
-               {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
-                     {
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-                     }
-                     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
-               }
-            }
+                       if ( l1_norms[i] != zero)
+                       {
+                          res0 = 0.0;
+                          res2 = 0.0;
+                          res = f_data[i];
+                          for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                          {
+                             ii = A_diag_j[jj];
+                             if (ii >= ns && ii < ne)
+                             {
+                                res0 -= A_diag_data[jj] * u_data[ii];
+                                res2 += A_diag_data[jj] * Vtemp_data[ii];
+                             }
+                             else
+                                res -= A_diag_data[jj] * tmp_data[ii];
+                          }
+                          for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                          {
+                             ii = A_offd_j[jj];
+                             res -= A_offd_data[jj] * Vext_data[ii];
+                          }
+                          u_data[i] *= prod;
+                          u_data[i] += relax_weight*(omega*res + res0 +
+                                one_minus_omega*res2) / l1_norms[i];
+                          /*u_data[i] += omega*(relax_weight*res + res0 +
+                            one_minus_weight*res2) / l1_norms[i];*/
+                       }
+                    }
+                 }
+
+              }
+              else
+              {
+                 for (i = n-1; i > -1; i--) /* interior points first */
+                 {
+
+                    /*-----------------------------------------------------------
+                     * If diagonal is nonzero, relax point i; otherwise, skip it.
+                     *-----------------------------------------------------------*/
+
+                    if ( l1_norms[i] != zero)
+                    {
+                       res0 = 0.0;
+                       res = f_data[i];
+                       res2 = 0.0;
+                       for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                       {
+                          ii = A_diag_j[jj];
+                          res0 -= A_diag_data[jj] * u_data[ii];
+                          res2 += A_diag_data[jj] * Vtemp_data[ii];
+                       }
+                       for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                       {
+                          ii = A_offd_j[jj];
+                          res -= A_offd_data[jj] * Vext_data[ii];
+                       }
+                       u_data[i] *= prod;
+                       u_data[i] += relax_weight*(omega*res + res0 +
+                             one_minus_omega*res2) / l1_norms[i];
+                       /*u_data[i] += omega*(relax_weight*res + res0 +
+                         one_minus_weight*res2) / l1_norms[i];*/
+                    }
+                 }
+              }
            }
 
-          }
-          else
-          {
-            for (i = n-1; i > -1; i--)	/* interior points first */
-            {
+           /*-----------------------------------------------------------------
+            * Relax only C or F points as determined by relax_points.
+            *-----------------------------------------------------------------*/
 
-               /*-----------------------------------------------------------
-                * If diagonal is nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if ( l1_norms[i] != zero)
-               {
-                  res0 = 0.0;
-                  res = f_data[i];
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
-               }
-            }
-          }
-         }
-
-         /*-----------------------------------------------------------------
-          * Relax only C or F points as determined by relax_points.
-          *-----------------------------------------------------------------*/
-
-         else
-         {
-          if (num_threads > 1)
-          {
-             tmp_data = Ztemp_data;
+           else
+           {
+              if (num_threads > 1)
+              {
+                 tmp_data = Ztemp_data;
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
-           for (i = 0; i < n; i++)
-              tmp_data[i] = u_data[i];
+                 for (i = 0; i < n; i++)
+                    tmp_data[i] = u_data[i];
 #ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for private(i,ii,j,jj,ns,ne,res,rest,size) HYPRE_SMP_SCHEDULE
 #endif
-           for (j = 0; j < num_threads; j++)
-           {
-            size = n/num_threads;
-            rest = n - size*num_threads;
-            if (j < rest)
-            {
-               ns = j*size+j;
-               ne = (j+1)*size+j+1;
-            }
-            else
-            {
-               ns = j*size+rest;
-               ne = (j+1)*size+rest;
-            }
-            for (i = ne-1; i > ns-1; i--) /* relax interior points */
-            {
+                 for (j = 0; j < num_threads; j++)
+                 {
+                    size = n/num_threads;
+                    rest = n - size*num_threads;
+                    if (j < rest)
+                    {
+                       ns = j*size+j;
+                       ne = (j+1)*size+j+1;
+                    }
+                    else
+                    {
+                       ns = j*size+rest;
+                       ne = (j+1)*size+rest;
+                    }
+                    for (i = ne-1; i > ns-1; i--) /* relax interior points */
+                    {
 
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
+                       /*-----------------------------------------------------------
+                        * If i is of the right type ( C or F ) and diagonal is
+                        * nonzero, relax point i; otherwise, skip it.
+                        *-----------------------------------------------------------*/
 
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
-               {
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  res = f_data[i];
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     if (ii >= ns && ii < ne)
-                     {
-                        res2 += A_diag_data[jj] * Vtemp_data[ii];
-                        res0 -= A_diag_data[jj] * u_data[ii];
-                     }
-                     else
-                        res -= A_diag_data[jj] * tmp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
-               }
-            }
+                       if (cf_marker[i] == relax_points
+                             && l1_norms[i] != zero)
+                       {
+                          res0 = 0.0;
+                          res2 = 0.0;
+                          res = f_data[i];
+                          for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                          {
+                             ii = A_diag_j[jj];
+                             if (ii >= ns && ii < ne)
+                             {
+                                res2 += A_diag_data[jj] * Vtemp_data[ii];
+                                res0 -= A_diag_data[jj] * u_data[ii];
+                             }
+                             else
+                                res -= A_diag_data[jj] * tmp_data[ii];
+                          }
+                          for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                          {
+                             ii = A_offd_j[jj];
+                             res -= A_offd_data[jj] * Vext_data[ii];
+                          }
+                          u_data[i] *= prod;
+                          u_data[i] += relax_weight*(omega*res + res0 +
+                                one_minus_omega*res2) / l1_norms[i];
+                          /*u_data[i] += omega*(relax_weight*res + res0 +
+                            one_minus_weight*res2) / l1_norms[i];*/
+                       }
+                    }
+                 }
+
+              }
+              else
+              {
+                 for (i = n-1; i > -1; i--) /* relax interior points */
+                 {
+
+                    /*-----------------------------------------------------------
+                     * If i is of the right type ( C or F ) and diagonal is
+
+                     * nonzero, relax point i; otherwise, skip it.
+                     *-----------------------------------------------------------*/
+
+                    if (cf_marker[i] == relax_points
+                          && l1_norms[i] != zero)
+                    {
+                       res = f_data[i];
+                       res0 = 0.0;
+                       res2 = 0.0;
+                       for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
+                       {
+                          ii = A_diag_j[jj];
+                          res0 -= A_diag_data[jj] * u_data[ii];
+                          res2 += A_diag_data[jj] * Vtemp_data[ii];
+                       }
+                       for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
+                       {
+                          ii = A_offd_j[jj];
+                          res -= A_offd_data[jj] * Vext_data[ii];
+                       }
+                       u_data[i] *= prod;
+                       u_data[i] += relax_weight*(omega*res + res0 +
+                             one_minus_omega*res2) / l1_norms[i];
+                       /*u_data[i] += omega*(relax_weight*res + res0 +
+                         one_minus_weight*res2) / l1_norms[i];*/
+                    }
+                 }
+              }
            }
-
-          }
-          else
-          {
-            for (i = n-1; i > -1; i--) /* relax interior points */
-            {
-
-               /*-----------------------------------------------------------
-                * If i is of the right type ( C or F ) and diagonal is
-
-                * nonzero, relax point i; otherwise, skip it.
-                *-----------------------------------------------------------*/
-
-               if (cf_marker[i] == relax_points
-                                && l1_norms[i] != zero)
-               {
-                  res = f_data[i];
-                  res0 = 0.0;
-                  res2 = 0.0;
-                  for (jj = A_diag_i[i]+1; jj < A_diag_i[i+1]; jj++)
-                  {
-                     ii = A_diag_j[jj];
-                     res0 -= A_diag_data[jj] * u_data[ii];
-                     res2 += A_diag_data[jj] * Vtemp_data[ii];
-                  }
-                  for (jj = A_offd_i[i]; jj < A_offd_i[i+1]; jj++)
-                  {
-                     ii = A_offd_j[jj];
-                     res -= A_offd_data[jj] * Vext_data[ii];
-                  }
-                  u_data[i] *= prod;
-                  u_data[i] += relax_weight*(omega*res + res0 +
-                        one_minus_omega*res2) / l1_norms[i];
-                  /*u_data[i] += omega*(relax_weight*res + res0 +
-                        one_minus_weight*res2) / l1_norms[i];*/
-               }
-            }
-          }
-         }
         }
         if (num_procs > 1)
         {
@@ -4017,22 +4003,21 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
          /* all processors are needed for these routines */
          A_CSR = hypre_ParCSRMatrixToCSRMatrixAll(A);
          f_vector = hypre_ParVectorToVectorAll(f);
-	 if (n)
-	 {
-	 
+         if (n)
+         {
 #else
-	 if (n)
-	 {
-	    A_CSR = hypre_ParCSRMatrixToCSRMatrixAll(A);
-	    f_vector = hypre_ParVectorToVectorAll(f);
+         if (n)
+         {
+            A_CSR = hypre_ParCSRMatrixToCSRMatrixAll(A);
+            f_vector = hypre_ParVectorToVectorAll(f);
 #endif
- 	    A_CSR_i = hypre_CSRMatrixI(A_CSR);
- 	    A_CSR_j = hypre_CSRMatrixJ(A_CSR);
- 	    A_CSR_data = hypre_CSRMatrixData(A_CSR);
-   	    f_vector_data = hypre_VectorData(f_vector);
+            A_CSR_i = hypre_CSRMatrixI(A_CSR);
+            A_CSR_j = hypre_CSRMatrixJ(A_CSR);
+            A_CSR_data = hypre_CSRMatrixData(A_CSR);
+            f_vector_data = hypre_VectorData(f_vector);
 
             A_mat = hypre_CTAlloc(HYPRE_Real,  n_global*n_global, HYPRE_MEMORY_HOST);
-            b_vec = hypre_CTAlloc(HYPRE_Real,  n_global, HYPRE_MEMORY_HOST);    
+            b_vec = hypre_CTAlloc(HYPRE_Real,  n_global, HYPRE_MEMORY_HOST);
 
             /*---------------------------------------------------------------
              *  Load CSR matrix into A_mat.
@@ -4055,18 +4040,17 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                u_data[i] = b_vec[first_index+i];
             }
 
-	    hypre_TFree(A_mat, HYPRE_MEMORY_HOST); 
+            hypre_TFree(A_mat, HYPRE_MEMORY_HOST);
             hypre_TFree(b_vec, HYPRE_MEMORY_HOST);
             hypre_CSRMatrixDestroy(A_CSR);
             A_CSR = NULL;
             hypre_SeqVectorDestroy(f_vector);
             f_vector = NULL;
-         
          }
 #ifdef HYPRE_NO_GLOBAL_PARTITION
          else
          {
-            
+
             hypre_CSRMatrixDestroy(A_CSR);
             A_CSR = NULL;
             hypre_SeqVectorDestroy(f_vector);
@@ -4075,7 +4059,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
 #endif
 
       }
-      break;   
+      break;
       case 98: /* Direct solve: use gaussian elimination & BLAS (with pivoting) */
       {
 
@@ -4091,22 +4075,21 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
          /* all processors are needed for these routines */
          A_CSR = hypre_ParCSRMatrixToCSRMatrixAll(A);
          f_vector = hypre_ParVectorToVectorAll(f);
-	 if (n)
-	 {
-	 
+         if (n)
+         {
 #else
-	 if (n)
-	 {
-	    A_CSR = hypre_ParCSRMatrixToCSRMatrixAll(A);
-	    f_vector = hypre_ParVectorToVectorAll(f);
+         if (n)
+         {
+            A_CSR = hypre_ParCSRMatrixToCSRMatrixAll(A);
+            f_vector = hypre_ParVectorToVectorAll(f);
 #endif
- 	    A_CSR_i = hypre_CSRMatrixI(A_CSR);
- 	    A_CSR_j = hypre_CSRMatrixJ(A_CSR);
- 	    A_CSR_data = hypre_CSRMatrixData(A_CSR);
-   	    f_vector_data = hypre_VectorData(f_vector);
+            A_CSR_i = hypre_CSRMatrixI(A_CSR);
+            A_CSR_j = hypre_CSRMatrixJ(A_CSR);
+            A_CSR_data = hypre_CSRMatrixData(A_CSR);
+            f_vector_data = hypre_VectorData(f_vector);
 
             A_mat = hypre_CTAlloc(HYPRE_Real,  n_global*n_global, HYPRE_MEMORY_HOST);
-            b_vec = hypre_CTAlloc(HYPRE_Real,  n_global, HYPRE_MEMORY_HOST);    
+            b_vec = hypre_CTAlloc(HYPRE_Real,  n_global, HYPRE_MEMORY_HOST);
 
             /*---------------------------------------------------------------
              *  Load CSR matrix into A_mat.
@@ -4116,7 +4099,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
             {
                for (jj = A_CSR_i[i]; jj < A_CSR_i[i+1]; jj++)
                {
-             
+
                   /* need col major */
                   column = A_CSR_j[jj];
                   A_mat[i + n_global*column] = A_CSR_data[jj];
@@ -4128,7 +4111,7 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
 
             /* write over A with LU */
             hypre_dgetrf(&n_global, &n_global, A_mat, &n_global, piv, &info);
-            
+
             /*now b_vec = inv(A)*b_vec  */
             hypre_dgetrs("N", &n_global, &one_i, A_mat, &n_global, piv, b_vec, &n_global, &info);
 
@@ -4139,30 +4122,28 @@ HYPRE_Int  hypre_BoomerAMGRelax( hypre_ParCSRMatrix *A,
                u_data[i] = b_vec[first_index+i];
             }
 
-	    hypre_TFree(A_mat, HYPRE_MEMORY_HOST); 
+            hypre_TFree(A_mat, HYPRE_MEMORY_HOST);
             hypre_TFree(b_vec, HYPRE_MEMORY_HOST);
             hypre_CSRMatrixDestroy(A_CSR);
             A_CSR = NULL;
             hypre_SeqVectorDestroy(f_vector);
             f_vector = NULL;
-         
          }
 #ifdef HYPRE_NO_GLOBAL_PARTITION
          else
          {
-            
+
             hypre_CSRMatrixDestroy(A_CSR);
             A_CSR = NULL;
             hypre_SeqVectorDestroy(f_vector);
             f_vector = NULL;
          }
 #endif
-
       }
-      break;   
+      break;
    }
 
-   return(relax_error); 
+   return(relax_error);
 }
 
 /*-------------------------------------------------------------------------
@@ -4239,20 +4220,25 @@ HYPRE_Int hypre_GaussElimSetup (hypre_ParAMGData *amg_data, HYPRE_Int level, HYP
              A_mat_local[i*global_num_rows + column] = A_offd_data[jj];
          }
       }
-      hypre_MPI_Allgatherv( A_mat_local, A_mat_local_size, HYPRE_MPI_REAL, A_mat, 
-		mat_info, mat_displs, HYPRE_MPI_REAL, new_comm);
+      hypre_MPI_Allgatherv( A_mat_local, A_mat_local_size, HYPRE_MPI_REAL, A_mat, mat_info, mat_displs, HYPRE_MPI_REAL, new_comm);
       if (relax_type == 99)
       {
           HYPRE_Real *AT_mat;
-	  AT_mat = hypre_CTAlloc(HYPRE_Real,  global_num_rows*global_num_rows, HYPRE_MEMORY_HOST);
+          AT_mat = hypre_CTAlloc(HYPRE_Real,  global_num_rows*global_num_rows, HYPRE_MEMORY_HOST);
           for (i=0; i < global_num_rows; i++)
-	     for (jj=0; jj < global_num_rows; jj++)
+          {
+             for (jj=0; jj < global_num_rows; jj++)
+             {
                  AT_mat[i*global_num_rows + jj] = A_mat[i+ jj*global_num_rows];
+             }
+          }
           hypre_ParAMGDataAMat(amg_data) = AT_mat;
           hypre_TFree(A_mat, HYPRE_MEMORY_HOST);
       }
       else
+      {
          hypre_ParAMGDataAMat(amg_data) = A_mat;
+      }
       hypre_ParAMGDataCommInfo(amg_data) = comm_info;
       hypre_ParAMGDataNewComm(amg_data) = new_comm;
       hypre_TFree(mat_info, HYPRE_MEMORY_HOST);
@@ -4263,7 +4249,7 @@ HYPRE_Int hypre_GaussElimSetup (hypre_ParAMGData *amg_data, HYPRE_Int level, HYP
 #ifdef HYPRE_PROFILE
    hypre_profile_times[HYPRE_TIMER_ID_GS_ELIM_SETUP] += hypre_MPI_Wtime();
 #endif
-   
+
    return hypre_error_flag;
 }
 
@@ -4281,12 +4267,12 @@ HYPRE_Int hypre_GaussElimSolve (hypre_ParAMGData *amg_data, HYPRE_Int level, HYP
    if (n)
    {
       MPI_Comm new_comm = hypre_ParAMGDataNewComm(amg_data);
-      hypre_ParVector *f = hypre_ParAMGDataFArray(amg_data)[level]; 
-      hypre_ParVector *u = hypre_ParAMGDataUArray(amg_data)[level]; 
+      hypre_ParVector *f = hypre_ParAMGDataFArray(amg_data)[level];
+      hypre_ParVector *u = hypre_ParAMGDataUArray(amg_data)[level];
       HYPRE_Real *A_mat = hypre_ParAMGDataAMat(amg_data);
       HYPRE_Real *b_vec = hypre_ParAMGDataBVec(amg_data);
-      HYPRE_Real *f_data = hypre_VectorData(hypre_ParVectorLocalVector(f)); 
-      HYPRE_Real *u_data = hypre_VectorData(hypre_ParVectorLocalVector(u)); 
+      HYPRE_Real *f_data = hypre_VectorData(hypre_ParVectorLocalVector(f));
+      HYPRE_Real *u_data = hypre_VectorData(hypre_ParVectorLocalVector(u));
       HYPRE_Real *A_tmp;
       HYPRE_Int *comm_info = hypre_ParAMGDataCommInfo(amg_data);
       HYPRE_Int *displs, *info;
@@ -4317,7 +4303,7 @@ HYPRE_Int hypre_GaussElimSolve (hypre_ParAMGData *amg_data, HYPRE_Int level, HYP
 
          /* write over A with LU */
          hypre_dgetrf(&n_global, &n_global, A_tmp, &n_global, piv, &my_info);
-            
+
          /*now b_vec = inv(A)*b_vec  */
          hypre_dgetrs("N", &n_global, &one_i, A_tmp, &n_global, piv, b_vec, &n_global, &my_info);
 
@@ -4347,8 +4333,8 @@ HYPRE_Int gselim(HYPRE_Real *A,
    HYPRE_Int    j,k,m;
    HYPRE_Real factor;
    HYPRE_Real divA;
-   
-   if (n==1)                           /* A is 1x1 */  
+
+   if (n==1)                           /* A is 1x1 */
    {
       if (A[0] != 0.0)
       {
@@ -4361,12 +4347,12 @@ HYPRE_Int gselim(HYPRE_Real *A,
          return(err_flag);
       }
    }
-   else                               /* A is nxn.  Forward elimination */ 
+   else                               /* A is nxn.  Forward elimination */
    {
       for (k = 0; k < n-1; k++)
       {
           if (A[k*n+k] != 0.0)
-          {          
+          {
              divA = 1.0/A[k*n+k];
              for (j = k+1; j < n; j++)
              {
@@ -4377,8 +4363,8 @@ HYPRE_Int gselim(HYPRE_Real *A,
                     {
                         A[j*n+m]  -= factor * A[k*n+m];
                     }
-                                     /* Elimination step for rhs */ 
-                    x[j] -= factor * x[k];              
+                                     /* Elimination step for rhs */
+                    x[j] -= factor * x[k];
                  }
              }
           }
@@ -4387,7 +4373,7 @@ HYPRE_Int gselim(HYPRE_Real *A,
        for (k = n-1; k > 0; --k)
        {
           if (A[k*n+k] != 0.0)
-          {          
+          {
               x[k] /= A[k*n+k];
               for (j = 0; j < k; j++)
               {
@@ -4403,6 +4389,6 @@ HYPRE_Int gselim(HYPRE_Real *A,
     }
 }
 #endif
-         
+
 
 

--- a/src/parcsr_ls/par_relax_more.c
+++ b/src/parcsr_ls/par_relax_more.c
@@ -658,51 +658,35 @@ HYPRE_Int hypre_BoomerAMGRelax_FCFJacobi( hypre_ParCSRMatrix *A,
                                           hypre_ParVector    *u,
                                           hypre_ParVector    *Vtemp)
 {
-
    HYPRE_Int i;
    HYPRE_Int relax_points[3];
    HYPRE_Int relax_type = 0;
-
-   hypre_ParVector    *Ztemp = NULL;
-
 
    relax_points[0] = -1; /*F */
    relax_points[1] =  1; /*C */
    relax_points[2] = -1; /*F */
 
-   /* if we are on the coarsest level ,the cf_marker will be null
-      and we just do one sweep regular jacobi */
+   /* cf == NULL --> size == 0 */
    if (cf_marker == NULL)
    {
-       hypre_BoomerAMGRelax(A,
-                            f,
-                            cf_marker,
-                            relax_type,
-                            0,
-                            relax_weight,
-                            0.0,
-                            NULL,
-                            u,
-                            Vtemp, Ztemp);
-   }
-   else
-   {
-      for (i=0; i < 3; i++)
-         hypre_BoomerAMGRelax(A,
-                              f,
-                              cf_marker,
-                              relax_type,
-                              relax_points[i],
-                              relax_weight,
-                              0.0,
-                              NULL,
-                              u,
-                              Vtemp, Ztemp);
+      hypre_assert(hypre_CSRMatrixNumRows(hypre_ParCSRMatrixDiag(A)) == 0);
    }
 
+   for (i=0; i < 3; i++)
+   {
+      hypre_BoomerAMGRelax(A,
+                           f,
+                           cf_marker,
+                           relax_type,
+                           relax_points[i],
+                           relax_weight,
+                           0.0,
+                           NULL,
+                           u,
+                           Vtemp, NULL);
+   }
 
    return hypre_error_flag;
-
 }
 
 /*--------------------------------------------------------------------------

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -4597,7 +4597,7 @@ main( hypre_int argc,
 
          HYPRE_BoomerAMGSetCGCIts(pcg_precond, cgcits);
          HYPRE_BoomerAMGSetInterpType(pcg_precond, interp_type);
-         HYPRE_BoomerAMGSetRestriction(amg_solver, restri_type); /* 0: P^T, 1: AIR, 2: AIR-2 */
+         HYPRE_BoomerAMGSetRestriction(pcg_precond, restri_type); /* 0: P^T, 1: AIR, 2: AIR-2 */
          HYPRE_BoomerAMGSetPostInterpType(pcg_precond, post_interp_type);
          HYPRE_BoomerAMGSetNumSamples(pcg_precond, gsmg_samples);
          HYPRE_BoomerAMGSetTol(pcg_precond, pc_tol);

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -2820,7 +2820,7 @@ main( hypre_int argc,
          HYPRE_ParCSRHybridSetLevelRelaxWt(amg_solver, relax_wt_level, level_w);
       if (level_ow > -1)
          HYPRE_ParCSRHybridSetLevelOuterWt(amg_solver, outer_wt_level, level_ow);
-      HYPRE_ParCSRHybridSetNonGalerkinTol(amg_solver, nongalerk_num_tol, nongalerk_tol); 
+      HYPRE_ParCSRHybridSetNonGalerkinTol(amg_solver, nongalerk_num_tol, nongalerk_tol);
 
       HYPRE_ParCSRHybridSetup(amg_solver, parcsr_A, b, x);
 
@@ -2882,6 +2882,7 @@ main( hypre_int argc,
       /* BM Aug 25, 2006 */
       HYPRE_BoomerAMGSetCGCIts(amg_solver, cgcits);
       HYPRE_BoomerAMGSetInterpType(amg_solver, interp_type);
+      HYPRE_BoomerAMGSetRestriction(amg_solver, restri_type); /* 0: P^T, 1: AIR, 2: AIR-2 */
       HYPRE_BoomerAMGSetPostInterpType(amg_solver, post_interp_type);
       HYPRE_BoomerAMGSetNumSamples(amg_solver, gsmg_samples);
       HYPRE_BoomerAMGSetCoarsenType(amg_solver, coarsen_type);
@@ -4596,6 +4597,7 @@ main( hypre_int argc,
 
          HYPRE_BoomerAMGSetCGCIts(pcg_precond, cgcits);
          HYPRE_BoomerAMGSetInterpType(pcg_precond, interp_type);
+         HYPRE_BoomerAMGSetRestriction(amg_solver, restri_type); /* 0: P^T, 1: AIR, 2: AIR-2 */
          HYPRE_BoomerAMGSetPostInterpType(pcg_precond, post_interp_type);
          HYPRE_BoomerAMGSetNumSamples(pcg_precond, gsmg_samples);
          HYPRE_BoomerAMGSetTol(pcg_precond, pc_tol);


### PR DESCRIPTION
I've run into an issue with hypre_BoomerAMGRelax_FCFJacobi (parcsr_ls/pre_relax_more.c, line 675). The if-condition tests if it is the last level, by checking **cf_marker == NULL** (the last level has no cf_marker, apparently). If so, do normal relax, o.w. do FCF. This makes sense in most cases. But it failed to address the following scenario...

_If there is one rank has local size 0 on some coarser levels for some reason (why?), so it has cf_marker == NULL but others have nonzero sizes and thus non-null cf_marker, that rank goes to the "if"-branch the others go to the "else". The processes go to different branches here. This will create problems: the else-branch has a loop of doing Relax 3 times but there is only 1 Relax in the if-branch, and consequently MPI crashed afterwards in the interpolation (par_cycle.c: line 687)._

The problem is that we cannot rely on **cf_marker == NULL** to say it is the last level. I propose this fix which moves the if-logic out of hypre_BoomerAMGRelax_FCFJacobi but inside hypre_BoomerAMGCycle (see the modified code) and tests if **level == num_levels-1** indeed. Fortunately, this is the only place where FCFJacobi is called.
