### PR TITLE
Add HYPRE_ParCSRHybridGetFinalResidualNorm

### DIFF
--- a/src/krylov/HYPRE_bicgstab.c
+++ b/src/krylov/HYPRE_bicgstab.c
@@ -205,6 +205,17 @@ HYPRE_BiCGSTABGetFinalRelativeResidualNorm( HYPRE_Solver  solver,
 }
 
 /*--------------------------------------------------------------------------
+ * HYPRE_BiCGSTABGetFinalResidualNorm
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_BiCGSTABGetFinalResidualNorm( HYPRE_Solver  solver,
+                                       HYPRE_Real         *norm   )
+{
+   return( hypre_BiCGSTABGetFinalResidualNorm( (void *) solver, norm ) );
+}
+
+/*--------------------------------------------------------------------------
  * HYPRE_BiCGSTABGetResidual
  *--------------------------------------------------------------------------*/
 

--- a/src/krylov/HYPRE_gmres.c
+++ b/src/krylov/HYPRE_gmres.c
@@ -324,6 +324,17 @@ HYPRE_GMRESGetFinalRelativeResidualNorm( HYPRE_Solver  solver,
 }
 
 /*--------------------------------------------------------------------------
+ * HYPRE_GMRESGetFinalResidualNorm
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_GMRESGetFinalResidualNorm( HYPRE_Solver  solver,
+                                       HYPRE_Real         *norm   )
+{
+   return( hypre_GMRESGetFinalResidualNorm( (void *) solver, norm ) );
+}
+
+/*--------------------------------------------------------------------------
  * HYPRE_GMRESGetResidual
  *--------------------------------------------------------------------------*/
 

--- a/src/krylov/HYPRE_krylov.h
+++ b/src/krylov/HYPRE_krylov.h
@@ -210,6 +210,12 @@ HYPRE_Int HYPRE_PCGGetFinalRelativeResidualNorm(HYPRE_Solver  solver,
                                           HYPRE_Real   *norm);
 
 /**
+ * Return the norm of the final residual.
+ **/
+HYPRE_Int HYPRE_PCGGetFinalResidualNorm(HYPRE_Solver  solver,
+                                  HYPRE_Real   *norm);
+
+/**
  * Return the residual.
  **/
 HYPRE_Int HYPRE_PCGGetResidual(HYPRE_Solver  solver,
@@ -399,6 +405,12 @@ HYPRE_Int HYPRE_GMRESGetNumIterations(HYPRE_Solver  solver,
  **/
 HYPRE_Int HYPRE_GMRESGetFinalRelativeResidualNorm(HYPRE_Solver  solver,
                                             HYPRE_Real   *norm);
+
+/**
+ * Return the norm of the final residual.
+ **/
+HYPRE_Int HYPRE_GMRESGetFinalResidualNorm(HYPRE_Solver  solver,
+                                    HYPRE_Real   *norm);
 
 /**
  * Return the residual.
@@ -1086,6 +1098,12 @@ HYPRE_Int HYPRE_BiCGSTABGetNumIterations(HYPRE_Solver  solver,
  **/
 HYPRE_Int HYPRE_BiCGSTABGetFinalRelativeResidualNorm(HYPRE_Solver  solver,
                                                HYPRE_Real   *norm);
+
+/**
+ * Return the norm of the final residual.
+ **/
+HYPRE_Int HYPRE_BiCGSTABGetFinalResidualNorm(HYPRE_Solver  solver,
+                                       HYPRE_Real   *norm);
 
 /**
  * Return the residual.

--- a/src/krylov/HYPRE_pcg.c
+++ b/src/krylov/HYPRE_pcg.c
@@ -357,6 +357,17 @@ HYPRE_PCGGetFinalRelativeResidualNorm( HYPRE_Solver  solver,
 }
 
 /*--------------------------------------------------------------------------
+ * HYPRE_PCGGetFinalResidualNorm
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_PCGGetFinalResidualNorm( HYPRE_Solver  solver,
+                               HYPRE_Real   *norm )
+{
+   return( hypre_PCGGetFinalResidualNorm( (void *) solver, norm ) );
+}
+
+/*--------------------------------------------------------------------------
  * HYPRE_PCGGetResidual
  *--------------------------------------------------------------------------*/
 

--- a/src/krylov/bicgstab.c
+++ b/src/krylov/bicgstab.c
@@ -384,7 +384,10 @@ hypre_BiCGSTABSolve(void  *bicgstab_vdata,
 
    (bicgstab_data -> num_iterations) = iter;
    if (b_norm > 0.0)
+   {
       (bicgstab_data -> rel_residual_norm) = r_norm/b_norm;
+      (bicgstab_data -> residual_norm) = r_norm;
+   }
    /* check for convergence before starting */
    if (r_norm == 0.0)
    {
@@ -503,9 +506,15 @@ hypre_BiCGSTABSolve(void  *bicgstab_vdata,
     
    (bicgstab_data -> num_iterations) = iter;
    if (b_norm > 0.0)
+   {
       (bicgstab_data -> rel_residual_norm) = r_norm/b_norm;
+      (bicgstab_data -> residual_norm) = r_norm;
+   }
    if (b_norm == 0.0)
+   {
       (bicgstab_data -> rel_residual_norm) = r_norm;
+      (bicgstab_data -> residual_norm) = r_norm;
+   }
 
    if (iter >= max_iter && r_norm > epsilon && epsilon > 0 && hybrid != -1) hypre_error(HYPRE_ERROR_CONV);
 
@@ -723,6 +732,21 @@ hypre_BiCGSTABGetFinalRelativeResidualNorm( void   *bicgstab_vdata,
    
    return hypre_error_flag;
 } 
+
+/*--------------------------------------------------------------------------
+ * hypre_BiCGSTABGetFinalResidualNorm
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_BiCGSTABGetFinalResidualNorm( void   *bicgstab_vdata,
+                                 HYPRE_Real *residual_norm )
+{
+	hypre_BiCGSTABData *bicgstab_data = (hypre_BiCGSTABData  *)bicgstab_vdata;
+
+   *residual_norm = (bicgstab_data -> residual_norm);
+
+   return hypre_error_flag;
+}
 
 /*--------------------------------------------------------------------------
  * hypre_BiCGSTABGetResidual

--- a/src/krylov/bicgstab.h
+++ b/src/krylov/bicgstab.h
@@ -105,6 +105,7 @@ typedef struct
    HYPRE_Int      hybrid;
    HYPRE_Real   tol;
    HYPRE_Real   cf_tol;
+   HYPRE_Real   residual_norm;
    HYPRE_Real   rel_residual_norm;
    HYPRE_Real   a_tol;
    

--- a/src/krylov/gmres.c
+++ b/src/krylov/gmres.c
@@ -832,9 +832,15 @@ hypre_GMRESSolve(void  *gmres_vdata,
 
    (gmres_data -> num_iterations) = iter;
    if (b_norm > 0.0)
+   {
       (gmres_data -> rel_residual_norm) = r_norm/b_norm;
+      (gmres_data -> residual_norm) = r_norm;
+   }
    if (b_norm == 0.0)
+   {
       (gmres_data -> rel_residual_norm) = r_norm;
+      (gmres_data -> residual_norm) = r_norm;
+   }
 
    if (iter >= max_iter && r_norm > epsilon && epsilon > 0 && hybrid != -1) hypre_error(HYPRE_ERROR_CONV);
 
@@ -1252,3 +1258,19 @@ hypre_GMRESGetFinalRelativeResidualNorm( void   *gmres_vdata,
    
    return hypre_error_flag;
 } 
+
+/*--------------------------------------------------------------------------
+ * hypre_GMRESGetFinalResidualNorm
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_GMRESGetFinalResidualNorm( void   *gmres_vdata,
+                                 HYPRE_Real *residual_norm )
+{
+   hypre_GMRESData *gmres_data = (hypre_GMRESData *)gmres_vdata;
+
+
+   *residual_norm = (gmres_data -> residual_norm);
+
+   return hypre_error_flag;
+}

--- a/src/krylov/krylov.h
+++ b/src/krylov/krylov.h
@@ -137,6 +137,7 @@ extern "C" {
     HYPRE_Int      hybrid;
     HYPRE_Real   tol;
     HYPRE_Real   cf_tol;
+    HYPRE_Real   residual_norm;
     HYPRE_Real   rel_residual_norm;
     HYPRE_Real   a_tol;
 
@@ -475,6 +476,7 @@ extern "C" {
     HYPRE_Real   tol;
     HYPRE_Real   cf_tol;
     HYPRE_Real   a_tol;
+    HYPRE_Real   residual_norm;
     HYPRE_Real   rel_residual_norm;
 
     void  *A;
@@ -1209,6 +1211,7 @@ extern "C" {
 
     /* log info (always logged) */
     HYPRE_Int      num_iterations;
+    HYPRE_Real   residual_norm;
     HYPRE_Real   rel_residual_norm;
 
     HYPRE_Int     print_level; /* printing when print_level>0 */
@@ -1293,6 +1296,7 @@ extern "C" {
   HYPRE_Int hypre_BiCGSTABGetConverged ( void *bicgstab_vdata , HYPRE_Int *converged );
   HYPRE_Int hypre_BiCGSTABGetNumIterations ( void *bicgstab_vdata , HYPRE_Int *num_iterations );
   HYPRE_Int hypre_BiCGSTABGetFinalRelativeResidualNorm ( void *bicgstab_vdata , HYPRE_Real *relative_residual_norm );
+  HYPRE_Int hypre_BiCGSTABGetFinalResidualNorm ( void *bicgstab_vdata , HYPRE_Real *relative_residual_norm );
   HYPRE_Int hypre_BiCGSTABGetResidual ( void *bicgstab_vdata , void **residual );
 
   /* cgnr.c */
@@ -1344,6 +1348,7 @@ extern "C" {
   HYPRE_Int hypre_GMRESGetNumIterations ( void *gmres_vdata , HYPRE_Int *num_iterations );
   HYPRE_Int hypre_GMRESGetConverged ( void *gmres_vdata , HYPRE_Int *converged );
   HYPRE_Int hypre_GMRESGetFinalRelativeResidualNorm ( void *gmres_vdata , HYPRE_Real *relative_residual_norm );
+  HYPRE_Int hypre_GMRESGetFinalResidualNorm ( void *gmres_vdata , HYPRE_Real *residual_norm );
 
   /* cogmres.c */
   void *hypre_COGMRESCreate ( hypre_COGMRESFunctions *gmres_functions );
@@ -1464,6 +1469,7 @@ extern "C" {
   HYPRE_Int HYPRE_BiCGSTABSetPrintLevel ( HYPRE_Solver solver , HYPRE_Int print_level );
   HYPRE_Int HYPRE_BiCGSTABGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *num_iterations );
   HYPRE_Int HYPRE_BiCGSTABGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
+  HYPRE_Int HYPRE_BiCGSTABGetFinalResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
   HYPRE_Int HYPRE_BiCGSTABGetResidual ( HYPRE_Solver solver , void *residual );
 
   /* HYPRE_cgnr.c */
@@ -1510,6 +1516,7 @@ extern "C" {
   HYPRE_Int HYPRE_GMRESGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *num_iterations );
   HYPRE_Int HYPRE_GMRESGetConverged ( HYPRE_Solver solver , HYPRE_Int *converged );
   HYPRE_Int HYPRE_GMRESGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
+  HYPRE_Int HYPRE_GMRESGetFinalResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
   HYPRE_Int HYPRE_GMRESGetResidual ( HYPRE_Solver solver , void *residual );
 
   /* HYPRE_cogmres.c */
@@ -1635,6 +1642,7 @@ extern "C" {
   HYPRE_Int HYPRE_PCGGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *num_iterations );
   HYPRE_Int HYPRE_PCGGetConverged ( HYPRE_Solver solver , HYPRE_Int *converged );
   HYPRE_Int HYPRE_PCGGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
+  HYPRE_Int HYPRE_PCGGetFinalResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
   HYPRE_Int HYPRE_PCGGetResidual ( HYPRE_Solver solver , void *residual );
 
   /* pcg.c */
@@ -1676,6 +1684,7 @@ extern "C" {
   HYPRE_Int hypre_PCGGetConverged ( void *pcg_vdata , HYPRE_Int *converged );
   HYPRE_Int hypre_PCGPrintLogging ( void *pcg_vdata , HYPRE_Int myid );
   HYPRE_Int hypre_PCGGetFinalRelativeResidualNorm ( void *pcg_vdata , HYPRE_Real *relative_residual_norm );
+  HYPRE_Int hypre_PCGGetFinalResidualNorm ( void *pcg_vdata , HYPRE_Real *residual_norm );
 
 #ifdef __cplusplus
   }

--- a/src/krylov/pcg.c
+++ b/src/krylov/pcg.c
@@ -723,9 +723,15 @@ hypre_PCGSolve( void *pcg_vdata,
 
    (pcg_data -> num_iterations) = i;
    if (bi_prod > 0.0)
+   {
+      (pcg_data -> residual_norm) = sqrt(i_prod);
       (pcg_data -> rel_residual_norm) = sqrt(i_prod/bi_prod);
+   }
    else /* actually, we'll never get here... */
+   {
+      (pcg_data -> residual_norm) = 0.0;
       (pcg_data -> rel_residual_norm) = 0.0;
+   }
 
    return hypre_error_flag;
 }
@@ -1201,6 +1207,23 @@ hypre_PCGGetFinalRelativeResidualNorm( void   *pcg_vdata,
    HYPRE_Real     rel_residual_norm = (pcg_data -> rel_residual_norm);
 
   *relative_residual_norm = rel_residual_norm;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_PCGGetFinalResidualNorm
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_PCGGetFinalResidualNorm( void   *pcg_vdata,
+                               HYPRE_Real *residual_norm )
+{
+   hypre_PCGData *pcg_data = (hypre_PCGData *)pcg_vdata;
+
+   HYPRE_Real     norm = (pcg_data -> residual_norm);
+
+  *residual_norm = norm;
 
    return hypre_error_flag;
 }

--- a/src/parcsr_ls/F90_HYPRE_parcsr_hybrid.c
+++ b/src/parcsr_ls/F90_HYPRE_parcsr_hybrid.c
@@ -862,6 +862,22 @@ hypre_F90_IFACE(hypre_parcsrhybridgetfinalrelat, HYPRE_PARCSRHYBRIDGETFINALRELAT
           hypre_F90_PassObj (HYPRE_Solver, solver),
           hypre_F90_PassRealRef (norm) ));
 }
+
+/*--------------------------------------------------------------------------
+ * HYPRE_ParCSRHybridGetFinalResidualNorm
+ *--------------------------------------------------------------------------*/
+
+void
+hypre_F90_IFACE(hypre_parcsrhybridgetfinalresid, HYPRE_PARCSRHYBRIDGETFINALRESID)
+   (hypre_F90_Obj *solver,
+    hypre_F90_Real *norm,
+    hypre_F90_Int *ierr)
+{
+   *ierr = (hypre_F90_Int)
+      (HYPRE_ParCSRHybridGetFinalResidualNorm(
+          hypre_F90_PassObj (HYPRE_Solver, solver),
+          hypre_F90_PassRealRef (norm) ));
+}
     
 #ifdef __cplusplus
 }

--- a/src/parcsr_ls/F90_HYPRE_parcsr_pcg.c
+++ b/src/parcsr_ls/F90_HYPRE_parcsr_pcg.c
@@ -347,6 +347,22 @@ hypre_F90_IFACE(hypre_parcsrpcggetfinalrelative, HYPRE_PARCSRPCGGETFINALRELATIVE
 }
 
 /*--------------------------------------------------------------------------
+ * HYPRE_ParCSRPCGGetFinalResidual
+ *--------------------------------------------------------------------------*/
+
+void
+hypre_F90_IFACE(hypre_parcsrpcggetfinalresidual, HYPRE_PARCSRPCGGETFINALRESIDUAL)
+   ( hypre_F90_Obj *solver,
+     hypre_F90_Real *norm,
+     hypre_F90_Int *ierr    )
+{
+   *ierr = (hypre_F90_Int)
+      ( HYPRE_ParCSRPCGGetFinalResidualNorm(
+           hypre_F90_PassObj (HYPRE_Solver, solver),
+           hypre_F90_PassRealRef (norm)    ) );
+}
+
+/*--------------------------------------------------------------------------
  * HYPRE_ParCSRDiagScaleSetup
  *--------------------------------------------------------------------------*/
 

--- a/src/parcsr_ls/HYPRE_parcsr_hybrid.c
+++ b/src/parcsr_ls/HYPRE_parcsr_hybrid.c
@@ -641,3 +641,14 @@ HYPRE_ParCSRHybridGetFinalRelativeResidualNorm( HYPRE_Solver solver,
 {
    return( hypre_AMGHybridGetFinalRelativeResidualNorm( (void *) solver, norm ) );
 }
+
+/*--------------------------------------------------------------------------
+ * HYPRE_ParCSRHybridGetFinalResidualNorm
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_ParCSRHybridGetFinalResidualNorm( HYPRE_Solver solver,
+                                                HYPRE_Real  *norm    )
+{
+   return( hypre_AMGHybridGetFinalResidualNorm( (void *) solver, norm ) );
+}

--- a/src/parcsr_ls/HYPRE_parcsr_ls.h
+++ b/src/parcsr_ls/HYPRE_parcsr_ls.h
@@ -164,6 +164,12 @@ HYPRE_Int HYPRE_BoomerAMGGetFinalRelativeResidualNorm(HYPRE_Solver  solver,
                                                       HYPRE_Real   *rel_resid_norm);
 
 /**
+ * Returns the norm of the final residual.
+ **/
+HYPRE_Int HYPRE_BoomerAMGGetFinalResidualNorm(HYPRE_Solver  solver,
+                                              HYPRE_Real   *resid_norm);
+
+/**
  * (Optional) Sets the size of the system of PDEs, if using the systems version.
  * The default is 1, i.e. a scalar system.
  **/
@@ -2218,6 +2224,9 @@ HYPRE_Int HYPRE_ParCSRPCGGetNumIterations(HYPRE_Solver  solver,
 
 HYPRE_Int HYPRE_ParCSRPCGGetFinalRelativeResidualNorm(HYPRE_Solver  solver,
                                                       HYPRE_Real   *norm);
+
+HYPRE_Int HYPRE_ParCSRPCGGetFinalResidualNorm(HYPRE_Solver  solver,
+                                              HYPRE_Real   *norm);
 /**
  * Returns the residual.
  **/

--- a/src/parcsr_ls/HYPRE_parcsr_pcg.c
+++ b/src/parcsr_ls/HYPRE_parcsr_pcg.c
@@ -221,6 +221,17 @@ HYPRE_ParCSRPCGGetFinalRelativeResidualNorm( HYPRE_Solver  solver,
    return( HYPRE_PCGGetFinalRelativeResidualNorm( solver, norm ) );
 }
 
+/*--------------------------------------------------------------------------
+ * HYPRE_ParCSRPCGGetFinalResidualNorm
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_ParCSRPCGGetFinalResidualNorm( HYPRE_Solver  solver,
+                                     HYPRE_Real   *norm   )
+{
+   return( HYPRE_PCGGetFinalResidualNorm( solver, norm ) );
+}
+
 
 /*--------------------------------------------------------------------------
  * HYPRE_ParCSRPCGGetResidual

--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -596,6 +596,7 @@ HYPRE_Int hypre_AMGHybridGetNumIterations ( void *AMGhybrid_vdata , HYPRE_Int *n
 HYPRE_Int hypre_AMGHybridGetDSCGNumIterations ( void *AMGhybrid_vdata , HYPRE_Int *dscg_num_its );
 HYPRE_Int hypre_AMGHybridGetPCGNumIterations ( void *AMGhybrid_vdata , HYPRE_Int *pcg_num_its );
 HYPRE_Int hypre_AMGHybridGetFinalRelativeResidualNorm ( void *AMGhybrid_vdata , HYPRE_Real *final_rel_res_norm );
+HYPRE_Int hypre_AMGHybridGetFinalResidualNorm ( void *AMGhybrid_vdata , HYPRE_Real *final_res_norm );
 HYPRE_Int hypre_AMGHybridSetup ( void *AMGhybrid_vdata , hypre_ParCSRMatrix *A , hypre_ParVector *b , hypre_ParVector *x );
 HYPRE_Int hypre_AMGHybridSolve ( void *AMGhybrid_vdata , hypre_ParCSRMatrix *A , hypre_ParVector *b , hypre_ParVector *x );
 
@@ -1085,6 +1086,7 @@ HYPRE_Int HYPRE_ParCSRHybridGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *
 HYPRE_Int HYPRE_ParCSRHybridGetDSCGNumIterations ( HYPRE_Solver solver , HYPRE_Int *dscg_num_its );
 HYPRE_Int HYPRE_ParCSRHybridGetPCGNumIterations ( HYPRE_Solver solver , HYPRE_Int *pcg_num_its );
 HYPRE_Int HYPRE_ParCSRHybridGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
+HYPRE_Int HYPRE_ParCSRHybridGetFinalResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
 
 /* HYPRE_parcsr_int.c */
 HYPRE_Int hypre_ParSetRandomValues ( void *v , HYPRE_Int seed );
@@ -1169,6 +1171,7 @@ HYPRE_Int HYPRE_ParCSRPCGSetPrintLevel ( HYPRE_Solver solver , HYPRE_Int level )
 HYPRE_Int HYPRE_ParCSRPCGSetLogging ( HYPRE_Solver solver , HYPRE_Int level );
 HYPRE_Int HYPRE_ParCSRPCGGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *num_iterations );
 HYPRE_Int HYPRE_ParCSRPCGGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
+HYPRE_Int HYPRE_ParCSRPCGGetFinalResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
 HYPRE_Int HYPRE_ParCSRPCGGetResidual ( HYPRE_Solver solver , HYPRE_ParVector *residual );
 HYPRE_Int HYPRE_ParCSRDiagScaleSetup ( HYPRE_Solver solver , HYPRE_ParCSRMatrix A , HYPRE_ParVector y , HYPRE_ParVector x );
 HYPRE_Int HYPRE_ParCSRDiagScale ( HYPRE_Solver solver , HYPRE_ParCSRMatrix HA , HYPRE_ParVector Hy , HYPRE_ParVector Hx );

--- a/src/parcsr_ls/amg_hybrid.c
+++ b/src/parcsr_ls/amg_hybrid.c
@@ -47,6 +47,7 @@ typedef struct
    /* log info (always logged) */
    HYPRE_Int             dscg_num_its;
    HYPRE_Int             pcg_num_its;
+   HYPRE_Real            final_res_norm;
    HYPRE_Real            final_rel_res_norm;
    HYPRE_Int             time_index;
 
@@ -1509,6 +1510,26 @@ hypre_AMGHybridGetFinalRelativeResidualNorm( void   *AMGhybrid_vdata,
 }
 
 /*--------------------------------------------------------------------------
+ * hypre_AMGHybridGetFinalResidualNorm
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_AMGHybridGetFinalResidualNorm( void   *AMGhybrid_vdata,
+                                     HYPRE_Real *final_res_norm )
+{
+   hypre_AMGHybridData *AMGhybrid_data =(hypre_AMGHybridData *) AMGhybrid_vdata;
+   if (!AMGhybrid_data)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+
+   *final_res_norm = (AMGhybrid_data -> final_res_norm);
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
  * hypre_AMGHybridSetup
  *--------------------------------------------------------------------------*/
 
@@ -1605,6 +1626,7 @@ hypre_AMGHybridSolve( void               *AMGhybrid_vdata,
    HYPRE_Int          converged=0;
    HYPRE_Int          num_variables = hypre_VectorSize(hypre_ParVectorLocalVector(b));
    HYPRE_Real         res_norm;
+   HYPRE_Real         rel_res_norm;
 
    HYPRE_Int          i, j;
    HYPRE_Int	      sol_print_level; /* print_level for solver */
@@ -1751,7 +1773,8 @@ hypre_AMGHybridSolve( void               *AMGhybrid_vdata,
       *---------------------------------------------------------------------*/
      hypre_PCGGetNumIterations(pcg_solver, &dscg_num_its);
      (AMGhybrid_data -> dscg_num_its) = dscg_num_its;
-     hypre_PCGGetFinalRelativeResidualNorm(pcg_solver, &res_norm);
+     hypre_PCGGetFinalRelativeResidualNorm(pcg_solver, &rel_res_norm);
+     hypre_PCGGetFinalResidualNorm(pcg_solver, &res_norm);
 
      hypre_PCGGetConverged(pcg_solver, &converged);
 
@@ -1806,7 +1829,8 @@ hypre_AMGHybridSolve( void               *AMGhybrid_vdata,
       *---------------------------------------------------------------------*/
       hypre_GMRESGetNumIterations(pcg_solver, &dscg_num_its);
       (AMGhybrid_data -> dscg_num_its) = dscg_num_its;
-      hypre_GMRESGetFinalRelativeResidualNorm(pcg_solver, &res_norm);
+      hypre_GMRESGetFinalRelativeResidualNorm(pcg_solver, &rel_res_norm);
+      hypre_GMRESGetFinalResidualNorm(pcg_solver, &res_norm);
 
       hypre_GMRESGetConverged(pcg_solver, &converged);
 
@@ -1857,7 +1881,8 @@ hypre_AMGHybridSolve( void               *AMGhybrid_vdata,
       *---------------------------------------------------------------------*/
      hypre_BiCGSTABGetNumIterations(pcg_solver, &dscg_num_its);
      (AMGhybrid_data -> dscg_num_its) = dscg_num_its;
-     hypre_BiCGSTABGetFinalRelativeResidualNorm(pcg_solver, &res_norm);
+     hypre_BiCGSTABGetFinalRelativeResidualNorm(pcg_solver, &rel_res_norm);
+     hypre_BiCGSTABGetFinalResidualNorm(pcg_solver, &res_norm);
 
      hypre_BiCGSTABGetConverged(pcg_solver, &converged);
 
@@ -1870,7 +1895,8 @@ hypre_AMGHybridSolve( void               *AMGhybrid_vdata,
    if (converged)
    {
       if (logging)
-         (AMGhybrid_data -> final_rel_res_norm) = res_norm;
+         (AMGhybrid_data -> final_rel_res_norm) = rel_res_norm;
+         (AMGhybrid_data -> final_res_norm) = res_norm;
    }
    /*-----------------------------------------------------------------------
     * ... otherwise, use AMG+solver
@@ -2014,8 +2040,10 @@ hypre_AMGHybridSolve( void               *AMGhybrid_vdata,
          (AMGhybrid_data -> pcg_num_its)  = pcg_num_its;
          if (logging)
          {
-            hypre_PCGGetFinalRelativeResidualNorm(pcg_solver, &res_norm);
-            (AMGhybrid_data -> final_rel_res_norm) = res_norm;
+            hypre_PCGGetFinalRelativeResidualNorm(pcg_solver, &rel_res_norm);
+            (AMGhybrid_data -> final_rel_res_norm) = rel_res_norm;
+            hypre_PCGGetFinalResidualNorm(pcg_solver, &res_norm);
+            (AMGhybrid_data -> final_res_norm) = res_norm;
          }
       }
       else if (solver_type == 2)
@@ -2034,8 +2062,10 @@ hypre_AMGHybridSolve( void               *AMGhybrid_vdata,
          (AMGhybrid_data -> pcg_num_its)  = pcg_num_its;
          if (logging)
          {
-            hypre_GMRESGetFinalRelativeResidualNorm(pcg_solver, &res_norm);
-            (AMGhybrid_data -> final_rel_res_norm) = res_norm;
+            hypre_GMRESGetFinalRelativeResidualNorm(pcg_solver, &rel_res_norm);
+            (AMGhybrid_data -> final_rel_res_norm) = rel_res_norm;
+            hypre_GMRESGetFinalResidualNorm(pcg_solver, &res_norm);
+            (AMGhybrid_data -> final_res_norm) = res_norm;
          }
       }
       else if (solver_type == 3)
@@ -2054,8 +2084,10 @@ hypre_AMGHybridSolve( void               *AMGhybrid_vdata,
          (AMGhybrid_data -> pcg_num_its)  = pcg_num_its;
          if (logging)
          {
-	    hypre_BiCGSTABGetFinalRelativeResidualNorm(pcg_solver, &res_norm);
-            (AMGhybrid_data -> final_rel_res_norm) = res_norm;
+	    hypre_BiCGSTABGetFinalRelativeResidualNorm(pcg_solver, &rel_res_norm);
+            (AMGhybrid_data -> final_rel_res_norm) = rel_res_norm;
+	    hypre_BiCGSTABGetFinalResidualNorm(pcg_solver, &res_norm);
+            (AMGhybrid_data -> final_res_norm) = res_norm;
          }
       }
    }


### PR DESCRIPTION
Also adds HYPRE_{PCG,GMRES,BiCGSTAB}GetFinalResidualNorm and some others as a consequence.

This PR aims to address #16. It is likely incomplete (other solvers, documentation, ...), but if you point me in the right direction I'd be happy to try and address the deficiencies.