### PR TITLE
fix hypre_BoomerAMGBuildRestrNeumannAIR() mixedint build error

### DIFF
--- a/src/parcsr_ls/par_lr_restr.c
+++ b/src/parcsr_ls/par_lr_restr.c
@@ -1669,7 +1669,7 @@ hypre_BoomerAMGBuildRestrDist2AIR( hypre_ParCSRMatrix   *A,
 HYPRE_Int
 hypre_BoomerAMGBuildRestrNeumannAIR( hypre_ParCSRMatrix   *A,
                                      HYPRE_Int            *CF_marker,
-                                     HYPRE_Int            *num_cpts_global,
+                                     HYPRE_BigInt         *num_cpts_global,
                                      HYPRE_Int             num_functions,
                                      HYPRE_Int            *dof_func,
                                      HYPRE_Int             NeumannDeg,


### PR DESCRIPTION
--enable-bigint --enable-bigint=no --enable-mixedint=yes

```
par_lr_restr.c:1670:1: error: conflicting types for ‘hypre_BoomerAMGBuildRestrNeumannAIR’
 hypre_BoomerAMGBuildRestrNeumannAIR( hypre_ParCSRMatrix   *A,
 ^
In file included from par_lr_restr.c:8:0:
_hypre_parcsr_ls.h:1711:11: note: previous declaration of ‘hypre_BoomerAMGBuildRestrNeumannAIR’ was here
 HYPRE_Int hypre_BoomerAMGBuildRestrNeumannAIR( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker, HYPRE_BigInt *num_cpts_global, HYPRE_Int num_functions, HYPRE_Int *dof_func, HYPRE$
           ^
par_lr_restr.c: In function ‘hypre_BoomerAMGBuildRestrNeumannAIR’:
par_lr_restr.c:1995:33: warning: passing argument 4 of ‘hypre_ParCSRMatrixCreate’ from incompatible pointer type [enabled by default]
                                 nnz_offd);
                                 ^
In file included from _hypre_parcsr_ls.h:18:0,
                 from par_lr_restr.c:8:
./../parcsr_mv/_hypre_parcsr_mv.h:778:21: note: expected ‘HYPRE_BigInt *’ but argument is of type ‘HYPRE_Int *’
 hypre_ParCSRMatrix *hypre_ParCSRMatrixCreate ( MPI_Comm comm , HYPRE_BigInt global_num_rows , HYPRE_BigInt global_num_cols , HYPRE_BigInt *row_starts , HYPRE_BigInt *col_star$
                     ^
par_lr_restr.c:2009:36: warning: assignment from incompatible pointer type [enabled by default]
```