### PR TITLE
GPU build doc

### DIFF
--- a/src/docs/usr-manual/ch-misc.rst
+++ b/src/docs/usr-manual/ch-misc.rst
@@ -163,7 +163,7 @@ include:
 GPU build
 ------------------------------------------------------------------------------
 
-Hypre can support GPUs with CUDA and OpenMP (:math:`{\ge}` 4.5). The related ``configure`` options are listed as follows
+Hypre can support GPUs with CUDA and OpenMP (:math:`{\ge}` 4.5). The related ``configure`` options are
 
 .. code-block:: none
 
@@ -173,17 +173,7 @@ Hypre can support GPUs with CUDA and OpenMP (:math:`{\ge}` 4.5). The related ``c
   --with-device-openmp    Use OpenMP 4.5 Device Directives. This may affect
                           which compiler is chosen.
 
-  --enable-nvtx           Use NVTX (default is NO).
-
-  --enable-cusparse       Use cuSPARSE (default is YES).
-
-  --enable-cub            Use CUB caching allocator (default is NO).
-
-  --enable-cublas         Use cuBLAS (default is NO).
-
-  --enable-curand         Use cuRAND (default is YES).
-
-Environment variables related to CUDA
+The related environment variables
 
 .. code-block:: none
 
@@ -194,7 +184,8 @@ Environment variables related to CUDA
 need to be set properly.
 
 When configured with ``--with-cuda`` or ``--with-device-openmp``, the memory allocated on the GPUs, by default, is the GPU device memory, which is not accessible from the CPUs.
-Hypre's Struct solvers can work fine with the device memory, whereas BoomerAMG and the SStruct solvers require the unified (CUDA managed) memory, for which
+Hypre's Struct solvers can work fine with only  device memory,
+whereas BoomerAMG and the SStruct solvers require  unified (CUDA managed) memory, for which
 the following option should be added
 
 .. code-block:: none
@@ -202,7 +193,8 @@ the following option should be added
   --enable-unified-memory Use unified memory for allocating the memory
                           (default is NO).
 
-Hypre's Struct solvers can also use RAJA and Kokkos as the backend of the BoxLoop. The related ``configure`` options include
+Hypre's Struct solvers can also choose RAJA and Kokkos as the backend.
+The ``configure`` options are
 
 .. code-block:: none
 
@@ -212,40 +204,16 @@ Hypre's Struct solvers can also use RAJA and Kokkos as the backend of the BoxLoo
   --with-kokkos           Use Kokkos. Require kokkos package to be compiled
                           properly(default is NO).
 
-  --with-raja-include=DIR User specifies that RAJA/*.h is in DIR. The options
-                          --with-raja-include --with-raja-libs and
-                          --with-raja-lib-dirs must be used together.
+To run on the GPUs with RAJA and Kokkos, the options ``--with-cuda`` and ``--with-device-openmp`` are also needed,
+and the RAJA and Kokkos libraries should be built with CUDA or OpenMP 4.5 correspondingly.
 
-  --with-raja-libs=LIBS   LIBS is space-separated list (enclosed in quotes) of
-                          libraries needed for RAJA (base name only). The
-                          options --with-raja-libs and --with-raja-lib-dirs
-                          must be used together.
+The other GPU related options include:
 
-  --with-raja-lib-dirs=DIRS
-                          DIRS is space-separated list (enclosed in quotes) of
-                          directories containing the libraries specified by
-                          --with-raja-libs, e.g "usr/lib /usr/local/lib". The
-                          options --with-raja-libs and --raja-blas-lib-dirs
-                          must be used together.
-
-  --with-kokkos-include=DIR
-                          User specifies that KOKKOS headers is in DIR. The
-                          options --with-kokkos-include --with-kokkos-libs and
-                          --with-kokkos-dirs must be used together.
-
-  --with-kokkos-libs=LIBS LIBS is space-separated list (enclosed in quotes) of
-                          libraries needed for KOKKOS (base name only). The
-                          options --with-kokkos-libs and --with-kokkos-dirs
-                          must be used together.
-
-  --with-kokkos-lib-dirs=DIRS
-                          DIRS is space-separated list (enclosed in quotes) of
-                          directories containing the libraries and
-                          Makefile.kokkos is assumed to be in DIRS/../ . The
-                          options --with-kokkos-libs and --with-kokkos-dirs
-                          must be used together.
-
-To run on the GPUs, the option ``--with-cuda`` or ``--with-device-openmp`` is also needed, and the provided RAJA and Kokkos libraries should have been built with CUDA or OpenMP 4.5 correspondingly.
+* ``--enable-nvtx``: enable NVTX annotations for CUDA profilers
+* ``--enable-cub`` : enable the caching GPU memory allocator in hypre
+* ``--enable-cusparse`` : choose cuSPARSE for GPU sparse kernels
+* ``--enable-cublas`` : choose cuBLAS for GPU dense kernels
+* ``--enable-curand`` : generating random numbers on GPUs
 
 Testing the Library
 ==============================================================================

--- a/src/docs/usr-manual/ch-misc.rst
+++ b/src/docs/usr-manual/ch-misc.rst
@@ -38,7 +38,7 @@ simplest method is to configure, compile and install the libraries in
 ``./hypre/lib`` and ``./hypre/include`` directories, which is accomplished by:
 
 .. code-block:: bash
-   
+
    ./configure
    make
 
@@ -90,14 +90,14 @@ options and variable settings to meet their needs.
 Some of the commonly used options include:
 
 .. code-block:: none
-   
-   --enable-debug                 Sets compiler flags to generate information 
+
+   --enable-debug                 Sets compiler flags to generate information
                                   needed for debugging.
    --enable-shared                Build shared libraries.
-                                  NOTE: in order to use the resulting shared 
+                                  NOTE: in order to use the resulting shared
                                         libraries the user MUST have the path to
-                                        the libraries defined in the environment 
-                                        variable LD_LIBRARY_PATH. 
+                                        the libraries defined in the environment
+                                        variable LD_LIBRARY_PATH.
    --with-print-errors            Print HYPRE errors
    --with-openmp                  Use OpenMP. This may affect which compiler is
                                   chosen.
@@ -113,7 +113,7 @@ and LAPACK libraries, which can be combined with any other option.  This is done
 as follows (currently, both libraries must be configured as external together):
 
 .. code-block:: bash
-   
+
    ./configure  --with-blas-lib="blas-lib-name" \
                 --with-blas-lib-dirs="path-to-blas-lib" \
                 --with-lapack-lib="lapack-lib-name" \
@@ -132,14 +132,14 @@ libraries occurs.  Make has several options that are called targets.  These
 include:
 
 .. code-block:: none
-   
+
    help         prints the details of each target
 
    all          default target in all directories
                 compile the entire library
                 does NOT rebuild documentation
 
-   clean        deletes all files from the current directory that are 
+   clean        deletes all files from the current directory that are
                    created by building the library
 
    distclean    deletes all files from the current directory that are created
@@ -160,6 +160,92 @@ include:
                 builds the test drivers; linking to the temporary locations to
                    simulate how application codes will link to HYPRE
 
+GPU build
+------------------------------------------------------------------------------
+
+Hypre can support GPUs with CUDA and OpenMP (:math:`{\ge}` 4.5). The related ``configure`` options are listed as follows
+
+.. code-block:: none
+
+  --with-cuda             Use CUDA. Require cuda-8.0 or higher (default is
+                          NO).
+
+  --with-device-openmp    Use OpenMP 4.5 Device Directives. This may affect
+                          which compiler is chosen.
+
+  --enable-nvtx           Use NVTX (default is NO).
+
+  --enable-cusparse       Use cuSPARSE (default is YES).
+
+  --enable-cub            Use CUB caching allocator (default is NO).
+
+  --enable-cublas         Use cuBLAS (default is NO).
+
+  --enable-curand         Use cuRAND (default is YES).
+
+Environment variables related to CUDA
+
+.. code-block:: none
+
+   HYPRE_CUDA_SM          (default 60)
+
+   CUDA_HOME              the CUDA home directory
+
+need to be set properly.
+
+When configured with ``--with-cuda`` or ``--with-device-openmp``, the memory allocated on the GPUs, by default, is the GPU device memory, which is not accessible from the CPUs.
+Hypre's Struct solvers can work fine with the device memory, whereas BoomerAMG and the SStruct solvers require the unified (CUDA managed) memory, for which
+the following option should be added
+
+.. code-block:: none
+
+  --enable-unified-memory Use unified memory for allocating the memory
+                          (default is NO).
+
+Hypre's Struct solvers can also use RAJA and Kokkos as the backend of the BoxLoop. The related ``configure`` options include
+
+.. code-block:: none
+
+  --with-raja             Use RAJA. Require RAJA package to be compiled
+                          properly (default is NO).
+
+  --with-kokkos           Use Kokkos. Require kokkos package to be compiled
+                          properly(default is NO).
+
+  --with-raja-include=DIR User specifies that RAJA/*.h is in DIR. The options
+                          --with-raja-include --with-raja-libs and
+                          --with-raja-lib-dirs must be used together.
+
+  --with-raja-libs=LIBS   LIBS is space-separated list (enclosed in quotes) of
+                          libraries needed for RAJA (base name only). The
+                          options --with-raja-libs and --with-raja-lib-dirs
+                          must be used together.
+
+  --with-raja-lib-dirs=DIRS
+                          DIRS is space-separated list (enclosed in quotes) of
+                          directories containing the libraries specified by
+                          --with-raja-libs, e.g "usr/lib /usr/local/lib". The
+                          options --with-raja-libs and --raja-blas-lib-dirs
+                          must be used together.
+
+  --with-kokkos-include=DIR
+                          User specifies that KOKKOS headers is in DIR. The
+                          options --with-kokkos-include --with-kokkos-libs and
+                          --with-kokkos-dirs must be used together.
+
+  --with-kokkos-libs=LIBS LIBS is space-separated list (enclosed in quotes) of
+                          libraries needed for KOKKOS (base name only). The
+                          options --with-kokkos-libs and --with-kokkos-dirs
+                          must be used together.
+
+  --with-kokkos-lib-dirs=DIRS
+                          DIRS is space-separated list (enclosed in quotes) of
+                          directories containing the libraries and
+                          Makefile.kokkos is assumed to be in DIRS/../ . The
+                          options --with-kokkos-libs and --with-kokkos-dirs
+                          must be used together.
+
+To run on the GPUs, the option ``--with-cuda`` or ``--with-device-openmp`` is also needed, and the provided RAJA and Kokkos libraries should have been built with CUDA or OpenMP 4.5 correspondingly.
 
 Testing the Library
 ==============================================================================
@@ -241,7 +327,7 @@ obtained from ``HYPRE_GetErrorArg()``.  To get a character string with a
 description of all errors in a given error flag, use
 
 .. code-block:: c
-   
+
    HYPRE_DescribeError(int hypre_ierr, char *descr);
 
 The global error flag can be cleared manually by calling
@@ -349,7 +435,7 @@ example, an integer array of length ``N`` may be declared in fortran as either
 of the following:
 
 .. code-block:: fortran
-   
+
    integer  array(N)
    integer  array(0:N-1)
 
@@ -358,12 +444,12 @@ usually corresponds to the length of a pointer.  However, there may be some
 machines where this is not the case.  On such machines, the Fortran type for a
 hypre object should be an ``integer`` of the appropriate length.
 
-This simple example illustrates the above information: 
+This simple example illustrates the above information:
 
 C prototype:
 
 .. code-block:: c
-   
+
    int HYPRE_IJMatrixSetValues(HYPRE_IJMatrix  matrix,
                                int  nrows, int  *ncols,
                                const int *rows, const int  *cols,

--- a/src/docs/usr-manual/solvers-boomeramg.rst
+++ b/src/docs/usr-manual/solvers-boomeramg.rst
@@ -113,8 +113,8 @@ A good overview of parallel smoothers and their properties can be found in
 [BFKY2011]_. Various of the described relaxation techniques are available:
 
 * weighted Jacobi relaxation,
-* a hybrid Gauss-Seidel / Jacobi relaxation scheme, 
-* a symmetric hybrid Gauss-Seidel / Jacobi relaxation scheme, 
+* a hybrid Gauss-Seidel / Jacobi relaxation scheme,
+* a symmetric hybrid Gauss-Seidel / Jacobi relaxation scheme,
 * l1-Gauss-Seidel or Jacobi,
 * Chebyshev smoothers,
 * hybrid block and Schwarz smoothers [Yang2004]_,
@@ -136,7 +136,7 @@ symmetric Gauss-Seidel.
 
 AMG for systems of PDEs
 ------------------------------------------------------------------------------
- 
+
 If the users wants to solve systems of PDEs and can provide information on which
 variables belong to which function, BoomerAMG's systems AMG version can also be
 used. Functions that enable the user to access the systems AMG version are
@@ -162,6 +162,24 @@ BoomerAMG also provides an additive V(1,1)-cycle as well as a mult-additive
 V(1,1)-cycle and a simplified versioni [VaYa2014]_. The additive variants can
 only be used with weighted Jacobi or l1-Jacobi smoothing.
 
+GPU-supported Options
+------------------------------------------------------------------------------
+In general, CUDA unified memory is required for running BoomerAMG solvers on GPUs,
+so hypre should be configured with ``--enable-unified-memory``.
+``HYPRE_Init()`` must be called and precede all the other hypre functions, and 
+``HYPRE_Finalize()`` must be called before exiting.
+To enable the execution of  AMG setup  on GPUs, one needs to explicitly specify the execution policy
+by
+
+.. code-block:: bash
+
+ hypre_HandleDefaultExecPolicy(hypre_handle()) = HYPRE_EXEC_DEVICE
+
+The currently available  GPU-supported BoomerAMG options include:
+
+* Coarsening: PMIS. No aggressive coarsening is supported,
+* Interpolation: direct interpolation, extended interpolation and extended+i interpolation,
+* Smoother: weighted Jacobi relaxation and l1-Jacobi.
 
 Miscellaneous
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Hi, All,

I wrote something in `chi-mis.rst` of the user manual on the GPU build. Please take a look. For the documentation of specific functions calls that support GPU, I think they should go to the ref-manual? Since it is generated from the headers, so I just need to add documentations to the `HYPRE_*.h`?

Thanks

-Ruipeng