### PR TITLE
Improve output from hypre_BoomerAMGSetupStats

### DIFF
--- a/src/parcsr_ls/par_stats.c
+++ b/src/parcsr_ls/par_stats.c
@@ -104,7 +104,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
 
    HYPRE_Int       i;
-   HYPRE_Int	   ndigits[2];
+   HYPRE_Int	   ndigits[4];
 
    HYPRE_BigInt    coarse_size;
    HYPRE_Int       entries;
@@ -400,15 +400,35 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
    if (block_mode)
    {
       ndigits[0] = hypre_ndigits(hypre_ParCSRBlockMatrixGlobalNumRows(A_block_array[0]));
-      ndigits[1] = hypre_ndigits(hypre_ParCSRBlockMatrixDNumNonzeros(A_block_array[0]));
+      ndigits[1] = hypre_ndigits(hypre_ParCSRBlockMatrixNumNonzeros(A_block_array[0]));
    }
    else
    {
       ndigits[0] = hypre_ndigits(hypre_ParCSRMatrixGlobalNumRows(A_array[0]));
-      ndigits[1] = hypre_ndigits(hypre_ParCSRMatrixDNumNonzeros(A_array[0]));
+      ndigits[1] = hypre_ndigits(hypre_ParCSRMatrixNumNonzeros(A_array[0]));
    }
    ndigits[0] = hypre_max(7, ndigits[0]);
    ndigits[1] = hypre_max(8, ndigits[1]);
+   ndigits[2] = 4;
+   for (level = 0; level < num_levels; level++)
+   {
+
+      if (block_mode)
+      {
+         fine_size = hypre_ParCSRBlockMatrixGlobalNumRows(A_block_array[level]);
+         global_nonzeros = hypre_ParCSRBlockMatrixNumNonzeros(A_block_array[level]);
+	 ndigits[2] = hypre_max(hypre_ndigits((HYPRE_BigInt) global_nonzeros / fine_size ), ndigits[2]);
+      }
+      else
+      {
+         fine_size = hypre_ParCSRMatrixGlobalNumRows(A_array[level]);
+         global_nonzeros = hypre_ParCSRMatrixNumNonzeros(A_array[level]);
+	 ndigits[2] = hypre_max(hypre_ndigits((HYPRE_BigInt) global_nonzeros / fine_size ), ndigits[2]);
+      }
+
+   }
+   ndigits[2] = ndigits[2] + 2;
+   ndigits[3] = ndigits[0] + ndigits[1] + ndigits[2];
 
    if(my_id == 0)
    {
@@ -418,8 +438,8 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
       hypre_printf("%s %*s ", "lev", ndigits[0], "rows");
       hypre_printf("%*s", ndigits[1], "entries");
       hypre_printf("%7s %5s %4s", "sparse", "min", "max");
-      hypre_printf("%6s %8s %11s\n", "avg", "min", "max");
-      for (i = 0; i < (53 + ndigits[0] + ndigits[1]); i++) hypre_printf("%s", "=");
+      hypre_printf("%*s %8s %11s\n", (ndigits[2] + 2), "avg", "min", "max");
+      for (i = 0; i < (49 + ndigits[3]); i++) hypre_printf("%s", "=");
       hypre_printf("\n");
    }
 
@@ -593,7 +613,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
           hypre_printf("%3d %*b %*.0f  %0.3f  %4d %4d",
                   level, ndigits[0], fine_size, ndigits[1], global_nonzeros,
                   sparse, global_min_e, global_max_e);
-          hypre_printf("  %4.1f  %10.3e  %10.3e\n", avg_entries,
+          hypre_printf("  %*.1f  %10.3e  %10.3e\n", ndigits[2], avg_entries,
                  global_min_rsum, global_max_rsum);
        }
 
@@ -627,7 +647,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
           hypre_printf("%3d %*b %*.0f  %0.3f  %4d %4d",
                   level, ndigits[0], fine_size, ndigits[1], global_nonzeros,
                   sparse, global_min_e, global_max_e);
-          hypre_printf("  %4.1f  %10.3e  %10.3e\n", avg_entries,
+          hypre_printf("  %*.1f  %10.3e  %10.3e\n", ndigits[2], avg_entries,
                  global_min_rsum, global_max_rsum);
        }
 

--- a/src/parcsr_ls/par_stats.c
+++ b/src/parcsr_ls/par_stats.c
@@ -656,16 +656,18 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
    }
 
-
-   if (block_mode)
+   ndigits[0] = 5;
+   if ((num_levels - 1))
    {
-      ndigits[0] = hypre_ndigits(hypre_ParCSRBlockMatrixGlobalNumRows(P_block_array[0]));
+      if (block_mode)
+      {
+         ndigits[0] = hypre_max(hypre_ndigits(hypre_ParCSRBlockMatrixGlobalNumRows(P_block_array[0])), ndigits[0]);
+      }
+      else
+      {
+         ndigits[0] = hypre_max(hypre_ndigits(hypre_ParCSRMatrixGlobalNumRows(P_array[0])), ndigits[0]);
+      }
    }
-   else
-   {
-      ndigits[0] = hypre_ndigits(hypre_ParCSRMatrixGlobalNumRows(P_array[0]));
-   }
-   ndigits[0] = hypre_max(5, ndigits[0]);
 
    if (my_id == 0)
    {

--- a/src/parcsr_ls/par_stats.c
+++ b/src/parcsr_ls/par_stats.c
@@ -744,7 +744,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
          
 
          }
-         avg_entries = ((HYPRE_Real) global_nonzeros) / ((HYPRE_Real) fine_size);
+         avg_entries = ((HYPRE_Real) (global_nonzeros - coarse_size)) / ((HYPRE_Real) (fine_size - coarse_size));
       }
       else 
       {
@@ -822,7 +822,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
             }
          
          }
-         avg_entries = ((HYPRE_Real) global_nonzeros) / ((HYPRE_Real) fine_size);
+         avg_entries = ((HYPRE_Real) (global_nonzeros - coarse_size)) / ((HYPRE_Real) (fine_size - coarse_size));
       }
 
 #ifdef HYPRE_NO_GLOBAL_PARTITION

--- a/src/parcsr_ls/par_stats.c
+++ b/src/parcsr_ls/par_stats.c
@@ -31,7 +31,7 @@ HYPRE_Int
 hypre_BoomerAMGSetupStats( void               *amg_vdata,
                         hypre_ParCSRMatrix *A         )
 {
-   MPI_Comm 	      comm = hypre_ParCSRMatrixComm(A);   
+   MPI_Comm 	      comm = hypre_ParCSRMatrixComm(A);
 
    hypre_ParAMGData *amg_data = (hypre_ParAMGData*) amg_vdata;
 
@@ -49,7 +49,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
    hypre_CSRBlockMatrix *A_block_diag;
 
-   hypre_CSRMatrix *A_offd;   
+   hypre_CSRMatrix *A_offd;
    HYPRE_Real      *A_offd_data;
    HYPRE_Int       *A_offd_i;
 
@@ -61,7 +61,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
    hypre_CSRBlockMatrix *P_block_diag;
 
-   hypre_CSRMatrix *P_offd;   
+   hypre_CSRMatrix *P_offd;
    HYPRE_Real      *P_offd_data;
    HYPRE_Int       *P_offd_i;
 
@@ -72,8 +72,8 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
    HYPRE_BigInt	    *row_starts;
 
- 
-   HYPRE_Int      num_levels; 
+
+   HYPRE_Int      num_levels;
    HYPRE_Int      coarsen_type;
    HYPRE_Int      interp_type;
    HYPRE_Int      restri_type;
@@ -84,13 +84,13 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
    HYPRE_Real  *send_buff;
    HYPRE_Real  *gather_buff;
- 
+
    /* Local variables */
 
    HYPRE_Int       level;
    HYPRE_Int       j;
    HYPRE_BigInt    fine_size;
- 
+
    HYPRE_Int       min_entries;
    HYPRE_Int       max_entries;
 
@@ -126,27 +126,27 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
    HYPRE_Real  *num_mem;
    HYPRE_Real  *num_coeffs;
    HYPRE_Real  *num_variables;
-   HYPRE_Real   total_variables; 
+   HYPRE_Real   total_variables;
    HYPRE_Real   operat_cmplxty;
    HYPRE_Real   grid_cmplxty = 0;
    HYPRE_Real   memory_cmplxty = 0;
 
    /* amg solve params */
    HYPRE_Int     max_iter;
-   HYPRE_Int     cycle_type;    
-   HYPRE_Int     *num_grid_sweeps;  
-   HYPRE_Int     *grid_relax_type;   
+   HYPRE_Int     cycle_type;
+   HYPRE_Int     *num_grid_sweeps;
+   HYPRE_Int     *grid_relax_type;
    HYPRE_Int      relax_order;
-   HYPRE_Int    **grid_relax_points; 
+   HYPRE_Int    **grid_relax_points;
    HYPRE_Real  *relax_weight;
    HYPRE_Real  *omega;
    HYPRE_Real   tol;
 
    HYPRE_Int block_mode;
    HYPRE_Int block_size, bnnz;
-   
+
    HYPRE_Real tmp_norm;
-   
+
 
    HYPRE_Int one = 1;
    HYPRE_Int minus_one = -1;
@@ -159,8 +159,8 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
    HYPRE_Int add_end;
    HYPRE_Int add_rlx;
    HYPRE_Real add_rlx_wt;
- 
-   hypre_MPI_Comm_size(comm, &num_procs);   
+
+   hypre_MPI_Comm_size(comm, &num_procs);
    hypre_MPI_Comm_rank(comm,&my_id);
    num_threads = hypre_NumThreads();
 
@@ -191,22 +191,22 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
    num_levels = hypre_ParAMGDataNumLevels(amg_data);
    max_iter   = hypre_ParAMGDataMaxIter(amg_data);
-   cycle_type = hypre_ParAMGDataCycleType(amg_data);    
-   num_grid_sweeps = hypre_ParAMGDataNumGridSweeps(amg_data);  
+   cycle_type = hypre_ParAMGDataCycleType(amg_data);
+   num_grid_sweeps = hypre_ParAMGDataNumGridSweeps(amg_data);
    grid_relax_type = hypre_ParAMGDataGridRelaxType(amg_data);
    grid_relax_points = hypre_ParAMGDataGridRelaxPoints(amg_data);
-   relax_weight = hypre_ParAMGDataRelaxWeight(amg_data); 
-   relax_order = hypre_ParAMGDataRelaxOrder(amg_data); 
-   omega = hypre_ParAMGDataOmega(amg_data); 
+   relax_weight = hypre_ParAMGDataRelaxWeight(amg_data);
+   relax_order = hypre_ParAMGDataRelaxOrder(amg_data);
+   omega = hypre_ParAMGDataOmega(amg_data);
    tol = hypre_ParAMGDataTol(amg_data);
 
    block_mode = hypre_ParAMGDataBlockMode(amg_data);
 
    send_buff     = hypre_CTAlloc(HYPRE_Real,  6, HYPRE_MEMORY_HOST);
 #ifdef HYPRE_NO_GLOBAL_PARTITION
-   gather_buff = hypre_CTAlloc(HYPRE_Real, 6, HYPRE_MEMORY_HOST);    
+   gather_buff = hypre_CTAlloc(HYPRE_Real, 6, HYPRE_MEMORY_HOST);
 #else
-   gather_buff = hypre_CTAlloc(HYPRE_Real, 6*num_procs, HYPRE_MEMORY_HOST);    
+   gather_buff = hypre_CTAlloc(HYPRE_Real, 6*num_procs, HYPRE_MEMORY_HOST);
 #endif
 
    if (my_id==0)
@@ -216,58 +216,58 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
       hypre_printf("\nBoomerAMG SETUP PARAMETERS:\n\n");
       hypre_printf(" Max levels = %d\n",hypre_ParAMGDataMaxLevels(amg_data));
       hypre_printf(" Num levels = %d\n\n",num_levels);
-      hypre_printf(" Strength Threshold = %f\n", 
+      hypre_printf(" Strength Threshold = %f\n",
                          hypre_ParAMGDataStrongThreshold(amg_data));
-      hypre_printf(" Interpolation Truncation Factor = %f\n", 
+      hypre_printf(" Interpolation Truncation Factor = %f\n",
                          hypre_ParAMGDataTruncFactor(amg_data));
-      hypre_printf(" Maximum Row Sum Threshold for Dependency Weakening = %f\n\n", 
+      hypre_printf(" Maximum Row Sum Threshold for Dependency Weakening = %f\n\n",
                          hypre_ParAMGDataMaxRowSum(amg_data));
 
       if (coarsen_type == 0)
       {
 	hypre_printf(" Coarsening Type = Cleary-Luby-Jones-Plassman\n");
       }
-      else if (hypre_abs(coarsen_type) == 1) 
+      else if (hypre_abs(coarsen_type) == 1)
       {
 	hypre_printf(" Coarsening Type = Ruge\n");
       }
-      else if (hypre_abs(coarsen_type) == 2) 
+      else if (hypre_abs(coarsen_type) == 2)
       {
 	hypre_printf(" Coarsening Type = Ruge2B\n");
       }
-      else if (hypre_abs(coarsen_type) == 3) 
+      else if (hypre_abs(coarsen_type) == 3)
       {
 	hypre_printf(" Coarsening Type = Ruge3\n");
       }
-      else if (hypre_abs(coarsen_type) == 4) 
+      else if (hypre_abs(coarsen_type) == 4)
       {
 	hypre_printf(" Coarsening Type = Ruge 3c \n");
       }
-      else if (hypre_abs(coarsen_type) == 5) 
+      else if (hypre_abs(coarsen_type) == 5)
       {
 	hypre_printf(" Coarsening Type = Ruge relax special points \n");
       }
-      else if (hypre_abs(coarsen_type) == 6) 
+      else if (hypre_abs(coarsen_type) == 6)
       {
 	hypre_printf(" Coarsening Type = Falgout-CLJP \n");
       }
-      else if (hypre_abs(coarsen_type) == 8) 
+      else if (hypre_abs(coarsen_type) == 8)
       {
 	hypre_printf(" Coarsening Type = PMIS \n");
       }
-      else if (hypre_abs(coarsen_type) == 10) 
+      else if (hypre_abs(coarsen_type) == 10)
       {
 	hypre_printf(" Coarsening Type = HMIS \n");
       }
-      else if (hypre_abs(coarsen_type) == 11) 
+      else if (hypre_abs(coarsen_type) == 11)
       {
 	hypre_printf(" Coarsening Type = Ruge 1st pass only \n");
       }
-      else if (hypre_abs(coarsen_type) == 9) 
+      else if (hypre_abs(coarsen_type) == 9)
       {
 	hypre_printf(" Coarsening Type = PMIS fixed random \n");
       }
-      else if (hypre_abs(coarsen_type) == 7) 
+      else if (hypre_abs(coarsen_type) == 7)
       {
 	hypre_printf(" Coarsening Type = CLJP, fixed random \n");
       }
@@ -279,7 +279,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
       {
         hypre_printf(" Coarsening Type = CGC-E \n");
       }
-      /*if (coarsen_type > 0) 
+      /*if (coarsen_type > 0)
       {
 	hypre_printf(" Hybrid Coarsening (switch to CLJP when coarsening slows)\n");
       }*/
@@ -296,10 +296,10 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
         else if (agg_interp_type == 3)
 	   hypre_printf(" Interpolation on agg. levels = 2-stage extended interpolation \n");
       }
-      
+
 
       if (coarsen_type)
-      	hypre_printf(" measures are determined %s\n\n", 
+      	hypre_printf(" measures are determined %s\n\n",
                   (measure_type ? "globally" : "locally"));
 
 #ifdef HYPRE_NO_GLOBAL_PARTITION
@@ -310,64 +310,64 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
       {
 	hypre_printf(" Interpolation = modified classical interpolation\n");
       }
-      else if (interp_type == 1) 
+      else if (interp_type == 1)
       {
 	hypre_printf(" Interpolation = LS interpolation \n");
       }
-      else if (interp_type == 2) 
+      else if (interp_type == 2)
       {
 	hypre_printf(" Interpolation = modified classical interpolation for hyperbolic PDEs\n");
       }
-      else if (interp_type == 3) 
+      else if (interp_type == 3)
       {
 	hypre_printf(" Interpolation = direct interpolation with separation of weights\n");
       }
-      else if (interp_type == 4) 
+      else if (interp_type == 4)
       {
 	hypre_printf(" Interpolation = multipass interpolation\n");
       }
-      else if (interp_type == 5) 
+      else if (interp_type == 5)
       {
 	hypre_printf(" Interpolation = multipass interpolation with separation of weights\n");
       }
-      else if (interp_type == 6) 
+      else if (interp_type == 6)
       {
 	hypre_printf(" Interpolation = extended+i interpolation\n");
       }
-      else if (interp_type == 7) 
+      else if (interp_type == 7)
       {
 	hypre_printf(" Interpolation = extended+i interpolation (if no common C point)\n");
       }
-      else if (interp_type == 12) 
+      else if (interp_type == 12)
       {
 	hypre_printf(" Interpolation = F-F interpolation\n");
       }
-      else if (interp_type == 13) 
+      else if (interp_type == 13)
       {
 	hypre_printf(" Interpolation = F-F1 interpolation\n");
       }
-      else if (interp_type == 14) 
+      else if (interp_type == 14)
       {
 	hypre_printf(" Interpolation = extended interpolation\n");
       }
-      else if (interp_type == 8) 
+      else if (interp_type == 8)
       {
 	hypre_printf(" Interpolation = standard interpolation\n");
       }
-      else if (interp_type == 9) 
+      else if (interp_type == 9)
       {
 	hypre_printf(" Interpolation = standard interpolation with separation of weights\n");
       }
-      else if (interp_type == 10) 
+      else if (interp_type == 10)
       {
 	hypre_printf(" Interpolation = block classical interpolation for nodal systems AMG\n");
       }
-      else if (interp_type == 11) 
+      else if (interp_type == 11)
       {
 	hypre_printf(" Interpolation = block classical interpolation with diagonal blocks\n");
 	hypre_printf("                 for nodal systems AMG\n");
       }
-      else if (interp_type == 24) 
+      else if (interp_type == 24)
       {
 	hypre_printf(" Interpolation = block direct interpolation \n");
 	hypre_printf("                 for nodal systems AMG\n");
@@ -380,7 +380,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
       if (restri_type == 1)
       {
          hypre_printf(" Restriction = local approximate ideal restriction (AIR-1)\n");
-      } 
+      }
       else if (restri_type == 2)
       {
          hypre_printf(" Restriction = local approximate ideal restriction (AIR-2)\n");
@@ -391,7 +391,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
          hypre_printf( "\nBlock Operator Matrix Information:\n");
            hypre_printf( "(Row sums and weights use sum of all elements in the block -keeping signs)\n\n");
       }
-      else 
+      else
       {
          hypre_printf( "\nOperator Matrix Information:\n\n");
       }
@@ -405,7 +405,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
    else
    {
       ndigits[0] = hypre_ndigits(hypre_ParCSRMatrixGlobalNumRows(A_array[0]));
-      ndigits[1] = hypre_ndigits(hypre_ParCSRMatrixDNumNonzeros(A_array[level]));
+      ndigits[1] = hypre_ndigits(hypre_ParCSRMatrixDNumNonzeros(A_array[0]));
    }
    ndigits[0] = hypre_max(7, ndigits[0]);
    ndigits[1] = hypre_max(8, ndigits[1]);
@@ -433,36 +433,36 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
    num_variables = hypre_CTAlloc(HYPRE_Real, num_levels, HYPRE_MEMORY_HOST);
 
    for (level = 0; level < num_levels; level++)
-   { 
+   {
 
       if (block_mode)
       {
          A_block_diag = hypre_ParCSRBlockMatrixDiag(A_block_array[level]);
          A_diag_data = hypre_CSRBlockMatrixData(A_block_diag);
          A_diag_i = hypre_CSRBlockMatrixI(A_block_diag);
-         
-         A_block_offd = hypre_ParCSRBlockMatrixOffd(A_block_array[level]);   
+
+         A_block_offd = hypre_ParCSRBlockMatrixOffd(A_block_array[level]);
          A_offd_data = hypre_CSRMatrixData(A_block_offd);
          A_offd_i = hypre_CSRMatrixI(A_block_offd);
-         
+
          block_size =  hypre_ParCSRBlockMatrixBlockSize(A_block_array[level]);
          bnnz = block_size*block_size;
 
          row_starts = hypre_ParCSRBlockMatrixRowStarts(A_block_array[level]);
-         
+
          fine_size = hypre_ParCSRBlockMatrixGlobalNumRows(A_block_array[level]);
          global_nonzeros = hypre_ParCSRBlockMatrixDNumNonzeros(A_block_array[level]);
          num_coeffs[level] = global_nonzeros;
          num_mem[level] = global_nonzeros;
          num_variables[level] = (HYPRE_Real) fine_size;
-  
+
          sparse = global_nonzeros /((HYPRE_Real) fine_size * (HYPRE_Real) fine_size);
-         
+
          min_entries = 0;
          max_entries = 0;
          min_rowsum = 0.0;
          max_rowsum = 0.0;
-         
+
          if (hypre_CSRBlockMatrixNumRows(A_block_diag))
          {
             min_entries = (A_diag_i[1]-A_diag_i[0])+(A_offd_i[1]-A_offd_i[0]);
@@ -471,21 +471,21 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
                hypre_CSRBlockMatrixBlockNorm(6, &A_diag_data[j*bnnz], &tmp_norm, block_size);
                min_rowsum += tmp_norm;
             }
-            
+
             for (j = A_offd_i[0]; j < A_offd_i[1]; j++)
             {
                hypre_CSRBlockMatrixBlockNorm(6, &A_offd_data[j*bnnz], &tmp_norm, block_size);
                min_rowsum += tmp_norm;
             }
-            
+
             max_rowsum = min_rowsum;
-            
+
             for (j = 0; j < hypre_CSRBlockMatrixNumRows(A_block_diag); j++)
             {
                entries = (A_diag_i[j+1]-A_diag_i[j])+(A_offd_i[j+1]-A_offd_i[j]);
                min_entries = hypre_min(entries, min_entries);
                max_entries = hypre_max(entries, max_entries);
-               
+
                rowsum = 0.0;
                for (i = A_diag_i[j]; i < A_diag_i[j+1]; i++)
                {
@@ -508,17 +508,17 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
          A_diag = hypre_ParCSRMatrixDiag(A_array[level]);
          A_diag_data = hypre_CSRMatrixData(A_diag);
          A_diag_i = hypre_CSRMatrixI(A_diag);
-         
-         A_offd = hypre_ParCSRMatrixOffd(A_array[level]);   
+
+         A_offd = hypre_ParCSRMatrixOffd(A_array[level]);
          A_offd_data = hypre_CSRMatrixData(A_offd);
          A_offd_i = hypre_CSRMatrixI(A_offd);
-         
+
          row_starts = hypre_ParCSRMatrixRowStarts(A_array[level]);
-         
+
          fine_size = hypre_ParCSRMatrixGlobalNumRows(A_array[level]);
          global_nonzeros = hypre_ParCSRMatrixDNumNonzeros(A_array[level]);
          num_coeffs[level] = global_nonzeros;
-         if (level == 0) 
+         if (level == 0)
             num_mem[level] += global_nonzeros;
          if (level == 0 && (additive == 0 || mult_additive == 0) )
             num_mem[level] += global_nonzeros;
@@ -528,14 +528,14 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
                num_mem[level] += global_nonzeros;
          }
          num_variables[level] = (HYPRE_Real) fine_size;
-         
+
          sparse = global_nonzeros /((HYPRE_Real) fine_size * (HYPRE_Real) fine_size);
 
          min_entries = 0;
          max_entries = 0;
          min_rowsum = 0.0;
          max_rowsum = 0.0;
-         
+
          if (hypre_CSRMatrixNumRows(A_diag))
          {
             min_entries = (A_diag_i[1]-A_diag_i[0])+(A_offd_i[1]-A_offd_i[0]);
@@ -543,30 +543,30 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
                min_rowsum += A_diag_data[j];
             for (j = A_offd_i[0]; j < A_offd_i[1]; j++)
                min_rowsum += A_offd_data[j];
-            
+
             max_rowsum = min_rowsum;
-            
+
             for (j = 0; j < hypre_CSRMatrixNumRows(A_diag); j++)
             {
                entries = (A_diag_i[j+1]-A_diag_i[j])+(A_offd_i[j+1]-A_offd_i[j]);
                min_entries = hypre_min(entries, min_entries);
                max_entries = hypre_max(entries, max_entries);
-               
+
                rowsum = 0.0;
                for (i = A_diag_i[j]; i < A_diag_i[j+1]; i++)
                   rowsum += A_diag_data[i];
-               
+
                for (i = A_offd_i[j]; i < A_offd_i[j+1]; i++)
                   rowsum += A_offd_data[i];
-               
+
                min_rowsum = hypre_min(rowsum, min_rowsum);
                max_rowsum = hypre_max(rowsum, max_rowsum);
             }
          }
          avg_entries = global_nonzeros / ((HYPRE_Real) fine_size);
       }
-      
-#ifdef HYPRE_NO_GLOBAL_PARTITION       
+
+#ifdef HYPRE_NO_GLOBAL_PARTITION
 
        numrows = (HYPRE_Int)(row_starts[1]-row_starts[0]);
        if (!numrows) /* if we don't have any rows, then don't have this count toward
@@ -575,35 +575,35 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
           min_entries = 1000000;
           min_rowsum =  1.0e7;
        }
-       
+
        send_buff[0] = - (HYPRE_Real) min_entries;
        send_buff[1] = (HYPRE_Real) max_entries;
        send_buff[2] = - min_rowsum;
        send_buff[3] = max_rowsum;
 
        hypre_MPI_Reduce(send_buff, gather_buff, 4, HYPRE_MPI_REAL, hypre_MPI_MAX, 0, comm);
-       
+
        if (my_id ==0)
        {
           global_min_e = - (HYPRE_Int)gather_buff[0];
           global_max_e = (HYPRE_Int)gather_buff[1];
           global_min_rsum = - gather_buff[2];
           global_max_rsum = gather_buff[3];
-          
+
           hypre_printf("%3d %*b %*.0f  %0.3f  %4d %4d",
                   level, ndigits[0], fine_size, ndigits[1], global_nonzeros,
                   sparse, global_min_e, global_max_e);
           hypre_printf("  %4.1f  %10.3e  %10.3e\n", avg_entries,
                  global_min_rsum, global_max_rsum);
        }
-       
+
 #else
 
        send_buff[0] = (HYPRE_Real) min_entries;
        send_buff[1] = (HYPRE_Real) max_entries;
        send_buff[2] = min_rowsum;
        send_buff[3] = max_rowsum;
-       
+
        hypre_MPI_Gather(send_buff,4,HYPRE_MPI_REAL,gather_buff,4,HYPRE_MPI_REAL,0,comm);
 
        if (my_id == 0)
@@ -633,10 +633,10 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
 #endif
 
-        
+
    }
 
-       
+
    if (block_mode)
    {
       ndigits[0] = hypre_ndigits(hypre_ParCSRBlockMatrixGlobalNumRows(P_block_array[0]));
@@ -654,12 +654,12 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
          hypre_printf( "\n\nBlock Interpolation Matrix Information:\n\n");
          hypre_printf( "(Row sums and weights use sum of all elements in the block - keeping signs)\n\n");
       }
-      else 
+      else
       {
          hypre_printf( "\n\nInterpolation Matrix Information:\n");
-        
+
       }
-      
+
       hypre_printf("%*s ", (2*ndigits[0] + 21), "entries/row");
       hypre_printf("%10s %10s %19s\n", "min", "max", "row sums");
       hypre_printf("lev %*s x %-*s min  max  avgW", ndigits[0], "rows", ndigits[0], "cols");
@@ -674,39 +674,39 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
    for (level = 0; level < num_levels-1; level++)
    {
-    
+
       if (block_mode)
       {
          P_block_diag = hypre_ParCSRBlockMatrixDiag(P_block_array[level]);
          P_diag_data = hypre_CSRBlockMatrixData(P_block_diag);
          P_diag_i = hypre_CSRBlockMatrixI(P_block_diag);
-         
-         P_block_offd = hypre_ParCSRBlockMatrixOffd(P_block_array[level]);   
+
+         P_block_offd = hypre_ParCSRBlockMatrixOffd(P_block_array[level]);
          P_offd_data = hypre_CSRBlockMatrixData(P_block_offd);
          P_offd_i = hypre_CSRBlockMatrixI(P_block_offd);
-         
+
          row_starts = hypre_ParCSRBlockMatrixRowStarts(P_block_array[level]);
-         
+
          fine_size = hypre_ParCSRBlockMatrixGlobalNumRows(P_block_array[level]);
          coarse_size = hypre_ParCSRBlockMatrixGlobalNumCols(P_block_array[level]);
          global_nonzeros = hypre_ParCSRBlockMatrixDNumNonzeros(P_block_array[level]);
          num_mem[level] += global_nonzeros;
- 
+
          min_weight = 1.0;
          max_weight = 0.0;
          max_rowsum = 0.0;
          min_rowsum = 0.0;
          min_entries = 0;
          max_entries = 0;
-         
+
          if (hypre_CSRBlockMatrixNumRows(P_block_diag))
          {
-            if (hypre_CSRBlockMatrixNumCols(P_block_diag)) 
+            if (hypre_CSRBlockMatrixNumCols(P_block_diag))
             {
                hypre_CSRBlockMatrixBlockNorm(6, &P_diag_data[0], &tmp_norm, block_size);
                min_weight = tmp_norm;
             }
-            
+
 
             for (j = P_diag_i[0]; j < P_diag_i[1]; j++)
             {
@@ -721,27 +721,27 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
             }
             for (j = P_offd_i[0]; j < P_offd_i[1]; j++)
-            {        
+            {
                hypre_CSRBlockMatrixBlockNorm(6, &P_offd_data[j*bnnz], &tmp_norm, block_size);
-               min_weight = hypre_min(min_weight, tmp_norm); 
- 
+               min_weight = hypre_min(min_weight, tmp_norm);
+
               if (tmp_norm != 1.0)
-                  max_weight = hypre_max(max_weight, tmp_norm);     
+                  max_weight = hypre_max(max_weight, tmp_norm);
 
                min_rowsum += tmp_norm;
             }
-            
+
             max_rowsum = min_rowsum;
-            
-            min_entries = (P_diag_i[1]-P_diag_i[0])+(P_offd_i[1]-P_offd_i[0]); 
+
+            min_entries = (P_diag_i[1]-P_diag_i[0])+(P_offd_i[1]-P_offd_i[0]);
             max_entries = 0;
-            
+
             for (j = 0; j < hypre_CSRBlockMatrixNumRows(P_block_diag); j++)
             {
                entries = (P_diag_i[j+1]-P_diag_i[j])+(P_offd_i[j+1]-P_offd_i[j]);
                min_entries = hypre_min(entries, min_entries);
                max_entries = hypre_max(entries, max_entries);
-               
+
                rowsum = 0.0;
                for (i = P_diag_i[j]; i < P_diag_i[j+1]; i++)
                {
@@ -753,51 +753,51 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
                   rowsum += tmp_norm;
                }
-               
+
                for (i = P_offd_i[j]; i < P_offd_i[j+1]; i++)
                {
                   hypre_CSRBlockMatrixBlockNorm(6, &P_offd_data[i*bnnz], &tmp_norm, block_size);
                   min_weight = hypre_min(min_weight, tmp_norm);
 
-                  if (tmp_norm != 1.0) 
+                  if (tmp_norm != 1.0)
                      max_weight = hypre_max(max_weight, P_offd_data[i]);
 
                   rowsum += tmp_norm;
                }
-               
+
                min_rowsum = hypre_min(rowsum, min_rowsum);
                max_rowsum = hypre_max(rowsum, max_rowsum);
             }
-         
+
 
          }
          avg_entries = ((HYPRE_Real) (global_nonzeros - coarse_size)) / ((HYPRE_Real) (fine_size - coarse_size));
       }
-      else 
+      else
       {
          P_diag = hypre_ParCSRMatrixDiag(P_array[level]);
          P_diag_data = hypre_CSRMatrixData(P_diag);
          P_diag_i = hypre_CSRMatrixI(P_diag);
-         
-         P_offd = hypre_ParCSRMatrixOffd(P_array[level]);   
+
+         P_offd = hypre_ParCSRMatrixOffd(P_array[level]);
          P_offd_data = hypre_CSRMatrixData(P_offd);
          P_offd_i = hypre_CSRMatrixI(P_offd);
-         
+
          row_starts = hypre_ParCSRMatrixRowStarts(P_array[level]);
-         
+
          fine_size = hypre_ParCSRMatrixGlobalNumRows(P_array[level]);
          coarse_size = hypre_ParCSRMatrixGlobalNumCols(P_array[level]);
          hypre_ParCSRMatrixSetDNumNonzeros(P_array[level]);
          global_nonzeros = hypre_ParCSRMatrixDNumNonzeros(P_array[level]);
          num_mem[level] += (HYPRE_Real) global_nonzeros;
-         
+
          min_weight = 1.0;
          max_weight = 0.0;
          max_rowsum = 0.0;
          min_rowsum = 0.0;
          min_entries = 0;
          max_entries = 0;
-         
+
          if (hypre_CSRMatrixNumRows(P_diag))
          {
             if (P_diag_data) min_weight = P_diag_data[0];
@@ -809,24 +809,24 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
                min_rowsum += P_diag_data[j];
             }
             for (j = P_offd_i[0]; j < P_offd_i[1]; j++)
-            {        
-               min_weight = hypre_min(min_weight, P_offd_data[j]); 
+            {
+               min_weight = hypre_min(min_weight, P_offd_data[j]);
                if (P_offd_data[j] != 1.0)
-                  max_weight = hypre_max(max_weight, P_offd_data[j]);     
+                  max_weight = hypre_max(max_weight, P_offd_data[j]);
                min_rowsum += P_offd_data[j];
             }
-            
+
             max_rowsum = min_rowsum;
-            
-            min_entries = (P_diag_i[1]-P_diag_i[0])+(P_offd_i[1]-P_offd_i[0]); 
+
+            min_entries = (P_diag_i[1]-P_diag_i[0])+(P_offd_i[1]-P_offd_i[0]);
             max_entries = 0;
-            
+
             for (j = 0; j < hypre_CSRMatrixNumRows(P_diag); j++)
             {
                entries = (P_diag_i[j+1]-P_diag_i[j])+(P_offd_i[j+1]-P_offd_i[j]);
                min_entries = hypre_min(entries, min_entries);
                max_entries = hypre_max(entries, max_entries);
-               
+
                rowsum = 0.0;
                for (i = P_diag_i[j]; i < P_diag_i[j+1]; i++)
                {
@@ -835,19 +835,19 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
                      max_weight = hypre_max(max_weight, P_diag_data[i]);
                   rowsum += P_diag_data[i];
                }
-               
+
                for (i = P_offd_i[j]; i < P_offd_i[j+1]; i++)
                {
                   min_weight = hypre_min(min_weight, P_offd_data[i]);
-                  if (P_offd_data[i] != 1.0) 
+                  if (P_offd_data[i] != 1.0)
                      max_weight = hypre_max(max_weight, P_offd_data[i]);
                   rowsum += P_offd_data[i];
                }
-               
+
                min_rowsum = hypre_min(rowsum, min_rowsum);
                max_rowsum = hypre_max(rowsum, max_rowsum);
             }
-         
+
          }
          avg_entries = ((HYPRE_Real) (global_nonzeros - coarse_size)) / ((HYPRE_Real) (fine_size - coarse_size));
       }
@@ -862,7 +862,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
          min_rowsum =  1.0e7;
          min_weight = 1.0e7;
        }
-       
+
       send_buff[0] = - (HYPRE_Real) min_entries;
       send_buff[1] = (HYPRE_Real) max_entries;
       send_buff[2] = - min_rowsum;
@@ -891,16 +891,16 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
 
 #else
-      
+
       send_buff[0] = (HYPRE_Real) min_entries;
       send_buff[1] = (HYPRE_Real) max_entries;
       send_buff[2] = min_rowsum;
       send_buff[3] = max_rowsum;
       send_buff[4] = min_weight;
       send_buff[5] = max_weight;
-      
+
       hypre_MPI_Gather(send_buff,6,HYPRE_MPI_REAL,gather_buff,6,HYPRE_MPI_REAL,0,comm);
-      
+
       if (my_id == 0)
       {
          global_min_e = 1000000;
@@ -909,7 +909,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
          global_max_rsum = 0.0;
          global_min_wt = 1.0e7;
          global_max_wt = 0.0;
-         
+
          for (j = 0; j < num_procs; j++)
          {
             numrows = row_starts[j+1] - row_starts[j];
@@ -923,7 +923,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
             global_max_rsum = hypre_max(global_max_rsum, gather_buff[j*6+3]);
             global_max_wt = hypre_max(global_max_wt, gather_buff[j*6+5]);
          }
-         
+
          hypre_printf("%3d %*b x %-*b %3d  %3d",
                 level, ndigits[0], fine_size, ndigits[0], coarse_size,
                 global_min_e, global_max_e);
@@ -947,7 +947,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
    }
    if (num_variables[0] != 0)
       grid_cmplxty = total_variables / num_variables[0];
- 
+
    if (my_id == 0 )
    {
       hypre_printf("\n\n");
@@ -958,10 +958,10 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
    }
 
    if (my_id == 0)
-   { 
+   {
       hypre_printf("\n\nBoomerAMG SOLVER PARAMETERS:\n\n");
       hypre_printf( "  Maximum number of cycles:         %d \n",max_iter);
-      hypre_printf( "  Stopping Tolerance:               %e \n",tol); 
+      hypre_printf( "  Stopping Tolerance:               %e \n",tol);
       hypre_printf( "  Cycle type (1 = V, 2 = W, etc.):  %d\n\n", cycle_type);
 
       if (additive == 0 || mult_additive == 0 || simple == 0)
@@ -1059,7 +1059,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
               hypre_printf("  %2d  %2d", minus_one, one);
             hypre_printf( "\n");
          }
-         else 
+         else
          {
             hypre_printf( "                  Pre-CG relaxation (down):");
             for (j = 0; j < num_grid_sweeps[1]; j++)
@@ -1108,7 +1108,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
               hypre_printf("  %2d", zero);
          hypre_printf( "\n\n");
       }
-      else 
+      else
       {
          hypre_printf( "  Relaxation Parameters:\n");
          hypre_printf( "   Visiting Grid:                     down   up  coarse\n");
@@ -1149,7 +1149,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
               hypre_printf("  %2d", zero);
             hypre_printf( "\n\n");
          }
-         else 
+         else
          {
             hypre_printf( "                  Pre-CG relaxation (down):");
             for (j = 0; j < num_grid_sweeps[1]; j++)
@@ -1191,9 +1191,9 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
    hypre_TFree(num_variables, HYPRE_MEMORY_HOST);
    hypre_TFree(send_buff, HYPRE_MEMORY_HOST);
    hypre_TFree(gather_buff, HYPRE_MEMORY_HOST);
-   
+
    return(0);
-}  
+}
 
 
 
@@ -1204,59 +1204,59 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
 
 HYPRE_Int    hypre_BoomerAMGWriteSolverParams(void* data)
-{ 
+{
    hypre_ParAMGData  *amg_data = (hypre_ParAMGData*) data;
- 
+
    /* amg solve params */
-   HYPRE_Int      num_levels; 
+   HYPRE_Int      num_levels;
    HYPRE_Int      max_iter;
-   HYPRE_Int      cycle_type;    
-   HYPRE_Int     *num_grid_sweeps;  
-   HYPRE_Int     *grid_relax_type;   
-   HYPRE_Int    **grid_relax_points; 
+   HYPRE_Int      cycle_type;
+   HYPRE_Int     *num_grid_sweeps;
+   HYPRE_Int     *grid_relax_type;
+   HYPRE_Int    **grid_relax_points;
    HYPRE_Int      relax_order;
    HYPRE_Real  *relax_weight;
    HYPRE_Real  *omega;
    HYPRE_Real   tol;
-   HYPRE_Int      smooth_type; 
-   HYPRE_Int      smooth_num_levels; 
+   HYPRE_Int      smooth_type;
+   HYPRE_Int      smooth_num_levels;
    /* amg output params */
    HYPRE_Int      amg_print_level;
- 
+
    HYPRE_Int      j;
    HYPRE_Int      one = 1;
    HYPRE_Int      minus_one = -1;
    HYPRE_Int      zero = 0;
- 
- 
+
+
    /*----------------------------------------------------------
     * Get the amg_data data
     *----------------------------------------------------------*/
 
    num_levels = hypre_ParAMGDataNumLevels(amg_data);
    max_iter   = hypre_ParAMGDataMaxIter(amg_data);
-   cycle_type = hypre_ParAMGDataCycleType(amg_data);    
-   num_grid_sweeps = hypre_ParAMGDataNumGridSweeps(amg_data);  
+   cycle_type = hypre_ParAMGDataCycleType(amg_data);
+   num_grid_sweeps = hypre_ParAMGDataNumGridSweeps(amg_data);
    grid_relax_type = hypre_ParAMGDataGridRelaxType(amg_data);
    grid_relax_points = hypre_ParAMGDataGridRelaxPoints(amg_data);
    relax_order = hypre_ParAMGDataRelaxOrder(amg_data);
-   relax_weight = hypre_ParAMGDataRelaxWeight(amg_data); 
-   omega = hypre_ParAMGDataOmega(amg_data); 
-   smooth_type = hypre_ParAMGDataSmoothType(amg_data); 
-   smooth_num_levels = hypre_ParAMGDataSmoothNumLevels(amg_data); 
+   relax_weight = hypre_ParAMGDataRelaxWeight(amg_data);
+   omega = hypre_ParAMGDataOmega(amg_data);
+   smooth_type = hypre_ParAMGDataSmoothType(amg_data);
+   smooth_num_levels = hypre_ParAMGDataSmoothNumLevels(amg_data);
    tol = hypre_ParAMGDataTol(amg_data);
- 
+
    amg_print_level = hypre_ParAMGDataPrintLevel(amg_data);
- 
+
    /*----------------------------------------------------------
     * AMG info
     *----------------------------------------------------------*/
- 
+
    if (amg_print_level == 1 || amg_print_level == 3)
-   { 
+   {
       hypre_printf("\n\nBoomerAMG SOLVER PARAMETERS:\n\n");
       hypre_printf( "  Maximum number of cycles:         %d \n",max_iter);
-      hypre_printf( "  Stopping Tolerance:               %e \n",tol); 
+      hypre_printf( "  Stopping Tolerance:               %e \n",tol);
       hypre_printf( "  Cycle type (1 = V, 2 = W, etc.):  %d\n\n", cycle_type);
       hypre_printf( "  Relaxation Parameters:\n");
       hypre_printf( "   Visiting Grid:                     down   up  coarse\n");
@@ -1297,7 +1297,7 @@ HYPRE_Int    hypre_BoomerAMGWriteSolverParams(void* data)
               hypre_printf("  %2d", zero);
          hypre_printf( "\n\n");
       }
-      else 
+      else
       {
          hypre_printf( "                  Pre-CG relaxation (down):");
          for (j = 0; j < num_grid_sweeps[1]; j++)
@@ -1325,6 +1325,6 @@ HYPRE_Int    hypre_BoomerAMGWriteSolverParams(void* data)
 
       hypre_printf( " Output flag (print_level): %d \n", amg_print_level);
    }
- 
+
    return 0;
 }

--- a/src/parcsr_ls/par_stats.c
+++ b/src/parcsr_ls/par_stats.c
@@ -104,7 +104,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
 
    HYPRE_Int       i;
-   
+   HYPRE_Int	   ndigits;
 
    HYPRE_BigInt    coarse_size;
    HYPRE_Int       entries;
@@ -572,7 +572,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
           global_min_rsum = - gather_buff[2];
           global_max_rsum = gather_buff[3];
           
-          hypre_printf( "%2d %7b %8.0f  %0.3f  %4d %4d",
+          hypre_printf("%3d %7b %8.0f  %0.3f  %4d %4d",
                   level, fine_size, global_nonzeros, sparse, global_min_e, 
                   global_max_e);
           hypre_printf("  %4.1f  %10.3e  %10.3e\n", avg_entries,
@@ -606,7 +606,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
              global_max_rsum = hypre_max(global_max_rsum, gather_buff[j*4 +3]);
           }
 
-          hypre_printf( "%2d %7b %8.0f  %0.3f  %4d %4d",
+          hypre_printf("%3d %7b %8.0f  %0.3f  %4d %4d",
                   level, fine_size, global_nonzeros, sparse, global_min_e, 
                   global_max_e);
           hypre_printf("  %4.1f  %10.3e  %10.3e\n", avg_entries,
@@ -619,6 +619,16 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
    }
 
        
+   if (block_mode)
+   {
+      ndigits = hypre_ndigits(hypre_ParCSRBlockMatrixGlobalNumRows(P_block_array[0]));
+   }
+   else
+   {
+      ndigits = hypre_ndigits(hypre_ParCSRMatrixGlobalNumRows(P_array[0]));
+   }
+   ndigits = hypre_max(5, ndigits);
+
    if (my_id == 0)
    {
       if (block_mode)
@@ -632,18 +642,17 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
         
       }
       
-      hypre_printf("                 entries/row    min     max");
-      hypre_printf("         row sums\n");
-      hypre_printf("lev  rows cols    min max  ");
-      hypre_printf("   weight   weight     min       max \n");
-      hypre_printf("=======================================");
-      hypre_printf("==========================\n");
+      hypre_printf("%*s ", (2*ndigits + 21), "entries/row");
+      hypre_printf("%10s %10s %19s\n", "min", "max", "row sums");
+      hypre_printf("lev %*s x %-*s min  max  avgW", ndigits, "rows", ndigits, "cols");
+      hypre_printf("%11s %11s %9s %11s\n", "weight", "weight", "min", "max");
+      for (i = 0; i < (70 + 2*ndigits); i++) hypre_printf("%s", "=");
+      hypre_printf("\n");
    }
-  
+
    /*-----------------------------------------------------
     *  Enter Statistics Loop
     *-----------------------------------------------------*/
-
 
    for (level = 0; level < num_levels-1; level++)
    {
@@ -854,10 +863,11 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
          global_min_wt = -gather_buff[4];
          global_max_wt = gather_buff[5];
 
-          hypre_printf( "%2d %5b x %-5b %3d %3d",
-                 level, fine_size, coarse_size,  global_min_e, global_max_e);
-         hypre_printf("  %10.3e %9.3e %9.3e %9.3e\n",
-                global_min_wt, global_max_wt, 
+         hypre_printf("%3d %*b x %-*b %3d  %3d",
+                level, ndigits, fine_size, ndigits, coarse_size,
+                global_min_e, global_max_e);
+         hypre_printf("  %4.1f  %10.3e  %10.3e  %10.3e  %10.3e\n",
+                avg_entries, global_min_wt, global_max_wt,
                 global_min_rsum, global_max_rsum);
       }
 
@@ -896,10 +906,11 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
             global_max_wt = hypre_max(global_max_wt, gather_buff[j*6+5]);
          }
          
-         hypre_printf( "%2d %5b x %-5b %3d %3d",
-                 level, fine_size, coarse_size,  global_min_e, global_max_e);
-         hypre_printf("  %10.3e %9.3e %9.3e %9.3e\n",
-                global_min_wt, global_max_wt, 
+         hypre_printf("%3d %*b x %-*b %3d  %3d",
+                level, ndigits, fine_size, ndigits, coarse_size, 
+                global_min_e, global_max_e);
+         hypre_printf("  %4.1f  %10.3e  %10.3e  %10.3e  %10.3e\n",
+                avg_entries, global_min_wt, global_max_wt, 
                 global_min_rsum, global_max_rsum);
       }
 
@@ -921,12 +932,12 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
  
    if (my_id == 0 )
    {
-      hypre_printf("\n\n     Complexity:    grid = %f\n",grid_cmplxty);
+      hypre_printf("\n\n");
+      hypre_printf("     Complexity:    grid = %f\n",grid_cmplxty);
       hypre_printf("                operator = %f\n",operat_cmplxty);
-      hypre_printf("                memory = %f\n",memory_cmplxty);
+      hypre_printf("                  memory = %f\n",memory_cmplxty);
+      hypre_printf("\n\n");
    }
-
-   if (my_id == 0) hypre_printf("\n\n");
 
    if (my_id == 0)
    { 

--- a/src/test/TEST_examples/bigint.saved
+++ b/src/test/TEST_examples/bigint.saved
@@ -2,45 +2,45 @@
 
 Operator Matrix Information:
 
-            nonzero         entries per row        row sums
-lev   rows  entries  sparse  min  max   avg       min         max
-===================================================================
- 0    1089     5313  0.004     3    5   4.9   0.000e+00   2.000e+00
- 1     545     4641  0.016     4    9   8.5   0.000e+00   2.500e+00
- 2     157     1535  0.062     4   14   9.8  -4.233e-16   3.020e+00
- 3      57      773  0.238     4   21  13.6   7.589e-17   3.294e+00
- 4      19      251  0.695     8   18  13.2   9.852e-02   2.814e+00
- 5       6       36  1.000     6    6   6.0   1.232e+00   1.875e+00
+             nonzero            entries/row          row sums
+lev    rows  entries sparse   min  max     avg      min         max
+======================================================================
+  0    1089     5313  0.004     3    5     4.9   0.000e+00   2.000e+00
+  1     545     4641  0.016     4    9     8.5   0.000e+00   2.500e+00
+  2     157     1535  0.062     4   14     9.8  -4.233e-16   3.020e+00
+  3      57      773  0.238     4   21    13.6   7.589e-17   3.294e+00
+  4      19      251  0.695     8   18    13.2   9.852e-02   2.814e+00
+  5       6       36  1.000     6    6     6.0   1.232e+00   1.875e+00
 
 
 Interpolation Matrix Information:
-                 entries/row    min     max         row sums
-lev  rows cols    min max     weight   weight     min       max 
-=================================================================
- 0  1089 x 545     1   4   2.500e-01 2.500e-01 7.500e-01 1.000e+00
- 1   545 x 157     1   4   7.143e-02 5.000e-01 2.857e-01 1.000e+00
- 2   157 x 57      1   6   2.767e-02 5.489e-01 2.630e-01 1.000e+00
- 3    57 x 19      0   5   1.892e-02 7.312e-01 0.000e+00 1.000e+00
- 4    19 x 6       0   4   2.675e-02 4.155e-01 0.000e+00 1.000e+00
+                    entries/row        min        max            row sums
+lev  rows x cols  min  max  avgW     weight      weight       min         max
+================================================================================
+  0  1089 x 545     1    4   3.9   2.500e-01   2.500e-01   7.500e-01   1.000e+00
+  1   545 x 157     1    4   2.8   7.143e-02   5.000e-01   2.857e-01   1.000e+00
+  2   157 x 57      1    6   3.1   2.767e-02   5.489e-01   2.630e-01   1.000e+00
+  3    57 x 19      0    5   2.4   1.892e-02   7.312e-01   0.000e+00   1.000e+00
+  4    19 x 6       0    4   2.2   2.675e-02   4.155e-01   0.000e+00   1.000e+00
 
 
      Complexity:    grid = 1.719927
                 operator = 2.361942
-                memory = 3.194052
+                  memory = 3.194052
 
 
 
 
 BoomerAMG SOLVER PARAMETERS:
 
-  Maximum number of cycles:         20 
-  Stopping Tolerance:               1.000000e-07 
+  Maximum number of cycles:         20
+  Stopping Tolerance:               1.000000e-07
   Cycle type (1 = V, 2 = W, etc.):  1
 
   Relaxation Parameters:
    Visiting Grid:                     down   up  coarse
-            Number of sweeps:            1    1     1 
-   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9 
+            Number of sweeps:            1    1     1
+   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9
    Point types, partial sweeps (1=C, -1=F):
                   Pre-CG relaxation (down):   1  -1
                    Post-CG relaxation (up):  -1   1
@@ -50,20 +50,20 @@ BoomerAMG SOLVER PARAMETERS:
 
 BoomerAMG SOLVER PARAMETERS:
 
-  Maximum number of cycles:         20 
-  Stopping Tolerance:               1.000000e-07 
+  Maximum number of cycles:         20
+  Stopping Tolerance:               1.000000e-07
   Cycle type (1 = V, 2 = W, etc.):  1
 
   Relaxation Parameters:
    Visiting Grid:                     down   up  coarse
-            Number of sweeps:            1    1     1 
-   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9 
+            Number of sweeps:            1    1     1
+   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9
    Point types, partial sweeps (1=C, -1=F):
                   Pre-CG relaxation (down):   1  -1
                    Post-CG relaxation (up):  -1   1
                              Coarsest grid:   0
 
- Output flag (print_level): 3 
+ Output flag (print_level): 3
 
 
 AMG SOLUTION INFO:
@@ -71,13 +71,13 @@ AMG SOLUTION INFO:
                residual        factor       residual
                --------        ------       --------
     Initial    2.854671e-02                 1.000000e+00
-    Cycle  1   2.995663e-03    0.104939     1.049390e-01 
-    Cycle  2   1.941234e-04    0.064801     6.800200e-03 
-    Cycle  3   1.245674e-05    0.064169     4.363634e-04 
-    Cycle  4   7.816537e-07    0.062749     2.738157e-05 
-    Cycle  5   4.829130e-08    0.061781     1.691659e-06 
-    Cycle  6   2.956748e-09    0.061227     1.035758e-07 
-    Cycle  7   1.801266e-10    0.060921     6.309890e-09 
+    Cycle  1   2.995663e-03    0.104939     1.049390e-01
+    Cycle  2   1.941234e-04    0.064801     6.800200e-03
+    Cycle  3   1.245674e-05    0.064169     4.363634e-04
+    Cycle  4   7.816537e-07    0.062749     2.738157e-05
+    Cycle  5   4.829130e-08    0.061781     1.691659e-06
+    Cycle  6   2.956748e-09    0.061227     1.035758e-07
+    Cycle  7   1.801266e-10    0.060921     6.309890e-09
 
 
  Average Convergence Factor = 0.067387
@@ -117,7 +117,7 @@ AMS Setup:
 
 
 Iters       ||r||_C     conv.rate  ||r||_C/||b||_C
------    ------------    ---------  ------------ 
+-----    ------------    ---------  ------------
     1    2.820328e-02    0.097467    9.746663e-02
     2    1.245772e-03    0.044171    4.305215e-03
     3    9.147965e-05    0.073432    3.161410e-04

--- a/src/test/TEST_examples/default.saved
+++ b/src/test/TEST_examples/default.saved
@@ -3,7 +3,7 @@
 
 
 Iters       ||r||_C     conv.rate  ||r||_C/||b||_C
------    ------------    ---------  ------------ 
+-----    ------------    ---------  ------------
     1    2.509980e+00    0.591608    5.916080e-01
     2    9.888265e-01    0.393958    2.330686e-01
     3    4.572262e-01    0.462393    1.077693e-01
@@ -24,7 +24,7 @@ Iters       ||r||_C     conv.rate  ||r||_C/||b||_C
 
 
 Iters       ||r||_C     conv.rate  ||r||_C/||b||_C
------    ------------    ---------  ------------ 
+-----    ------------    ---------  ------------
     1    3.503257e-02    0.004729    4.728807e-03
     2    1.386843e-04    0.003959    1.872005e-05
     3    8.429961e-07    0.006079    1.137903e-07
@@ -35,7 +35,7 @@ Iters       ||r||_C     conv.rate  ||r||_C/||b||_C
 
 
 Iters       ||r||_2     conv.rate  ||r||_2/||b||_2
------    ------------   ---------  ------------ 
+-----    ------------   ---------  ------------
     1    2.168867e-03    0.290645    2.906446e-01
     2    8.424332e-05    0.038842    1.128924e-02
     3    1.941992e-06    0.023052    2.602417e-04
@@ -61,7 +61,7 @@ PCG Setup:
 
 
 Iters       ||r||_2     conv.rate  ||r||_2/||b||_2
------    ------------   ---------  ------------ 
+-----    ------------   ---------  ------------
     1    2.449562e-03    0.323361    3.233611e-01
     2    1.589475e-04    0.064888    2.098229e-02
     3    6.225562e-06    0.039167    8.218220e-04
@@ -87,45 +87,45 @@ Final Relative Residual Norm = 5.961443e-08
 
 Operator Matrix Information:
 
-            nonzero         entries per row        row sums
-lev   rows  entries  sparse  min  max   avg       min         max
-===================================================================
- 0    1089     5313  0.004     3    5   4.9   0.000e+00   2.000e+00
- 1     545     4641  0.016     4    9   8.5   0.000e+00   2.500e+00
- 2     157     1535  0.062     4   14   9.8  -4.233e-16   3.020e+00
- 3      57      773  0.238     4   21  13.6   7.589e-17   3.294e+00
- 4      19      251  0.695     8   18  13.2   9.852e-02   2.814e+00
- 5       6       36  1.000     6    6   6.0   1.232e+00   1.875e+00
+             nonzero            entries/row          row sums
+lev    rows  entries sparse   min  max     avg      min         max
+======================================================================
+  0    1089     5313  0.004     3    5     4.9   0.000e+00   2.000e+00
+  1     545     4641  0.016     4    9     8.5   0.000e+00   2.500e+00
+  2     157     1535  0.062     4   14     9.8  -4.233e-16   3.020e+00
+  3      57      773  0.238     4   21    13.6   7.589e-17   3.294e+00
+  4      19      251  0.695     8   18    13.2   9.852e-02   2.814e+00
+  5       6       36  1.000     6    6     6.0   1.232e+00   1.875e+00
 
 
 Interpolation Matrix Information:
-                 entries/row    min     max         row sums
-lev  rows cols    min max     weight   weight     min       max 
-=================================================================
- 0  1089 x 545     1   4   2.500e-01 2.500e-01 7.500e-01 1.000e+00
- 1   545 x 157     1   4   7.143e-02 5.000e-01 2.857e-01 1.000e+00
- 2   157 x 57      1   6   2.767e-02 5.489e-01 2.630e-01 1.000e+00
- 3    57 x 19      0   5   1.892e-02 7.312e-01 0.000e+00 1.000e+00
- 4    19 x 6       0   4   2.675e-02 4.155e-01 0.000e+00 1.000e+00
+                    entries/row        min        max            row sums
+lev  rows x cols  min  max  avgW     weight      weight       min         max
+================================================================================
+  0  1089 x 545     1    4   3.9   2.500e-01   2.500e-01   7.500e-01   1.000e+00
+  1   545 x 157     1    4   2.8   7.143e-02   5.000e-01   2.857e-01   1.000e+00
+  2   157 x 57      1    6   3.1   2.767e-02   5.489e-01   2.630e-01   1.000e+00
+  3    57 x 19      0    5   2.4   1.892e-02   7.312e-01   0.000e+00   1.000e+00
+  4    19 x 6       0    4   2.2   2.675e-02   4.155e-01   0.000e+00   1.000e+00
 
 
      Complexity:    grid = 1.719927
                 operator = 2.361942
-                memory = 3.194052
+                  memory = 3.194052
 
 
 
 
 BoomerAMG SOLVER PARAMETERS:
 
-  Maximum number of cycles:         20 
-  Stopping Tolerance:               1.000000e-07 
+  Maximum number of cycles:         20
+  Stopping Tolerance:               1.000000e-07
   Cycle type (1 = V, 2 = W, etc.):  1
 
   Relaxation Parameters:
    Visiting Grid:                     down   up  coarse
-            Number of sweeps:            1    1     1 
-   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9 
+            Number of sweeps:            1    1     1
+   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9
    Point types, partial sweeps (1=C, -1=F):
                   Pre-CG relaxation (down):   1  -1
                    Post-CG relaxation (up):  -1   1
@@ -135,20 +135,20 @@ BoomerAMG SOLVER PARAMETERS:
 
 BoomerAMG SOLVER PARAMETERS:
 
-  Maximum number of cycles:         20 
-  Stopping Tolerance:               1.000000e-07 
+  Maximum number of cycles:         20
+  Stopping Tolerance:               1.000000e-07
   Cycle type (1 = V, 2 = W, etc.):  1
 
   Relaxation Parameters:
    Visiting Grid:                     down   up  coarse
-            Number of sweeps:            1    1     1 
-   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9 
+            Number of sweeps:            1    1     1
+   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9
    Point types, partial sweeps (1=C, -1=F):
                   Pre-CG relaxation (down):   1  -1
                    Post-CG relaxation (up):  -1   1
                              Coarsest grid:   0
 
- Output flag (print_level): 3 
+ Output flag (print_level): 3
 
 
 AMG SOLUTION INFO:
@@ -156,13 +156,13 @@ AMG SOLUTION INFO:
                residual        factor       residual
                --------        ------       --------
     Initial    2.854671e-02                 1.000000e+00
-    Cycle  1   2.995663e-03    0.104939     1.049390e-01 
-    Cycle  2   1.941234e-04    0.064801     6.800200e-03 
-    Cycle  3   1.245674e-05    0.064169     4.363634e-04 
-    Cycle  4   7.816537e-07    0.062749     2.738157e-05 
-    Cycle  5   4.829130e-08    0.061781     1.691659e-06 
-    Cycle  6   2.956748e-09    0.061227     1.035758e-07 
-    Cycle  7   1.801266e-10    0.060921     6.309890e-09 
+    Cycle  1   2.995663e-03    0.104939     1.049390e-01
+    Cycle  2   1.941234e-04    0.064801     6.800200e-03
+    Cycle  3   1.245674e-05    0.064169     4.363634e-04
+    Cycle  4   7.816537e-07    0.062749     2.738157e-05
+    Cycle  5   4.829130e-08    0.061781     1.691659e-06
+    Cycle  6   2.956748e-09    0.061227     1.035758e-07
+    Cycle  7   1.801266e-10    0.060921     6.309890e-09
 
 
  Average Convergence Factor = 0.067387
@@ -181,45 +181,45 @@ Final Relative Residual Norm = 6.309890e-09
 
 Operator Matrix Information:
 
-            nonzero         entries per row        row sums
-lev   rows  entries  sparse  min  max   avg       min         max
-===================================================================
- 0    1089     5313  0.004     3    5   4.9   0.000e+00   2.000e+00
- 1     545     4641  0.016     4    9   8.5   0.000e+00   2.500e+00
- 2     157     1535  0.062     4   14   9.8  -4.233e-16   3.020e+00
- 3      57      773  0.238     4   21  13.6   7.589e-17   3.294e+00
- 4      19      251  0.695     8   18  13.2   9.852e-02   2.814e+00
- 5       6       36  1.000     6    6   6.0   1.232e+00   1.875e+00
+             nonzero            entries/row          row sums
+lev    rows  entries sparse   min  max     avg      min         max
+======================================================================
+  0    1089     5313  0.004     3    5     4.9   0.000e+00   2.000e+00
+  1     545     4641  0.016     4    9     8.5   0.000e+00   2.500e+00
+  2     157     1535  0.062     4   14     9.8  -4.233e-16   3.020e+00
+  3      57      773  0.238     4   21    13.6   7.589e-17   3.294e+00
+  4      19      251  0.695     8   18    13.2   9.852e-02   2.814e+00
+  5       6       36  1.000     6    6     6.0   1.232e+00   1.875e+00
 
 
 Interpolation Matrix Information:
-                 entries/row    min     max         row sums
-lev  rows cols    min max     weight   weight     min       max 
-=================================================================
- 0  1089 x 545     1   4   2.500e-01 2.500e-01 7.500e-01 1.000e+00
- 1   545 x 157     1   4   7.143e-02 5.000e-01 2.857e-01 1.000e+00
- 2   157 x 57      1   6   2.767e-02 5.489e-01 2.630e-01 1.000e+00
- 3    57 x 19      0   5   1.892e-02 7.312e-01 0.000e+00 1.000e+00
- 4    19 x 6       0   4   2.675e-02 4.155e-01 0.000e+00 1.000e+00
+                    entries/row        min        max            row sums
+lev  rows x cols  min  max  avgW     weight      weight       min         max
+================================================================================
+  0  1089 x 545     1    4   3.9   2.500e-01   2.500e-01   7.500e-01   1.000e+00
+  1   545 x 157     1    4   2.8   7.143e-02   5.000e-01   2.857e-01   1.000e+00
+  2   157 x 57      1    6   3.1   2.767e-02   5.489e-01   2.630e-01   1.000e+00
+  3    57 x 19      0    5   2.4   1.892e-02   7.312e-01   0.000e+00   1.000e+00
+  4    19 x 6       0    4   2.2   2.675e-02   4.155e-01   0.000e+00   1.000e+00
 
 
      Complexity:    grid = 1.719927
                 operator = 2.361942
-                memory = 3.194052
+                  memory = 3.194052
 
 
 
 
 BoomerAMG SOLVER PARAMETERS:
 
-  Maximum number of cycles:         20 
-  Stopping Tolerance:               1.000000e-07 
+  Maximum number of cycles:         20
+  Stopping Tolerance:               1.000000e-07
   Cycle type (1 = V, 2 = W, etc.):  1
 
   Relaxation Parameters:
    Visiting Grid:                     down   up  coarse
-            Number of sweeps:            1    1     1 
-   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9 
+            Number of sweeps:            1    1     1
+   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9
    Point types, partial sweeps (1=C, -1=F):
                   Pre-CG relaxation (down):   1  -1
                    Post-CG relaxation (up):  -1   1
@@ -229,20 +229,20 @@ BoomerAMG SOLVER PARAMETERS:
 
 BoomerAMG SOLVER PARAMETERS:
 
-  Maximum number of cycles:         20 
-  Stopping Tolerance:               1.000000e-07 
+  Maximum number of cycles:         20
+  Stopping Tolerance:               1.000000e-07
   Cycle type (1 = V, 2 = W, etc.):  1
 
   Relaxation Parameters:
    Visiting Grid:                     down   up  coarse
-            Number of sweeps:            1    1     1 
-   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9 
+            Number of sweeps:            1    1     1
+   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:      3    3     9
    Point types, partial sweeps (1=C, -1=F):
                   Pre-CG relaxation (down):   1  -1
                    Post-CG relaxation (up):  -1   1
                              Coarsest grid:   0
 
- Output flag (print_level): 3 
+ Output flag (print_level): 3
 
 
 AMG SOLUTION INFO:
@@ -250,13 +250,13 @@ AMG SOLUTION INFO:
                residual        factor       residual
                --------        ------       --------
     Initial    2.854671e-02                 1.000000e+00
-    Cycle  1   2.995663e-03    0.104939     1.049390e-01 
-    Cycle  2   1.941234e-04    0.064801     6.800200e-03 
-    Cycle  3   1.245674e-05    0.064169     4.363634e-04 
-    Cycle  4   7.816537e-07    0.062749     2.738157e-05 
-    Cycle  5   4.829130e-08    0.061781     1.691659e-06 
-    Cycle  6   2.956748e-09    0.061227     1.035758e-07 
-    Cycle  7   1.801266e-10    0.060921     6.309890e-09 
+    Cycle  1   2.995663e-03    0.104939     1.049390e-01
+    Cycle  2   1.941234e-04    0.064801     6.800200e-03
+    Cycle  3   1.245674e-05    0.064169     4.363634e-04
+    Cycle  4   7.816537e-07    0.062749     2.738157e-05
+    Cycle  5   4.829130e-08    0.061781     1.691659e-06
+    Cycle  6   2.956748e-09    0.061227     1.035758e-07
+    Cycle  7   1.801266e-10    0.060921     6.309890e-09
 
 
  Average Convergence Factor = 0.067387
@@ -276,7 +276,7 @@ AMG SOLUTION INFO:
 
 
 Iters       ||r||_C     conv.rate  ||r||_C/||b||_C
------    ------------    ---------  ------------ 
+-----    ------------    ---------  ------------
     1    3.503257e-02    0.004729    4.728807e-03
     2    1.386843e-04    0.003959    1.872005e-05
     3    8.429961e-07    0.006079    1.137903e-07
@@ -296,7 +296,7 @@ PCG Setup:
 
 
 Iters       ||r||_2     conv.rate  ||r||_2/||b||_2
------    ------------   ---------  ------------ 
+-----    ------------   ---------  ------------
     1    2.449562e-03    0.323361    3.233611e-01
     2    1.589475e-04    0.064888    2.098229e-02
     3    6.225562e-06    0.039167    8.218220e-04
@@ -323,7 +323,7 @@ Final Relative Residual Norm = 5.961443e-08
 
 
 Iters       ||r||_C     conv.rate  ||r||_C/||b||_C
------    ------------    ---------  ------------ 
+-----    ------------    ---------  ------------
     1    2.197899e+00    0.373165    3.731645e-01
     2    4.545887e-01    0.206829    7.718115e-02
     3    1.058488e-01    0.232845    1.797126e-02
@@ -363,7 +363,7 @@ Final Relative Residual Norm = 6.57147e-07
 
 # Output file: default.out.10
 ***************************************************
-* Preconditioned Conjugate Gradient solver 
+* Preconditioned Conjugate Gradient solver
 * maximum no. of iterations = 100
 * convergence tolerance     = 1.000000e-06
 *--------------------------------------------------
@@ -388,7 +388,7 @@ AMG Schwarz relax weight = 1.000000e+00
 
 
 Iters       ||r||_2     conv.rate  ||r||_2/||b||_2
------    ------------   ---------  ------------ 
+-----    ------------   ---------  ------------
     1    6.568705e-03    0.794868    7.948685e-01
     2    2.229023e-03    0.339340    2.697305e-01
     3    4.395103e-04    0.197176    5.318444e-02
@@ -410,27 +410,27 @@ Iters       ||r||_2     conv.rate  ||r||_2/||b||_2
 ** HYPRE final residual norm       = 5.739829e-09
 ***************************************************
 # Output file: default.out.11
- 2   132 x 29      0   4   5.687e-03 5.328e-01 0.000e+00 1.000e+00
- 3    29 x 4       1   4   6.881e-03 4.675e-01 7.079e-02 1.000e+00
+  2   132 x 29      0    4   3.5   5.687e-03   5.328e-01   0.000e+00   1.000e+00
+  3    29 x 4       1    4   2.7   6.881e-03   4.675e-01   7.079e-02   1.000e+00
 
 
      Complexity:    grid = 1.651974
                 operator = 2.383776
-                memory = 3.295125
+                  memory = 3.295125
 
 
 
 
 BoomerAMG SOLVER PARAMETERS:
 
-  Maximum number of cycles:         1 
-  Stopping Tolerance:               0.000000e+00 
+  Maximum number of cycles:         1
+  Stopping Tolerance:               0.000000e+00
   Cycle type (1 = V, 2 = W, etc.):  1
 
   Relaxation Parameters:
    Visiting Grid:                     down   up  coarse
-            Number of sweeps:            2    2     1 
-   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:     13   14     9 
+            Number of sweeps:            2    2     1
+   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:     13   14     9
    Point types, partial sweeps (1=C, -1=F):
                   Pre-CG relaxation (down):   0   0
                    Post-CG relaxation (up):   0   0
@@ -508,7 +508,7 @@ LOBPCG Solve:
 
 
 Iters       ||r||_C     conv.rate  ||r||_C/||b||_C
------    ------------    ---------  ------------ 
+-----    ------------    ---------  ------------
     1    2.267211e-01    0.040016    4.001582e-02
     2    3.255341e-03    0.014358    5.745609e-04
     3    6.649011e-05    0.020425    1.173537e-05
@@ -520,7 +520,7 @@ Iters       ||r||_C     conv.rate  ||r||_C/||b||_C
 
 
 Iters       ||r||_C     conv.rate  ||r||_C/||b||_C
------    ------------    ---------  ------------ 
+-----    ------------    ---------  ------------
     1    2.267211e-01    0.040016    4.001582e-02
     2    3.255341e-03    0.014358    5.745609e-04
     3    6.649011e-05    0.020425    1.173537e-05
@@ -535,14 +535,14 @@ AMG SOLUTION INFO:
                residual        factor       residual
                --------        ------       --------
     Initial    2.334657e-01                 1.000000e+00
-    Cycle  1   3.447912e-02    0.147684     1.476839e-01 
-    Cycle  2   5.073235e-03    0.147139     2.173011e-02 
-    Cycle  3   7.530408e-04    0.148434     3.225487e-03 
-    Cycle  4   1.131421e-04    0.150247     4.846199e-04 
-    Cycle  5   1.713572e-05    0.151453     7.339717e-05 
-    Cycle  6   2.620347e-06    0.152917     1.122369e-05 
-    Cycle  7   4.055800e-07    0.154781     1.737214e-06 
-    Cycle  8   6.362639e-08    0.156878     2.725299e-07 
+    Cycle  1   3.447912e-02    0.147684     1.476839e-01
+    Cycle  2   5.073235e-03    0.147139     2.173011e-02
+    Cycle  3   7.530408e-04    0.148434     3.225487e-03
+    Cycle  4   1.131421e-04    0.150247     4.846199e-04
+    Cycle  5   1.713572e-05    0.151453     7.339717e-05
+    Cycle  6   2.620347e-06    0.152917     1.122369e-05
+    Cycle  7   4.055800e-07    0.154781     1.737214e-06
+    Cycle  8   6.362639e-08    0.156878     2.725299e-07
 
 
  Average Convergence Factor = 0.151156
@@ -565,14 +565,14 @@ AMG SOLUTION INFO:
                residual        factor       residual
                --------        ------       --------
     Initial    2.334657e-01                 1.000000e+00
-    Cycle  1   3.447912e-02    0.147684     1.476839e-01 
-    Cycle  2   5.073235e-03    0.147139     2.173011e-02 
-    Cycle  3   7.530408e-04    0.148434     3.225487e-03 
-    Cycle  4   1.131421e-04    0.150247     4.846199e-04 
-    Cycle  5   1.713572e-05    0.151453     7.339717e-05 
-    Cycle  6   2.620347e-06    0.152917     1.122369e-05 
-    Cycle  7   4.055800e-07    0.154781     1.737214e-06 
-    Cycle  8   6.362639e-08    0.156878     2.725299e-07 
+    Cycle  1   3.447912e-02    0.147684     1.476839e-01
+    Cycle  2   5.073235e-03    0.147139     2.173011e-02
+    Cycle  3   7.530408e-04    0.148434     3.225487e-03
+    Cycle  4   1.131421e-04    0.150247     4.846199e-04
+    Cycle  5   1.713572e-05    0.151453     7.339717e-05
+    Cycle  6   2.620347e-06    0.152917     1.122369e-05
+    Cycle  7   4.055800e-07    0.154781     1.737214e-06
+    Cycle  8   6.362639e-08    0.156878     2.725299e-07
 
 
  Average Convergence Factor = 0.151156
@@ -612,7 +612,7 @@ AMS Setup:
 
 
 Iters       ||r||_C     conv.rate  ||r||_C/||b||_C
------    ------------    ---------  ------------ 
+-----    ------------    ---------  ------------
     1    2.820328e-02    0.097467    9.746663e-02
     2    1.245772e-03    0.044171    4.305215e-03
     3    9.147965e-05    0.073432    3.161410e-04

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1785,6 +1785,7 @@ void HYPRE_Finalize();
 
 /* hypre_printf.c */
 // #ifdef HYPRE_BIGINT
+HYPRE_Int hypre_ndigits( HYPRE_BigInt number );
 HYPRE_Int hypre_printf( const char *format , ... );
 HYPRE_Int hypre_fprintf( FILE *stream , const char *format, ... );
 HYPRE_Int hypre_sprintf( char *s , const char *format, ... );

--- a/src/utilities/hypre_printf.c
+++ b/src/utilities/hypre_printf.c
@@ -116,6 +116,20 @@ free_format( char *newformat )
    return 0;
 }
 
+HYPRE_Int
+hypre_ndigits( HYPRE_BigInt number )
+{
+   HYPRE_Int     ndigits = 0;
+
+   while(number)
+   {
+      number /= 10;
+      ndigits++;
+   }
+
+   return ndigits;
+}
+
 /* printf functions */
 
 HYPRE_Int


### PR DESCRIPTION
In this PR, I'm adding a new column in "Interpolation Matrix Information" that gives the average number of Fine-Coarse connections per row of the prolongation operator for each level. Also, I'm fixing minor details such as the format of the tables and deletion of a few trailing whitespaces.