### PR TITLE
Compile hypre_nvtx.c with nvcc

### DIFF
--- a/src/utilities/Makefile
+++ b/src/utilities/Makefile
@@ -45,7 +45,6 @@ FILES =\
  hypre_hopscotch_hash.c\
  hypre_merge_sort.c\
  hypre_mpi_comm_f2c.c\
- hypre_nvtx.c\
  hypre_prefix_sum.c\
  hypre_printf.c\
  hypre_qsort.c\
@@ -60,7 +59,8 @@ CUFILES=\
  hypre_cuda_utils.c\
  hypre_general.c\
  hypre_memory.c\
- hypre_omp_device.c
+ hypre_omp_device.c \
+ hypre_nvtx.c
 
 COBJS = ${FILES:.c=.o}
 CUOBJS = ${CUFILES:.c=.obj}


### PR DESCRIPTION
Small fix for the case `--enable-nvtx`. It appears #138 missed moving hypre_nvtx.c to `CUFILES`. With this change, I'm now able to compile and run `test/ij` with HYPRE configure using `--with-cuda=yes --enable-nvtx`. Thank you.