### PR TITLE
added new extended(interptype 16), extended+i(iinterptype 17) and i

### DIFF
--- a/src/parcsr_ls/CMakeLists.txt
+++ b/src/parcsr_ls/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SRCS
   HYPRE_ams.c
   HYPRE_ads.c
   HYPRE_ame.c
+  par_2s_interp.c
   par_amg.c
   par_amg_setup.c
   par_amg_solve.c

--- a/src/parcsr_ls/CMakeLists.txt
+++ b/src/parcsr_ls/CMakeLists.txt
@@ -70,6 +70,7 @@ set(SRCS
   par_interp.c
   par_jacobi_interp.c
   par_krylov_func.c
+  par_mod_lr_interp.c
   par_multi_interp.c
   par_laplace_27pt.c
   par_laplace_9pt.c

--- a/src/parcsr_ls/Makefile
+++ b/src/parcsr_ls/Makefile
@@ -78,6 +78,7 @@ FILES =\
  HYPRE_ams.c\
  HYPRE_ads.c\
  HYPRE_ame.c\
+ par_2s_interp.c\
  par_amg.c\
  par_amg_setup.c\
  par_amg_solve.c\
@@ -102,6 +103,7 @@ FILES =\
  par_interp_trunc_device.c\
  par_jacobi_interp.c\
  par_krylov_func.c\
+ par_mod_lr_interp.c\
  par_multi_interp.c\
  par_laplace.c\
  par_laplace_27pt.c\

--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -1564,6 +1564,15 @@ HYPRE_Int hypre_BoomerAMGBuildExtPICCInterp ( hypre_ParCSRMatrix *A , HYPRE_Int 
 HYPRE_Int hypre_BoomerAMGBuildFFInterp ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_Int num_functions , HYPRE_Int *dof_func , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
 HYPRE_Int hypre_BoomerAMGBuildFF1Interp ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_Int num_functions , HYPRE_Int *dof_func , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
 HYPRE_Int hypre_BoomerAMGBuildExtInterp ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_Int num_functions , HYPRE_Int *dof_func , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
+HYPRE_Int hypre_BoomerAMGBuildExtInterp ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_Int num_functions , HYPRE_Int *dof_func , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
+
+/* par_mod_lr_interp.c */
+HYPRE_Int hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker, hypre_ParCSRMatrix *S, HYPRE_BigInt *num_cpts_global, HYPRE_Int debug_flag, HYPRE_Real trunc_factor, HYPRE_Int max_elmts, HYPRE_Int *col_offd_S_to_A, hypre_ParCSRMatrix  **P_ptr);
+HYPRE_Int hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker, hypre_ParCSRMatrix *S, HYPRE_BigInt *num_cpts_global, HYPRE_Int debug_flag, HYPRE_Real trunc_factor, HYPRE_Int max_elmts, HYPRE_Int *col_offd_S_to_A, hypre_ParCSRMatrix  **P_ptr);
+
+
+/* par_2s_interp.c */
+HYPRE_Int hypre_BoomerAMGBuildModPartialExtInterp ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
 
 /* par_multi_interp.c */
 HYPRE_Int hypre_BoomerAMGBuildMultipass ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_Int num_functions , HYPRE_Int *dof_func , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int P_max_elmts , HYPRE_Int weight_option , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );

--- a/src/parcsr_ls/par_2s_interp.c
+++ b/src/parcsr_ls/par_2s_interp.c
@@ -1,0 +1,521 @@
+/******************************************************************************
+ * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+
+#include "_hypre_parcsr_ls.h"
+
+/*---------------------------------------------------------------------------
+ * hypre_BoomerAMGBuildModExtInterp
+ *  Comment:
+ *--------------------------------------------------------------------------*/
+HYPRE_Int
+hypre_BoomerAMGBuildModPartialExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
+                              hypre_ParCSRMatrix   *S, HYPRE_BigInt *num_cpts_global,
+                              HYPRE_BigInt *num_old_cpts_global,
+                              HYPRE_Int debug_flag,
+                              HYPRE_Real trunc_factor, HYPRE_Int max_elmts,
+                              HYPRE_Int *col_offd_S_to_A,
+                              hypre_ParCSRMatrix  **P_ptr)
+{
+   /* Communication Variables */
+   MPI_Comm                 comm = hypre_ParCSRMatrixComm(A);
+   hypre_ParCSRCommHandle  *comm_handle = NULL;
+   hypre_ParCSRCommPkg     *comm_pkg = NULL;
+
+   HYPRE_Int              my_id, num_procs;
+
+   /* Variables to store input variables */
+   hypre_CSRMatrix *A_diag = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Real      *A_diag_data = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int       *A_diag_i = hypre_CSRMatrixI(A_diag);
+
+   hypre_CSRMatrix *A_offd = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Real      *A_offd_data = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int       *A_offd_i = hypre_CSRMatrixI(A_offd);
+
+   HYPRE_Int        n_fine = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_BigInt     total_global_cpts;
+   HYPRE_BigInt     total_old_global_cpts;
+
+   /* Interpolation matrix P */
+   hypre_ParCSRMatrix *P;
+   hypre_CSRMatrix    *P_diag;
+   hypre_CSRMatrix    *P_offd;
+
+   HYPRE_Real      *P_diag_data = NULL;
+   HYPRE_Int       *P_diag_i, *P_diag_j = NULL;
+   HYPRE_Real      *P_offd_data = NULL;
+   HYPRE_Int       *P_offd_i, *P_offd_j = NULL;
+
+   /* Intermediate matrices */
+   hypre_ParCSRMatrix *As_FF, *As_FC, *W;
+   HYPRE_Real *D_q, *D_w;
+   HYPRE_Real *D_q_offd = NULL;
+   hypre_CSRMatrix *As_FF_diag;
+   hypre_CSRMatrix *As_FF_offd;
+   hypre_CSRMatrix *As_FC_diag;
+   hypre_CSRMatrix *As_FC_offd;
+   hypre_CSRMatrix *W_diag;
+   hypre_CSRMatrix *W_offd;
+
+   HYPRE_Int *As_FF_diag_i;
+   HYPRE_Int *As_FF_diag_j;
+   HYPRE_Int *As_FF_offd_i;
+   HYPRE_Int *As_FF_offd_j;
+   HYPRE_Int *As_FC_diag_i;
+   HYPRE_Int *As_FC_offd_i;
+   HYPRE_Int *W_diag_i;
+   HYPRE_Int *W_offd_i;
+   HYPRE_Int *W_diag_j;
+   HYPRE_Int *W_offd_j;
+
+   HYPRE_Real *As_FF_diag_data;
+   HYPRE_Real *As_FF_offd_data;
+   HYPRE_Real *As_FC_diag_data;
+   HYPRE_Real *As_FC_offd_data;
+   HYPRE_Real *W_diag_data;
+   HYPRE_Real *W_offd_data;
+   HYPRE_Real *buf_data = NULL;
+
+   HYPRE_BigInt    *col_map_offd_P = NULL;
+   HYPRE_BigInt    *new_col_map_offd = NULL;
+   HYPRE_Int        P_diag_size;
+   HYPRE_Int        P_offd_size;
+   HYPRE_Int        num_cols_A_FF_offd;
+   HYPRE_Int        new_ncols_P_offd;
+   HYPRE_Int        num_cols_P_offd;
+   HYPRE_Int       *P_marker = NULL;
+
+   /* Loop variables */
+   HYPRE_Int        index;
+   HYPRE_Int        i, j;
+   HYPRE_Int       *cpt_array;
+   HYPRE_Int       *new_fpt_array;
+   HYPRE_Int       *start_array;
+   HYPRE_Int       *new_fine_to_fine;
+   HYPRE_Int start, stop, startf, stopf, startnewf, stopnewf;
+   HYPRE_Int cnt_diag, cnt_offd, row, c_pt, fpt;
+   HYPRE_Int startc, num_sends;
+
+   /* Definitions */
+   //HYPRE_Real       wall_time;
+   HYPRE_Int n_Cpts, n_Fpts, n_old_Cpts, n_new_Fpts;
+   HYPRE_Int num_threads = hypre_NumThreads();
+
+   //if (debug_flag==4) wall_time = time_getWallclockSeconds();
+
+   /* BEGIN */
+   hypre_MPI_Comm_size(comm, &num_procs);
+   hypre_MPI_Comm_rank(comm,&my_id);
+
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+   if (my_id == (num_procs -1)) total_global_cpts = num_cpts_global[1];
+   if (my_id == (num_procs -1)) total_old_global_cpts = num_old_cpts_global[1];
+   hypre_MPI_Bcast(&total_global_cpts, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+   hypre_MPI_Bcast(&total_old_global_cpts, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+   n_Cpts = num_cpts_global[1]-num_cpts_global[0];
+   n_old_Cpts = num_old_cpts_global[1]-num_old_cpts_global[0];
+#else
+   total_global_cpts = num_cpts_global[num_procs];
+   total_old_global_cpts = num_old_cpts_global[num_procs];
+   n_Cpts = num_cpts_global[my_id+1]-num_cpts_global[my_id];
+   n_old_Cpts = num_old_cpts_global[my_id+1]-num_old_cpts_global[my_id];
+#endif
+
+   hypre_ParCSRMatrixGenerateFFFC3(A, CF_marker, num_cpts_global, S, &As_FC, &As_FF);
+
+   As_FC_diag = hypre_ParCSRMatrixDiag(As_FC);
+   As_FC_diag_i = hypre_CSRMatrixI(As_FC_diag);
+   As_FC_diag_data = hypre_CSRMatrixData(As_FC_diag);
+   As_FC_offd = hypre_ParCSRMatrixOffd(As_FC);
+   As_FC_offd_i = hypre_CSRMatrixI(As_FC_offd);
+   As_FC_offd_data = hypre_CSRMatrixData(As_FC_offd);
+   As_FF_diag = hypre_ParCSRMatrixDiag(As_FF);
+   As_FF_diag_i = hypre_CSRMatrixI(As_FF_diag);
+   As_FF_diag_j = hypre_CSRMatrixJ(As_FF_diag);
+   As_FF_diag_data = hypre_CSRMatrixData(As_FF_diag);
+   As_FF_offd = hypre_ParCSRMatrixOffd(As_FF);
+   As_FF_offd_i = hypre_CSRMatrixI(As_FF_offd);
+   As_FF_offd_j = hypre_CSRMatrixJ(As_FF_offd);
+   As_FF_offd_data = hypre_CSRMatrixData(As_FF_offd);
+   n_new_Fpts = hypre_CSRMatrixNumRows(As_FF_diag);
+   n_Fpts = hypre_CSRMatrixNumRows(As_FC_diag);
+   n_new_Fpts = n_old_Cpts - n_Cpts;
+   num_cols_A_FF_offd = hypre_CSRMatrixNumCols(As_FF_offd);
+
+   D_q = hypre_CTAlloc(HYPRE_Real, n_Fpts, HYPRE_MEMORY_HOST);
+   new_fine_to_fine = hypre_CTAlloc(HYPRE_Int, n_new_Fpts, HYPRE_MEMORY_HOST);
+   D_w = hypre_CTAlloc(HYPRE_Real, n_new_Fpts, HYPRE_MEMORY_HOST);
+   cpt_array = hypre_CTAlloc(HYPRE_Int, num_threads, HYPRE_MEMORY_HOST);
+   new_fpt_array = hypre_CTAlloc(HYPRE_Int, num_threads, HYPRE_MEMORY_HOST);
+   start_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel private(i,j,start,stop,startf,stopf,startnewf,stopnewf,row,fpt)
+#endif
+   {
+      HYPRE_Int my_thread_num = hypre_GetThreadNum();
+      HYPRE_Real beta, gamma;
+
+      start = (n_fine/num_threads)*my_thread_num;
+      if (my_thread_num == num_threads-1)
+      {
+         stop = n_fine;
+      }
+      else
+      {
+         stop = (n_fine/num_threads)*(my_thread_num+1);
+      }
+      start_array[my_thread_num+1] = stop;
+      row = 0;
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0) 
+         {
+            cpt_array[my_thread_num]++;
+         }
+         else if (CF_marker[i] == -2) 
+         {
+            new_fpt_array[my_thread_num]++;
+         }
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num == 0)
+      {
+         for (i=1; i < num_threads; i++)
+         {
+            cpt_array[i] += cpt_array[i-1];
+            new_fpt_array[i] += new_fpt_array[i-1];
+         }
+      }
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num > 0)
+      {
+         startf = start - cpt_array[my_thread_num-1];
+      }
+      else
+      {
+         startf = 0;
+      }
+
+      if (my_thread_num < num_threads-1)
+      {
+         stopf = stop - cpt_array[my_thread_num];
+      }
+      else
+      {
+         stopf = n_Fpts;
+      }
+
+      /* Create D_q = D_beta */
+      for (i=startf; i < stopf; i++)
+      {
+         for (j=As_FC_diag_i[i]; j < As_FC_diag_i[i+1]; j++)
+         {
+            D_q[i] += As_FC_diag_data[j];
+         }
+         for (j=As_FC_offd_i[i]; j < As_FC_offd_i[i+1]; j++)
+         {
+            D_q[i] += As_FC_offd_data[j];
+         }
+      }
+
+      row = 0;
+      if (my_thread_num) row = new_fpt_array[my_thread_num-1];
+      fpt = startf;
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] == -2) 
+         {
+            new_fine_to_fine[row++] = fpt++;
+         }
+         else if (CF_marker[i] == -1)
+         {
+            fpt++;
+         }
+      }
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+     if (my_thread_num == 0)
+     {
+         if (num_cols_A_FF_offd)
+         {
+            D_q_offd = hypre_CTAlloc(HYPRE_Real, num_cols_A_FF_offd, HYPRE_MEMORY_HOST);
+         }
+         index = 0;
+         comm_pkg = hypre_ParCSRMatrixCommPkg(As_FF);
+         if (!comm_pkg)
+         {
+            hypre_MatvecCommPkgCreate(As_FF);
+            comm_pkg = hypre_ParCSRMatrixCommPkg(As_FF);
+         }
+         num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+         buf_data = hypre_CTAlloc(HYPRE_Real, hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends), HYPRE_MEMORY_HOST);
+         for (i = 0; i < num_sends; i++)
+         {
+            startc = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+            for (j = startc; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg, i+1); j++)
+            {
+               buf_data[index++] = D_q[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+            }
+         }
+
+         comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, buf_data, D_q_offd);
+         hypre_ParCSRCommHandleDestroy(comm_handle);
+
+     }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      /* Create D_w = D_alpha + D_gamma */
+      row = 0;
+      if (my_thread_num) row = new_fpt_array[my_thread_num-1];
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] == -2)
+         {
+            for (j=A_diag_i[i]; j < A_diag_i[i+1]; j++)
+            {
+               D_w[row] += A_diag_data[j];
+            }
+            for (j=A_offd_i[i]; j < A_offd_i[i+1]; j++)
+            {
+               D_w[row] += A_offd_data[j];
+            }
+            for (j=As_FF_diag_i[row]+1; j < As_FF_diag_i[row+1]; j++)
+            {
+               if (D_q[As_FF_diag_j[j]]) D_w[row] -= As_FF_diag_data[j];
+            }
+            for (j=As_FF_offd_i[row]; j < As_FF_offd_i[row+1]; j++)
+            {
+               if (D_q_offd[As_FF_offd_j[j]]) D_w[row] -= As_FF_offd_data[j];
+            }
+            D_w[row] -= D_q[new_fine_to_fine[row]];
+            row++;
+         }
+      }
+
+      startnewf = 0;
+      if (my_thread_num) startnewf = new_fpt_array[my_thread_num-1];
+      stopnewf = new_fpt_array[my_thread_num];
+      for (i=startnewf; i<stopnewf; i++)
+      {
+         j = As_FF_diag_i[i];      
+         if (D_w[i]) 
+         { 
+            beta = 1.0/D_w[i];
+            As_FF_diag_data[j] = beta*D_q[i];
+            for (j=As_FF_diag_i[i]+1; j < As_FF_diag_i[i+1]; j++)
+               As_FF_diag_data[j] *= beta;
+            for (j=As_FF_offd_i[i]; j < As_FF_offd_i[i+1]; j++)
+               As_FF_offd_data[j] *= beta;
+         } 
+         else 
+         { 
+            As_FF_diag_data[j] = D_q[i];
+         } 
+      }
+      for (i=startf; i<stopf; i++)
+      {
+         if (D_q[i]) gamma = -1.0/D_q[i]; 
+         else gamma = 0.0;
+         for (j=As_FC_diag_i[i]; j < As_FC_diag_i[i+1]; j++)
+            As_FC_diag_data[j] *= gamma;
+         for (j=As_FC_offd_i[i]; j < As_FC_offd_i[i+1]; j++)
+            As_FC_offd_data[j] *= gamma;
+      }
+
+   }   /* end parallel region */ 
+
+   W = hypre_ParMatmul(As_FF, As_FC);
+   W_diag = hypre_ParCSRMatrixDiag(W);
+   W_offd = hypre_ParCSRMatrixOffd(W);
+   W_diag_i = hypre_CSRMatrixI(W_diag); 
+   W_diag_j = hypre_CSRMatrixJ(W_diag); 
+   W_diag_data = hypre_CSRMatrixData(W_diag); 
+   W_offd_i = hypre_CSRMatrixI(W_offd); 
+   W_offd_j = hypre_CSRMatrixJ(W_offd); 
+   W_offd_data = hypre_CSRMatrixData(W_offd); 
+   num_cols_P_offd = hypre_CSRMatrixNumCols(W_offd);
+   /*-----------------------------------------------------------------------
+    *  Intialize data for P
+    *-----------------------------------------------------------------------*/
+   P_diag_i    = hypre_CTAlloc(HYPRE_Int,  n_old_Cpts+1, HYPRE_MEMORY_HOST);
+   P_offd_i    = hypre_CTAlloc(HYPRE_Int,  n_old_Cpts+1, HYPRE_MEMORY_HOST);
+
+   P_diag_size = n_Cpts + hypre_CSRMatrixI(W_diag)[n_new_Fpts];
+   P_offd_size = hypre_CSRMatrixI(W_offd)[n_new_Fpts];
+
+   if (P_diag_size)
+   {
+      P_diag_j    = hypre_CTAlloc(HYPRE_Int,  P_diag_size, HYPRE_MEMORY_HOST);
+      P_diag_data = hypre_CTAlloc(HYPRE_Real,  P_diag_size, HYPRE_MEMORY_HOST);
+   }
+
+   if (P_offd_size)
+   {
+      P_offd_j    = hypre_CTAlloc(HYPRE_Int,  P_offd_size, HYPRE_MEMORY_HOST);
+      P_offd_data = hypre_CTAlloc(HYPRE_Real,  P_offd_size, HYPRE_MEMORY_HOST);
+   }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel private(i,j,start,stop,startnewf,stopnewf,c_pt,row,cnt_diag,cnt_offd)
+#endif
+   {
+      HYPRE_Int rowp;
+      HYPRE_Int my_thread_num = hypre_GetThreadNum();
+      start = start_array[my_thread_num];
+      stop = start_array[my_thread_num+1];
+
+      if (my_thread_num > 0)
+         c_pt = cpt_array[my_thread_num-1];
+      else
+         c_pt = 0;
+      row = 0;
+      if (my_thread_num) row = new_fpt_array[my_thread_num-1];
+      rowp = row;
+      if (my_thread_num > 0) rowp = row+cpt_array[my_thread_num-1];
+      cnt_diag = W_diag_i[row]+c_pt;
+      cnt_offd = W_offd_i[row];
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0)
+         {
+            rowp++;
+            P_diag_j[cnt_diag] = c_pt++;
+            P_diag_data[cnt_diag++] = 1.0;
+            P_diag_i[rowp] = cnt_diag;
+            P_offd_i[rowp] = cnt_offd;
+         }
+         else if (CF_marker[i] == -2)
+         {
+            rowp++;
+            for (j=W_diag_i[row]; j < W_diag_i[row+1]; j++)
+            {
+               P_diag_j[cnt_diag] = W_diag_j[j];
+               P_diag_data[cnt_diag++] = W_diag_data[j];
+            }
+            for (j=W_offd_i[row]; j < W_offd_i[row+1]; j++)
+            {
+               P_offd_j[cnt_offd] = W_offd_j[j];
+               P_offd_data[cnt_offd++] = W_offd_data[j];
+            }
+            row++;
+            P_diag_i[rowp] = cnt_diag;
+            P_offd_i[rowp] = cnt_offd;
+         }
+      }
+   }   /* end parallel region */ 
+   
+   /*-----------------------------------------------------------------------
+    *  Create matrix
+    *-----------------------------------------------------------------------*/
+
+   P = hypre_ParCSRMatrixCreate(comm,
+         total_old_global_cpts,
+         total_global_cpts,
+         num_old_cpts_global,
+         num_cpts_global,
+         num_cols_P_offd,
+         P_diag_i[n_old_Cpts],
+         P_offd_i[n_old_Cpts]);
+
+   P_diag = hypre_ParCSRMatrixDiag(P);
+   hypre_CSRMatrixData(P_diag) = P_diag_data;
+   hypre_CSRMatrixI(P_diag) = P_diag_i;
+   hypre_CSRMatrixJ(P_diag) = P_diag_j;
+   P_offd = hypre_ParCSRMatrixOffd(P);
+   hypre_CSRMatrixData(P_offd) = P_offd_data;
+   hypre_CSRMatrixI(P_offd) = P_offd_i;
+   hypre_CSRMatrixJ(P_offd) = P_offd_j;
+   hypre_ParCSRMatrixOwnsRowStarts(P) = 0;
+   hypre_ParCSRMatrixColMapOffd(P) = hypre_ParCSRMatrixColMapOffd(W);
+   hypre_ParCSRMatrixColMapOffd(W) = NULL;
+
+   hypre_CSRMatrixMemoryLocation(P_diag) = HYPRE_MEMORY_HOST;
+   hypre_CSRMatrixMemoryLocation(P_offd) = HYPRE_MEMORY_HOST;
+
+   /* Compress P, removing coefficients smaller than trunc_factor * Max */
+   if (trunc_factor != 0.0 || max_elmts > 0)
+   {
+      HYPRE_Int *map;
+      hypre_BoomerAMGInterpTruncation(P, trunc_factor, max_elmts);
+      P_diag_data = hypre_CSRMatrixData(P_diag);
+      P_diag_i = hypre_CSRMatrixI(P_diag);
+      P_diag_j = hypre_CSRMatrixJ(P_diag);
+      P_offd_data = hypre_CSRMatrixData(P_offd);
+      P_offd_i = hypre_CSRMatrixI(P_offd);
+      P_offd_j = hypre_CSRMatrixJ(P_offd);
+      P_diag_size = P_diag_i[n_old_Cpts];
+      P_offd_size = P_offd_i[n_old_Cpts];
+
+      col_map_offd_P = hypre_ParCSRMatrixColMapOffd(P);
+      if (num_cols_P_offd)
+      {
+         P_marker = hypre_CTAlloc(HYPRE_Int, num_cols_P_offd, HYPRE_MEMORY_HOST);
+         for (i=0; i < P_offd_size; i++)
+         {
+            P_marker[P_offd_j[i]] = 1;
+         }
+      
+         new_ncols_P_offd = 0;
+         for (i=0; i < num_cols_P_offd; i++)
+            if (P_marker[i]) new_ncols_P_offd++;
+
+         new_col_map_offd = hypre_CTAlloc(HYPRE_BigInt, new_ncols_P_offd, HYPRE_MEMORY_HOST);
+         map = hypre_CTAlloc(HYPRE_Int, new_ncols_P_offd, HYPRE_MEMORY_HOST);
+
+         index = 0;
+         for (i=0; i < num_cols_P_offd; i++)
+            if (P_marker[i])
+            {
+               new_col_map_offd[index] = col_map_offd_P[i];
+               map[index++] = i;
+            }
+         hypre_TFree(P_marker, HYPRE_MEMORY_HOST);
+
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+         for (i=0; i < P_offd_size; i++)
+         {
+            P_offd_j[i] = hypre_BinarySearch(map, P_offd_j[i],
+               new_ncols_P_offd);
+         }
+         hypre_TFree(col_map_offd_P, HYPRE_MEMORY_HOST);
+         hypre_ParCSRMatrixColMapOffd(P) = new_col_map_offd; 
+         hypre_CSRMatrixNumCols(P_offd) = new_ncols_P_offd; 
+         hypre_TFree(map, HYPRE_MEMORY_HOST);
+      }
+   }
+
+   hypre_MatvecCommPkgCreate(P);
+
+   *P_ptr = P;
+
+   /* Deallocate memory */
+   hypre_TFree(D_q, HYPRE_MEMORY_HOST);
+   hypre_TFree(D_q_offd, HYPRE_MEMORY_HOST);
+   hypre_TFree(D_w, HYPRE_MEMORY_HOST);
+   hypre_TFree(cpt_array, HYPRE_MEMORY_HOST);
+   hypre_TFree(new_fpt_array, HYPRE_MEMORY_HOST);
+   hypre_TFree(start_array, HYPRE_MEMORY_HOST);
+   hypre_TFree(new_fine_to_fine, HYPRE_MEMORY_HOST);
+   hypre_TFree(buf_data, HYPRE_MEMORY_HOST);
+   hypre_ParCSRMatrixDestroy(As_FF);
+   hypre_ParCSRMatrixDestroy(As_FC);
+   hypre_ParCSRMatrixDestroy(W);
+
+   return hypre_error_flag;
+}

--- a/src/parcsr_ls/par_amg.c
+++ b/src/parcsr_ls/par_amg.c
@@ -3171,7 +3171,7 @@ hypre_BoomerAMGSetAggInterpType( void     *data,
       hypre_error_in_arg(1);
       return hypre_error_flag;
    }
-   if (agg_interp_type < 0 || agg_interp_type > 4)
+   if (agg_interp_type < 0 || agg_interp_type > 6)
    {
       hypre_error_in_arg(2);
       return hypre_error_flag;

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -1525,6 +1525,16 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                                                 agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P1);
                }
 
+               else if (agg_interp_type == 5)
+                  hypre_BoomerAMGBuildModExtInterp(A_array[level],
+                                                   CF_marker, S, coarse_pnts_global1,
+                                                   debug_flag,
+                                                   agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P1);
+               else if (agg_interp_type == 6)
+                  hypre_BoomerAMGBuildModExtPIInterp(A_array[level],
+                                                   CF_marker, S, coarse_pnts_global1,
+                                                   debug_flag,
+                                                   agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P1);
                if (agg_interp_type == 4)
                {
                   hypre_BoomerAMGCorrectCFMarker (CF_marker, local_num_vars,
@@ -1555,7 +1565,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                   /*if (num_functions > 1 && nodal > -1 && (!block_mode) )
                      dof_func_array[level+1] = coarse_dof_func;*/
                   hypre_TFree(col_offd_S_to_A, HYPRE_MEMORY_HOST);
-                  if (agg_interp_type == 1)
+                  if (agg_interp_type == 1 || agg_interp_type == 6)
                   {
                      hypre_BoomerAMGBuildPartialExtPIInterp(A_array[level],
                                                             CF_marker, S, coarse_pnts_global,
@@ -1579,6 +1589,14 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                                                           dof_func_array[level], debug_flag, agg_P12_trunc_factor,
                                                           agg_P12_max_elmts, col_offd_S_to_A, &P2);
                   }
+                  else if (agg_interp_type == 5)
+                  {
+                     hypre_BoomerAMGBuildModPartialExtInterp(A_array[level],
+                                                CF_marker, S, coarse_pnts_global, coarse_pnts_global1,
+                                                debug_flag,
+                                                agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P2);
+                  }
+
 
                   if (hypre_ParAMGDataModularizedMatMat(amg_data))
                   {
@@ -1666,6 +1684,20 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                                                    num_functions, dof_func_array[level], debug_flag,
                                                    agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P1);
                   }
+                  else if (agg_interp_type == 5)
+                  {
+                     hypre_BoomerAMGBuildModExtInterp(A_array[level],
+                                                   CF3_marker, S, coarse_pnts_global1,
+                                                   debug_flag,
+                                                   agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P1);
+                  }
+                  else if (agg_interp_type == 6)
+                  {
+                     hypre_BoomerAMGBuildModExtPIInterp(A_array[level],
+                                                   CF3_marker, S, coarse_pnts_global1,
+                                                   debug_flag,
+                                                   agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P1);
+                  }
 
                   hypre_BoomerAMGCorrectCFMarker2 (CFN_marker,
                                                    local_num_vars/num_functions, CF2_marker);
@@ -1690,7 +1722,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                                              &coarse_dof_func,&coarse_pnts_global);
                   /*if (num_functions > 1 && nodal > -1 && (!block_mode) )
                      dof_func_array[level+1] = coarse_dof_func;*/
-                  if (agg_interp_type == 1)
+                  if (agg_interp_type == 1 || agg_interp_type == 6)
                   {
                      hypre_BoomerAMGBuildPartialExtPIInterp(A_array[level],
                                                             CF_marker, S, coarse_pnts_global,
@@ -1713,6 +1745,13 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                                                           coarse_pnts_global1, num_functions,
                                                           dof_func_array[level], debug_flag, agg_P12_trunc_factor,
                                                           agg_P12_max_elmts, col_offd_S_to_A, &P2);
+                  }
+                  else if (agg_interp_type == 5)
+                  {
+                     hypre_BoomerAMGBuildModPartialExtInterp(A_array[level],
+                                                CF_marker, S, coarse_pnts_global, coarse_pnts_global1,
+                                                debug_flag,
+                                                agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P2);
                   }
 
                   if (hypre_ParAMGDataModularizedMatMat(amg_data))
@@ -1884,6 +1923,21 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                                              debug_flag, trunc_factor, P_max_elmts, col_offd_S_to_A, &P);
                hypre_TFree(col_offd_S_to_A, HYPRE_MEMORY_HOST);
             }
+            else if (interp_type == 16) /*Extended classical MM interpolation */
+            {
+               hypre_BoomerAMGBuildModExtInterp(A_array[level], CF_marker,
+                                             S, coarse_pnts_global, 
+                                             debug_flag, trunc_factor, P_max_elmts, col_offd_S_to_A, &P);
+               hypre_TFree(col_offd_S_to_A, HYPRE_MEMORY_HOST);
+            }
+            else if (interp_type == 17) /*Extended+i MM interpolation */
+            {
+               hypre_BoomerAMGBuildModExtPIInterp(A_array[level], CF_marker,
+                                             S, coarse_pnts_global, 
+                                             debug_flag, trunc_factor, P_max_elmts, col_offd_S_to_A, &P);
+               hypre_TFree(col_offd_S_to_A, HYPRE_MEMORY_HOST);
+            }
+
             else if (interp_type == 7) /*Extended+i (if no common C) interpolation */
             {
                hypre_BoomerAMGBuildExtPICCInterp(A_array[level], CF_marker,

--- a/src/parcsr_ls/par_lr_interp.c
+++ b/src/parcsr_ls/par_lr_interp.c
@@ -1056,6 +1056,7 @@ hypre_BoomerAMGBuildExtPIInterp(hypre_ParCSRMatrix   *A,
 
    /* Communication Variables */
    MPI_Comm                     comm = hypre_ParCSRMatrixComm(A);
+
    hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
 
 

--- a/src/parcsr_ls/par_mod_lr_interp.c
+++ b/src/parcsr_ls/par_mod_lr_interp.c
@@ -365,11 +365,15 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
       {
          P_marker = hypre_CTAlloc(HYPRE_Int, num_cols_P_offd, HYPRE_MEMORY_HOST);
          for (i=0; i < P_offd_size; i++)
+         {
             P_marker[P_offd_j[i]] = 1;
+         }
       
          new_ncols_P_offd = 0;
          for (i=0; i < num_cols_P_offd; i++)
+         {
             if (P_marker[i]) new_ncols_P_offd++;
+         }
 
          new_col_map_offd = hypre_CTAlloc(HYPRE_BigInt, new_ncols_P_offd, HYPRE_MEMORY_HOST);
          map = hypre_CTAlloc(HYPRE_Int, new_ncols_P_offd, HYPRE_MEMORY_HOST);
@@ -392,6 +396,7 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
             P_offd_j[i] = hypre_BinarySearch(map, P_offd_j[i],
                new_ncols_P_offd);
          }
+
          hypre_TFree(col_map_offd_P, HYPRE_MEMORY_HOST);
          hypre_ParCSRMatrixColMapOffd(P) = new_col_map_offd; 
          hypre_CSRMatrixNumCols(P_offd) = new_ncols_P_offd; 

--- a/src/parcsr_ls/par_mod_lr_interp.c
+++ b/src/parcsr_ls/par_mod_lr_interp.c
@@ -22,7 +22,7 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
 {
    /* Communication Variables */
    MPI_Comm                 comm = hypre_ParCSRMatrixComm(A);
-
+   HYPRE_MemoryLocation memory_location_P = hypre_ParCSRMatrixMemoryLocation(A);
 
    HYPRE_Int              my_id, num_procs;
 
@@ -127,8 +127,8 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
    As_FF_offd_data = hypre_CSRMatrixData(As_FF_offd);
    n_Fpts = hypre_CSRMatrixNumRows(As_FF_diag);
 
-   D_q = hypre_CTAlloc(HYPRE_Real, n_Fpts, HYPRE_MEMORY_HOST);
-   D_w = hypre_CTAlloc(HYPRE_Real, n_Fpts, HYPRE_MEMORY_HOST);
+   D_q = hypre_CTAlloc(HYPRE_Real, n_Fpts, memory_location_P);
+   D_w = hypre_CTAlloc(HYPRE_Real, n_Fpts, memory_location_P);
    cpt_array = hypre_CTAlloc(HYPRE_Int, num_threads, HYPRE_MEMORY_HOST);
    start_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
    startf_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
@@ -256,22 +256,22 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
    /*-----------------------------------------------------------------------
     *  Intialize data for P
     *-----------------------------------------------------------------------*/
-   P_diag_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, HYPRE_MEMORY_HOST);
-   P_offd_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, HYPRE_MEMORY_HOST);
+   P_diag_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, memory_location_P);
+   P_offd_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, memory_location_P);
 
    P_diag_size = n_Cpts + hypre_CSRMatrixI(W_diag)[n_Fpts];
    P_offd_size = hypre_CSRMatrixI(W_offd)[n_Fpts];
 
    if (P_diag_size)
    {
-      P_diag_j    = hypre_CTAlloc(HYPRE_Int,  P_diag_size, HYPRE_MEMORY_HOST);
-      P_diag_data = hypre_CTAlloc(HYPRE_Real,  P_diag_size, HYPRE_MEMORY_HOST);
+      P_diag_j    = hypre_CTAlloc(HYPRE_Int,  P_diag_size, memory_location_P);
+      P_diag_data = hypre_CTAlloc(HYPRE_Real,  P_diag_size, memory_location_P);
    }
 
    if (P_offd_size)
    {
-      P_offd_j    = hypre_CTAlloc(HYPRE_Int,  P_offd_size, HYPRE_MEMORY_HOST);
-      P_offd_data = hypre_CTAlloc(HYPRE_Real,  P_offd_size, HYPRE_MEMORY_HOST);
+      P_offd_j    = hypre_CTAlloc(HYPRE_Int,  P_offd_size, memory_location_P);
+      P_offd_data = hypre_CTAlloc(HYPRE_Real,  P_offd_size, memory_location_P);
    }
 
 #ifdef HYPRE_USING_OPENMP
@@ -343,8 +343,8 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
    hypre_ParCSRMatrixColMapOffd(P) = hypre_ParCSRMatrixColMapOffd(W);
    hypre_ParCSRMatrixColMapOffd(W) = NULL;
 
-   hypre_CSRMatrixMemoryLocation(P_diag) = HYPRE_MEMORY_HOST;
-   hypre_CSRMatrixMemoryLocation(P_offd) = HYPRE_MEMORY_HOST;
+   hypre_CSRMatrixMemoryLocation(P_diag) = memory_location_P;
+   hypre_CSRMatrixMemoryLocation(P_offd) = memory_location_P;
 
    /* Compress P, removing coefficients smaller than trunc_factor * Max */
    if (trunc_factor != 0.0 || max_elmts > 0)
@@ -404,8 +404,8 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
    *P_ptr = P;
 
    /* Deallocate memory */
-   hypre_TFree(D_q, HYPRE_MEMORY_HOST);
-   hypre_TFree(D_w, HYPRE_MEMORY_HOST);
+   hypre_TFree(D_q, memory_location_P);
+   hypre_TFree(D_w, memory_location_P);
    hypre_TFree(cpt_array, HYPRE_MEMORY_HOST);
    hypre_TFree(start_array, HYPRE_MEMORY_HOST);
    hypre_TFree(startf_array, HYPRE_MEMORY_HOST);
@@ -430,6 +430,7 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
 {
    /* Communication Variables */
    MPI_Comm                 comm = hypre_ParCSRMatrixComm(A);
+   HYPRE_MemoryLocation memory_location_P = hypre_ParCSRMatrixMemoryLocation(A);
    hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
    hypre_ParCSRCommHandle  *comm_handle = NULL;
 
@@ -563,11 +564,11 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
 #else
    first_index = hypre_ParCSRMatrixRowStarts(As_FF)[my_id];
 #endif
-   tmp_FF_diag_data = hypre_CTAlloc(HYPRE_Real, As_FF_diag_i[n_Fpts], HYPRE_MEMORY_HOST);
+   tmp_FF_diag_data = hypre_CTAlloc(HYPRE_Real, As_FF_diag_i[n_Fpts], memory_location_P);
 
-   D_q = hypre_CTAlloc(HYPRE_Real, n_Fpts, HYPRE_MEMORY_HOST);
-   D_theta = hypre_CTAlloc(HYPRE_Real, n_Fpts, HYPRE_MEMORY_HOST);
-   D_w = hypre_CTAlloc(HYPRE_Real, n_Fpts, HYPRE_MEMORY_HOST);
+   D_q = hypre_CTAlloc(HYPRE_Real, n_Fpts, memory_location_P);
+   D_theta = hypre_CTAlloc(HYPRE_Real, n_Fpts, memory_location_P);
+   D_w = hypre_CTAlloc(HYPRE_Real, n_Fpts, memory_location_P);
    cpt_array = hypre_CTAlloc(HYPRE_Int, num_threads, HYPRE_MEMORY_HOST);
    start_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
    startf_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
@@ -646,7 +647,7 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
       {
          if (num_cols_A_FF_offd)
          {
-            D_q_offd = hypre_CTAlloc(HYPRE_Real,  num_cols_A_FF_offd, HYPRE_MEMORY_HOST);
+            D_q_offd = hypre_CTAlloc(HYPRE_Real,  num_cols_A_FF_offd, memory_location_P);
          }
          index = 0;
          comm_pkg = hypre_ParCSRMatrixCommPkg(As_FF);
@@ -656,7 +657,7 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
             comm_pkg = hypre_ParCSRMatrixCommPkg(As_FF);
          }
          num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
-         buf_data = hypre_CTAlloc(HYPRE_Real, hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends), HYPRE_MEMORY_HOST);
+         buf_data = hypre_CTAlloc(HYPRE_Real, hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends), memory_location_P);
          for (i = 0; i < num_sends; i++)
          {
             startc = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
@@ -771,22 +772,22 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
    /*-----------------------------------------------------------------------
     *  Intialize data for P
     *-----------------------------------------------------------------------*/
-   P_diag_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, HYPRE_MEMORY_HOST);
-   P_offd_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, HYPRE_MEMORY_HOST);
+   P_diag_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, memory_location_P);
+   P_offd_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, memory_location_P);
 
    P_diag_size = n_Cpts + hypre_CSRMatrixI(W_diag)[n_Fpts];
    P_offd_size = hypre_CSRMatrixI(W_offd)[n_Fpts];
 
    if (P_diag_size)
    {
-      P_diag_j    = hypre_CTAlloc(HYPRE_Int,  P_diag_size, HYPRE_MEMORY_HOST);
-      P_diag_data = hypre_CTAlloc(HYPRE_Real,  P_diag_size, HYPRE_MEMORY_HOST);
+      P_diag_j    = hypre_CTAlloc(HYPRE_Int,  P_diag_size, memory_location_P);
+      P_diag_data = hypre_CTAlloc(HYPRE_Real,  P_diag_size, memory_location_P);
    }
 
    if (P_offd_size)
    {
-      P_offd_j    = hypre_CTAlloc(HYPRE_Int,  P_offd_size, HYPRE_MEMORY_HOST);
-      P_offd_data = hypre_CTAlloc(HYPRE_Real,  P_offd_size, HYPRE_MEMORY_HOST);
+      P_offd_j    = hypre_CTAlloc(HYPRE_Int,  P_offd_size, memory_location_P);
+      P_offd_data = hypre_CTAlloc(HYPRE_Real,  P_offd_size, memory_location_P);
    }
 
 #ifdef HYPRE_USING_OPENMP
@@ -858,8 +859,8 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
    hypre_ParCSRMatrixColMapOffd(P) = hypre_ParCSRMatrixColMapOffd(W);
    hypre_ParCSRMatrixColMapOffd(W) = NULL;
 
-   hypre_CSRMatrixMemoryLocation(P_diag) = HYPRE_MEMORY_HOST;
-   hypre_CSRMatrixMemoryLocation(P_offd) = HYPRE_MEMORY_HOST;
+   hypre_CSRMatrixMemoryLocation(P_diag) = memory_location_P;
+   hypre_CSRMatrixMemoryLocation(P_offd) = memory_location_P;
 
    /* Compress P, removing coefficients smaller than trunc_factor * Max */
    if (trunc_factor != 0.0 || max_elmts > 0)
@@ -919,15 +920,15 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
    *P_ptr = P;
 
    /* Deallocate memory */
-   hypre_TFree(D_q, HYPRE_MEMORY_HOST);
-   hypre_TFree(D_q_offd, HYPRE_MEMORY_HOST);
-   hypre_TFree(D_w, HYPRE_MEMORY_HOST);
-   hypre_TFree(D_theta, HYPRE_MEMORY_HOST);
+   hypre_TFree(D_q, memory_location_P);
+   hypre_TFree(D_q_offd, memory_location_P);
+   hypre_TFree(D_w, memory_location_P);
+   hypre_TFree(D_theta, memory_location_P);
    hypre_TFree(cpt_array, HYPRE_MEMORY_HOST);
    hypre_TFree(start_array, HYPRE_MEMORY_HOST);
    hypre_TFree(startf_array, HYPRE_MEMORY_HOST);
-   hypre_TFree(buf_data, HYPRE_MEMORY_HOST);
-   hypre_TFree(tmp_FF_diag_data, HYPRE_MEMORY_HOST);
+   hypre_TFree(buf_data, memory_location_P);
+   hypre_TFree(tmp_FF_diag_data, memory_location_P);
    hypre_ParCSRMatrixDestroy(As_FF);
    hypre_ParCSRMatrixDestroy(As_FC);
    hypre_ParCSRMatrixDestroy(W);

--- a/src/parcsr_ls/par_mod_lr_interp.c
+++ b/src/parcsr_ls/par_mod_lr_interp.c
@@ -1,0 +1,938 @@
+/******************************************************************************
+ * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+
+#include "_hypre_parcsr_ls.h"
+#include "aux_interp.h"
+
+/*---------------------------------------------------------------------------
+ * hypre_BoomerAMGBuildModExtInterp
+ *  Comment:
+ *--------------------------------------------------------------------------*/
+HYPRE_Int
+hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
+                              hypre_ParCSRMatrix   *S, HYPRE_BigInt *num_cpts_global,
+                              HYPRE_Int debug_flag,
+                              HYPRE_Real trunc_factor, HYPRE_Int max_elmts,
+                              HYPRE_Int *col_offd_S_to_A,
+                              hypre_ParCSRMatrix  **P_ptr)
+{
+   /* Communication Variables */
+   MPI_Comm                 comm = hypre_ParCSRMatrixComm(A);
+
+
+   HYPRE_Int              my_id, num_procs;
+
+   /* Variables to store input variables */
+   hypre_CSRMatrix *A_diag = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Real      *A_diag_data = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int       *A_diag_i = hypre_CSRMatrixI(A_diag);
+
+   hypre_CSRMatrix *A_offd = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Real      *A_offd_data = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int       *A_offd_i = hypre_CSRMatrixI(A_offd);
+
+   HYPRE_Int        n_fine = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_BigInt     total_global_cpts;
+
+   /* Interpolation matrix P */
+   hypre_ParCSRMatrix *P;
+   hypre_CSRMatrix    *P_diag;
+   hypre_CSRMatrix    *P_offd;
+
+   HYPRE_Real      *P_diag_data = NULL;
+   HYPRE_Int       *P_diag_i, *P_diag_j = NULL;
+   HYPRE_Real      *P_offd_data = NULL;
+   HYPRE_Int       *P_offd_i, *P_offd_j = NULL;
+
+   /* Intermediate matrices */
+   hypre_ParCSRMatrix *As_FF, *As_FC, *W;
+   HYPRE_Real *D_q, *D_w;
+   hypre_CSRMatrix *As_FF_diag;
+   hypre_CSRMatrix *As_FF_offd;
+   hypre_CSRMatrix *As_FC_diag;
+   hypre_CSRMatrix *As_FC_offd;
+   hypre_CSRMatrix *W_diag;
+   hypre_CSRMatrix *W_offd;
+
+   HYPRE_Int *As_FF_diag_i;
+   HYPRE_Int *As_FF_offd_i;
+   HYPRE_Int *As_FC_diag_i;
+   HYPRE_Int *As_FC_offd_i;
+   HYPRE_Int *W_diag_i;
+   HYPRE_Int *W_offd_i;
+   HYPRE_Int *W_diag_j;
+   HYPRE_Int *W_offd_j;
+
+   HYPRE_Real *As_FF_diag_data;
+   HYPRE_Real *As_FF_offd_data;
+   HYPRE_Real *As_FC_diag_data;
+   HYPRE_Real *As_FC_offd_data;
+   HYPRE_Real *W_diag_data;
+   HYPRE_Real *W_offd_data;
+
+   HYPRE_BigInt    *col_map_offd_P = NULL;
+   HYPRE_BigInt    *new_col_map_offd = NULL;
+   HYPRE_Int        P_diag_size;
+   HYPRE_Int        P_offd_size;
+   HYPRE_Int        new_ncols_P_offd;
+   HYPRE_Int        num_cols_P_offd;
+   HYPRE_Int       *P_marker = NULL;
+
+   /* Loop variables */
+   HYPRE_Int        index;
+   HYPRE_Int        i, j;
+   HYPRE_Int       *cpt_array;
+   HYPRE_Int       *start_array;
+   HYPRE_Int       *startf_array;
+   HYPRE_Int start, stop, startf, stopf;
+   HYPRE_Int cnt_diag, cnt_offd, row, c_pt;
+
+   /* Definitions */
+   //HYPRE_Real       wall_time;
+   HYPRE_Int n_Cpts, n_Fpts;
+   HYPRE_Int num_threads = hypre_NumThreads();
+
+   //if (debug_flag==4) wall_time = time_getWallclockSeconds();
+
+   /* BEGIN */
+   hypre_MPI_Comm_size(comm, &num_procs);
+   hypre_MPI_Comm_rank(comm,&my_id);
+
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+   if (my_id == (num_procs -1)) total_global_cpts = num_cpts_global[1];
+   hypre_MPI_Bcast(&total_global_cpts, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+   n_Cpts = num_cpts_global[1]-num_cpts_global[0];
+#else
+   total_global_cpts = num_cpts_global[num_procs];
+   n_Cpts = num_cpts_global[my_id+1]-num_cpts_global[my_id];
+#endif
+
+   hypre_ParCSRMatrixGenerateFFFC(A, CF_marker, num_cpts_global, S, &As_FC, &As_FF);
+
+   As_FC_diag = hypre_ParCSRMatrixDiag(As_FC);
+   As_FC_diag_i = hypre_CSRMatrixI(As_FC_diag);
+   As_FC_diag_data = hypre_CSRMatrixData(As_FC_diag);
+   As_FC_offd = hypre_ParCSRMatrixOffd(As_FC);
+   As_FC_offd_i = hypre_CSRMatrixI(As_FC_offd);
+   As_FC_offd_data = hypre_CSRMatrixData(As_FC_offd);
+   As_FF_diag = hypre_ParCSRMatrixDiag(As_FF);
+   As_FF_diag_i = hypre_CSRMatrixI(As_FF_diag);
+   As_FF_diag_data = hypre_CSRMatrixData(As_FF_diag);
+   As_FF_offd = hypre_ParCSRMatrixOffd(As_FF);
+   As_FF_offd_i = hypre_CSRMatrixI(As_FF_offd);
+   As_FF_offd_data = hypre_CSRMatrixData(As_FF_offd);
+   n_Fpts = hypre_CSRMatrixNumRows(As_FF_diag);
+
+   D_q = hypre_CTAlloc(HYPRE_Real, n_Fpts, HYPRE_MEMORY_HOST);
+   D_w = hypre_CTAlloc(HYPRE_Real, n_Fpts, HYPRE_MEMORY_HOST);
+   cpt_array = hypre_CTAlloc(HYPRE_Int, num_threads, HYPRE_MEMORY_HOST);
+   start_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
+   startf_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel private(i,j,start,stop,startf,stopf,row)
+#endif
+   {
+      HYPRE_Int my_thread_num = hypre_GetThreadNum();
+      HYPRE_Real beta, gamma;
+
+      start = (n_fine/num_threads)*my_thread_num;
+      if (my_thread_num == num_threads-1)
+      {
+         stop = n_fine;
+      }
+      else
+      {
+         stop = (n_fine/num_threads)*(my_thread_num+1);
+      }
+      start_array[my_thread_num+1] = stop;
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0) 
+         {
+            cpt_array[my_thread_num]++;
+         }
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num == 0)
+      {
+         for (i=1; i < num_threads; i++)
+         {
+            cpt_array[i] += cpt_array[i-1];
+         }
+      }
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num > 0)
+         startf = start - cpt_array[my_thread_num-1];
+      else
+         startf = 0;
+
+      if (my_thread_num < num_threads-1)
+         stopf = stop - cpt_array[my_thread_num];
+      else
+         stopf = n_Fpts;
+
+      startf_array[my_thread_num+1] = stopf;
+
+      /* Create D_q = D_beta */
+      for (i=startf; i < stopf; i++)
+      {
+         for (j=As_FC_diag_i[i]; j < As_FC_diag_i[i+1]; j++)
+         {
+            D_q[i] += As_FC_diag_data[j];
+         }
+         for (j=As_FC_offd_i[i]; j < As_FC_offd_i[i+1]; j++)
+         {
+            D_q[i] += As_FC_offd_data[j];
+         }
+      }
+
+      /* Create D_w = D_alpha + D_gamma */
+      row = startf;
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] < 0)
+         {
+            for (j=A_diag_i[i]; j < A_diag_i[i+1]; j++)
+            {
+               D_w[row] += A_diag_data[j];
+            }
+            for (j=A_offd_i[i]; j < A_offd_i[i+1]; j++)
+            {
+               D_w[row] += A_offd_data[j];
+            }
+            for (j=As_FF_diag_i[row]+1; j < As_FF_diag_i[row+1]; j++)
+            {
+               D_w[row] -= As_FF_diag_data[j];
+            }
+            for (j=As_FF_offd_i[row]; j < As_FF_offd_i[row+1]; j++)
+            {
+               D_w[row] -= As_FF_offd_data[j];
+            }
+            D_w[row] -= D_q[row];
+            row++;
+         }
+      }
+
+      for (i=startf; i<stopf; i++)
+      {
+         j = As_FF_diag_i[i];      
+         if (D_w[i]) beta = 1.0/D_w[i];
+         else beta = 1.0;
+         As_FF_diag_data[j] = beta*D_q[i];
+         if (D_q[i]) gamma = -1.0/D_q[i]; 
+         else gamma = 1.0;
+         for (j=As_FF_diag_i[i]+1; j < As_FF_diag_i[i+1]; j++)
+            As_FF_diag_data[j] *= beta;
+         for (j=As_FF_offd_i[i]; j < As_FF_offd_i[i+1]; j++)
+            As_FF_offd_data[j] *= beta;
+         for (j=As_FC_diag_i[i]; j < As_FC_diag_i[i+1]; j++)
+            As_FC_diag_data[j] *= gamma;
+         for (j=As_FC_offd_i[i]; j < As_FC_offd_i[i+1]; j++)
+            As_FC_offd_data[j] *= gamma;
+      }
+
+   }   /* end parallel region */ 
+
+   W = hypre_ParMatmul(As_FF, As_FC);
+   W_diag = hypre_ParCSRMatrixDiag(W);
+   W_offd = hypre_ParCSRMatrixOffd(W);
+   W_diag_i = hypre_CSRMatrixI(W_diag); 
+   W_diag_j = hypre_CSRMatrixJ(W_diag); 
+   W_diag_data = hypre_CSRMatrixData(W_diag); 
+   W_offd_i = hypre_CSRMatrixI(W_offd); 
+   W_offd_j = hypre_CSRMatrixJ(W_offd); 
+   W_offd_data = hypre_CSRMatrixData(W_offd); 
+   num_cols_P_offd = hypre_CSRMatrixNumCols(W_offd);
+   /*-----------------------------------------------------------------------
+    *  Intialize data for P
+    *-----------------------------------------------------------------------*/
+   P_diag_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, HYPRE_MEMORY_HOST);
+   P_offd_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, HYPRE_MEMORY_HOST);
+
+   P_diag_size = n_Cpts + hypre_CSRMatrixI(W_diag)[n_Fpts];
+   P_offd_size = hypre_CSRMatrixI(W_offd)[n_Fpts];
+
+   if (P_diag_size)
+   {
+      P_diag_j    = hypre_CTAlloc(HYPRE_Int,  P_diag_size, HYPRE_MEMORY_HOST);
+      P_diag_data = hypre_CTAlloc(HYPRE_Real,  P_diag_size, HYPRE_MEMORY_HOST);
+   }
+
+   if (P_offd_size)
+   {
+      P_offd_j    = hypre_CTAlloc(HYPRE_Int,  P_offd_size, HYPRE_MEMORY_HOST);
+      P_offd_data = hypre_CTAlloc(HYPRE_Real,  P_offd_size, HYPRE_MEMORY_HOST);
+   }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel private(i,j,start,stop,startf,stopf,c_pt,row,cnt_diag,cnt_offd)
+#endif
+   {
+      HYPRE_Int my_thread_num = hypre_GetThreadNum();
+      startf = startf_array[my_thread_num];
+      stopf = startf_array[my_thread_num+1];
+      start = start_array[my_thread_num];
+      stop = start_array[my_thread_num+1];
+
+      if (my_thread_num > 0)
+         c_pt = cpt_array[my_thread_num-1];
+      else
+         c_pt = 0;
+      cnt_diag = W_diag_i[startf]+c_pt;
+      cnt_offd = W_offd_i[startf];
+      row = startf;
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0)
+         {
+            P_diag_j[cnt_diag] = c_pt++;
+            P_diag_data[cnt_diag++] = 1.0;
+         }
+         else
+         {
+            for (j=W_diag_i[row]; j < W_diag_i[row+1]; j++)
+            {
+               P_diag_j[cnt_diag] = W_diag_j[j];
+               P_diag_data[cnt_diag++] = W_diag_data[j];
+            }
+            for (j=W_offd_i[row]; j < W_offd_i[row+1]; j++)
+            {
+               P_offd_j[cnt_offd] = W_offd_j[j];
+               P_offd_data[cnt_offd++] = W_offd_data[j];
+            }
+            row++;
+         }
+         P_diag_i[i+1] = cnt_diag;
+         P_offd_i[i+1] = cnt_offd;
+      }
+
+   }   /* end parallel region */ 
+   
+   /*-----------------------------------------------------------------------
+    *  Create matrix
+    *-----------------------------------------------------------------------*/
+
+   P = hypre_ParCSRMatrixCreate(comm,
+         hypre_ParCSRMatrixGlobalNumRows(A),
+         total_global_cpts,
+         hypre_ParCSRMatrixColStarts(A),
+         num_cpts_global,
+         num_cols_P_offd,
+         P_diag_i[n_fine],
+         P_offd_i[n_fine]);
+
+   P_diag = hypre_ParCSRMatrixDiag(P);
+   hypre_CSRMatrixData(P_diag) = P_diag_data;
+   hypre_CSRMatrixI(P_diag) = P_diag_i;
+   hypre_CSRMatrixJ(P_diag) = P_diag_j;
+   P_offd = hypre_ParCSRMatrixOffd(P);
+   hypre_CSRMatrixData(P_offd) = P_offd_data;
+   hypre_CSRMatrixI(P_offd) = P_offd_i;
+   hypre_CSRMatrixJ(P_offd) = P_offd_j;
+   hypre_ParCSRMatrixOwnsRowStarts(P) = 0;
+   hypre_ParCSRMatrixColMapOffd(P) = hypre_ParCSRMatrixColMapOffd(W);
+   hypre_ParCSRMatrixColMapOffd(W) = NULL;
+
+   hypre_CSRMatrixMemoryLocation(P_diag) = HYPRE_MEMORY_HOST;
+   hypre_CSRMatrixMemoryLocation(P_offd) = HYPRE_MEMORY_HOST;
+
+   /* Compress P, removing coefficients smaller than trunc_factor * Max */
+   if (trunc_factor != 0.0 || max_elmts > 0)
+   {
+      HYPRE_Int *map;
+      hypre_BoomerAMGInterpTruncation(P, trunc_factor, max_elmts);
+      P_diag_data = hypre_CSRMatrixData(P_diag);
+      P_diag_i = hypre_CSRMatrixI(P_diag);
+      P_diag_j = hypre_CSRMatrixJ(P_diag);
+      P_offd_data = hypre_CSRMatrixData(P_offd);
+      P_offd_i = hypre_CSRMatrixI(P_offd);
+      P_offd_j = hypre_CSRMatrixJ(P_offd);
+      P_diag_size = P_diag_i[n_fine];
+      P_offd_size = P_offd_i[n_fine];
+   
+      col_map_offd_P = hypre_ParCSRMatrixColMapOffd(P);
+      if (num_cols_P_offd)
+      {
+         P_marker = hypre_CTAlloc(HYPRE_Int, num_cols_P_offd, HYPRE_MEMORY_HOST);
+         for (i=0; i < P_offd_size; i++)
+            P_marker[P_offd_j[i]] = 1;
+      
+         new_ncols_P_offd = 0;
+         for (i=0; i < num_cols_P_offd; i++)
+            if (P_marker[i]) new_ncols_P_offd++;
+
+         new_col_map_offd = hypre_CTAlloc(HYPRE_BigInt, new_ncols_P_offd, HYPRE_MEMORY_HOST);
+         map = hypre_CTAlloc(HYPRE_Int, new_ncols_P_offd, HYPRE_MEMORY_HOST);
+
+         index = 0;
+         for (i=0; i < num_cols_P_offd; i++)
+            if (P_marker[i])
+            {
+               new_col_map_offd[index] = col_map_offd_P[i];
+               map[index++] = i;
+            }
+         hypre_TFree(P_marker, HYPRE_MEMORY_HOST);
+
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+         for (i=0; i < P_offd_size; i++)
+         {
+            P_offd_j[i] = hypre_BinarySearch(map, P_offd_j[i],
+               new_ncols_P_offd);
+         }
+         hypre_TFree(col_map_offd_P, HYPRE_MEMORY_HOST);
+         hypre_ParCSRMatrixColMapOffd(P) = new_col_map_offd; 
+         hypre_CSRMatrixNumCols(P_offd) = new_ncols_P_offd; 
+         hypre_TFree(map, HYPRE_MEMORY_HOST);
+      }
+   }
+
+   hypre_MatvecCommPkgCreate(P);
+
+   *P_ptr = P;
+
+   /* Deallocate memory */
+   hypre_TFree(D_q, HYPRE_MEMORY_HOST);
+   hypre_TFree(D_w, HYPRE_MEMORY_HOST);
+   hypre_TFree(cpt_array, HYPRE_MEMORY_HOST);
+   hypre_TFree(start_array, HYPRE_MEMORY_HOST);
+   hypre_TFree(startf_array, HYPRE_MEMORY_HOST);
+   hypre_ParCSRMatrixDestroy(As_FF);
+   hypre_ParCSRMatrixDestroy(As_FC);
+   hypre_ParCSRMatrixDestroy(W);
+
+   return hypre_error_flag;
+}
+
+/*---------------------------------------------------------------------------
+ * hypre_BoomerAMGBuildModExtPIInterp
+ *  Comment:
+ *--------------------------------------------------------------------------*/
+HYPRE_Int
+hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
+                              hypre_ParCSRMatrix   *S, HYPRE_BigInt *num_cpts_global,
+                              HYPRE_Int debug_flag,
+                              HYPRE_Real trunc_factor, HYPRE_Int max_elmts,
+                              HYPRE_Int *col_offd_S_to_A,
+                              hypre_ParCSRMatrix  **P_ptr)
+{
+   /* Communication Variables */
+   MPI_Comm                 comm = hypre_ParCSRMatrixComm(A);
+   hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
+   hypre_ParCSRCommHandle  *comm_handle = NULL;
+
+   HYPRE_Int              my_id, num_procs;
+
+   /* Variables to store input variables */
+   hypre_CSRMatrix *A_diag = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Real      *A_diag_data = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int       *A_diag_i = hypre_CSRMatrixI(A_diag);
+
+   hypre_CSRMatrix *A_offd = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Real      *A_offd_data = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int       *A_offd_i = hypre_CSRMatrixI(A_offd);
+
+   HYPRE_Int        n_fine = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_BigInt     total_global_cpts;
+
+   hypre_CSRMatrix *As_FF_ext = NULL;
+   HYPRE_Real      *As_FF_ext_data = NULL;
+   HYPRE_Int       *As_FF_ext_i = NULL;
+   HYPRE_BigInt    *As_FF_ext_j = NULL;
+
+   /* Interpolation matrix P */
+   hypre_ParCSRMatrix *P;
+   hypre_CSRMatrix    *P_diag;
+   hypre_CSRMatrix    *P_offd;
+
+   HYPRE_Real      *P_diag_data = NULL;
+   HYPRE_Int       *P_diag_i, *P_diag_j = NULL;
+   HYPRE_Real      *P_offd_data = NULL;
+   HYPRE_Int       *P_offd_i, *P_offd_j = NULL;
+
+   /* Intermediate matrices */
+   hypre_ParCSRMatrix *As_FF, *As_FC, *W;
+   HYPRE_Real *D_q, *D_w, *D_theta, *D_q_offd = NULL;
+   hypre_CSRMatrix *As_FF_diag;
+   hypre_CSRMatrix *As_FF_offd;
+   hypre_CSRMatrix *As_FC_diag;
+   hypre_CSRMatrix *As_FC_offd;
+   hypre_CSRMatrix *W_diag;
+   hypre_CSRMatrix *W_offd;
+
+   HYPRE_Int *As_FF_diag_i;
+   HYPRE_Int *As_FF_diag_j;
+   HYPRE_Int *As_FF_offd_i;
+   HYPRE_Int *As_FF_offd_j = NULL;
+   HYPRE_Int *As_FC_diag_i;
+   HYPRE_Int *As_FC_offd_i;
+   HYPRE_Int *W_diag_i;
+   HYPRE_Int *W_offd_i;
+   HYPRE_Int *W_diag_j;
+   HYPRE_Int *W_offd_j = NULL;
+
+   HYPRE_Real *As_FF_diag_data;
+   HYPRE_Real *As_FF_offd_data = NULL;
+   HYPRE_Real *As_FC_diag_data;
+   HYPRE_Real *As_FC_offd_data = NULL;
+   HYPRE_Real *W_diag_data;
+   HYPRE_Real *W_offd_data = NULL;
+   HYPRE_Real *buf_data = NULL;
+   HYPRE_Real *tmp_FF_diag_data = NULL;
+
+   HYPRE_BigInt    *col_map_offd_P = NULL;
+   HYPRE_BigInt    *new_col_map_offd = NULL;
+   HYPRE_BigInt     first_index;
+   HYPRE_Int        P_diag_size;
+   HYPRE_Int        P_offd_size;
+   HYPRE_Int        new_ncols_P_offd;
+   HYPRE_Int        num_cols_P_offd;
+   HYPRE_Int       *P_marker = NULL;
+
+   /* Loop variables */
+   HYPRE_Int        index, startc, num_sends;
+   HYPRE_Int        i, j, jj, k, kk;
+   HYPRE_Int       *cpt_array;
+   HYPRE_Int       *start_array;
+   HYPRE_Int       *startf_array;
+   HYPRE_Int start, stop, startf, stopf;
+   HYPRE_Int cnt_diag, cnt_offd, row, c_pt;
+   HYPRE_Int num_cols_A_FF_offd;
+   HYPRE_Real value, value1, theta;
+
+   /* Definitions */
+   //HYPRE_Real       wall_time;
+   HYPRE_Int n_Cpts, n_Fpts;
+   HYPRE_Int num_threads = hypre_NumThreads();
+
+   //if (debug_flag==4) wall_time = time_getWallclockSeconds();
+
+   /* BEGIN */
+   hypre_MPI_Comm_size(comm, &num_procs);
+   hypre_MPI_Comm_rank(comm,&my_id);
+
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+   if (my_id == (num_procs -1)) total_global_cpts = num_cpts_global[1];
+   hypre_MPI_Bcast(&total_global_cpts, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+   n_Cpts = num_cpts_global[1]-num_cpts_global[0];
+#else
+   total_global_cpts = num_cpts_global[num_procs];
+   n_Cpts = num_cpts_global[my_id+1]-num_cpts_global[my_id];
+#endif
+
+   hypre_ParCSRMatrixGenerateFFFC(A, CF_marker, num_cpts_global, S, &As_FC, &As_FF);
+
+   if (num_procs > 1)
+   {
+      As_FF_ext = hypre_ParCSRMatrixExtractBExt(As_FF,As_FF,1);
+      As_FF_ext_i = hypre_CSRMatrixI(As_FF_ext);
+      As_FF_ext_j = hypre_CSRMatrixBigJ(As_FF_ext);
+      As_FF_ext_data = hypre_CSRMatrixData(As_FF_ext);
+   }
+
+   As_FC_diag = hypre_ParCSRMatrixDiag(As_FC);
+   As_FC_diag_i = hypre_CSRMatrixI(As_FC_diag);
+   As_FC_diag_data = hypre_CSRMatrixData(As_FC_diag);
+   As_FC_offd = hypre_ParCSRMatrixOffd(As_FC);
+   As_FC_offd_i = hypre_CSRMatrixI(As_FC_offd);
+   As_FC_offd_data = hypre_CSRMatrixData(As_FC_offd);
+   As_FF_diag = hypre_ParCSRMatrixDiag(As_FF);
+   As_FF_diag_i = hypre_CSRMatrixI(As_FF_diag);
+   As_FF_diag_j = hypre_CSRMatrixJ(As_FF_diag);
+   As_FF_diag_data = hypre_CSRMatrixData(As_FF_diag);
+   As_FF_offd = hypre_ParCSRMatrixOffd(As_FF);
+   As_FF_offd_i = hypre_CSRMatrixI(As_FF_offd);
+   As_FF_offd_j = hypre_CSRMatrixJ(As_FF_offd);
+   As_FF_offd_data = hypre_CSRMatrixData(As_FF_offd);
+   n_Fpts = hypre_CSRMatrixNumRows(As_FF_diag);
+   num_cols_A_FF_offd = hypre_CSRMatrixNumCols(As_FF_offd);
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+   first_index = hypre_ParCSRMatrixRowStarts(As_FF)[0];
+#else
+   first_index = hypre_ParCSRMatrixRowStarts(As_FF)[my_id];
+#endif
+   tmp_FF_diag_data = hypre_CTAlloc(HYPRE_Real, As_FF_diag_i[n_Fpts], HYPRE_MEMORY_HOST);
+
+   D_q = hypre_CTAlloc(HYPRE_Real, n_Fpts, HYPRE_MEMORY_HOST);
+   D_theta = hypre_CTAlloc(HYPRE_Real, n_Fpts, HYPRE_MEMORY_HOST);
+   D_w = hypre_CTAlloc(HYPRE_Real, n_Fpts, HYPRE_MEMORY_HOST);
+   cpt_array = hypre_CTAlloc(HYPRE_Int, num_threads, HYPRE_MEMORY_HOST);
+   start_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
+   startf_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel private(i,j,jj,k,kk,start,stop,startf,stopf,row,theta,value,value1)
+#endif
+   {
+      HYPRE_Int my_thread_num = hypre_GetThreadNum();
+
+      start = (n_fine/num_threads)*my_thread_num;
+      if (my_thread_num == num_threads-1)
+      {
+         stop = n_fine;
+      }
+      else
+      {
+         stop = (n_fine/num_threads)*(my_thread_num+1);
+      }
+      start_array[my_thread_num+1] = stop;
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0) 
+         {
+            cpt_array[my_thread_num]++;
+         }
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num == 0)
+      {
+         for (i=1; i < num_threads; i++)
+         {
+            cpt_array[i] += cpt_array[i-1];
+         }
+      }
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num > 0)
+         startf = start - cpt_array[my_thread_num-1];
+      else
+         startf = 0;
+
+      if (my_thread_num < num_threads-1)
+         stopf = stop - cpt_array[my_thread_num];
+      else
+         stopf = n_Fpts;
+
+      startf_array[my_thread_num+1] = stopf;
+
+      for (i=startf; i < stopf; i++)
+      {
+         for (j=As_FC_diag_i[i]; j < As_FC_diag_i[i+1]; j++)
+         {
+            D_q[i] += As_FC_diag_data[j];
+         }
+         for (j=As_FC_offd_i[i]; j < As_FC_offd_i[i+1]; j++)
+         {
+            D_q[i] += As_FC_offd_data[j];
+         }
+      }
+
+      for (j = As_FF_diag_i[startf]; j < As_FF_diag_i[stopf]; j++)
+      {
+         tmp_FF_diag_data[j] = As_FF_diag_data[j];
+      }
+
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num == 0)
+      {
+         if (num_cols_A_FF_offd)
+         {
+            D_q_offd = hypre_CTAlloc(HYPRE_Real,  num_cols_A_FF_offd, HYPRE_MEMORY_HOST);
+         }
+         index = 0;
+         comm_pkg = hypre_ParCSRMatrixCommPkg(As_FF);
+         if (!comm_pkg)
+         {
+            hypre_MatvecCommPkgCreate(As_FF);
+            comm_pkg = hypre_ParCSRMatrixCommPkg(As_FF);
+         }
+         num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+         buf_data = hypre_CTAlloc(HYPRE_Real, hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends), HYPRE_MEMORY_HOST);
+         for (i = 0; i < num_sends; i++)
+         {
+            startc = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+            for (j = startc; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg, i+1); j++)
+            {
+               buf_data[index++] = D_q[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+            }
+         }
+
+         comm_handle = hypre_ParCSRCommHandleCreate( 1, comm_pkg, buf_data, D_q_offd);
+         hypre_ParCSRCommHandleDestroy(comm_handle);
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+
+      row = startf;
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] < 0)
+         {
+            for (j=A_diag_i[i]; j < A_diag_i[i+1]; j++)
+            {
+               D_w[row] += A_diag_data[j];
+            }
+            for (j=A_offd_i[i]; j < A_offd_i[i+1]; j++)
+            {
+               D_w[row] += A_offd_data[j];
+            }
+            for (j=As_FF_diag_i[row]+1; j < As_FF_diag_i[row+1]; j++)
+            {
+               D_w[row] -= As_FF_diag_data[j];
+            }
+            for (j=As_FF_offd_i[row]; j < As_FF_offd_i[row+1]; j++)
+            {
+               D_w[row] -= As_FF_offd_data[j];
+            }
+            D_w[row] -= D_q[row];
+            row++;
+         }
+      }
+
+      for (i=startf; i<stopf; i++)
+      {
+         for (j = As_FF_diag_i[i]+1; j < As_FF_diag_i[i+1]; j++)
+         {
+            jj = As_FF_diag_j[j];
+            value = D_q[jj];
+            for (k = As_FF_diag_i[jj]+1; k < As_FF_diag_i[jj+1]; k++)
+            {
+               kk = As_FF_diag_j[k];
+               if (kk == i)
+               {
+                  value1 = tmp_FF_diag_data[k];
+                  value += value1;
+                  D_theta[i] += As_FF_diag_data[j]*value1/value;
+                  break;
+               }
+            }
+            As_FF_diag_data[j] /= value;
+         }
+         for (j = As_FF_offd_i[i]; j < As_FF_offd_i[i+1]; j++)
+         {
+            jj = As_FF_offd_j[j];
+            value = D_q_offd[jj];
+            for (k = As_FF_ext_i[jj]; k < As_FF_ext_i[jj+1]; k++)
+            {
+               kk = (HYPRE_Int)(As_FF_ext_j[k] - first_index);
+               if (kk == i)
+               {
+                  value1 = As_FF_ext_data[k];
+                  value += value1;
+                  D_theta[i] += As_FF_offd_data[j]*value1/value;
+                  break;
+               }
+            }
+            As_FF_offd_data[j] /= value;
+         }
+         As_FF_diag_data[As_FF_diag_i[i]] = 1.0;
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+
+      for (i=startf; i<stopf; i++)
+      {
+         theta = (D_theta[i]+D_w[i]);
+         if (theta) 
+         {
+            theta = -1.0/theta;
+            for (j=As_FF_diag_i[i]; j < As_FF_diag_i[i+1]; j++)
+               As_FF_diag_data[j] *= theta;
+            for (j=As_FF_offd_i[i]; j < As_FF_offd_i[i+1]; j++)
+               As_FF_offd_data[j] *= theta;
+         }
+      }
+
+   }   /* end parallel region */ 
+
+   W = hypre_ParMatmul(As_FF, As_FC);
+   W_diag = hypre_ParCSRMatrixDiag(W);
+   W_offd = hypre_ParCSRMatrixOffd(W);
+   W_diag_i = hypre_CSRMatrixI(W_diag); 
+   W_diag_j = hypre_CSRMatrixJ(W_diag); 
+   W_diag_data = hypre_CSRMatrixData(W_diag); 
+   W_offd_i = hypre_CSRMatrixI(W_offd); 
+   W_offd_j = hypre_CSRMatrixJ(W_offd); 
+   W_offd_data = hypre_CSRMatrixData(W_offd); 
+   num_cols_P_offd = hypre_CSRMatrixNumCols(W_offd);
+   /*-----------------------------------------------------------------------
+    *  Intialize data for P
+    *-----------------------------------------------------------------------*/
+   P_diag_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, HYPRE_MEMORY_HOST);
+   P_offd_i    = hypre_CTAlloc(HYPRE_Int,  n_fine+1, HYPRE_MEMORY_HOST);
+
+   P_diag_size = n_Cpts + hypre_CSRMatrixI(W_diag)[n_Fpts];
+   P_offd_size = hypre_CSRMatrixI(W_offd)[n_Fpts];
+
+   if (P_diag_size)
+   {
+      P_diag_j    = hypre_CTAlloc(HYPRE_Int,  P_diag_size, HYPRE_MEMORY_HOST);
+      P_diag_data = hypre_CTAlloc(HYPRE_Real,  P_diag_size, HYPRE_MEMORY_HOST);
+   }
+
+   if (P_offd_size)
+   {
+      P_offd_j    = hypre_CTAlloc(HYPRE_Int,  P_offd_size, HYPRE_MEMORY_HOST);
+      P_offd_data = hypre_CTAlloc(HYPRE_Real,  P_offd_size, HYPRE_MEMORY_HOST);
+   }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel private(i,j,start,stop,startf,stopf,c_pt,row,cnt_diag,cnt_offd)
+#endif
+   {
+      HYPRE_Int my_thread_num = hypre_GetThreadNum();
+      startf = startf_array[my_thread_num];
+      stopf = startf_array[my_thread_num+1];
+      start = start_array[my_thread_num];
+      stop = start_array[my_thread_num+1];
+
+      if (my_thread_num > 0)
+         c_pt = cpt_array[my_thread_num-1];
+      else
+         c_pt = 0;
+      cnt_diag = W_diag_i[startf]+c_pt;
+      cnt_offd = W_offd_i[startf];
+      row = startf;
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0)
+         {
+            P_diag_j[cnt_diag] = c_pt++;
+            P_diag_data[cnt_diag++] = 1.0;
+         }
+         else
+         {
+            for (j=W_diag_i[row]; j < W_diag_i[row+1]; j++)
+            {
+               P_diag_j[cnt_diag] = W_diag_j[j];
+               P_diag_data[cnt_diag++] = W_diag_data[j];
+            }
+            for (j=W_offd_i[row]; j < W_offd_i[row+1]; j++)
+            {
+               P_offd_j[cnt_offd] = W_offd_j[j];
+               P_offd_data[cnt_offd++] = W_offd_data[j];
+            }
+            row++;
+         }
+         P_diag_i[i+1] = cnt_diag;
+         P_offd_i[i+1] = cnt_offd;
+      }
+
+   }   /* end parallel region */ 
+   
+   /*-----------------------------------------------------------------------
+    *  Create matrix
+    *-----------------------------------------------------------------------*/
+
+   P = hypre_ParCSRMatrixCreate(comm,
+         hypre_ParCSRMatrixGlobalNumRows(A),
+         total_global_cpts,
+         hypre_ParCSRMatrixColStarts(A),
+         num_cpts_global,
+         num_cols_P_offd,
+         P_diag_i[n_fine],
+         P_offd_i[n_fine]);
+
+   P_diag = hypre_ParCSRMatrixDiag(P);
+   hypre_CSRMatrixData(P_diag) = P_diag_data;
+   hypre_CSRMatrixI(P_diag) = P_diag_i;
+   hypre_CSRMatrixJ(P_diag) = P_diag_j;
+   P_offd = hypre_ParCSRMatrixOffd(P);
+   hypre_CSRMatrixData(P_offd) = P_offd_data;
+   hypre_CSRMatrixI(P_offd) = P_offd_i;
+   hypre_CSRMatrixJ(P_offd) = P_offd_j;
+   hypre_ParCSRMatrixOwnsRowStarts(P) = 0;
+   hypre_ParCSRMatrixColMapOffd(P) = hypre_ParCSRMatrixColMapOffd(W);
+   hypre_ParCSRMatrixColMapOffd(W) = NULL;
+
+   hypre_CSRMatrixMemoryLocation(P_diag) = HYPRE_MEMORY_HOST;
+   hypre_CSRMatrixMemoryLocation(P_offd) = HYPRE_MEMORY_HOST;
+
+   /* Compress P, removing coefficients smaller than trunc_factor * Max */
+   if (trunc_factor != 0.0 || max_elmts > 0)
+   {
+      HYPRE_Int *map;
+      hypre_BoomerAMGInterpTruncation(P, trunc_factor, max_elmts);
+      P_diag_data = hypre_CSRMatrixData(P_diag);
+      P_diag_i = hypre_CSRMatrixI(P_diag);
+      P_diag_j = hypre_CSRMatrixJ(P_diag);
+      P_offd_data = hypre_CSRMatrixData(P_offd);
+      P_offd_i = hypre_CSRMatrixI(P_offd);
+      P_offd_j = hypre_CSRMatrixJ(P_offd);
+      P_diag_size = P_diag_i[n_fine];
+      P_offd_size = P_offd_i[n_fine];
+
+      col_map_offd_P = hypre_ParCSRMatrixColMapOffd(P);
+      if (num_cols_P_offd)
+      {
+         P_marker = hypre_CTAlloc(HYPRE_Int, num_cols_P_offd, HYPRE_MEMORY_HOST);
+         for (i=0; i < P_offd_size; i++)
+            P_marker[P_offd_j[i]] = 1;
+      
+         new_ncols_P_offd = 0;
+         for (i=0; i < num_cols_P_offd; i++)
+            if (P_marker[i]) new_ncols_P_offd++;
+
+         new_col_map_offd = hypre_CTAlloc(HYPRE_BigInt, new_ncols_P_offd, HYPRE_MEMORY_HOST);
+         map = hypre_CTAlloc(HYPRE_Int, new_ncols_P_offd, HYPRE_MEMORY_HOST);
+
+         index = 0;
+         for (i=0; i < num_cols_P_offd; i++)
+            if (P_marker[i])
+            {
+                new_col_map_offd[index] = col_map_offd_P[i];
+                map[index++] = i;
+            }
+         hypre_TFree(P_marker, HYPRE_MEMORY_HOST);
+
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+         for (i=0; i < P_offd_size; i++)
+         {
+            P_offd_j[i] = hypre_BinarySearch(map, P_offd_j[i],
+               new_ncols_P_offd);
+         }
+         hypre_TFree(col_map_offd_P, HYPRE_MEMORY_HOST);
+         hypre_ParCSRMatrixColMapOffd(P) = new_col_map_offd; 
+         hypre_CSRMatrixNumCols(P_offd) = new_ncols_P_offd; 
+         hypre_TFree(map, HYPRE_MEMORY_HOST);
+      }
+   }
+
+   hypre_MatvecCommPkgCreate(P);
+
+   *P_ptr = P;
+
+   /* Deallocate memory */
+   hypre_TFree(D_q, HYPRE_MEMORY_HOST);
+   hypre_TFree(D_q_offd, HYPRE_MEMORY_HOST);
+   hypre_TFree(D_w, HYPRE_MEMORY_HOST);
+   hypre_TFree(D_theta, HYPRE_MEMORY_HOST);
+   hypre_TFree(cpt_array, HYPRE_MEMORY_HOST);
+   hypre_TFree(start_array, HYPRE_MEMORY_HOST);
+   hypre_TFree(startf_array, HYPRE_MEMORY_HOST);
+   hypre_TFree(buf_data, HYPRE_MEMORY_HOST);
+   hypre_TFree(tmp_FF_diag_data, HYPRE_MEMORY_HOST);
+   hypre_ParCSRMatrixDestroy(As_FF);
+   hypre_ParCSRMatrixDestroy(As_FC);
+   hypre_ParCSRMatrixDestroy(W);
+   hypre_CSRMatrixDestroy(As_FF_ext);
+
+   return hypre_error_flag;
+}
+

--- a/src/parcsr_ls/par_stats.c
+++ b/src/parcsr_ls/par_stats.c
@@ -343,6 +343,18 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
       {
          hypre_printf(" Interpolation = extended interpolation\n");
       }
+      else if (interp_type == 15)
+      {
+         hypre_printf(" Interpolation = direct interpolation with separation of weights\n");
+      }
+      else if (interp_type == 16)
+      {
+         hypre_printf(" Interpolation = extended interpolation with MMs\n");
+      }
+      else if (interp_type == 17)
+      {
+         hypre_printf(" Interpolation = extended+i interpolation with MMs\n");
+      }
       else if (interp_type == 8)
       {
          hypre_printf(" Interpolation = standard interpolation\n");

--- a/src/parcsr_mv/CMakeLists.txt
+++ b/src/parcsr_mv/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SRCS
   F90_HYPRE_parcsr_vector.c
   F90_parcsr_matrix.c
   F90_par_vector.c
+  gen_fffc.c
   HYPRE_parcsr_matrix.c
   HYPRE_parcsr_vector.c
   new_commpkg.c

--- a/src/parcsr_mv/Makefile
+++ b/src/parcsr_mv/Makefile
@@ -35,6 +35,7 @@ FILES =\
  F90_par_vector.c\
  HYPRE_parcsr_matrix.c\
  HYPRE_parcsr_vector.c\
+ gen_fffc.c\
  new_commpkg.c\
  numbers.c\
  par_csr_aat.c\

--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -677,6 +677,10 @@ HYPRE_Int HYPRE_ParVectorInnerProd ( HYPRE_ParVector x , HYPRE_ParVector y , HYP
 HYPRE_Int HYPRE_VectorToParVector ( MPI_Comm comm , HYPRE_Vector b , HYPRE_BigInt *partitioning , HYPRE_ParVector *vector );
 HYPRE_Int HYPRE_ParVectorGetValues ( HYPRE_ParVector vector, HYPRE_Int num_values, HYPRE_BigInt *indices , HYPRE_Complex *values);
 
+/*gen_fffc.c */
+HYPRE_Int hypre_ParCSRMatrixGenerateFFFC(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
+HYPRE_Int hypre_ParCSRMatrixGenerateFFFC3(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
+
 /* new_commpkg.c */
 HYPRE_Int hypre_PrintCommpkg ( hypre_ParCSRMatrix *A , const char *file_name );
 HYPRE_Int hypre_ParCSRCommPkgCreateApart_core ( MPI_Comm comm , HYPRE_BigInt *col_map_off_d , HYPRE_BigInt first_col_diag , HYPRE_Int num_cols_off_d , HYPRE_BigInt global_num_cols , HYPRE_Int *p_num_recvs , HYPRE_Int **p_recv_procs , HYPRE_Int **p_recv_vec_starts , HYPRE_Int *p_num_sends , HYPRE_Int **p_send_procs , HYPRE_Int **p_send_map_starts , HYPRE_Int **p_send_map_elements , hypre_IJAssumedPart *apart );

--- a/src/parcsr_mv/gen_fffc.c
+++ b/src/parcsr_mv/gen_fffc.c
@@ -24,6 +24,7 @@ hypre_ParCSRMatrixGenerateFFFC( hypre_ParCSRMatrix  *A,
                                 hypre_ParCSRMatrix **A_FF_ptr)
 {
    MPI_Comm                 comm     = hypre_ParCSRMatrixComm(A);
+   HYPRE_MemoryLocation memory_location_P = hypre_ParCSRMatrixMemoryLocation(A);
    hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
    hypre_ParCSRCommHandle  *comm_handle;
 
@@ -280,10 +281,10 @@ hypre_ParCSRMatrixGenerateFFFC( hypre_ParCSRMatrix  *A,
             }
          }
 
-         A_FF_diag_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
-         A_FC_diag_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
-         A_FF_offd_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
-         A_FC_offd_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
+         A_FF_diag_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, memory_location_P);
+         A_FC_diag_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, memory_location_P);
+         A_FF_offd_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, memory_location_P);
+         A_FC_offd_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, memory_location_P);
       }
 
 #ifdef HYPRE_USING_OPENMP
@@ -343,14 +344,14 @@ hypre_ParCSRMatrixGenerateFFFC( hypre_ParCSRMatrix  *A,
          d_count_FF = A_FF_diag_i[row];
          o_count_FC = A_FC_offd_i[row];
          o_count_FF = A_FF_offd_i[row];
-         A_FF_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FF, HYPRE_MEMORY_HOST);
-         A_FC_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FC, HYPRE_MEMORY_HOST);
-         A_FF_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FF, HYPRE_MEMORY_HOST);
-         A_FC_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FC, HYPRE_MEMORY_HOST);
-         A_FF_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FF, HYPRE_MEMORY_HOST);
-         A_FC_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FC, HYPRE_MEMORY_HOST);
-         A_FF_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FF, HYPRE_MEMORY_HOST);
-         A_FC_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FC, HYPRE_MEMORY_HOST);
+         A_FF_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FF, memory_location_P);
+         A_FC_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FC, memory_location_P);
+         A_FF_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FF, memory_location_P);
+         A_FC_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FC, memory_location_P);
+         A_FF_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FF, memory_location_P);
+         A_FC_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FC, memory_location_P);
+         A_FF_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FF, memory_location_P);
+         A_FC_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FC, memory_location_P);
       }
 
 #ifdef HYPRE_USING_OPENMP
@@ -440,6 +441,9 @@ hypre_ParCSRMatrixGenerateFFFC( hypre_ParCSRMatrix  *A,
    hypre_ParCSRMatrixOwnsColStarts(A_FC) = 0;
    hypre_ParCSRMatrixColMapOffd(A_FC) = col_map_offd_A_FC;
 
+   hypre_CSRMatrixMemoryLocation(A_FC_diag) = memory_location_P;
+   hypre_CSRMatrixMemoryLocation(A_FC_offd) = memory_location_P;
+
    A_FF_diag = hypre_ParCSRMatrixDiag(A_FF);
    hypre_CSRMatrixData(A_FF_diag) = A_FF_diag_data;
    hypre_CSRMatrixI(A_FF_diag) = A_FF_diag_i;
@@ -451,6 +455,9 @@ hypre_ParCSRMatrixGenerateFFFC( hypre_ParCSRMatrix  *A,
    hypre_ParCSRMatrixOwnsRowStarts(A_FF) = 0;
    hypre_ParCSRMatrixOwnsColStarts(A_FF) = 0;
    hypre_ParCSRMatrixColMapOffd(A_FF) = col_map_offd_A_FF;
+
+   hypre_CSRMatrixMemoryLocation(A_FF_diag) = memory_location_P;
+   hypre_CSRMatrixMemoryLocation(A_FF_offd) = memory_location_P;
 
    hypre_TFree(fine_to_coarse, HYPRE_MEMORY_HOST);
    hypre_TFree(fine_to_fine, HYPRE_MEMORY_HOST);
@@ -484,6 +491,7 @@ hypre_ParCSRMatrixGenerateFFFC3( hypre_ParCSRMatrix *A,
                                 hypre_ParCSRMatrix **A_FF_ptr)
 {
    MPI_Comm                 comm     = hypre_ParCSRMatrixComm(A);
+   HYPRE_MemoryLocation memory_location_P = hypre_ParCSRMatrixMemoryLocation(A);
    hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
    hypre_ParCSRCommHandle  *comm_handle;
 
@@ -760,10 +768,10 @@ hypre_ParCSRMatrixGenerateFFFC3( hypre_ParCSRMatrix *A,
             }
          }
 
-         A_FF_diag_i = hypre_CTAlloc(HYPRE_Int,n_new_Fpts+1, HYPRE_MEMORY_HOST);
-         A_FC_diag_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
-         A_FF_offd_i = hypre_CTAlloc(HYPRE_Int,n_new_Fpts+1, HYPRE_MEMORY_HOST);
-         A_FC_offd_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
+         A_FF_diag_i = hypre_CTAlloc(HYPRE_Int,n_new_Fpts+1, memory_location_P);
+         A_FC_diag_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, memory_location_P);
+         A_FF_offd_i = hypre_CTAlloc(HYPRE_Int,n_new_Fpts+1, memory_location_P);
+         A_FC_offd_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, memory_location_P);
       }
 
 #ifdef HYPRE_USING_OPENMP
@@ -846,14 +854,14 @@ hypre_ParCSRMatrixGenerateFFFC3( hypre_ParCSRMatrix *A,
          d_count_FF = A_FF_diag_i[row];
          o_count_FC = A_FC_offd_i[rowc];
          o_count_FF = A_FF_offd_i[row];
-         A_FF_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FF, HYPRE_MEMORY_HOST);
-         A_FC_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FC, HYPRE_MEMORY_HOST);
-         A_FF_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FF, HYPRE_MEMORY_HOST);
-         A_FC_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FC, HYPRE_MEMORY_HOST);
-         A_FF_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FF, HYPRE_MEMORY_HOST);
-         A_FC_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FC, HYPRE_MEMORY_HOST);
-         A_FF_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FF, HYPRE_MEMORY_HOST);
-         A_FC_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FC, HYPRE_MEMORY_HOST);
+         A_FF_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FF, memory_location_P);
+         A_FC_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FC, memory_location_P);
+         A_FF_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FF, memory_location_P);
+         A_FC_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FC, memory_location_P);
+         A_FF_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FF, memory_location_P);
+         A_FC_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FC, memory_location_P);
+         A_FF_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FF, memory_location_P);
+         A_FC_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FC, memory_location_P);
       }
 
 #ifdef HYPRE_USING_OPENMP
@@ -974,6 +982,9 @@ hypre_ParCSRMatrixGenerateFFFC3( hypre_ParCSRMatrix *A,
    hypre_ParCSRMatrixOwnsColStarts(A_FC) = 0;
    hypre_ParCSRMatrixColMapOffd(A_FC) = col_map_offd_A_FC;
 
+   hypre_CSRMatrixMemoryLocation(A_FC_diag) = memory_location_P;
+   hypre_CSRMatrixMemoryLocation(A_FC_offd) = memory_location_P;
+
    A_FF_diag = hypre_ParCSRMatrixDiag(A_FF);
    hypre_CSRMatrixData(A_FF_diag) = A_FF_diag_data;
    hypre_CSRMatrixI(A_FF_diag) = A_FF_diag_i;
@@ -985,6 +996,9 @@ hypre_ParCSRMatrixGenerateFFFC3( hypre_ParCSRMatrix *A,
    hypre_ParCSRMatrixOwnsRowStarts(A_FF) = 1;
    hypre_ParCSRMatrixOwnsColStarts(A_FF) = 0;
    hypre_ParCSRMatrixColMapOffd(A_FF) = col_map_offd_A_FF;
+
+   hypre_CSRMatrixMemoryLocation(A_FF_diag) = memory_location_P;
+   hypre_CSRMatrixMemoryLocation(A_FF_offd) = memory_location_P;
 
    hypre_TFree(fine_to_coarse, HYPRE_MEMORY_HOST);
    hypre_TFree(fine_to_fine, HYPRE_MEMORY_HOST);

--- a/src/parcsr_mv/gen_fffc.c
+++ b/src/parcsr_mv/gen_fffc.c
@@ -1,0 +1,1007 @@
+/******************************************************************************
+ * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+
+#include "_hypre_utilities.h"
+#include "hypre_hopscotch_hash.h"
+#include "_hypre_parcsr_mv.h"
+#include "_hypre_lapack.h"
+#include "_hypre_blas.h"
+
+/* -----------------------------------------------------------------------------
+ * generate AFF or AFC
+ * ----------------------------------------------------------------------------- */
+
+HYPRE_Int
+hypre_ParCSRMatrixGenerateFFFC( hypre_ParCSRMatrix  *A,
+                                HYPRE_Int           *CF_marker,
+                                HYPRE_BigInt        *cpts_starts,
+                                hypre_ParCSRMatrix  *S,
+                                hypre_ParCSRMatrix **A_FC_ptr,
+                                hypre_ParCSRMatrix **A_FF_ptr)
+{
+   MPI_Comm                 comm     = hypre_ParCSRMatrixComm(A);
+   hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
+   hypre_ParCSRCommHandle  *comm_handle;
+
+   /* diag part of A */
+   hypre_CSRMatrix    *A_diag   = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Complex      *A_diag_data = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int          *A_diag_i = hypre_CSRMatrixI(A_diag);
+   HYPRE_Int          *A_diag_j = hypre_CSRMatrixJ(A_diag);
+   /* off-diag part of A */
+   hypre_CSRMatrix    *A_offd   = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Complex      *A_offd_data = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int          *A_offd_i = hypre_CSRMatrixI(A_offd);
+   HYPRE_Int          *A_offd_j = hypre_CSRMatrixJ(A_offd);
+
+   HYPRE_Int           n_fine = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Int           num_cols_A_offd = hypre_CSRMatrixNumCols(A_offd);
+
+   /* diag part of S */
+   hypre_CSRMatrix    *S_diag   = hypre_ParCSRMatrixDiag(S);
+   HYPRE_Int          *S_diag_i = hypre_CSRMatrixI(S_diag);
+   HYPRE_Int          *S_diag_j = hypre_CSRMatrixJ(S_diag);
+   /* off-diag part of S */
+   hypre_CSRMatrix    *S_offd   = hypre_ParCSRMatrixOffd(S);
+   HYPRE_Int          *S_offd_i = hypre_CSRMatrixI(S_offd);
+   HYPRE_Int          *S_offd_j = hypre_CSRMatrixJ(S_offd);
+
+   hypre_ParCSRMatrix *A_FC;
+   hypre_CSRMatrix    *A_FC_diag, *A_FC_offd;
+   HYPRE_Int          *A_FC_diag_i, *A_FC_diag_j, *A_FC_offd_i, *A_FC_offd_j=NULL;
+   HYPRE_Complex      *A_FC_diag_data, *A_FC_offd_data=NULL;
+   HYPRE_Int           num_cols_offd_A_FC;
+   HYPRE_BigInt       *col_map_offd_A_FC = NULL;
+
+   hypre_ParCSRMatrix *A_FF;
+   hypre_CSRMatrix    *A_FF_diag, *A_FF_offd;
+   HYPRE_Int          *A_FF_diag_i, *A_FF_diag_j, *A_FF_offd_i, *A_FF_offd_j;
+   HYPRE_Complex      *A_FF_diag_data, *A_FF_offd_data;
+   HYPRE_Int           num_cols_offd_A_FF;
+   HYPRE_BigInt       *col_map_offd_A_FF = NULL;
+
+   HYPRE_Int          *fine_to_coarse;
+   HYPRE_Int          *fine_to_fine;
+   HYPRE_Int          *fine_to_coarse_offd = NULL;
+   HYPRE_Int          *fine_to_fine_offd = NULL;
+
+   HYPRE_Int           i, j, jj;
+   HYPRE_Int           startc, index;
+   HYPRE_Int           cpt, fpt, row;
+   HYPRE_Int          *CF_marker_offd = NULL;
+   HYPRE_Int          *int_buf_data = NULL;
+   HYPRE_BigInt       *big_convert;
+   HYPRE_BigInt       *big_convert_offd = NULL;
+   HYPRE_BigInt       *big_buf_data = NULL;
+
+   HYPRE_BigInt        total_global_fpts, total_global_cpts, *fpts_starts;
+   HYPRE_Int           my_id, num_procs, num_sends;
+   HYPRE_Int           d_count_FF, d_count_FC, o_count_FF, o_count_FC;
+   HYPRE_Int           n_Fpts;
+   HYPRE_Int          *cpt_array, *fpt_array;
+   HYPRE_Int           start, stop;
+   HYPRE_Int           num_threads;
+
+   num_threads = hypre_NumThreads();  
+
+   /* MPI size and rank*/
+   hypre_MPI_Comm_size(comm, &num_procs);
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+   fine_to_coarse = hypre_CTAlloc(HYPRE_Int, n_fine, HYPRE_MEMORY_HOST);
+   fine_to_fine = hypre_CTAlloc(HYPRE_Int, n_fine, HYPRE_MEMORY_HOST);
+   big_convert = hypre_CTAlloc(HYPRE_BigInt, n_fine, HYPRE_MEMORY_HOST);
+
+   cpt_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
+   fpt_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel private(i,j,jj,start,stop,row,cpt,fpt,d_count_FC,d_count_FF,o_count_FC,o_count_FF)
+#endif
+   {
+      HYPRE_Int my_thread_num = hypre_GetThreadNum();
+
+      start = (n_fine/num_threads)*my_thread_num;
+      if (my_thread_num == num_threads-1)
+      {
+         stop = n_fine;
+      }
+      else
+      {
+         stop = (n_fine/num_threads)*(my_thread_num+1);
+      }
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0)
+         {
+            cpt_array[my_thread_num+1]++;
+         }
+         else
+         {
+            fpt_array[my_thread_num+1]++;
+         }
+      }
+   
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num == 0)
+      {
+         for (i=1; i < num_threads; i++)
+         {
+            cpt_array[i+1] += cpt_array[i];
+            fpt_array[i+1] += fpt_array[i];
+         }
+      }
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+
+      cpt = cpt_array[my_thread_num];
+      fpt = fpt_array[my_thread_num];
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0)
+         {
+            fine_to_coarse[i] = cpt++;
+            fine_to_fine[i] = -1;
+         }
+         else
+         {
+            fine_to_fine[i] = fpt++;
+            fine_to_coarse[i] = -1;
+         }
+      }
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+
+      if (my_thread_num == 0)
+      {
+         n_Fpts = fpt_array[num_threads];
+
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+         fpts_starts = hypre_TAlloc(HYPRE_BigInt, 2, HYPRE_MEMORY_HOST);
+         hypre_MPI_Scan(&n_Fpts, fpts_starts+1, 1, HYPRE_MPI_BIG_INT, hypre_MPI_SUM, comm);
+         fpts_starts[0] = fpts_starts[1] - n_Fpts;
+         if (my_id == num_procs - 1)
+         {
+            total_global_fpts = fpts_starts[1];
+            total_global_cpts = cpts_starts[1];
+         }
+         hypre_MPI_Bcast(&total_global_fpts, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+         hypre_MPI_Bcast(&total_global_cpts, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+#else
+         fpts_starts = hypre_CTAlloc(HYPRE_BigInt, num_procs+1, HYPRE_MEMORY_HOST);
+         hypre_MPI_Allgather(&n_Fpts, 1, HYPRE_MPI_BIG_INT, &fpts_starts[1], 1, HYPRE_MPI_BIG_INT, comm);
+         fpts_starts[0] = 0;
+         for (i = 2; i < num_procs+1; i++)
+         {
+            fpts_starts[i] += fpts_starts[i-1];
+         }
+         total_global_fpts = fpts_starts[num_procs];
+         total_global_cpts = cpts_starts[num_procs];
+#endif
+      }
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0)
+         {
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+            big_convert[i] = (HYPRE_BigInt)fine_to_coarse[i] + cpts_starts[0];
+#else
+            big_convert[i] = (HYPRE_BigInt)fine_to_coarse[i] + cpts_starts[my_id];
+#endif
+         }
+         else
+         {
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+            big_convert[i] = (HYPRE_BigInt)fine_to_fine[i] + fpts_starts[0];
+#else
+            big_convert[i] = (HYPRE_BigInt)fine_to_fine[i] + fpts_starts[my_id];
+#endif
+         }
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num == 0)
+      {
+         if (num_cols_A_offd) 
+         {
+            CF_marker_offd = hypre_CTAlloc(HYPRE_Int,  num_cols_A_offd, HYPRE_MEMORY_HOST);
+            big_convert_offd = hypre_CTAlloc(HYPRE_BigInt,  num_cols_A_offd, HYPRE_MEMORY_HOST);
+            fine_to_coarse_offd = hypre_CTAlloc(HYPRE_Int,  num_cols_A_offd, HYPRE_MEMORY_HOST);
+            fine_to_fine_offd = hypre_CTAlloc(HYPRE_Int,  num_cols_A_offd, HYPRE_MEMORY_HOST);
+         }
+         index = 0;
+         num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+         int_buf_data = hypre_CTAlloc(HYPRE_Int,  hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends), HYPRE_MEMORY_HOST);
+         big_buf_data = hypre_CTAlloc(HYPRE_BigInt,  hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends), HYPRE_MEMORY_HOST);
+         for (i = 0; i < num_sends; i++)
+         {
+            startc = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+            for (j = startc; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg, i+1); j++)
+            {
+               int_buf_data[index] = CF_marker[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+               big_buf_data[index++] = big_convert[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+            }
+         }
+
+         comm_handle = hypre_ParCSRCommHandleCreate( 11, comm_pkg, int_buf_data, CF_marker_offd);
+
+         hypre_ParCSRCommHandleDestroy(comm_handle);
+
+         comm_handle = hypre_ParCSRCommHandleCreate( 21, comm_pkg, big_buf_data, big_convert_offd);
+
+         hypre_ParCSRCommHandleDestroy(comm_handle);
+
+         num_cols_offd_A_FC = 0;
+         num_cols_offd_A_FF = 0;
+         if (num_cols_A_offd) 
+         {
+            for (i=0; i < num_cols_A_offd; i++)
+            {
+               if (CF_marker_offd[i] > 0)
+               {
+                  fine_to_coarse_offd[i] = num_cols_offd_A_FC++;
+                  fine_to_fine_offd[i] = -1;
+               }
+               else
+               {
+                  fine_to_fine_offd[i] = num_cols_offd_A_FF++;
+                  fine_to_coarse_offd[i] = -1;
+               }
+            }
+
+            col_map_offd_A_FF = hypre_TAlloc(HYPRE_BigInt, num_cols_offd_A_FF, HYPRE_MEMORY_HOST);
+            col_map_offd_A_FC = hypre_TAlloc(HYPRE_BigInt, num_cols_offd_A_FC, HYPRE_MEMORY_HOST);
+  
+            cpt = 0;
+            fpt = 0;
+            for (i=0; i < num_cols_A_offd; i++)
+            {
+               if (CF_marker_offd[i] > 0)
+               {
+                  col_map_offd_A_FC[cpt++] = big_convert_offd[i];
+               }
+               else
+               {
+                   col_map_offd_A_FF[fpt++] = big_convert_offd[i];
+               }
+            }
+         }
+
+         A_FF_diag_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
+         A_FC_diag_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
+         A_FF_offd_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
+         A_FC_offd_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      d_count_FC = 0;
+      d_count_FF = 0;
+      o_count_FC = 0;
+      o_count_FF = 0;
+      row = fpt_array[my_thread_num];
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] < 0)
+         {
+            row++;
+            d_count_FF++; /* account for diagonal element */
+            for (j = S_diag_i[i]; j < S_diag_i[i+1]; j++)
+            {
+               jj = S_diag_j[j];
+               if (CF_marker[jj] > 0) 
+   	       d_count_FC++;
+               else
+                  d_count_FF++;
+            }
+            A_FF_diag_i[row] = d_count_FF;
+            A_FC_diag_i[row] = d_count_FC;
+            for (j = S_offd_i[i]; j < S_offd_i[i+1]; j++)
+            {
+               jj = S_offd_j[j];
+               if (CF_marker_offd[jj] > 0) 
+   	       o_count_FC++;
+               else
+                  o_count_FF++;
+            }
+            A_FF_offd_i[row] = o_count_FF;
+            A_FC_offd_i[row] = o_count_FC;
+         }
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num == 0)
+      {
+         HYPRE_Int fpt2;
+         for (i=1; i<num_threads+1; i++)
+         {
+            fpt = fpt_array[i];
+            fpt2 = fpt_array[i-1];
+            A_FC_diag_i[fpt] += A_FC_diag_i[fpt2]; 
+            A_FF_diag_i[fpt] += A_FF_diag_i[fpt2]; 
+            A_FC_offd_i[fpt] += A_FC_offd_i[fpt2]; 
+            A_FF_offd_i[fpt] += A_FF_offd_i[fpt2]; 
+         }
+         row = fpt_array[num_threads];
+         d_count_FC = A_FC_diag_i[row];
+         d_count_FF = A_FF_diag_i[row];
+         o_count_FC = A_FC_offd_i[row];
+         o_count_FF = A_FF_offd_i[row];
+         A_FF_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FF, HYPRE_MEMORY_HOST);
+         A_FC_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FC, HYPRE_MEMORY_HOST);
+         A_FF_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FF, HYPRE_MEMORY_HOST);
+         A_FC_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FC, HYPRE_MEMORY_HOST);
+         A_FF_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FF, HYPRE_MEMORY_HOST);
+         A_FC_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FC, HYPRE_MEMORY_HOST);
+         A_FF_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FF, HYPRE_MEMORY_HOST);
+         A_FC_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FC, HYPRE_MEMORY_HOST);
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      row = fpt_array[my_thread_num];
+      d_count_FC = A_FC_diag_i[row];
+      d_count_FF = A_FF_diag_i[row];
+      o_count_FC = A_FC_offd_i[row];
+      o_count_FF = A_FF_offd_i[row];
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] < 0)
+         {
+            HYPRE_Int jS, jA;
+            row++;
+            jA = A_diag_i[i];
+            A_FF_diag_j[d_count_FF] = fine_to_fine[A_diag_j[jA]];
+            A_FF_diag_data[d_count_FF++] = A_diag_data[jA++];
+            for (j = S_diag_i[i]; j < S_diag_i[i+1]; j++)
+            {
+               jA = A_diag_i[i]+1;
+               jS = S_diag_j[j];
+               while (A_diag_j[jA] != jS) jA++; 
+               if (CF_marker[S_diag_j[j]] > 0)
+               {
+                  A_FC_diag_j[d_count_FC] = fine_to_coarse[A_diag_j[jA]];
+                  A_FC_diag_data[d_count_FC++] = A_diag_data[jA++];
+               }
+               else
+               {
+                  A_FF_diag_j[d_count_FF] = fine_to_fine[A_diag_j[jA]];
+                  A_FF_diag_data[d_count_FF++] = A_diag_data[jA++];
+               }
+            }
+            A_FF_diag_i[row] = d_count_FF;
+            A_FC_diag_i[row] = d_count_FC;
+            for (j = S_offd_i[i]; j < S_offd_i[i+1]; j++)
+            {
+               jA = A_offd_i[i];
+               jS = S_offd_j[j];
+               while (jS != A_offd_j[jA]) jA++;
+               if (CF_marker_offd[S_offd_j[j]] > 0)
+               {
+                  A_FC_offd_j[o_count_FC] = fine_to_coarse_offd[A_offd_j[jA]];
+                  A_FC_offd_data[o_count_FC++] = A_offd_data[jA++];
+               }
+               else
+               {
+                  A_FF_offd_j[o_count_FF] = fine_to_fine_offd[A_offd_j[jA]];
+                  A_FF_offd_data[o_count_FF++] = A_offd_data[jA++];
+               }
+            }
+            A_FF_offd_i[row] = o_count_FF;
+            A_FC_offd_i[row] = o_count_FC;
+         }
+      }
+   } /*end parallel region */
+
+   A_FC = hypre_ParCSRMatrixCreate(comm,
+            total_global_fpts,
+            total_global_cpts,
+            fpts_starts,
+            cpts_starts,
+            num_cols_offd_A_FC,
+            A_FC_diag_i[n_Fpts],
+            A_FC_offd_i[n_Fpts]);
+
+   A_FF = hypre_ParCSRMatrixCreate(comm,
+            total_global_fpts,
+            total_global_fpts,
+            fpts_starts,
+            fpts_starts,
+            num_cols_offd_A_FF,
+            A_FF_diag_i[n_Fpts],
+            A_FF_offd_i[n_Fpts]);
+
+   A_FC_diag = hypre_ParCSRMatrixDiag(A_FC);
+   hypre_CSRMatrixData(A_FC_diag) = A_FC_diag_data;
+   hypre_CSRMatrixI(A_FC_diag) = A_FC_diag_i;
+   hypre_CSRMatrixJ(A_FC_diag) = A_FC_diag_j;
+   A_FC_offd = hypre_ParCSRMatrixOffd(A_FC);
+   hypre_CSRMatrixData(A_FC_offd) = A_FC_offd_data;
+   hypre_CSRMatrixI(A_FC_offd) = A_FC_offd_i;
+   hypre_CSRMatrixJ(A_FC_offd) = A_FC_offd_j;
+   hypre_ParCSRMatrixOwnsRowStarts(A_FC) = 1;
+   hypre_ParCSRMatrixOwnsColStarts(A_FC) = 0;
+   hypre_ParCSRMatrixColMapOffd(A_FC) = col_map_offd_A_FC;
+
+   A_FF_diag = hypre_ParCSRMatrixDiag(A_FF);
+   hypre_CSRMatrixData(A_FF_diag) = A_FF_diag_data;
+   hypre_CSRMatrixI(A_FF_diag) = A_FF_diag_i;
+   hypre_CSRMatrixJ(A_FF_diag) = A_FF_diag_j;
+   A_FF_offd = hypre_ParCSRMatrixOffd(A_FF);
+   hypre_CSRMatrixData(A_FF_offd) = A_FF_offd_data;
+   hypre_CSRMatrixI(A_FF_offd) = A_FF_offd_i;
+   hypre_CSRMatrixJ(A_FF_offd) = A_FF_offd_j;
+   hypre_ParCSRMatrixOwnsRowStarts(A_FF) = 0;
+   hypre_ParCSRMatrixOwnsColStarts(A_FF) = 0;
+   hypre_ParCSRMatrixColMapOffd(A_FF) = col_map_offd_A_FF;
+
+   hypre_TFree(fine_to_coarse, HYPRE_MEMORY_HOST);
+   hypre_TFree(fine_to_fine, HYPRE_MEMORY_HOST);
+   hypre_TFree(big_convert, HYPRE_MEMORY_HOST);
+   hypre_TFree(fine_to_coarse_offd, HYPRE_MEMORY_HOST);
+   hypre_TFree(fine_to_fine_offd, HYPRE_MEMORY_HOST);
+   hypre_TFree(big_convert_offd, HYPRE_MEMORY_HOST);
+   hypre_TFree(CF_marker_offd, HYPRE_MEMORY_HOST);
+   hypre_TFree(int_buf_data, HYPRE_MEMORY_HOST);
+   hypre_TFree(big_buf_data, HYPRE_MEMORY_HOST);
+
+   hypre_TFree(cpt_array, HYPRE_MEMORY_HOST);
+   hypre_TFree(fpt_array, HYPRE_MEMORY_HOST);
+
+   *A_FC_ptr = A_FC;
+   *A_FF_ptr = A_FF;
+
+   return hypre_error_flag;
+}
+
+/* -----------------------------------------------------------------------------
+ * generate AFF, AFC, AFC2 for 2 stage interpolation
+ * ----------------------------------------------------------------------------- */
+
+HYPRE_Int
+hypre_ParCSRMatrixGenerateFFFC3( hypre_ParCSRMatrix *A,
+                                HYPRE_Int           *CF_marker,
+                                HYPRE_BigInt        *cpts_starts,
+                                hypre_ParCSRMatrix  *S,
+                                hypre_ParCSRMatrix **A_FC_ptr,
+                                hypre_ParCSRMatrix **A_FF_ptr)
+{
+   MPI_Comm                 comm     = hypre_ParCSRMatrixComm(A);
+   hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
+   hypre_ParCSRCommHandle  *comm_handle;
+
+   /* diag part of A */
+   hypre_CSRMatrix    *A_diag   = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Complex      *A_diag_data = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int          *A_diag_i = hypre_CSRMatrixI(A_diag);
+   HYPRE_Int          *A_diag_j = hypre_CSRMatrixJ(A_diag);
+   /* off-diag part of A */
+   hypre_CSRMatrix    *A_offd   = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Complex      *A_offd_data = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int          *A_offd_i = hypre_CSRMatrixI(A_offd);
+   HYPRE_Int          *A_offd_j = hypre_CSRMatrixJ(A_offd);
+
+   HYPRE_Int           n_fine = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Int           num_cols_A_offd = hypre_CSRMatrixNumCols(A_offd);
+
+   /* diag part of S */
+   hypre_CSRMatrix    *S_diag   = hypre_ParCSRMatrixDiag(S);
+   HYPRE_Int          *S_diag_i = hypre_CSRMatrixI(S_diag);
+   HYPRE_Int          *S_diag_j = hypre_CSRMatrixJ(S_diag);
+   /* off-diag part of S */
+   hypre_CSRMatrix    *S_offd   = hypre_ParCSRMatrixOffd(S);
+   HYPRE_Int          *S_offd_i = hypre_CSRMatrixI(S_offd);
+   HYPRE_Int          *S_offd_j = hypre_CSRMatrixJ(S_offd);
+
+   hypre_ParCSRMatrix *A_FC;
+   hypre_CSRMatrix    *A_FC_diag, *A_FC_offd;
+   HYPRE_Int          *A_FC_diag_i, *A_FC_diag_j, *A_FC_offd_i, *A_FC_offd_j=NULL;
+   HYPRE_Complex      *A_FC_diag_data, *A_FC_offd_data=NULL;
+   HYPRE_Int           num_cols_offd_A_FC;
+   HYPRE_BigInt       *col_map_offd_A_FC = NULL;
+
+   hypre_ParCSRMatrix *A_FF;
+   hypre_CSRMatrix    *A_FF_diag, *A_FF_offd;
+   HYPRE_Int          *A_FF_diag_i, *A_FF_diag_j, *A_FF_offd_i, *A_FF_offd_j;
+   HYPRE_Complex      *A_FF_diag_data, *A_FF_offd_data;
+   HYPRE_Int           num_cols_offd_A_FF;
+   HYPRE_BigInt       *col_map_offd_A_FF = NULL;
+
+   HYPRE_Int          *fine_to_coarse;
+   HYPRE_Int          *fine_to_fine;
+   HYPRE_Int          *fine_to_coarse_offd = NULL;
+   HYPRE_Int          *fine_to_fine_offd = NULL;
+
+   HYPRE_Int           i, j, jj;
+   HYPRE_Int           startc, index;
+   HYPRE_Int           cpt, fpt, new_fpt, row, rowc;
+   HYPRE_Int          *CF_marker_offd = NULL;
+   HYPRE_Int          *int_buf_data = NULL;
+   HYPRE_BigInt       *big_convert;
+   HYPRE_BigInt       *big_convert_offd = NULL;
+   HYPRE_BigInt       *big_buf_data = NULL;
+
+   HYPRE_BigInt        total_global_fpts, total_global_cpts, total_global_new_fpts;
+   HYPRE_BigInt       *fpts_starts, *new_fpts_starts;
+   HYPRE_Int           my_id, num_procs, num_sends;
+   HYPRE_Int           d_count_FF, d_count_FC, o_count_FF, o_count_FC;
+   HYPRE_Int           n_Fpts;
+   HYPRE_Int           n_new_Fpts;
+   HYPRE_Int          *cpt_array, *fpt_array, *new_fpt_array;
+   HYPRE_Int           start, stop;
+   HYPRE_Int           num_threads;
+
+   num_threads = hypre_NumThreads();  
+
+   /* MPI size and rank*/
+   hypre_MPI_Comm_size(comm, &num_procs);
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+   fine_to_coarse = hypre_CTAlloc(HYPRE_Int, n_fine, HYPRE_MEMORY_HOST);
+   fine_to_fine = hypre_CTAlloc(HYPRE_Int, n_fine, HYPRE_MEMORY_HOST);
+   big_convert = hypre_CTAlloc(HYPRE_BigInt, n_fine, HYPRE_MEMORY_HOST);
+
+   cpt_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
+   fpt_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
+   new_fpt_array = hypre_CTAlloc(HYPRE_Int, num_threads+1, HYPRE_MEMORY_HOST);
+#ifdef HYPRE_USING_OPENMP
+#pragma omp parallel private(i,j,jj,start,stop,row,rowc,cpt,new_fpt,fpt,d_count_FC,d_count_FF,o_count_FC,o_count_FF)
+#endif
+   {
+      HYPRE_Int my_thread_num = hypre_GetThreadNum();
+
+      start = (n_fine/num_threads)*my_thread_num;
+      if (my_thread_num == num_threads-1)
+      {
+         stop = n_fine;
+      }
+      else
+      {
+         stop = (n_fine/num_threads)*(my_thread_num+1);
+      }
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0)
+         {
+            cpt_array[my_thread_num+1]++;
+         }
+         else if (CF_marker[i] == -2)
+         {
+            new_fpt_array[my_thread_num+1]++;
+            fpt_array[my_thread_num+1]++;
+         }
+         else 
+         {
+            fpt_array[my_thread_num+1]++;
+         }
+      }
+   
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num == 0)
+      {
+         for (i=1; i < num_threads; i++)
+         {
+            cpt_array[i+1] += cpt_array[i];
+            fpt_array[i+1] += fpt_array[i];
+            new_fpt_array[i+1] += new_fpt_array[i];
+         }
+      }
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+
+      cpt = cpt_array[my_thread_num];
+      fpt = fpt_array[my_thread_num];
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0)
+         {
+            fine_to_coarse[i] = cpt++;
+            fine_to_fine[i] = -1;
+         }
+         else
+         {
+            fine_to_fine[i] = fpt++;
+            fine_to_coarse[i] = -1;
+         }
+      }
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+
+      if (my_thread_num == 0)
+      {
+         n_Fpts = fpt_array[num_threads];
+         n_new_Fpts = new_fpt_array[num_threads];
+
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+         fpts_starts = hypre_TAlloc(HYPRE_BigInt, 2, HYPRE_MEMORY_HOST);
+         new_fpts_starts = hypre_TAlloc(HYPRE_BigInt, 2, HYPRE_MEMORY_HOST);
+         hypre_MPI_Scan(&n_Fpts, fpts_starts+1, 1, HYPRE_MPI_BIG_INT, hypre_MPI_SUM, comm);
+         hypre_MPI_Scan(&n_new_Fpts, new_fpts_starts+1, 1, HYPRE_MPI_BIG_INT, hypre_MPI_SUM, comm);
+         fpts_starts[0] = fpts_starts[1] - n_Fpts;
+         new_fpts_starts[0] = new_fpts_starts[1] - n_new_Fpts;
+         if (my_id == num_procs - 1)
+         {
+            total_global_new_fpts = new_fpts_starts[1];
+            total_global_fpts = fpts_starts[1];
+            total_global_cpts = cpts_starts[1];
+         }
+         hypre_MPI_Bcast(&total_global_new_fpts, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+         hypre_MPI_Bcast(&total_global_fpts, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+         hypre_MPI_Bcast(&total_global_cpts, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+#else
+         fpts_starts = hypre_CTAlloc(HYPRE_BigInt, num_procs+1, HYPRE_MEMORY_HOST);
+         new_fpts_starts = hypre_TAlloc(HYPRE_BigInt, num_procs+1, HYPRE_MEMORY_HOST);
+         hypre_MPI_Allgather(&n_Fpts, 1, HYPRE_MPI_BIG_INT, &fpts_starts[1], 1, HYPRE_MPI_BIG_INT, comm);
+         hypre_MPI_Allgather(&n_new_Fpts, 1, HYPRE_MPI_BIG_INT, &new_fpts_starts[1], 1, HYPRE_MPI_BIG_INT, comm);
+         fpts_starts[0] = 0;
+         new_fpts_starts[0] = 0;
+         for (i = 2; i < num_procs+1; i++)
+         {
+            fpts_starts[i] += fpts_starts[i-1];
+            new_fpts_starts[i] += new_fpts_starts[i-1];
+         }
+         total_global_new_fpts = new_fpts_starts[num_procs];
+         total_global_fpts = fpts_starts[num_procs];
+         total_global_cpts = cpts_starts[num_procs];
+#endif
+      }
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] > 0)
+         {
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+            big_convert[i] = (HYPRE_BigInt)fine_to_coarse[i] + cpts_starts[0];
+#else
+            big_convert[i] = (HYPRE_BigInt)fine_to_coarse[i] + cpts_starts[my_id];
+#endif
+         }
+         else
+         {
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+            big_convert[i] = (HYPRE_BigInt)fine_to_fine[i] + fpts_starts[0];
+#else
+            big_convert[i] = (HYPRE_BigInt)fine_to_fine[i] + fpts_starts[my_id];
+#endif
+         }
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num == 0)
+      {
+         if (num_cols_A_offd) 
+         {
+            CF_marker_offd = hypre_CTAlloc(HYPRE_Int,  num_cols_A_offd, HYPRE_MEMORY_HOST);
+            big_convert_offd = hypre_CTAlloc(HYPRE_BigInt,  num_cols_A_offd, HYPRE_MEMORY_HOST);
+            fine_to_coarse_offd = hypre_CTAlloc(HYPRE_Int,  num_cols_A_offd, HYPRE_MEMORY_HOST);
+            fine_to_fine_offd = hypre_CTAlloc(HYPRE_Int,  num_cols_A_offd, HYPRE_MEMORY_HOST);
+         }
+         index = 0;
+         num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+         int_buf_data = hypre_CTAlloc(HYPRE_Int,  hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends), HYPRE_MEMORY_HOST);
+         big_buf_data = hypre_CTAlloc(HYPRE_BigInt,  hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends), HYPRE_MEMORY_HOST);
+         for (i = 0; i < num_sends; i++)
+         {
+            startc = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+            for (j = startc; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg, i+1); j++)
+            {
+               int_buf_data[index] = CF_marker[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+               big_buf_data[index++] = big_convert[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+            }
+         }
+
+         comm_handle = hypre_ParCSRCommHandleCreate( 11, comm_pkg, int_buf_data, CF_marker_offd);
+
+         hypre_ParCSRCommHandleDestroy(comm_handle);
+
+         comm_handle = hypre_ParCSRCommHandleCreate( 21, comm_pkg, big_buf_data, big_convert_offd);
+
+         hypre_ParCSRCommHandleDestroy(comm_handle);
+
+         num_cols_offd_A_FC = 0;
+         num_cols_offd_A_FF = 0;
+         if (num_cols_A_offd) 
+         {
+            for (i=0; i < num_cols_A_offd; i++)
+            {
+               if (CF_marker_offd[i] > 0)
+               {
+                  fine_to_coarse_offd[i] = num_cols_offd_A_FC++;
+                  fine_to_fine_offd[i] = -1;
+               }
+               else
+               {
+                  fine_to_fine_offd[i] = num_cols_offd_A_FF++;
+                  fine_to_coarse_offd[i] = -1;
+               }
+            }
+
+            col_map_offd_A_FF = hypre_TAlloc(HYPRE_BigInt, num_cols_offd_A_FF, HYPRE_MEMORY_HOST);
+            col_map_offd_A_FC = hypre_TAlloc(HYPRE_BigInt, num_cols_offd_A_FC, HYPRE_MEMORY_HOST);
+  
+            cpt = 0;
+            fpt = 0;
+            for (i=0; i < num_cols_A_offd; i++)
+            {
+               if (CF_marker_offd[i] > 0)
+               {
+                  col_map_offd_A_FC[cpt++] = big_convert_offd[i];
+               }
+               else
+               {
+                   col_map_offd_A_FF[fpt++] = big_convert_offd[i];
+               }
+            }
+         }
+
+         A_FF_diag_i = hypre_CTAlloc(HYPRE_Int,n_new_Fpts+1, HYPRE_MEMORY_HOST);
+         A_FC_diag_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
+         A_FF_offd_i = hypre_CTAlloc(HYPRE_Int,n_new_Fpts+1, HYPRE_MEMORY_HOST);
+         A_FC_offd_i = hypre_CTAlloc(HYPRE_Int,n_Fpts+1, HYPRE_MEMORY_HOST);
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      d_count_FC = 0;
+      d_count_FF = 0;
+      o_count_FC = 0;
+      o_count_FF = 0;
+      row = new_fpt_array[my_thread_num];
+      rowc = fpt_array[my_thread_num];
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] == -2)
+         {
+            row++;
+            rowc++;
+            d_count_FF++; /* account for diagonal element */
+            for (j = S_diag_i[i]; j < S_diag_i[i+1]; j++)
+            {
+               jj = S_diag_j[j];
+               if (CF_marker[jj] > 0) 
+   	       d_count_FC++;
+               else
+                  d_count_FF++;
+            }
+            A_FF_diag_i[row] = d_count_FF;
+            A_FC_diag_i[rowc] = d_count_FC;
+            for (j = S_offd_i[i]; j < S_offd_i[i+1]; j++)
+            {
+               jj = S_offd_j[j];
+               if (CF_marker_offd[jj] > 0) 
+   	       o_count_FC++;
+               else
+                  o_count_FF++;
+            }
+            A_FF_offd_i[row] = o_count_FF;
+            A_FC_offd_i[rowc] = o_count_FC;
+         }
+         else if (CF_marker[i] == -1)
+         {
+            rowc++;
+            for (j = S_diag_i[i]; j < S_diag_i[i+1]; j++)
+            {
+               jj = S_diag_j[j];
+               if (CF_marker[jj] > 0) 
+   	       d_count_FC++;
+            }
+            A_FC_diag_i[rowc] = d_count_FC;
+            for (j = S_offd_i[i]; j < S_offd_i[i+1]; j++)
+            {
+               jj = S_offd_j[j];
+               if (CF_marker_offd[jj] > 0) 
+   	       o_count_FC++;
+            }
+            A_FC_offd_i[rowc] = o_count_FC;
+         }
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      if (my_thread_num == 0)
+      {
+         HYPRE_Int fpt2, new_fpt2;
+         for (i=1; i<num_threads+1; i++)
+         {
+            fpt = fpt_array[i];
+            new_fpt = new_fpt_array[i];
+            fpt2 = fpt_array[i-1];
+            new_fpt2 = new_fpt_array[i-1];
+            A_FC_diag_i[fpt] += A_FC_diag_i[fpt2]; 
+            A_FF_diag_i[new_fpt] += A_FF_diag_i[new_fpt2]; 
+            A_FC_offd_i[fpt] += A_FC_offd_i[fpt2]; 
+            A_FF_offd_i[new_fpt] += A_FF_offd_i[new_fpt2]; 
+         }
+         row = new_fpt_array[num_threads];
+         rowc = fpt_array[num_threads];
+         d_count_FC = A_FC_diag_i[rowc];
+         d_count_FF = A_FF_diag_i[row];
+         o_count_FC = A_FC_offd_i[rowc];
+         o_count_FF = A_FF_offd_i[row];
+         A_FF_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FF, HYPRE_MEMORY_HOST);
+         A_FC_diag_j = hypre_CTAlloc(HYPRE_Int,d_count_FC, HYPRE_MEMORY_HOST);
+         A_FF_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FF, HYPRE_MEMORY_HOST);
+         A_FC_offd_j = hypre_CTAlloc(HYPRE_Int,o_count_FC, HYPRE_MEMORY_HOST);
+         A_FF_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FF, HYPRE_MEMORY_HOST);
+         A_FC_diag_data = hypre_CTAlloc(HYPRE_Real,d_count_FC, HYPRE_MEMORY_HOST);
+         A_FF_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FF, HYPRE_MEMORY_HOST);
+         A_FC_offd_data = hypre_CTAlloc(HYPRE_Real,o_count_FC, HYPRE_MEMORY_HOST);
+      }
+
+#ifdef HYPRE_USING_OPENMP
+#pragma omp barrier
+#endif
+      row = new_fpt_array[my_thread_num];
+      rowc = fpt_array[my_thread_num];
+      d_count_FC = A_FC_diag_i[rowc];
+      d_count_FF = A_FF_diag_i[row];
+      o_count_FC = A_FC_offd_i[rowc];
+      o_count_FF = A_FF_offd_i[row];
+      for (i=start; i < stop; i++)
+      {
+         if (CF_marker[i] == -2)
+         {
+            HYPRE_Int jS, jA;
+            row++;
+            rowc++;
+            jA = A_diag_i[i];
+            A_FF_diag_j[d_count_FF] = fine_to_fine[A_diag_j[jA]];
+            A_FF_diag_data[d_count_FF++] = A_diag_data[jA++];
+            for (j = S_diag_i[i]; j < S_diag_i[i+1]; j++)
+            {
+               jA = A_diag_i[i]+1;
+               jS = S_diag_j[j];
+               while (A_diag_j[jA] != jS) jA++; 
+               if (CF_marker[S_diag_j[j]] > 0)
+               {
+                  A_FC_diag_j[d_count_FC] = fine_to_coarse[A_diag_j[jA]];
+                  A_FC_diag_data[d_count_FC++] = A_diag_data[jA++];
+               }
+               else
+               {
+                  A_FF_diag_j[d_count_FF] = fine_to_fine[A_diag_j[jA]];
+                  A_FF_diag_data[d_count_FF++] = A_diag_data[jA++];
+               }
+            }
+            A_FF_diag_i[row] = d_count_FF;
+            A_FC_diag_i[rowc] = d_count_FC;
+            for (j = S_offd_i[i]; j < S_offd_i[i+1]; j++)
+            {
+               jA = A_offd_i[i];
+               jS = S_offd_j[j];
+               while (jS != A_offd_j[jA]) jA++;
+               if (CF_marker_offd[S_offd_j[j]] > 0)
+               {
+                  A_FC_offd_j[o_count_FC] = fine_to_coarse_offd[A_offd_j[jA]];
+                  A_FC_offd_data[o_count_FC++] = A_offd_data[jA++];
+               }
+               else
+               {
+                  A_FF_offd_j[o_count_FF] = fine_to_fine_offd[A_offd_j[jA]];
+                  A_FF_offd_data[o_count_FF++] = A_offd_data[jA++];
+               }
+            }
+            A_FF_offd_i[row] = o_count_FF;
+            A_FC_offd_i[rowc] = o_count_FC;
+         }
+         else if (CF_marker[i] == -1)
+         {
+            HYPRE_Int jS, jA;
+            rowc++;
+            for (j = S_diag_i[i]; j < S_diag_i[i+1]; j++)
+            {
+               jA = A_diag_i[i]+1;
+               jS = S_diag_j[j];
+               while (A_diag_j[jA] != jS) jA++; 
+               if (CF_marker[S_diag_j[j]] > 0)
+               {
+                  A_FC_diag_j[d_count_FC] = fine_to_coarse[A_diag_j[jA]];
+                  A_FC_diag_data[d_count_FC++] = A_diag_data[jA++];
+               }
+            }
+            A_FC_diag_i[rowc] = d_count_FC;
+            for (j = S_offd_i[i]; j < S_offd_i[i+1]; j++)
+            {
+               jA = A_offd_i[i];
+               jS = S_offd_j[j];
+               while (jS != A_offd_j[jA]) jA++;
+               if (CF_marker_offd[S_offd_j[j]] > 0)
+               {
+                  A_FC_offd_j[o_count_FC] = fine_to_coarse_offd[A_offd_j[jA]];
+                  A_FC_offd_data[o_count_FC++] = A_offd_data[jA++];
+               }
+            }
+            A_FC_offd_i[rowc] = o_count_FC;
+         }
+      }
+   } /*end parallel region */
+
+   A_FC = hypre_ParCSRMatrixCreate(comm,
+            total_global_fpts,
+            total_global_cpts,
+            fpts_starts,
+            cpts_starts,
+            num_cols_offd_A_FC,
+            A_FC_diag_i[n_Fpts],
+            A_FC_offd_i[n_Fpts]);
+
+   A_FF = hypre_ParCSRMatrixCreate(comm,
+            total_global_new_fpts,
+            total_global_fpts,
+            new_fpts_starts,
+            fpts_starts,
+            num_cols_offd_A_FF,
+            A_FF_diag_i[n_new_Fpts],
+            A_FF_offd_i[n_new_Fpts]);
+
+   A_FC_diag = hypre_ParCSRMatrixDiag(A_FC);
+   hypre_CSRMatrixData(A_FC_diag) = A_FC_diag_data;
+   hypre_CSRMatrixI(A_FC_diag) = A_FC_diag_i;
+   hypre_CSRMatrixJ(A_FC_diag) = A_FC_diag_j;
+   A_FC_offd = hypre_ParCSRMatrixOffd(A_FC);
+   hypre_CSRMatrixData(A_FC_offd) = A_FC_offd_data;
+   hypre_CSRMatrixI(A_FC_offd) = A_FC_offd_i;
+   hypre_CSRMatrixJ(A_FC_offd) = A_FC_offd_j;
+   hypre_ParCSRMatrixOwnsRowStarts(A_FC) = 1;
+   hypre_ParCSRMatrixOwnsColStarts(A_FC) = 0;
+   hypre_ParCSRMatrixColMapOffd(A_FC) = col_map_offd_A_FC;
+
+   A_FF_diag = hypre_ParCSRMatrixDiag(A_FF);
+   hypre_CSRMatrixData(A_FF_diag) = A_FF_diag_data;
+   hypre_CSRMatrixI(A_FF_diag) = A_FF_diag_i;
+   hypre_CSRMatrixJ(A_FF_diag) = A_FF_diag_j;
+   A_FF_offd = hypre_ParCSRMatrixOffd(A_FF);
+   hypre_CSRMatrixData(A_FF_offd) = A_FF_offd_data;
+   hypre_CSRMatrixI(A_FF_offd) = A_FF_offd_i;
+   hypre_CSRMatrixJ(A_FF_offd) = A_FF_offd_j;
+   hypre_ParCSRMatrixOwnsRowStarts(A_FF) = 1;
+   hypre_ParCSRMatrixOwnsColStarts(A_FF) = 0;
+   hypre_ParCSRMatrixColMapOffd(A_FF) = col_map_offd_A_FF;
+
+   hypre_TFree(fine_to_coarse, HYPRE_MEMORY_HOST);
+   hypre_TFree(fine_to_fine, HYPRE_MEMORY_HOST);
+   hypre_TFree(big_convert, HYPRE_MEMORY_HOST);
+   hypre_TFree(fine_to_coarse_offd, HYPRE_MEMORY_HOST);
+   hypre_TFree(fine_to_fine_offd, HYPRE_MEMORY_HOST);
+   hypre_TFree(big_convert_offd, HYPRE_MEMORY_HOST);
+   hypre_TFree(CF_marker_offd, HYPRE_MEMORY_HOST);
+   hypre_TFree(int_buf_data, HYPRE_MEMORY_HOST);
+   hypre_TFree(big_buf_data, HYPRE_MEMORY_HOST);
+
+   hypre_TFree(cpt_array, HYPRE_MEMORY_HOST);
+   hypre_TFree(fpt_array, HYPRE_MEMORY_HOST);
+   hypre_TFree(new_fpt_array, HYPRE_MEMORY_HOST);
+
+   *A_FC_ptr = A_FC;
+   *A_FF_ptr = A_FF;
+
+   return hypre_error_flag;
+}

--- a/src/test/TEST_ij/agg_interp.jobs
+++ b/src/test/TEST_ij/agg_interp.jobs
@@ -15,10 +15,15 @@
 #     7: 2s-ext interpolation all levels (tr = 0.3 P12_tr = 0.2)
 #     8: multipass interpolation all levels
 #     9: 2s-ei interpolation all levels (Pmx = 4, P12_mx = 3)
-#     8: multipass interpolation all levels for systems problem unknown approach
-#     8: 2s-ei interpolation all levels for systems problem unknown approach
-#     8: multipass interpolation all levels for systems problem hybrid approach
-#     8: 2s-ei interpolation all levels for systems problem hybrid approach
+#    10: multipass interpolation all levels for systems problem unknown approach
+#    11: 2s-ei interpolation all levels for systems problem unknown approach
+#    12: multipass interpolation all levels for systems problem hybrid approach
+#    13: 2s-ei interpolation all levels for systems problem hybrid approach
+#    14: 2s-mod-ext interpolation 1 level (agg_Pmx 4) 
+#    15: 2s-mod-ext interpolation 1 level (agg_tr 0.3) 
+#    16: 2s-mod-ei-ext interpolation 1 level (agg_P12 6 agg_Pmx 4) 
+#    17: 2s-mod-ext interpolation all levels for systems problem unknown approach
+#    18: 2s-mod-ext interpolation all levels for systems problem hybrid approach
 #=============================================================================
 
 mpirun -np 8 ./ij    -rhsrand -n 30 29 31 -P 2 2 2 -agg_nl 1 -agg_interp 1 -agg_Pmx 4 -solver 1 -rlx 6 \
@@ -60,3 +65,17 @@ mpirun -np 8 ./ij    -rhsrand -n 20 19 22 -P 2 2 2 -sysL 3 -nf 3 -agg_nl 10 -agg
 mpirun -np 8 ./ij    -rhsrand -n 20 19 22 -P 2 2 2 -sysL 3 -nf 3 -agg_nl 10 -agg_interp 1 -agg_Pmx 4 -agg_P12_mx 4 -nodal 1 -solver 1 -rlx 6 \
  >> agg_interp.out.13
 
+mpirun -np 8 ./ij    -rhsrand -n 30 29 31 -P 2 2 2 -agg_nl 1 -agg_interp 5 -agg_Pmx 4 -solver 1 -rlx 6 \
+ >> agg_interp.out.14
+
+mpirun -np 8 ./ij    -rhsrand -n 30 29 31 -P 2 2 2 -agg_nl 1 -agg_interp 5 -agg_tr 0.3 -solver 1 -rlx 6 \
+ >> agg_interp.out.15
+
+mpirun -np 8 ./ij    -rhsrand -n 30 29 31 -P 2 2 2 -agg_nl 1 -agg_interp 6 -agg_Pmx 4 -agg_P12_mx 4 -solver 1 -rlx 6 \
+ >> agg_interp.out.16
+
+mpirun -np 8 ./ij    -rhsrand -n 20 19 22 -P 2 2 2 -sysL 3 -nf 3 -agg_nl 10 -interptype 16 -agg_interp 5 -agg_Pmx 4 -agg_P12_mx 4 -solver 1 -rlx 6 \
+ >> agg_interp.out.17
+
+mpirun -np 8 ./ij    -rhsrand -n 20 19 22 -P 2 2 2 -sysL 3 -nf 3 -agg_nl 10 -interptype 17 -agg_interp 5 -agg_tr 0.2 -agg_P12_tr 0.2 -nodal 1 -solver 1 -rlx 6 \
+ >> agg_interp.out.18

--- a/src/test/TEST_ij/agg_interp.saved
+++ b/src/test/TEST_ij/agg_interp.saved
@@ -76,3 +76,33 @@ Final Relative Residual Norm = 5.870410e-09
 Iterations = 16
 Final Relative Residual Norm = 5.087936e-09
 
+# Output file: agg_interp.out.14
+
+
+Iterations = 10
+Final Relative Residual Norm = 2.697794e-09
+
+# Output file: agg_interp.out.15
+
+
+Iterations = 10
+Final Relative Residual Norm = 7.511453e-09
+
+# Output file: agg_interp.out.16
+
+
+Iterations = 9
+Final Relative Residual Norm = 6.146679e-09
+
+# Output file: agg_interp.out.17
+
+
+Iterations = 17
+Final Relative Residual Norm = 8.827480e-09
+
+# Output file: agg_interp.out.18
+
+
+Iterations = 16
+Final Relative Residual Norm = 3.464377e-09
+

--- a/src/test/TEST_ij/agg_interp.sh
+++ b/src/test/TEST_ij/agg_interp.sh
@@ -26,6 +26,11 @@ FILES="\
  ${TNAME}.out.11\
  ${TNAME}.out.12\
  ${TNAME}.out.13\
+ ${TNAME}.out.14\
+ ${TNAME}.out.15\
+ ${TNAME}.out.16\
+ ${TNAME}.out.17\
+ ${TNAME}.out.18\
 "
 
 for i in $FILES

--- a/src/test/TEST_ij/interp.jobs
+++ b/src/test/TEST_ij/interp.jobs
@@ -38,7 +38,7 @@ mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -interptype 8 \
 mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -interptype 0 -Pmx 0 -falgout \
  > interp.out.6
 
-mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -interptype 16 \
+mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -interptype 16 -Pmx 12 \
  > interp.out.7
 
 mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -interptype 17 \

--- a/src/test/TEST_ij/interp.jobs
+++ b/src/test/TEST_ij/interp.jobs
@@ -6,13 +6,15 @@
 
 #=============================================================================
 # ij: Run default case with different interpolation operators
-#    1: Extended interpolation
-#    2: FF interpolation
-#    3: standard interpolation
-#    4: Extended interpolation and truncation max 4 elmts per row
-#    5: FF interpolation and truncation max 4 elmts per row
-#    6: standard interpolation and truncation max 4 elmts per row
-#    7: Classical modified interpolation
+#    0: Extended+i interpolation
+#    1: FF interpolation
+#    2: standard interpolation
+#    3: Extended interpolation and truncation max 4 elmts per row
+#    4: FF interpolation and truncation max 4 elmts per row
+#    5: standard interpolation and truncation max 4 elmts per row
+#    6: Classical modified interpolation
+#    7: Mod Extended interpolation and truncation max 4 elmts per row
+#    8: Mod Extended+i interpolation and truncation max 4 elmts per row
 #=============================================================================
 
 mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -Pmx 0 \
@@ -35,5 +37,11 @@ mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -interptype 8 \
 
 mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -interptype 0 -Pmx 0 -falgout \
  > interp.out.6
+
+mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -interptype 16 \
+ > interp.out.7
+
+mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -interptype 17 \
+ > interp.out.8
 
 

--- a/src/test/TEST_ij/interp.saved
+++ b/src/test/TEST_ij/interp.saved
@@ -47,3 +47,17 @@
                 operator = 3.541020
                    cycle = 7.080340
 
+# Output file: interp.out.7
+ Average Convergence Factor = 0.220928
+
+     Complexity:    grid = 1.587556
+                operator = 2.682041
+                   cycle = 5.362993
+
+# Output file: interp.out.8
+ Average Convergence Factor = 0.194361
+
+     Complexity:    grid = 1.586667
+                operator = 2.681224
+                   cycle = 5.360748
+

--- a/src/test/TEST_ij/interp.saved
+++ b/src/test/TEST_ij/interp.saved
@@ -48,11 +48,11 @@
                    cycle = 7.080340
 
 # Output file: interp.out.7
- Average Convergence Factor = 0.220928
+ Average Convergence Factor = 0.219604
 
-     Complexity:    grid = 1.587556
-                operator = 2.682041
-                   cycle = 5.362993
+     Complexity:    grid = 1.571556
+                operator = 2.958639
+                   cycle = 5.916190
 
 # Output file: interp.out.8
  Average Convergence Factor = 0.194361

--- a/src/test/TEST_ij/interp.sh
+++ b/src/test/TEST_ij/interp.sh
@@ -20,6 +20,8 @@ FILES="\
  ${TNAME}.out.4\
  ${TNAME}.out.5\
  ${TNAME}.out.6\
+ ${TNAME}.out.7\
+ ${TNAME}.out.8\
 "
 
 for i in $FILES


### PR DESCRIPTION
Hi all,
I have added the new interpolation routines to hypre. The regression tests on tux were clean (except cmake, since I have an old cmake). I also have not run the gpu regression tests.
There are basically 3 new interpolation routines: new extended, new extended+i and new 2stage extended. There is also a new option for 2stage extended+i (agg_interp 6), but it does not have all the new elements, just uses the new extended+i for one stage, but the old portion for the second stage.