### PR TITLE
Fixed convergence on issue #70

### DIFF
--- a/src/parcsr_ls/par_amg.c
+++ b/src/parcsr_ls/par_amg.c
@@ -200,7 +200,7 @@ hypre_BoomerAMGCreate()
    fcycle = 0;
    cycle_type = 1;
    converge_type = 0;
-   tol = 1.0e-7;
+   tol = 1.0e-6;
 
    num_sweeps = 1;
    relax_down = 13;

--- a/src/parcsr_ls/par_mgr.c
+++ b/src/parcsr_ls/par_mgr.c
@@ -73,7 +73,7 @@ hypre_MGRCreate()
   (mgr_data -> use_default_fsolver) = -1; // set to -1 to avoid printing when not used
   (mgr_data -> omega) = 1.;
   (mgr_data -> max_iter) = 20;
-  (mgr_data -> tol) = 1.0e-7;
+  (mgr_data -> tol) = 1.0e-6;
   (mgr_data -> relax_type) = 0;
   (mgr_data -> relax_order) = 1; // not fully utilized. Only used to compute L1-norms.
   (mgr_data -> interp_type) = NULL;


### PR DESCRIPTION
Respected @rfalgout ,
On your issue on Convergence tolerance defaults #70 you have asked to change the tolerance value from 1e-7 to 1e-6 on two parameters file par_amg.c and par_mgr.c. This PR fixes these tolerances on the above mentioned two files