### PR TITLE
Added support to periodic geometries in FAC solver and fixed its setup

### DIFF
--- a/src/sstruct_ls/fac_amr_fcoarsen.c
+++ b/src/sstruct_ls/fac_amr_fcoarsen.c
@@ -2504,7 +2504,8 @@ hypre_AMR_FCoarsen( hypre_SStructMatrix  *   A,
 
          data_space = hypre_StructMatrixDataSpace(crse_smatrix);
          cdata_space_ranks= hypre_CTAlloc(HYPRE_Int,  cbox_array_size, HYPRE_MEMORY_HOST);
-         cdata_space_ranks[0]= 0;
+         if (cbox_array_size)
+            cdata_space_ranks[0]= 0;
          for (i= 1; i< cbox_array_size; i++)
          {
             cdata_space_ranks[i]= cdata_space_ranks[i-1]+

--- a/src/sstruct_ls/fac_cfstencil_box.c
+++ b/src/sstruct_ls/fac_cfstencil_box.c
@@ -63,6 +63,8 @@ hypre_CF_StenBox( hypre_Box              *fgrid_box,
    * should be adjusted so that the flooring of the MapFineToCoarse does not
    * introduce extra coarse nodes in the coarsened box. Only the lower bound
    * needs to be adjusted.
+   * The upper bound has to be adjusted if its index is negative - i.e. periodic
+   * grids
    *--------------------------------------------------------------------------*/
    hypre_CopyBox(fgrid_box, &contracted_box);
    for (i= 0; i< ndim; i++)
@@ -70,7 +72,12 @@ hypre_CF_StenBox( hypre_Box              *fgrid_box,
       remainder= hypre_BoxIMin(&contracted_box)[i] % rfactors[i];
       if (remainder)
       {
-          hypre_BoxIMin(&contracted_box)[i]+= rfactors[i] - remainder;
+          hypre_BoxIMin(&contracted_box)[i]+= rfactors[i] - hypre_abs(remainder);
+      }
+      remainder= hypre_BoxIMax(&contracted_box)[i] % rfactors[i];
+      if (remainder)
+      {
+          hypre_BoxIMax(&contracted_box)[i] -= hypre_abs( remainder );
       }
    }
 

--- a/src/sstruct_ls/fac_interp2.c
+++ b/src/sstruct_ls/fac_interp2.c
@@ -432,6 +432,12 @@ hypre_FacSemiInterpSetup2( void                 *fac_interp_vdata,
                              hypre_BoxManEntryIMax(crse_entry));
          if(crse_proc == myproc)
          {
+            for (k= ndim; k< HYPRE_MAXDIM; k++)
+            {
+                hypre_BoxIMinD(&cbox, k)= 0;
+                hypre_BoxIMaxD(&cbox, k)= 0;
+            }
+
             hypre_AppendBox(&cbox,
                             hypre_BoxArrayArrayBoxArray(identity_arrayboxes[vars], ci));
 

--- a/src/sstruct_ls/fac_setup2.c
+++ b/src/sstruct_ls/fac_setup2.c
@@ -200,6 +200,9 @@ hypre_FacSetup2( void                 *fac_vdata,
                                         hypre_SStructPGridNVars(pgrid), 
                                         hypre_SStructPGridVarTypes(pgrid) );
 
+         HYPRE_SStructGridSetPeriodic ( grid_level[level], part_fine,
+                                        hypre_SStructPGridPeriodic(pgrid) );
+
          /*-----------------------------------------------------------------------
           * Create the coarsest level grid if A has only 1 level
           *-----------------------------------------------------------------------*/
@@ -215,6 +218,9 @@ hypre_FacSetup2( void                 *fac_vdata,
             HYPRE_SStructGridSetVariables( grid_level[level], part_crse,
                                            hypre_SStructPGridNVars(pgrid),
                                            hypre_SStructPGridVarTypes(pgrid) );
+
+            HYPRE_SStructGridSetPeriodic ( grid_level[level], part_crse,
+                                           hypre_SStructPGridPeriodic(pgrid) );
          }
       }
 
@@ -249,9 +255,15 @@ hypre_FacSetup2( void                 *fac_vdata,
                                         hypre_SStructPGridNVars(pgrid), 
                                         hypre_SStructPGridVarTypes(pgrid) );
 
+         HYPRE_SStructGridSetPeriodic ( grid_level[level], part_crse,
+                                        hypre_SStructPGridPeriodic(pgrid) );
+
          HYPRE_SStructGridSetVariables( grid_level[level-1], part_fine, 
                                         hypre_SStructPGridNVars(pgrid), 
                                         hypre_SStructPGridVarTypes(pgrid) );
+
+         HYPRE_SStructGridSetPeriodic ( grid_level[level-1], part_fine,
+                                        hypre_SStructPGridPeriodic(pgrid) );
 
          /* coarsest SStructGrid */
          if (level == 1)
@@ -259,6 +271,9 @@ hypre_FacSetup2( void                 *fac_vdata,
             HYPRE_SStructGridSetVariables( grid_level[level-1], part_crse, 
                                            hypre_SStructPGridNVars(pgrid), 
                                            hypre_SStructPGridVarTypes(pgrid) );
+
+            HYPRE_SStructGridSetPeriodic ( grid_level[level-1], part_crse,
+                                           hypre_SStructPGridPeriodic(pgrid) );
          }
       }
 
@@ -352,18 +367,25 @@ hypre_FacSetup2( void                 *fac_vdata,
          hypre_CopyIndex(hypre_SStructUEntryToIndex(Uentry), to_index);
          to_var  =  hypre_SStructUEntryToVar(Uentry);
 
-         if ( part_to_level[part] >= part_to_level[to_part] )
+         if ( part_to_level[part] > part_to_level[to_part] )
          {
             level        = part_to_level[part];
             level_part   = part_fine;
             level_topart = part_crse;
          }
-         else
+         else if ( part_to_level[part] < part_to_level[to_part] )
          {
             level        = part_to_level[to_part];
             level_part   = part_crse;
             level_topart = part_fine;
          }
+         else
+         {
+            level        = part_to_level[part];
+            level_part   = part_fine;
+            level_topart = part_fine;
+         }
+
          nrows[level]++;
 
          HYPRE_SStructGraphAddEntries(graph_level[level], level_part, index,

--- a/src/sstruct_mv/HYPRE_sstruct_graph.c
+++ b/src/sstruct_mv/HYPRE_sstruct_graph.c
@@ -340,6 +340,7 @@ HYPRE_SStructGraphAssemble( HYPRE_SStructGraph graph )
    HYPRE_Int                 to_proc;
    HYPRE_BigInt              Uverank, rank;
    hypre_BoxManEntry        *boxman_entry;
+   HYPRE_Int                *num_ghost;
                          
    HYPRE_Int                 nprocs, myproc;
    HYPRE_Int                 part, var;
@@ -360,7 +361,6 @@ HYPRE_SStructGraphAssemble( HYPRE_SStructGraph graph )
    void                      *info;
    hypre_Box                 *bbox, *new_box;
    hypre_Box               ***new_gboxes, *new_gbox;
-   HYPRE_Int                 *num_ghost;
 
    /*---------------------------------------------------------
     *  If AP, then may need to redo the box managers
@@ -573,13 +573,14 @@ HYPRE_SStructGraphAssemble( HYPRE_SStructGraph graph )
          Uveoffsets[part][var] = Uvesize;
          sgrid = hypre_SStructPGridSGrid(pgrid, var);
          boxes = hypre_StructGridBoxes(sgrid);
+         num_ghost = hypre_StructGridNumGhost(sgrid);
          hypre_ForBoxI(i, boxes)
          {
             box = hypre_BoxArrayBox(boxes, i);
             vol = 1;
             for (d = 0; d < ndim; d++)
             {
-               vol *= (hypre_BoxSizeD(box, d) + 2);
+               vol *= (hypre_BoxSizeD(box, d) + num_ghost[2*d] + num_ghost[2*d+1]);
             }
             Uvesize += vol;
          }

--- a/src/struct_mv/struct_communication.c
+++ b/src/struct_mv/struct_communication.c
@@ -180,8 +180,7 @@ hypre_CommPkgCreate( hypre_CommInfo   *comm_info,
       data_box = hypre_BoxArrayBox(send_data_space, i);
       data_offset += hypre_BoxVolume(data_box) * num_values;
 
-      /* RDF: This should always be true, but it's not for FAC.  Find out why. */
-      if (i < hypre_BoxArrayArraySize(send_boxes))
+      assert( i < hypre_BoxArrayArraySize(send_boxes) );
       {
          box_array = hypre_BoxArrayArrayBoxArray(send_boxes, i);
          num_boxes += hypre_BoxArraySize(box_array);
@@ -324,8 +323,7 @@ hypre_CommPkgCreate( hypre_CommInfo   *comm_info,
       data_box = hypre_BoxArrayBox(recv_data_space, i);
       data_offset += hypre_BoxVolume(data_box) * num_values;
 
-      /* RDF: This should always be true, but it's not for FAC.  Find out why. */
-      if (i < hypre_BoxArrayArraySize(recv_boxes))
+      assert (i < hypre_BoxArrayArraySize(recv_boxes));
       {
          box_array = hypre_BoxArrayArrayBoxArray(recv_boxes, i);
          num_boxes += hypre_BoxArraySize(box_array);


### PR DESCRIPTION
It has been chosen to not modify manual entries indices when they are added to
the graph since they are used by the FAC assembler to compute stencil ranks and
adding/subtracting periodicity to their indices would modify their relative
position.
Instead it has been chosen to modify:

hypre_SStructGraphGetUVEntryRank

 - returns the right rank even if index entry is out of bounding box

hypre_SStructGridFindBoxManEntry

 - returns the right boxmanentry even if index entry is out of bounding box

Also the following modification were required by periodic geometries:

hypre_AMR_CFCoarsen

 - added support to periodic grids when determining stencil connection patterns

hypre_CF_StenBox

 - when coarsening fine boxes also the upper bound is adjusted to avoid adding
   extra coarse cells when its index is negative (i.e. periodic grids)

hypre_FacSetup2

 - modified to copy to new grid parts also the original periodic vector

hypre_FacZeroCFSten

 - added support to periodic grids

hypre_FacZeroFCSten

 - added support to periodic grids

HYPRE_SStructGraphAssemble

 - removed assumption num_ghost = 1

The following changes were made to fix some bus in the FAC solver setup

hypre_AMR_FCoarsen

 - added check for empty coarse box arrays

hypre_AMR_CFCoarsen

 - avoid to coarsen the same row twice
 - improved check on computed stencil rank for connections to the coarsened fine box

hypre_FacSemiInterpSetup2

 - reimplemented intralevel communication algorithm
   . temp_grid was not enough to retrieve the remote boxnum since only connected
     boxes were communicated while proc could still recieve info of regions not
     connected to any of the owned boxes
   . recv_boxes needed to be indixed as the recv_data_space boxes for
     hypre_CommPkgCreate.

hypre_FacSetup2

 - added support to intralevel connections when copying non-stencil graph
   structures to composite matrices

hypre_CommPkgCreate

 - additional check on send/recv sizes introduced for FAC should be now
   superfluous since the changes to hypre_FacSemiInterpSetup2