### PR TITLE
FIx for AMS crash when using the FEI.

### DIFF
--- a/src/FEI_mv/fei-hypre/HYPRE_LinSysCore.h
+++ b/src/FEI_mv/fei-hypre/HYPRE_LinSysCore.h
@@ -68,12 +68,12 @@ enum HYpreconID {HYIDENTITY,HYDIAGONAL,HYPILUT,HYPARASAILS,HYBOOMERAMG,HYML,
 
 typedef struct 
 {
-   int    *EdgeNodeList_;
-   int    *NodeNumbers_;
-   int    numEdges_;
-   int    numLocalNodes_;
-   int    numNodes_;
-   double *NodalCoord_;
+   HYPRE_BigInt *EdgeNodeList_;
+   HYPRE_BigInt *NodeNumbers_;
+   HYPRE_Int    numEdges_;
+   HYPRE_Int    numLocalNodes_;
+   HYPRE_Int    numNodes_;
+   HYPRE_Real   *NodalCoord_;
 } HYPRE_FEI_AMSData;
 
 // *************************************************************************


### PR DESCRIPTION
Change AMSData structure to use HYPRE_BigInt , HYPRE_Int and HYPRE_Real data types.
Use hypre_CTAlloc and hypre_TFree for allocations sent to the ams
solver.
Remove one AMSData free due to double free in hypre_AMSFEIDestroy.