### PR TITLE
For AIR, the set function HYPRE_BoomerAMGSetGridRelaxPoints is used, …

### DIFF
--- a/src/parcsr_ls/HYPRE_parcsr_amg.c
+++ b/src/parcsr_ls/HYPRE_parcsr_amg.c
@@ -723,9 +723,6 @@ HYPRE_BoomerAMGSetRelaxOrder( HYPRE_Solver  solver,
 
 /*--------------------------------------------------------------------------
  * HYPRE_BoomerAMGSetGridRelaxPoints
- * DEPRECATED.  There are memory management problems associated with the
- * use of a user-supplied array (who releases it?).
- * Ulrike Yang suspects that nobody uses this function.
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int

--- a/src/parcsr_ls/HYPRE_parcsr_ls.h
+++ b/src/parcsr_ls/HYPRE_parcsr_ls.h
@@ -771,8 +771,8 @@ HYPRE_Int HYPRE_BoomerAMGSetRelaxOrder(HYPRE_Solver  solver,
 /*
  * (Optional) Defines in which order the points are relaxed.
  *
- * Note: This routine will be phased out!!!!
- * Use HYPRE\_BoomerAMGSetRelaxOrder instead.
+ * Note: For some applications HYPRE\_BoomerAMGSetRelaxOrder may be
+ * useful instead.
  **/
 HYPRE_Int HYPRE_BoomerAMGSetGridRelaxPoints(HYPRE_Solver   solver,
                                             HYPRE_Int    **grid_relax_points);


### PR DESCRIPTION
…however, there were two comments in the code declaring this obsolete. These comments were removed/modified.