### PR TITLE
SuperLU bug fixes

### DIFF
--- a/src/parcsr_ls/HYPRE_parcsr_ilu.c
+++ b/src/parcsr_ls/HYPRE_parcsr_ilu.c
@@ -177,3 +177,11 @@ HYPRE_ILUGetFinalRelativeResidualNorm(  HYPRE_Solver solver, HYPRE_Real *res_nor
 {
    return hypre_ILUGetFinalRelativeResidualNorm(solver, res_norm);
 }
+/*--------------------------------------------------------------------------
+ * HYPRE_ILUSetLocalReordering
+ *--------------------------------------------------------------------------*/
+HYPRE_Int
+HYPRE_ILUSetLocalReordering(  HYPRE_Solver solver, HYPRE_Int ordering_type )
+{
+   return hypre_ILUSetLocalReordering(solver, ordering_type);
+}

--- a/src/parcsr_ls/HYPRE_parcsr_ls.h
+++ b/src/parcsr_ls/HYPRE_parcsr_ls.h
@@ -1195,6 +1195,12 @@ HYPRE_Int HYPRE_BoomerAMGGetGridHierarchy(HYPRE_Solver solver,
 #ifdef HYPRE_USING_DSUPERLU
 /**
  * HYPRE_BoomerAMGSetDSLUThreshold
+ *
+ * Usage:
+ *  Set slu_threshold >= max_coarse_size (from HYPRE_BoomerAMGSetMaxCoarseSize(...))
+ *  to turn on use of superLU for the coarse grid solve. SuperLU is used if the 
+ *  coarse grid size > max_coarse_size and the grid level is < (max_num_levels - 1) 
+ *  (set with HYPRE_BoomerAMGSetMaxLevels(...)).
  **/
 
 HYPRE_Int HYPRE_BoomerAMGSetDSLUThreshold (HYPRE_Solver solver,

--- a/src/parcsr_ls/par_amg.c
+++ b/src/parcsr_ls/par_amg.c
@@ -481,8 +481,12 @@ hypre_BoomerAMGDestroy( void *data )
    HYPRE_ANNOTATION_BEGIN("BoomerAMG.destroy");
 
 #ifdef HYPRE_USING_DSUPERLU
-   if (hypre_ParAMGDataDSLUThreshold(amg_data) > 0)
+//   if (hypre_ParAMGDataDSLUThreshold(amg_data) > 0)
+   if (hypre_ParAMGDataDSLUSolver(amg_data) != NULL)
+   {
       hypre_SLUDistDestroy(hypre_ParAMGDataDSLUSolver(amg_data));
+      hypre_ParAMGDataDSLUSolver(amg_data) = NULL;
+   }
 #endif
 
    if (hypre_ParAMGDataMaxEigEst(amg_data))

--- a/src/parcsr_ls/superlu.c
+++ b/src/parcsr_ls/superlu.c
@@ -59,12 +59,16 @@ HYPRE_Int hypre_SLUDistSetup( HYPRE_Solver *solver, hypre_ParCSRMatrix *A, HYPRE
 
    num_rows = hypre_CSRMatrixNumRows(A_local);
    /* Now convert hypre matrix to a SuperMatrix */
+#ifdef HYPRE_MIXEDINT
    rowptr = hypre_CSRMatrixI(A_local);
    big_rowptr = hypre_CTAlloc(HYPRE_BigInt, (num_rows+1), HYPRE_MEMORY_HOST);
    for(i=0; i<(num_rows+1); i++)
    {
       big_rowptr[i] = (HYPRE_BigInt)rowptr[i];
    } 
+#else
+   big_rowptr = hypre_CSRMatrixI(A_local);
+#endif
    dCreate_CompRowLoc_Matrix_dist(
             &(dslu_data->A_dslu),global_num_rows,global_num_rows,
             hypre_CSRMatrixNumNonzeros(A_local),
@@ -76,6 +80,9 @@ HYPRE_Int hypre_SLUDistSetup( HYPRE_Solver *solver, hypre_ParCSRMatrix *A, HYPRE
 
    /* DOK: SuperLU frees assigned data, so set them to null before 
     * calling hypre_CSRMatrixdestroy on A_local to avoid double free memory error */
+#ifndef HYPRE_MIXEDINT
+   hypre_CSRMatrixI(A_local) = NULL;
+#endif
    hypre_CSRMatrixData(A_local) = NULL;
    hypre_CSRMatrixBigJ(A_local) = NULL;
    hypre_CSRMatrixDestroy(A_local);

--- a/src/parcsr_ls/superlu.c
+++ b/src/parcsr_ls/superlu.c
@@ -79,7 +79,8 @@ HYPRE_Int hypre_SLUDistSetup( HYPRE_Solver *solver, hypre_ParCSRMatrix *A, HYPRE
             SLU_NR_loc, SLU_D, SLU_GE);
 
    /* DOK: SuperLU frees assigned data, so set them to null before 
-    * calling hypre_CSRMatrixdestroy on A_local to avoid double free memory error */
+    * calling hypre_CSRMatrixdestroy on A_local to avoid memory errors. 
+   */
 #ifndef HYPRE_MIXEDINT
    hypre_CSRMatrixI(A_local) = NULL;
 #endif


### PR DESCRIPTION
This PR fixes some issues with using superLU as a coarse grid solver within BoomerAMG:
1. Fixed a memory bug for cases when the superLU solver is destroyed without being created
2. Fixed mixedInt bug that resulted from inconsistent integer types between superLU and hyper
3. Updated hypre to be consistent with latest version of superLU.
NOTE: There are still some compiler warnings with building hypre with superLU, since superLU uses 32bit integer types for some of its function arguments even if xsdk_index = 64. Another warning that shows up is because hype's BigInt is of type long long, where as superLU uses long when xsdk_index = 64. I believe this warning is benign, but I am not sure how to turn it off.