### PR TITLE
Fix issue108

### DIFF
--- a/src/struct_ls/semi.c
+++ b/src/struct_ls/semi.c
@@ -81,7 +81,7 @@ hypre_StructInterpAssemble( hypre_StructMatrix  *A,
    hypre_CommInfoProjectSend(comm_info, index, stride);
    hypre_CommInfoProjectRecv(comm_info, index, stride);
 
-   for (s = 0; s < 3; s++)
+   for (s = 0; s < 4; s++)
    {
       switch(s)
       {
@@ -89,12 +89,18 @@ hypre_StructInterpAssemble( hypre_StructMatrix  *A,
             box_aa = hypre_CommInfoSendBoxes(comm_info);
             hypre_SetIndex3(hypre_CommInfoSendStride(comm_info), 1, 1, 1);
             break;
+
          case 1:
             box_aa = hypre_CommInfoRecvBoxes(comm_info);
             hypre_SetIndex3(hypre_CommInfoRecvStride(comm_info), 1, 1, 1);
             break;
+
          case 2:
             box_aa = hypre_CommInfoSendRBoxes(comm_info);
+            break;
+
+         case 3:
+            box_aa = hypre_CommInfoRecvRBoxes(comm_info);
             break;
       }
 

--- a/src/struct_mv/_hypre_struct_mv.h
+++ b/src/struct_mv/_hypre_struct_mv.h
@@ -3089,12 +3089,8 @@ typedef struct hypre_StructStencil_struct
 /*--------------------------------------------------------------------------
  * hypre_CommInfo:
  *
- * For "reverse" communication, the following are not needed (may be NULL)
- *    send_rboxnums, send_rboxes, send_transforms
- *
- * For "forward" communication, the following are not needed (may be NULL)
- *    recv_rboxnums, recv_rboxes, recv_transforms
- *
+ * For "reverse" communication, send_transforms is not needed (may be NULL).
+ * For "forward" communication, recv_transforms is not needed (may be NULL).
  *--------------------------------------------------------------------------*/
 
 typedef struct hypre_CommInfo_struct

--- a/src/struct_mv/communication_info.c
+++ b/src/struct_mv/communication_info.c
@@ -116,6 +116,8 @@ hypre_CommInfoProjectRecv( hypre_CommInfo  *comm_info,
 {
    hypre_ProjectBoxArrayArray(hypre_CommInfoRecvBoxes(comm_info),
                               index, stride);
+   hypre_ProjectBoxArrayArray(hypre_CommInfoRecvRBoxes(comm_info),
+                              index, stride);
    hypre_CopyIndex(stride, hypre_CommInfoRecvStride(comm_info));
 
    return hypre_error_flag;

--- a/src/struct_mv/struct_communication.c
+++ b/src/struct_mv/struct_communication.c
@@ -45,12 +45,13 @@ hypre_CommPkgCreate( hypre_CommInfo   *comm_info,
    HYPRE_Int             ndim = hypre_CommInfoNDim(comm_info);
    hypre_BoxArrayArray  *send_boxes;
    hypre_BoxArrayArray  *recv_boxes;
+   hypre_BoxArrayArray  *send_rboxes;
+   hypre_BoxArrayArray  *recv_rboxes;
    hypre_IndexRef        send_stride;
    hypre_IndexRef        recv_stride;
    HYPRE_Int           **send_processes;
    HYPRE_Int           **recv_processes;
    HYPRE_Int           **send_rboxnums;
-   hypre_BoxArrayArray  *send_rboxes;
 
    HYPRE_Int             num_transforms;
    hypre_Index          *coords;
@@ -70,6 +71,7 @@ hypre_CommPkgCreate( hypre_CommInfo   *comm_info,
    hypre_BoxArray       *box_array;
    hypre_Box            *box;
    hypre_BoxArray       *rbox_array;
+   hypre_Box            *rbox;
    hypre_Box            *data_box;
    HYPRE_Int            *data_offsets;
    HYPRE_Int             data_offset;
@@ -92,6 +94,7 @@ hypre_CommPkgCreate( hypre_CommInfo   *comm_info,
       recv_processes  = hypre_CommInfoSendProcesses(comm_info);
       send_rboxnums   = hypre_CommInfoRecvRBoxnums(comm_info);
       send_rboxes     = hypre_CommInfoRecvRBoxes(comm_info);
+      recv_rboxes     = hypre_CommInfoSendRBoxes(comm_info);
       send_transforms = hypre_CommInfoRecvTransforms(comm_info); /* may be NULL */
 
       box_array = send_data_space;
@@ -108,6 +111,7 @@ hypre_CommPkgCreate( hypre_CommInfo   *comm_info,
       recv_processes  = hypre_CommInfoRecvProcesses(comm_info);
       send_rboxnums   = hypre_CommInfoSendRBoxnums(comm_info);
       send_rboxes     = hypre_CommInfoSendRBoxes(comm_info);
+      recv_rboxes     = hypre_CommInfoRecvRBoxes(comm_info);
       send_transforms = hypre_CommInfoSendTransforms(comm_info); /* may be NULL */
    }
    num_transforms = hypre_CommInfoNumTransforms(comm_info);
@@ -227,10 +231,12 @@ hypre_CommPkgCreate( hypre_CommInfo   *comm_info,
    {
       i = comm_boxes_i[m];
       j = comm_boxes_j[m];
-      box_array = hypre_BoxArrayArrayBoxArray(send_boxes, i);
-      box = hypre_BoxArrayBox(box_array, j);
+      box_array  = hypre_BoxArrayArrayBoxArray(send_boxes, i);
+      rbox_array = hypre_BoxArrayArrayBoxArray(send_rboxes, i);
+      box  = hypre_BoxArrayBox(box_array, j);
+      rbox = hypre_BoxArrayBox(rbox_array, j);
 
-      if (hypre_BoxVolume(box) != 0)
+      if ((hypre_BoxVolume(box) != 0) && (hypre_BoxVolume(rbox) != 0))
       {
          p = comm_boxes_p[m];
 
@@ -357,10 +363,12 @@ hypre_CommPkgCreate( hypre_CommInfo   *comm_info,
    {
       i = comm_boxes_i[m];
       j = comm_boxes_j[m];
-      box_array = hypre_BoxArrayArrayBoxArray(recv_boxes, i);
-      box = hypre_BoxArrayBox(box_array, j);
+      box_array  = hypre_BoxArrayArrayBoxArray(recv_boxes, i);
+      rbox_array = hypre_BoxArrayArrayBoxArray(recv_rboxes, i);
+      box  = hypre_BoxArrayBox(box_array, j);
+      rbox = hypre_BoxArrayBox(rbox_array, j);
 
-      if (hypre_BoxVolume(box) != 0)
+      if ((hypre_BoxVolume(box) != 0) && (hypre_BoxVolume(rbox) != 0))
       {
          p = comm_boxes_p[m];
 

--- a/src/struct_mv/struct_communication.h
+++ b/src/struct_mv/struct_communication.h
@@ -11,12 +11,8 @@
 /*--------------------------------------------------------------------------
  * hypre_CommInfo:
  *
- * For "reverse" communication, the following are not needed (may be NULL)
- *    send_rboxnums, send_rboxes, send_transforms
- *
- * For "forward" communication, the following are not needed (may be NULL)
- *    recv_rboxnums, recv_rboxes, recv_transforms
- *
+ * For "reverse" communication, send_transforms is not needed (may be NULL).
+ * For "forward" communication, recv_transforms is not needed (may be NULL).
  *--------------------------------------------------------------------------*/
 
 typedef struct hypre_CommInfo_struct

--- a/src/test/TEST_struct/periodic.jobs
+++ b/src/test/TEST_struct/periodic.jobs
@@ -33,7 +33,7 @@ mpirun -np 2 ./struct -n 20 20 10 -p  20 0 20 -P 1 1 2 -skip 1 -rap 1 -solver 1 
 > periodic.out.41
 
 #=============================================================================
-# Check SMG for power-of-two systems
+# Check SMG
 #=============================================================================
 
 # power-of-two
@@ -42,3 +42,6 @@ mpirun -np 1 ./struct -n 16 16 16 -p 16 0 16 -P 1 1 1 -solver 0 > periodic.out.5
 mpirun -np 2 ./struct -n  8 16 16 -p 16 0 16 -P 2 1 1 -solver 0 > periodic.out.51
 mpirun -np 4 ./struct -n  8  8 16 -p 16 0 16 -P 2 2 1 -solver 0 > periodic.out.52
 mpirun -np 4 ./struct -n 16  8  8 -p 16 0 16 -P 1 2 2 -solver 0 > periodic.out.53
+
+# non-power-of-two
+mpirun -np 3 ./struct -n 10 10 10 -p  0 0 30 -P 1 1 3 -solver 0 > periodic.out.60

--- a/src/test/TEST_struct/periodic.saved
+++ b/src/test/TEST_struct/periodic.saved
@@ -62,3 +62,6 @@ Final Relative Residual Norm = 3.701014e-07
 Iterations = 7
 Final Relative Residual Norm = 3.701014e-07
 
+# Output file: periodic.out.60
+Iterations = 10
+Final Relative Residual Norm = 1.565392e-07

--- a/src/test/TEST_struct/periodic.sh
+++ b/src/test/TEST_struct/periodic.sh
@@ -69,6 +69,7 @@ FILES="\
  ${TNAME}.out.51\
  ${TNAME}.out.52\
  ${TNAME}.out.53\
+ ${TNAME}.out.60\
 "
 
 for i in $FILES


### PR DESCRIPTION
This PR fixes issue #108. 

When building the interpolation operator of SMG for a case with periodic boundary conditions and more than one processor in the coarsening direction, it may happen that a box has zero volume, meanwhile, its corresponding rbox has a non-zero volume and vice-versa. In this situation, the communication matrix is non-symmetric, resulting in a deadlock. With this PR, boxes are communicated (sent/received) only if their matching rboxes have non-zero volume. A new regression test was added to make sure the code works properly in this particular situation.