### PR TITLE
Use autoheader to generate HYPRE_config.h.in

### DIFF
--- a/src/config/HYPRE_config.h.in
+++ b/src/config/HYPRE_config.h.in
@@ -1,95 +1,113 @@
-/******************************************************************************
- * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
- * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
- *
- * SPDX-License-Identifier: (Apache-2.0 OR MIT)
- ******************************************************************************/
-
 /* config/HYPRE_config.h.in.  Generated from configure.in by autoheader.  */
 
-/* Release name */
-#undef HYPRE_RELEASE_NAME
+/* Define to dummy `main' function (if any) required to link to the Fortran
+   libraries. */
+#undef FC_DUMMY_MAIN
 
-/* Version number */
-#undef HYPRE_RELEASE_VERSION
+/* Define if F77 and FC dummy `main' functions are identical. */
+#undef FC_DUMMY_MAIN_EQ_F77
 
-/* Date of release */
-#undef HYPRE_RELEASE_DATE
+/* Define to a macro mangling the given C identifier (in lower and upper
+   case), which must not contain underscores, for linking with Fortran. */
+#undef FC_FUNC
 
-/* Time of release */
-#undef HYPRE_RELEASE_TIME
+/* As FC_FUNC, but for C identifiers containing underscores. */
+#undef FC_FUNC_
 
-/* Bug reports */
-#undef HYPRE_RELEASE_BUGS
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef HAVE_INTTYPES_H
 
-/* Define to 1 for Solaris. */
-#undef HYPRE_SOLARIS
+/* Define to 1 if you have the <memory.h> header file. */
+#undef HAVE_MEMORY_H
 
-/* Define to 1 for Linux on platforms running any version of CHAOS */
-#undef HYPRE_LINUX_CHAOS
+/* Define to 1 if using MLI */
+#undef HAVE_MLI
 
-/* Define to 1 for Linux platforms */
-#undef HYPRE_LINUX
+/* Define to 1 if you have the `MPI_Comm_f2c' function. */
+#undef HAVE_MPI_COMM_F2C
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#undef HAVE_STRING_H
+
+/* Define to 1 if using SuperLU */
+#undef HAVE_SUPERLU
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#undef HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#undef HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
 
 /* Define to 1 for Alpha platforms */
 #undef HYPRE_ALPHA
 
-/* Define to 1 for RS6000 platforms */
-#undef HYPRE_RS6000
-
-/* Define to 1 for IRIX64 platforms */
-#undef HYPRE_IRIX64
-
-/* Define to 1 if using long long int for HYPRE_BigInt */
-#undef HYPRE_MIXEDINT
-
 /* Define to 1 if using long long int for HYPRE_Int and HYPRE_BigInt */
 #undef HYPRE_BIGINT
-
-/* Define to 1 if using single precision values for HYPRE_Real */
-#undef HYPRE_SINGLE
-
-/* Define to 1 if using quad precision values for HYPRE_Real */
-#undef HYPRE_LONG_DOUBLE
 
 /* Define to 1 if using complex values */
 #undef HYPRE_COMPLEX
 
-/* Define to be the max dimension size (must be at least 3) */
-#undef HYPRE_MAXDIM
+/* Define to 1 if in debug mode */
+#undef HYPRE_DEBUG
 
-/* Define to 1 if using persistent communication */
-#undef HYPRE_USING_PERSISTENT_COMM
+/* Define to 1 if using OpenMP on device [target alloc version] */
+#undef HYPRE_DEVICE_OPENMP_ALLOC
 
-/* Define to 1 if hopscotch hashing */
-#undef HYPRE_HOPSCOTCH
+/* Define to 1 if strictly checking OpenMP offload directives */
+#undef HYPRE_DEVICE_OPENMP_CHECK
+
+/* Define as follows to set the Fortran name mangling scheme: 0 = unspecified;
+   1 = no underscores; 2 = one underscore; 3 = two underscores; 4 = caps, no
+   underscores; 5 = one underscore before and after */
+#undef HYPRE_FMANGLE
+
+/* BLAS mangling */
+#undef HYPRE_FMANGLE_BLAS
+
+/* LAPACK mangling */
+#undef HYPRE_FMANGLE_LAPACK
 
 /* Define to 1 if an MPI library is found */
 #undef HYPRE_HAVE_MPI
 
-/* Define to 1 if Node Aware MPI library is used */
-#undef HYPRE_USING_NODE_AWARE_MPI
-
 /* Define to 1 if the routine MPI_Comm_f2c is found */
 #undef HYPRE_HAVE_MPI_COMM_F2C
 
-/* Disable MPI, enable serial codes */
-#undef HYPRE_SEQUENTIAL
+/* Define to 1 if hopscotch hashing */
+#undef HYPRE_HOPSCOTCH
 
-/* Using HYPRE timing routines */
-#undef HYPRE_TIMING
+/* Define to 1 for HP platforms */
+#undef HYPRE_HPPA
 
-/* Using dxml for BLAS */
-#undef HYPRE_USING_DXML
+/* Define to 1 for IRIX64 platforms */
+#undef HYPRE_IRIX64
 
-/* Using essl for BLAS */
-#undef HYPRE_USING_ESSL
+/* Define to 1 for Linux platform */
+#undef HYPRE_LINUX
 
-/* Using internal Hypre routines */
-#undef HYPRE_USING_HYPRE_BLAS
+/* Define to 1 for Linux on platforms running any version of CHAOS */
+#undef HYPRE_LINUX_CHAOS
 
-/* Using internal Hypre routines */
-#undef HYPRE_USING_HYPRE_LAPACK
+/* Define to 1 if using quad precision values for HYPRE_Real */
+#undef HYPRE_LONG_DOUBLE
+
+/* Define to be the max dimension size (must be at least 3) */
+#undef HYPRE_MAXDIM
+
+/* Define to 1 if using long long int for HYPRE_BigInt */
+#undef HYPRE_MIXEDINT
 
 /* No global partitioning being used */
 #undef HYPRE_NO_GLOBAL_PARTITION
@@ -97,107 +115,122 @@
 /* Print HYPRE errors */
 #undef HYPRE_PRINT_ERRORS
 
-/* Enable OpenMP support */
-#undef HYPRE_USING_OPENMP
+/* Bug reports */
+#undef HYPRE_RELEASE_BUGS
 
-/*- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * MEMORY
- *- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -*/
+/* Date of release */
+#undef HYPRE_RELEASE_DATE
 
-/* Define to 1 if using host memory only */
-#undef HYPRE_USING_HOST_MEMORY
+/* Release name */
+#undef HYPRE_RELEASE_NAME
 
-/* Define to 1 if using device memory without UM */
-#undef HYPRE_USING_DEVICE_MEMORY
+/* Time of release */
+#undef HYPRE_RELEASE_TIME
 
-/* Define to 1 if using unified memory */
-#undef HYPRE_USING_UNIFIED_MEMORY
+/* Version number */
+#undef HYPRE_RELEASE_VERSION
 
-/*- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * EXECUTION
- *- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -*/
-/* Define to 1 if executing on device with CUDA */
-#undef HYPRE_USING_CUDA
+/* Define to 1 for RS6000 platforms */
+#undef HYPRE_RS6000
 
-/* Define to 1 if executing on device with OpenMP  */
-#undef HYPRE_USING_DEVICE_OPENMP
+/* Disable MPI, enable serial codes. */
+#undef HYPRE_SEQUENTIAL
 
-/* Define to 1 if using OpenMP on device [target alloc version] */
-#undef HYPRE_DEVICE_OPENMP_ALLOC
+/* Define to 1 if using single precision values for HYPRE_Real */
+#undef HYPRE_SINGLE
 
-/* Define to 1 if using OpenMP on device [target mapped version] */
-#undef HYPRE_DEVICE_OPENMP_MAPPED
+/* Define to 1 for Solaris. */
+#undef HYPRE_SOLARIS
 
-/* Define to 1 if strictly checking OpenMP offload directives */
-#undef HYPRE_DEVICE_OPENMP_CHECK
-
-/* Define to 1 if executing on host/device with RAJA */
-#undef HYPRE_USING_RAJA
-
-/* Define to 1 if executing on host/device with KOKKOS */
-#undef HYPRE_USING_KOKKOS
-
-/* Define to 1 if using NVIDIA Tools Extension (NVTX) */
-#undef HYPRE_USING_NVTX
-
-/* Define to 1 if using cuSPARSE */
-#undef HYPRE_USING_CUSPARSE
-
-/* Define to 1 if using CUB */
-#undef HYPRE_USING_CUB_ALLOCATOR
-
-/* Define to 1 if using cuBLAS */
-#undef HYPRE_USING_CUBLAS
-
-/* Define to 1 if using cuRAND */
-#undef HYPRE_USING_CURAND
-
-/* Define to 1 if using GPU aware MPI */
-#undef HYPRE_WITH_GPU_AWARE_MPI
-
-/* Define to 1 if using CUDA streams */
-#undef HYPRE_USING_CUDA_STREAMS
-
-/* Define as follows to set the Fortran name mangling scheme:
- * 0 = unspecified
- * 1 = no underscores
- * 2 = one underscore
- * 3 = two underscores
- * 4 = caps, no underscores
- * 5 = one underscore before and after */
-#undef HYPRE_FMANGLE
-
-/* Define as in HYPRE_FMANGLE to set the BLAS name mangling scheme */
-#undef HYPRE_FMANGLE_BLAS
-
-/* Define as in HYPRE_FMANGLE to set the LAPACK name mangling scheme */
-#undef HYPRE_FMANGLE_LAPACK
-
-/* Define to a macro mangling the given C identifier (in lower and upper
- * case), which must not contain underscores, for linking with Fortran. */
-#undef FC_FUNC
-
-/* As HYPRE_FC_FUNC, but for C identifiers containing underscores. */
-#undef FC_FUNC_
+/* Using HYPRE timing routines */
+#undef HYPRE_TIMING
 
 /* Define to 1 if Caliper instrumentation is enabled */
 #undef HYPRE_USING_CALIPER
 
-/* Define to 1 if using SuperLU */
-#undef HAVE_SUPERLU
+/* Define to 1 if using cuBLAS */
+#undef HYPRE_USING_CUBLAS
+
+/* Define to 1 if using CUB */
+#undef HYPRE_USING_CUB_ALLOCATOR
+
+/* Define to 1 if executing on device with CUDA */
+#undef HYPRE_USING_CUDA
+
+/* Define to 1 if using CUDA streams */
+#undef HYPRE_USING_CUDA_STREAMS
+
+/* Define to 1 if using cuRAND */
+#undef HYPRE_USING_CURAND
+
+/* Define to 1 if using cuSPARSE */
+#undef HYPRE_USING_CUSPARSE
+
+/* Define to 1 if using device memory without UM */
+#undef HYPRE_USING_DEVICE_MEMORY
+
+/* Define to 1 if executing on device with OpenMP */
+#undef HYPRE_USING_DEVICE_OPENMP
 
 /* Define to 1 if using DSuperLU */
 #undef HYPRE_USING_DSUPERLU
 
-/* Define to 1 if using MLI */
-#undef HAVE_MLI
+/* Using dxml for Blas */
+#undef HYPRE_USING_DXML
 
-/* Define to 1 if in debug mode */
-#undef HYPRE_DEBUG
+/* Using ESSL for Lapack */
+#undef HYPRE_USING_ESSL
 
-/* if not in debug mode, define NDEBUG */
-#ifndef HYPRE_DEBUG
-#ifndef NDEBUG
-#define NDEBUG
-#endif
-#endif
+/* Define to 1 if using host memory only */
+#undef HYPRE_USING_HOST_MEMORY
+
+/* Using internal HYPRE routines */
+#undef HYPRE_USING_HYPRE_BLAS
+
+/* Using internal HYPRE routines */
+#undef HYPRE_USING_HYPRE_LAPACK
+
+/* Define to 1 if executing on host/device with KOKKOS */
+#undef HYPRE_USING_KOKKOS
+
+/* Define to 1 if Node Aware MPI library is used */
+#undef HYPRE_USING_NODE_AWARE_MPI
+
+/* NVTX being used */
+#undef HYPRE_USING_NVTX
+
+/* Enable OpenMP support */
+#undef HYPRE_USING_OPENMP
+
+/* Define to 1 if using persistent communication */
+#undef HYPRE_USING_PERSISTENT_COMM
+
+/* Define to 1 if executing on host/device with RAJA */
+#undef HYPRE_USING_RAJA
+
+/* Define to 1 if using unified memory */
+#undef HYPRE_USING_UNIFIED_MEMORY
+
+/* Define to 1 if using GPU aware MPI */
+#undef HYPRE_WITH_GPU_AWARE_MPI
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* Define to 1 if you have the ANSI C header files. */
+#undef STDC_HEADERS

--- a/src/config/bootstrap
+++ b/src/config/bootstrap
@@ -15,6 +15,7 @@ ln -s config/configure.in .
 rm -rf aclocal.m4 configure autom4te.cache
 
 autoconf --include=config
+autoheader configure.in
 rm configure.in
 
 cat >> configure <<EOF

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -225,7 +225,7 @@ AS_HELP_STRING([--enable-mixedint],
 )
 if test "$hypre_using_mixedint" = "yes"
 then
-   AC_DEFINE(HYPRE_MIXEDINT, 1)
+   AC_DEFINE(HYPRE_MIXEDINT, 1, [Define to 1 if using long long int for HYPRE_BigInt])
 fi
 
 AC_ARG_ENABLE(bigint,
@@ -241,7 +241,7 @@ AS_HELP_STRING([--enable-bigint],
 )
 if test "$hypre_using_bigint" = "yes"
 then
-   AC_DEFINE(HYPRE_BIGINT, 1)
+   AC_DEFINE(HYPRE_BIGINT, 1, [Define to 1 if using long long int for HYPRE_Int and HYPRE_BigInt])
 fi
 
 AC_ARG_ENABLE(single,
@@ -257,7 +257,7 @@ AS_HELP_STRING([--enable-single],
 )
 if test "$hypre_using_single" = "yes"
 then
-   AC_DEFINE(HYPRE_SINGLE, 1)
+   AC_DEFINE(HYPRE_SINGLE, 1, [Define to 1 if using single precision values for HYPRE_Real])
 fi
 
 AC_ARG_ENABLE(longdouble,
@@ -273,7 +273,7 @@ AS_HELP_STRING([--enable-longdouble],
 )
 if test "$hypre_using_longdouble" = "yes"
 then
-   AC_DEFINE(HYPRE_LONG_DOUBLE, 1)
+   AC_DEFINE(HYPRE_LONG_DOUBLE, 1, [Define to 1 if using quad precision values for HYPRE_Real])
 fi
 
 AC_ARG_ENABLE(complex,
@@ -289,7 +289,7 @@ AS_HELP_STRING([--enable-complex],
 )
 if test "$hypre_using_complex" = "yes"
 then
-   AC_DEFINE(HYPRE_COMPLEX, 1)
+   AC_DEFINE(HYPRE_COMPLEX, 1, [Define to 1 if using complex values])
 fi
 
 AC_ARG_ENABLE(maxdim,
@@ -299,7 +299,7 @@ AS_HELP_STRING([--enable-maxdim=MAXDIM],
 [hypre_maxdim=${enableval}],
 [hypre_maxdim=3]
 )
-AC_DEFINE_UNQUOTED(HYPRE_MAXDIM, [$hypre_maxdim], [Max dimension])
+AC_DEFINE_UNQUOTED(HYPRE_MAXDIM, [$hypre_maxdim], [Define to be the max dimension size (must be at least 3)])
 
 AC_ARG_ENABLE(persistent,
 AS_HELP_STRING([--enable-persistent],
@@ -313,7 +313,7 @@ AS_HELP_STRING([--enable-persistent],
 )
 if test "$hypre_using_persistent" = "yes"
 then
-   AC_DEFINE(HYPRE_USING_PERSISTENT_COMM, 1)
+   AC_DEFINE(HYPRE_USING_PERSISTENT_COMM, 1, [Define to 1 if using persistent communication])
 fi
 
 AC_ARG_ENABLE(hopscotch,
@@ -329,7 +329,7 @@ AS_HELP_STRING([--enable-hopscotch],
 )
 if test "$hypre_using_hopscotch" = "yes"
 then
-   AC_DEFINE(HYPRE_HOPSCOTCH, 1)
+   AC_DEFINE(HYPRE_HOPSCOTCH, 1, [Define to 1 if hopscotch hashing])
 fi
 
 dnl * The --with-no-global-partition option is retained here for
@@ -844,11 +844,19 @@ AS_HELP_STRING([--with-fmangle=FMANGLE],
                [FMANGLE contains a string indicating the type of name mangling
                 to use when calling hypre from Fortran.  It can be set to:
                 "no-underscores", "one-underscore", "two-underscores",
-                "caps-no-underscores, and "one-before-after".]),
+                "caps-no-underscores", and "one-before-after".]),
 [hypre_fmangle=0; AC_HYPRE_SET_FMANGLE],
 [hypre_fmangle=0]
 )
-AC_DEFINE_UNQUOTED(HYPRE_FMANGLE, [$hypre_fmangle], [Fortran mangling])
+AC_DEFINE_UNQUOTED(HYPRE_FMANGLE, 
+		   [$hypre_fmangle],
+[Define as follows to set the Fortran name mangling scheme:
+ 0 = unspecified;
+ 1 = no underscores;
+ 2 = one underscore;
+ 3 = two underscores;
+ 4 = caps, no underscores;
+ 5 = one underscore before and after])
 
 dnl * Define a generic macro to set hypre_fmangle_blaslapack based on withval
 AC_DEFUN([AC_HYPRE_SET_FMANGLE_BLAS],
@@ -944,7 +952,7 @@ AS_HELP_STRING([--with-superlu],
 )
 
 AS_IF([test "x$with_superlu" = "xyes"],
-      [AC_DEFINE(HAVE_SUPERLU, 1, [Have external SuperLU library.])],
+      [AC_DEFINE(HAVE_SUPERLU, 1, [Define to 1 if using SuperLU])],
       [])
 
 AC_ARG_WITH(superlu-include,
@@ -976,7 +984,7 @@ AS_HELP_STRING([--with-dsuperlu],
 )
 
 AS_IF([test "x$with_dsuperlu" = "xyes"],
-      [AC_DEFINE(HYPRE_USING_DSUPERLU, 1, [Have external DSuperLU library.])],
+      [AC_DEFINE(HYPRE_USING_DSUPERLU, 1, [Define to 1 if using DSuperLU])],
       [])
 
 AC_ARG_WITH(dsuperlu-include,
@@ -1166,7 +1174,7 @@ AS_HELP_STRING([--with-caliper],
                [hypre_using_caliper=no])
 
 AS_IF([test "x$with_caliper" = "xyes"],
-      [AC_DEFINE(HYPRE_USING_CALIPER, 1, [Using Caliper instrumentation])],
+      [AC_DEFINE(HYPRE_USING_CALIPER, 1, [Define to 1 if Caliper instrumentation is enabled])],
       [])
 
 AC_ARG_WITH(caliper-include,
@@ -1335,7 +1343,7 @@ else
        hypre_cv_func_MPI_Comm_f2c_macro=no)])
    if test $ac_cv_func_MPI_Comm_f2c = yes \
       || test $hypre_cv_func_MPI_Comm_f2c_macro = yes; then
-     AC_DEFINE(HYPRE_HAVE_MPI_COMM_F2C)
+     AC_DEFINE(HYPRE_HAVE_MPI_COMM_F2C,1,[Define to 1 if the routine MPI_Comm_f2c is found])
    fi
 fi
 
@@ -1345,13 +1353,13 @@ if test "$hypre_using_global_partition" = "no"
 then
 dnl   if test "$hypre_using_mpi" != "no"
 dnl   then
-      AC_DEFINE(HYPRE_NO_GLOBAL_PARTITION, 1)
+      AC_DEFINE(HYPRE_NO_GLOBAL_PARTITION, 1, [No global partitioning being used])
 dnl   fi
 fi
 
 if test "$hypre_using_node_aware_mpi" = "yes"
 then
-   AC_DEFINE(HYPRE_USING_NODE_AWARE_MPI, 1)
+   AC_DEFINE(HYPRE_USING_NODE_AWARE_MPI, 1, [Define to 1 if Node Aware MPI library is used])
 fi
 
 dnl *********************************************************************
@@ -1461,7 +1469,7 @@ then
       then
          HYPRE_FEI_SUBDIRS="femli $HYPRE_FEI_SUBDIRS"
          HYPRE_FEI_FEMLI_FILES="$HYPRE_SRCDIR/FEI_mv/femli/*.o"
-         AC_DEFINE(HAVE_MLI, 1, [Using MLI.])
+         AC_DEFINE(HAVE_MLI, 1, [Define to 1 if using MLI])
       fi
    fi
    AC_CHECK_LIB(stdc++, __gxx_personality_v0, LIBS="$LIBS -lstdc++")
@@ -1494,7 +1502,7 @@ dnl *********************************************************************
 if test "$hypre_using_debug" = "yes"
 then
    AC_HYPRE_DEBUG_FLAGS
-   AC_DEFINE([HYPRE_DEBUG], 1, [HYPRE in debug mode])
+   AC_DEFINE([HYPRE_DEBUG], 1, [Define to 1 if in debug mode])
 else
    AC_HYPRE_OPTIMIZATION_FLAGS
 fi
@@ -1662,7 +1670,7 @@ dnl *********************************************************************
 if test "x$hypre_user_chose_raja" = "xyes"
 then
    RAJA_LIBS=" $HYPRE_RAJA_LIB_DIR $HYPRE_RAJA_LIB "
-   AC_DEFINE(HYPRE_USING_RAJA, 1, [RAJA being used])
+   AC_DEFINE(HYPRE_USING_RAJA, 1, [Define to 1 if executing on host/device with RAJA])
 
    if test "$hypre_using_cuda" != "yes"
    then
@@ -1684,7 +1692,7 @@ dnl *********************************************************************
 if test "x$hypre_user_chose_kokkos" = "xyes"
 then
    KOKKOS_LIBS="$HYPRE_KOKKOS_LIB_DIR $HYPRE_KOKKOS_LIB"
-   AC_DEFINE(HYPRE_USING_KOKKOS, 1, [KOKKOS being used])
+   AC_DEFINE(HYPRE_USING_KOKKOS, 1, [Define to 1 if executing on host/device with KOKKOS])
 
    if test "$hypre_using_cuda" != "yes"
    then
@@ -1705,33 +1713,33 @@ dnl * Set cuda options
 dnl *********************************************************************
 if test "$hypre_user_chose_cuda" = "yes"
 then
-   AC_DEFINE(HYPRE_USING_CUDA, 1, [CUDA being used])
+   AC_DEFINE(HYPRE_USING_CUDA, 1, [Define to 1 if executing on device with CUDA])
 
-   AC_DEFINE(HYPRE_USING_CUSPARSE, 1, [cuSPARSE being used])
+   AC_DEFINE(HYPRE_USING_CUSPARSE, 1, [Define to 1 if using cuSPARSE])
 
    if test "$hypre_using_nvtx" = "yes"
    then
-      AC_DEFINE(HYPRE_USING_NVTX, 1, [NVTX being used])
+      AC_DEFINE(HYPRE_USING_NVTX, 1, [Define to 1 if using NVIDIA Tools Extension (NVTX)])
    fi
 
    if test "$hypre_using_cusparse" = "yes"
    then
-      AC_DEFINE(HYPRE_USING_CUSPARSE, 1, [CUSPARSE being used])
+      AC_DEFINE(HYPRE_USING_CUSPARSE, 1, [Define to 1 if using cuSPARSE])
    fi
 
    if test "$hypre_using_cub" = "yes"
    then
-      AC_DEFINE(HYPRE_USING_CUB_ALLOCATOR, 1, [CUB allocator being used])
+      AC_DEFINE(HYPRE_USING_CUB_ALLOCATOR, 1, [Define to 1 if using CUB])
    fi
 
    if test "$hypre_using_cublas" = "yes"
    then
-      AC_DEFINE(HYPRE_USING_CUBLAS, 1, [CUBLAS being used])
+      AC_DEFINE(HYPRE_USING_CUBLAS, 1, [Define to 1 if using cuBLAS])
    fi
 
    if test "$hypre_using_curand" = "yes"
    then
-      AC_DEFINE(HYPRE_USING_CURAND, 1, [CURAND being used])
+      AC_DEFINE(HYPRE_USING_CURAND, 1, [Define to 1 if using cuRAND])
    fi
 
    dnl let CC/CXX and LINK be CUCC and let host compiler be CXX
@@ -1825,16 +1833,16 @@ dnl * Set Device OpenMP options
 dnl *********************************************************************
 if test "$hypre_using_device_openmp" = "yes"
 then
-   AC_DEFINE(HYPRE_USING_CUSPARSE, 1, [cuSPARSE being used])
+   AC_DEFINE(HYPRE_USING_CUSPARSE, 1, [Define to 1 if using cuSPARSE])
 
    if test "$hypre_using_nvtx" = "yes"
    then
       AC_DEFINE(HYPRE_USING_NVTX, 1, [NVTX being used])
    fi
-   AC_DEFINE(HYPRE_USING_DEVICE_OPENMP, 1, [Enable OpenMP (>=4.5) device directives])
-   AC_DEFINE(HYPRE_DEVICE_OPENMP_ALLOC, 1, [Enable device OpenMP target alloc version])
+   AC_DEFINE(HYPRE_USING_DEVICE_OPENMP, 1, [Define to 1 if executing on device with OpenMP])
+   AC_DEFINE(HYPRE_DEVICE_OPENMP_ALLOC, 1, [Define to 1 if using OpenMP on device [target alloc version]])
 
-   dnl AC_DEFINE(HYPRE_DEVICE_OPENMP_MAPPED, 1, [Enable device OpenMP target mapped version])
+   dnl AC_DEFINE(HYPRE_DEVICE_OPENMP_MAPPED, 1, [Define to 1 if using OpenMP on device [target mapped version]])
 
    dnl AC_CHECK_PROGS(CUCC, nvcc)
 
@@ -1852,7 +1860,7 @@ then
    fi
    if test "$hypre_using_debug" = "yes"
    then
-      AC_DEFINE(HYPRE_DEVICE_OPENMP_CHECK, 1, [Strictly checking OpenMP offload directives])
+      AC_DEFINE(HYPRE_DEVICE_OPENMP_CHECK, 1, [Define to 1 if strictly checking OpenMP offload directives])
    fi
 
    HYPRE_CUDA_INCL="-I${HYPRE_CUDA_PATH}/include"
@@ -1921,7 +1929,7 @@ fi
 
 if test "x$hypre_using_cuda_streams" = "xyes"
 then
-   AC_DEFINE([HYPRE_USING_CUDA_STREAMS],1,[HYPRE WITH CUDA STREAMS])
+   AC_DEFINE([HYPRE_USING_CUDA_STREAMS],1,[Define to 1 if using CUDA streams])
 fi
 
 dnl *********************************************************************
@@ -1929,19 +1937,19 @@ dnl * Set memory env
 dnl *********************************************************************
 if test "x$hypre_using_um" = "xyes"
 then
-   AC_DEFINE([HYPRE_USING_UNIFIED_MEMORY],1,[HYPRE WITH UNIFIED MEMORY])
+   AC_DEFINE([HYPRE_USING_UNIFIED_MEMORY],1,[Define to 1 if using unified memory])
 else
    if [test "x$hypre_user_chose_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes"]
    then
-      AC_DEFINE([HYPRE_USING_DEVICE_MEMORY],1,[HYPRE WITH DEVICE MEMORY])
+      AC_DEFINE([HYPRE_USING_DEVICE_MEMORY],1,[Define to 1 if using device memory without UM])
    else
-      AC_DEFINE([HYPRE_USING_HOST_MEMORY],1,[HYPRE WITH HOST MEMORY])
+      AC_DEFINE([HYPRE_USING_HOST_MEMORY],1,[Define to 1 if using host memory only])
    fi
 fi
 
 if test "$hypre_gpu_mpi" = "yes"
 then
-   AC_DEFINE([HYPRE_WITH_GPU_AWARE_MPI],1,[HYPRE WITH GPU AWARE MPI])
+   AC_DEFINE([HYPRE_WITH_GPU_AWARE_MPI],1,[Define to 1 if using GPU aware MPI])
 fi
 
 dnl *********************************************************************
@@ -2107,4 +2115,4 @@ dnl * Define the files to be configured and made
 dnl *********************************************************************
 AC_CONFIG_FILES([config/Makefile.config])
 
-AC_OUTPUT
+AC_OUTPUT()

--- a/src/config/hypre_blas_macros.m4
+++ b/src/config/hypre_blas_macros.m4
@@ -297,7 +297,7 @@ dnl **************************************************************
        else
           hypre_fmangle_blas=4
        fi
-       AC_DEFINE_UNQUOTED(HYPRE_FMANGLE_BLAS, [$hypre_fmangle_blas], [BLAS mangling])
+       AC_DEFINE_UNQUOTED(HYPRE_FMANGLE_BLAS, [$hypre_fmangle_blas], [Define as in HYPRE_FMANGLE to set the BLAS name mangling scheme])
     fi 
 dnl **************************************************************
 dnl Restore LIBS and LDFLAGS

--- a/src/config/hypre_lapack_macros.m4
+++ b/src/config/hypre_lapack_macros.m4
@@ -272,7 +272,7 @@ dnl **************************************************************
        else
           hypre_fmangle_lapack=4
        fi
-       AC_DEFINE_UNQUOTED(HYPRE_FMANGLE_LAPACK, [$hypre_fmangle_lapack], [LAPACK mangling])
+       AC_DEFINE_UNQUOTED(HYPRE_FMANGLE_LAPACK, [$hypre_fmangle_lapack], [Define as in HYPRE_FMANGLE to set the LAPACK name mangling scheme])
     fi                    
 
 dnl **************************************************************

--- a/src/config/hypre_macros_misc.m4
+++ b/src/config/hypre_macros_misc.m4
@@ -54,7 +54,7 @@ if test x = x"$MPILIBS"; then
   $2
   :
 else
-  AC_DEFINE(HYPRE_HAVE_MPI,1,[Found the MPI library.])
+  AC_DEFINE(HYPRE_HAVE_MPI,1,[Define to 1 if an MPI library is found])
   $1
   :
 fi
@@ -415,19 +415,19 @@ dnl *
 dnl *    define type of architecture
    case $HYPRE_ARCH in
       alpha)
-         AC_DEFINE(HYPRE_ALPHA)
+         AC_DEFINE(HYPRE_ALPHA,1,[Define to 1 for Alpha platforms])
          ;;
       sun* | solaris*)
-         AC_DEFINE(HYPRE_SOLARIS)
+         AC_DEFINE(HYPRE_SOLARIS,1,[Define to 1 for Solaris.])
          ;;
       hp* | HP*)
-         AC_DEFINE(HYPRE_HPPA)
+         AC_DEFINE(HYPRE_HPPA,1,[Define to 1 for HP platforms])
          ;;
       rs6000 | RS6000 | *bgl* | *BGL* | ppc64*)
-         AC_DEFINE(HYPRE_RS6000)
+         AC_DEFINE(HYPRE_RS6000,1,[Define to 1 for RS6000 platforms])
          ;;
       IRIX64)
-         AC_DEFINE(HYPRE_IRIX64)
+         AC_DEFINE(HYPRE_IRIX64,1,[Define to 1 for IRIX64 platforms])
          ;;
       Linux | linux | LINUX)
          if test -r /etc/home.config
@@ -435,14 +435,14 @@ dnl *    define type of architecture
             systemtype=`grep ^SYS_TYPE /etc/home.config | cut -d" " -f2`
             case $systemtype in
                chaos*)
-                  AC_DEFINE(HYPRE_LINUX_CHAOS)
+                  AC_DEFINE(HYPRE_LINUX_CHAOS,1,[Define to 1 for Linux on platforms running any version of CHAOS])
                   ;;
                *)
-                  AC_DEFINE(HYPRE_LINUX)
+                  AC_DEFINE(HYPRE_LINUX,1,[Define to 1 for Linux platform])
                   ;;
             esac
          else
-            AC_DEFINE(HYPRE_LINUX)
+            AC_DEFINE(HYPRE_LINUX,1,[Define to 1 for Linux platform])
          fi
          ;;
    esac

--- a/src/configure
+++ b/src/configure
@@ -738,6 +738,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -887,6 +888,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1139,6 +1141,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1276,7 +1287,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1429,6 +1440,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1575,7 +1587,7 @@ Optional Packages:
                           name mangling to use when calling hypre from
                           Fortran. It can be set to: "no-underscores",
                           "one-underscore", "two-underscores",
-                          "caps-no-underscores, and "one-before-after".
+                          "caps-no-underscores", and "one-before-after".
   --with-fmangle-blas=FMANGLE
                           Name mangling for BLAS. See --with-fmangle.
   --with-fmangle-lapack=FMANGLE
@@ -2793,7 +2805,8 @@ fi
 
 if test "$hypre_using_mixedint" = "yes"
 then
-   $as_echo "#define HYPRE_MIXEDINT 1" >>confdefs.h
+
+$as_echo "#define HYPRE_MIXEDINT 1" >>confdefs.h
 
 fi
 
@@ -2812,7 +2825,8 @@ fi
 
 if test "$hypre_using_bigint" = "yes"
 then
-   $as_echo "#define HYPRE_BIGINT 1" >>confdefs.h
+
+$as_echo "#define HYPRE_BIGINT 1" >>confdefs.h
 
 fi
 
@@ -2831,7 +2845,8 @@ fi
 
 if test "$hypre_using_single" = "yes"
 then
-   $as_echo "#define HYPRE_SINGLE 1" >>confdefs.h
+
+$as_echo "#define HYPRE_SINGLE 1" >>confdefs.h
 
 fi
 
@@ -2850,7 +2865,8 @@ fi
 
 if test "$hypre_using_longdouble" = "yes"
 then
-   $as_echo "#define HYPRE_LONG_DOUBLE 1" >>confdefs.h
+
+$as_echo "#define HYPRE_LONG_DOUBLE 1" >>confdefs.h
 
 fi
 
@@ -2869,7 +2885,8 @@ fi
 
 if test "$hypre_using_complex" = "yes"
 then
-   $as_echo "#define HYPRE_COMPLEX 1" >>confdefs.h
+
+$as_echo "#define HYPRE_COMPLEX 1" >>confdefs.h
 
 fi
 
@@ -2901,7 +2918,8 @@ fi
 
 if test "$hypre_using_persistent" = "yes"
 then
-   $as_echo "#define HYPRE_USING_PERSISTENT_COMM 1" >>confdefs.h
+
+$as_echo "#define HYPRE_USING_PERSISTENT_COMM 1" >>confdefs.h
 
 fi
 
@@ -2919,7 +2937,8 @@ fi
 
 if test "$hypre_using_hopscotch" = "yes"
 then
-   $as_echo "#define HYPRE_HOPSCOTCH 1" >>confdefs.h
+
+$as_echo "#define HYPRE_HOPSCOTCH 1" >>confdefs.h
 
 fi
 
@@ -7240,20 +7259,23 @@ fi
 $as_echo "$hypre_cv_func_MPI_Comm_f2c_macro" >&6; }
    if test $ac_cv_func_MPI_Comm_f2c = yes \
       || test $hypre_cv_func_MPI_Comm_f2c_macro = yes; then
-     $as_echo "#define HYPRE_HAVE_MPI_COMM_F2C 1" >>confdefs.h
+
+$as_echo "#define HYPRE_HAVE_MPI_COMM_F2C 1" >>confdefs.h
 
    fi
 fi
 
 if test "$hypre_using_global_partition" = "no"
 then
-      $as_echo "#define HYPRE_NO_GLOBAL_PARTITION 1" >>confdefs.h
+
+$as_echo "#define HYPRE_NO_GLOBAL_PARTITION 1" >>confdefs.h
 
 fi
 
 if test "$hypre_using_node_aware_mpi" = "yes"
 then
-   $as_echo "#define HYPRE_USING_NODE_AWARE_MPI 1" >>confdefs.h
+
+$as_echo "#define HYPRE_USING_NODE_AWARE_MPI 1" >>confdefs.h
 
 fi
 
@@ -8742,23 +8764,28 @@ $as_echo "$HYPRE_ARCH" >&6; }
    fi
    case $HYPRE_ARCH in
       alpha)
-         $as_echo "#define HYPRE_ALPHA 1" >>confdefs.h
+
+$as_echo "#define HYPRE_ALPHA 1" >>confdefs.h
 
          ;;
       sun* | solaris*)
-         $as_echo "#define HYPRE_SOLARIS 1" >>confdefs.h
+
+$as_echo "#define HYPRE_SOLARIS 1" >>confdefs.h
 
          ;;
       hp* | HP*)
-         $as_echo "#define HYPRE_HPPA 1" >>confdefs.h
+
+$as_echo "#define HYPRE_HPPA 1" >>confdefs.h
 
          ;;
       rs6000 | RS6000 | *bgl* | *BGL* | ppc64*)
-         $as_echo "#define HYPRE_RS6000 1" >>confdefs.h
+
+$as_echo "#define HYPRE_RS6000 1" >>confdefs.h
 
          ;;
       IRIX64)
-         $as_echo "#define HYPRE_IRIX64 1" >>confdefs.h
+
+$as_echo "#define HYPRE_IRIX64 1" >>confdefs.h
 
          ;;
       Linux | linux | LINUX)
@@ -8767,16 +8794,19 @@ $as_echo "$HYPRE_ARCH" >&6; }
             systemtype=`grep ^SYS_TYPE /etc/home.config | cut -d" " -f2`
             case $systemtype in
                chaos*)
-                  $as_echo "#define HYPRE_LINUX_CHAOS 1" >>confdefs.h
+
+$as_echo "#define HYPRE_LINUX_CHAOS 1" >>confdefs.h
 
                   ;;
                *)
-                  $as_echo "#define HYPRE_LINUX 1" >>confdefs.h
+
+$as_echo "#define HYPRE_LINUX 1" >>confdefs.h
 
                   ;;
             esac
          else
-            $as_echo "#define HYPRE_LINUX 1" >>confdefs.h
+
+$as_echo "#define HYPRE_LINUX 1" >>confdefs.h
 
          fi
          ;;


### PR DESCRIPTION
The bootstrap script calls `autoconf`, but `autoconf` does not take care of populating `HYPRE_config.h.in` with all the `AC_DEFINE`s in the `configure.in` and the various `.m4` files. That means folks have been manually adding these to `HYPRE_config.h.in` and the `AC_DEFINE`s have been useless. Obviously, manually dealing with these is error prone, especially when one is adding new functionality, like, say, HIP support. :)

This PR aims to fix that.

The autotool program `autoheader` specifically deals with parsing the `configure.in` file for the `AC_DEFINE`s and then creates the `HYPRE_config.h.in` file. So we add a call to `autoheader` after `autoconf` in the bootstrap script. In order for `autoheader` to work correctly, however, all three arguments to *all* invocations of `AC_DEFINE` *must* be supplied. In fact, `autoheader` emits a "warning", but it's actually an error, if you don't do this.

So the first commit in this PR populates all three arguments to all the `AC_DEFINE` variables. Feel free to provide more correct or otherwise better descriptions and I'll fixup that commit. The next commit adds the `autoheader` invocation. Then I run `bootstrap` and generate the now automatically created `HYPRE_config.h.in`. The diff is hard to read, so I used 

<pre>
grep undef HYPRE_config.h.in | sort > old_config.txt
</pre>

 before generating the new file, similarly after and then diffed those two files.

<pre>
diff old_config.txt new_config.txt 
> #undef FC_DUMMY_MAIN
> #undef FC_DUMMY_MAIN_EQ_F77
2a5,6
> #undef HAVE_INTTYPES_H
> #undef HAVE_MEMORY_H
3a8,12
> #undef HAVE_MPI_COMM_F2C
> #undef HAVE_STDINT_H
> #undef HAVE_STDLIB_H
> #undef HAVE_STRING_H
> #undef HAVE_STRINGS_H
4a14,16
> #undef HAVE_SYS_STAT_H
> #undef HAVE_SYS_TYPES_H
> #undef HAVE_UNISTD_H
11d22
< #undef HYPRE_DEVICE_OPENMP_MAPPED
17a29
> #undef HYPRE_HPPA
58a71,77
> #undef PACKAGE_BUGREPORT
> #undef PACKAGE_NAME
> #undef PACKAGE_STRING
> #undef PACKAGE_TARNAME
> #undef PACKAGE_URL
> #undef PACKAGE_VERSION
> #undef STDC_HEADERS
</pre>

So it seems mostly stuff regarding versioning and compiler stuff. The two sticking out (to me anyway) are `HYPRE_DEVICE_OPENMP_MAPPED` and `HYPRE_HPPA`. In the former case, that `AC_DEFINE` is commented out in the `configure.in` file, but it appears it was never manually removed. Similarly, in the latter case, that `AC_DEFINE` was added, but the variable never manually added to the `HYPRE_config.h.in`.

The final commit is bootstrap changes to the configure script. They are mostly whitespace and what I believe to differences between my system and the system last used to generate configure (the `runstatedir` business). I believe we can safely wipe that commit out from history in this PR, but I thought I would include it for review.