### PR TITLE
Fix issue96

### DIFF
--- a/src/parcsr_ls/par_coarsen.c
+++ b/src/parcsr_ls/par_coarsen.c
@@ -898,7 +898,7 @@ hypre_BoomerAMGCoarsenRuge( hypre_ParCSRMatrix    *S,
 
    HYPRE_BigInt     num_nonzeros    = hypre_ParCSRMatrixNumNonzeros(A);
    HYPRE_BigInt     global_num_rows = hypre_ParCSRMatrixGlobalNumRows(A);
-   HYPRE_Int        avg_nnzrow      = num_nonzeros/global_num_rows;
+   HYPRE_Int        avg_nnzrow;
 
    hypre_CSRMatrix *S_ext = NULL;
    HYPRE_Int       *S_ext_i = NULL;
@@ -925,7 +925,6 @@ hypre_BoomerAMGCoarsenRuge( hypre_ParCSRMatrix    *S,
    HYPRE_Int        ji, jj, jk, jm, index;
    HYPRE_Int        set_empty = 1;
    HYPRE_Int        C_i_nonempty = 0;
-   //HYPRE_Int      num_nonzeros;
    HYPRE_Int        cut, nnzrow;
    HYPRE_Int        num_procs, my_id;
    HYPRE_Int        num_sends = 0;
@@ -1158,9 +1157,10 @@ hypre_BoomerAMGCoarsenRuge( hypre_ParCSRMatrix    *S,
    }
 
    /* Set dense rows as SF_PT */
-   cut = cut_factor*avg_nnzrow;
-   if (cut > 0)
+   if ((cut_factor > 0) && (global_num_rows > 0))
    {
+      avg_nnzrow = num_nonzeros/global_num_rows;
+      cut = cut_factor*avg_nnzrow;
       for (j = 0; j < num_variables; j++)
       {
          nnzrow = (A_i[j+1] - A_i[j]) + (A_offd_i[j+1] - A_offd_i[j]);

--- a/src/test/TEST_ij/coarsening.jobs
+++ b/src/test/TEST_ij/coarsening.jobs
@@ -59,3 +59,4 @@ mpirun -np 8  ./ij -P 2 2 2 -cljp1  -interptype 0 -Pmx 0 > coarsening.out.12
 
 mpirun -np 8  ./ij -P 2 2 2 -pmis1 > coarsening.out.13
 
+mpirun -np 1  ./ij -n 2 2 2 -agg_nl 1 -mxrs 0.1 > coarsening.out.14

--- a/src/test/TEST_ij/coarsening.saved
+++ b/src/test/TEST_ij/coarsening.saved
@@ -72,3 +72,6 @@ Final Relative Residual Norm = 2.784139e-09
 BoomerAMG Iterations = 14
 Final Relative Residual Norm = 3.301634e-09
 
+# Output file: coarsening.out.14
+BoomerAMG Iterations = 10
+Final Relative Residual Norm = 7.834527e-09

--- a/src/test/TEST_ij/coarsening.sh
+++ b/src/test/TEST_ij/coarsening.sh
@@ -36,6 +36,7 @@ FILES="\
  ${TNAME}.out.11\
  ${TNAME}.out.12\
  ${TNAME}.out.13\
+ ${TNAME}.out.14\
 "
 
 for i in $FILES


### PR DESCRIPTION
When aggressive coarsening is used, the second stage strength matrix S2 might have zero size. In this case, computing the average number of nonzeros per row, as done by BoomerAMGCoarsenRuge, causes a SIGFPE (division by zero). With this PR, the computation of avg_nnzrow is done only when it makes sense. A new regression test is added to make sure the code works in this corner case. This fixes issue #96.