### PR TITLE
A few GPU-specific fixes/updates

### DIFF
--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -422,7 +422,7 @@ T warp_prefix_sum(hypre_int lane_id, T in, T &all_sum)
    for (hypre_int d = 2; d <=HYPRE_WARP_SIZE; d <<= 1)
    {
       T t = __shfl_up_sync(HYPRE_WARP_FULL_MASK, in, d >> 1);
-      if ( (lane_id & (d - 1)) == d - 1 )
+      if ( (lane_id & (d - 1)) == (d - 1) )
       {
          in += t;
       }
@@ -440,7 +440,7 @@ T warp_prefix_sum(hypre_int lane_id, T in, T &all_sum)
    {
       T t = __shfl_xor_sync(HYPRE_WARP_FULL_MASK, in, d);
 
-      if ( (lane_id & (d - 1)) == d - 1)
+      if ( (lane_id & (d - 1)) == (d - 1))
       {
         if ( (lane_id & ((d << 1) - 1)) == ((d << 1) - 1) )
          {

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -373,28 +373,28 @@ hypre_double atomicAdd(hypre_double* address, hypre_double val)
 
 template <typename T>
 static __device__ __forceinline__
-T __shfl_sync(unsigned mask, T val, hypre_int src_line, hypre_int width=32)
+T __shfl_sync(unsigned mask, T val, hypre_int src_line, hypre_int width=HYPRE_WARP_SIZE)
 {
    return __shfl(val, src_line, width);
 }
 
 template <typename T>
 static __device__ __forceinline__
-T __shfl_down_sync(unsigned mask, T val, unsigned delta, hypre_int width=32)
+T __shfl_down_sync(unsigned mask, T val, unsigned delta, hypre_int width=HYPRE_WARP_SIZE)
 {
    return __shfl_down(val, delta, width);
 }
 
 template <typename T>
 static __device__ __forceinline__
-T __shfl_xor_sync(unsigned mask, T val, unsigned lanemask, hypre_int width=32)
+T __shfl_xor_sync(unsigned mask, T val, unsigned lanemask, hypre_int width=HYPRE_WARP_SIZE)
 {
    return __shfl_xor(val, lanemask, width);
 }
 
 template <typename T>
 static __device__ __forceinline__
-T __shfl_up_sync(unsigned mask, T val, unsigned delta, hypre_int width=32)
+T __shfl_up_sync(unsigned mask, T val, unsigned delta, hypre_int width=HYPRE_WARP_SIZE)
 {
    return __shfl_up(val, delta, width);
 }
@@ -419,7 +419,7 @@ static __device__ __forceinline__
 T warp_prefix_sum(hypre_int lane_id, T in, T &all_sum)
 {
 #pragma unroll
-   for (hypre_int d = 2; d <= 32; d <<= 1)
+   for (hypre_int d = 2; d <=HYPRE_WARP_SIZE; d <<= 1)
    {
       T t = __shfl_up_sync(HYPRE_WARP_FULL_MASK, in, d >> 1);
       if ( (lane_id & (d - 1)) == d - 1 )
@@ -428,15 +428,15 @@ T warp_prefix_sum(hypre_int lane_id, T in, T &all_sum)
       }
    }
 
-   all_sum = __shfl_sync(HYPRE_WARP_FULL_MASK, in, 31);
+   all_sum = __shfl_sync(HYPRE_WARP_FULL_MASK, in, HYPRE_WARP_SIZE-1);
 
-   if (lane_id == 31)
+   if (lane_id == HYPRE_WARP_SIZE-1)
    {
       in = 0;
    }
 
 #pragma unroll
-   for (hypre_int d = 16; d > 0; d >>= 1)
+   for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
    {
       T t = __shfl_xor_sync(HYPRE_WARP_FULL_MASK, in, d);
 
@@ -460,7 +460,7 @@ static __device__ __forceinline__
 T warp_reduce_sum(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in += __shfl_down_sync(HYPRE_WARP_FULL_MASK, in, d);
   }
@@ -472,7 +472,7 @@ static __device__ __forceinline__
 T warp_allreduce_sum(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in += __shfl_xor_sync(HYPRE_WARP_FULL_MASK, in, d);
   }
@@ -484,7 +484,7 @@ static __device__ __forceinline__
 T warp_reduce_max(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in = max(in, __shfl_down_sync(HYPRE_WARP_FULL_MASK, in, d));
   }
@@ -496,7 +496,7 @@ static __device__ __forceinline__
 T warp_allreduce_max(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in = max(in, __shfl_xor_sync(HYPRE_WARP_FULL_MASK, in, d));
   }
@@ -508,7 +508,7 @@ static __device__ __forceinline__
 T warp_reduce_min(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in = min(in, __shfl_down_sync(HYPRE_WARP_FULL_MASK, in, d));
   }
@@ -520,7 +520,7 @@ static __device__ __forceinline__
 T warp_allreduce_min(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in = min(in, __shfl_xor_sync(HYPRE_WARP_FULL_MASK, in, d));
   }

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -442,7 +442,7 @@ T warp_prefix_sum(hypre_int lane_id, T in, T &all_sum)
 
       if ( (lane_id & (d - 1)) == d - 1)
       {
-         if ( (lane_id & (d << 1 - 1)) == (d << 1 - 1) )
+        if ( (lane_id & ((d << 1) - 1)) == ((d << 1) - 1) )
          {
             in += t;
          }

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -872,8 +872,10 @@ __inline__ __host__ __device__
 T blockReduceSum(T val)
 {
 #ifdef __CUDA_ARCH__
-   //static __shared__ T shared[32]; // Shared mem for 32 partial sums
-   __shared__ T shared[32];        // Shared mem for 32 partial sums
+   //static __shared__ T shared[HYPRE_WARP_SIZE]; // Shared mem for HYPRE_WARP_SIZE partial sums
+
+   __shared__ T shared[HYPRE_WARP_SIZE];        // Shared mem for HYPRE_WARP_SIZE partial sums
+
    //HYPRE_Int lane = threadIdx.x % warpSize;
    //HYPRE_Int wid  = threadIdx.x / warpSize;
    HYPRE_Int lane = threadIdx.x & (warpSize - 1);
@@ -1848,4 +1850,3 @@ struct hypre_cub_CachingDeviceAllocator
 
 
 #endif
-

--- a/src/utilities/hypre_cuda_reducer.h
+++ b/src/utilities/hypre_cuda_reducer.h
@@ -139,8 +139,10 @@ __inline__ __host__ __device__
 T blockReduceSum(T val)
 {
 #ifdef __CUDA_ARCH__
-   //static __shared__ T shared[32]; // Shared mem for 32 partial sums
-   __shared__ T shared[32];        // Shared mem for 32 partial sums
+   //static __shared__ T shared[HYPRE_WARP_SIZE]; // Shared mem for HYPRE_WARP_SIZE partial sums
+
+   __shared__ T shared[HYPRE_WARP_SIZE];        // Shared mem for HYPRE_WARP_SIZE partial sums
+
    //HYPRE_Int lane = threadIdx.x % warpSize;
    //HYPRE_Int wid  = threadIdx.x / warpSize;
    HYPRE_Int lane = threadIdx.x & (warpSize - 1);
@@ -275,4 +277,3 @@ struct ReduceSum
 #endif /* #if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) */
 #endif /* #if defined(HYPRE_USING_CUDA) */
 #endif /* #ifndef HYPRE_CUDA_REDUCER_H */
-

--- a/src/utilities/hypre_cuda_utils.c
+++ b/src/utilities/hypre_cuda_utils.c
@@ -60,7 +60,7 @@ hypre_GetDefaultCUDAGridDimension( HYPRE_Int n,
    {
       HYPRE_Int num_warps_per_block = num_threads_per_block >> 5;
 
-      hypre_assert(num_warps_per_block * 32 == num_threads_per_block);
+      hypre_assert(num_warps_per_block * HYPRE_WARP_SIZE == num_threads_per_block);
 
       num_blocks = (n + num_warps_per_block - 1) / num_warps_per_block;
    }

--- a/src/utilities/hypre_cuda_utils.c
+++ b/src/utilities/hypre_cuda_utils.c
@@ -377,7 +377,8 @@ hypreDevice_CsrRowPtrsToIndicesWithRowNum(HYPRE_Int nrows, HYPRE_Int nnz, HYPRE_
 
 struct hypre_empty_row_functor
 {
-   /* typedef bool result_type; */
+   // This is needed for clang
+   typedef bool result_type;
 
    __device__
    bool operator()(const thrust::tuple<HYPRE_Int, HYPRE_Int>& t) const

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -436,7 +436,7 @@ T warp_prefix_sum(hypre_int lane_id, T in, T &all_sum)
 
       if ( (lane_id & (d - 1)) == d - 1)
       {
-         if ( (lane_id & (d << 1 - 1)) == (d << 1 - 1) )
+        if ( (lane_id & ((d << 1) - 1)) == ((d << 1) - 1) )
          {
             in += t;
          }

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -367,28 +367,28 @@ hypre_double atomicAdd(hypre_double* address, hypre_double val)
 
 template <typename T>
 static __device__ __forceinline__
-T __shfl_sync(unsigned mask, T val, hypre_int src_line, hypre_int width=32)
+T __shfl_sync(unsigned mask, T val, hypre_int src_line, hypre_int width=HYPRE_WARP_SIZE)
 {
    return __shfl(val, src_line, width);
 }
 
 template <typename T>
 static __device__ __forceinline__
-T __shfl_down_sync(unsigned mask, T val, unsigned delta, hypre_int width=32)
+T __shfl_down_sync(unsigned mask, T val, unsigned delta, hypre_int width=HYPRE_WARP_SIZE)
 {
    return __shfl_down(val, delta, width);
 }
 
 template <typename T>
 static __device__ __forceinline__
-T __shfl_xor_sync(unsigned mask, T val, unsigned lanemask, hypre_int width=32)
+T __shfl_xor_sync(unsigned mask, T val, unsigned lanemask, hypre_int width=HYPRE_WARP_SIZE)
 {
    return __shfl_xor(val, lanemask, width);
 }
 
 template <typename T>
 static __device__ __forceinline__
-T __shfl_up_sync(unsigned mask, T val, unsigned delta, hypre_int width=32)
+T __shfl_up_sync(unsigned mask, T val, unsigned delta, hypre_int width=HYPRE_WARP_SIZE)
 {
    return __shfl_up(val, delta, width);
 }
@@ -413,7 +413,7 @@ static __device__ __forceinline__
 T warp_prefix_sum(hypre_int lane_id, T in, T &all_sum)
 {
 #pragma unroll
-   for (hypre_int d = 2; d <= 32; d <<= 1)
+   for (hypre_int d = 2; d <=HYPRE_WARP_SIZE; d <<= 1)
    {
       T t = __shfl_up_sync(HYPRE_WARP_FULL_MASK, in, d >> 1);
       if ( (lane_id & (d - 1)) == d - 1 )
@@ -422,15 +422,15 @@ T warp_prefix_sum(hypre_int lane_id, T in, T &all_sum)
       }
    }
 
-   all_sum = __shfl_sync(HYPRE_WARP_FULL_MASK, in, 31);
+   all_sum = __shfl_sync(HYPRE_WARP_FULL_MASK, in, HYPRE_WARP_SIZE-1);
 
-   if (lane_id == 31)
+   if (lane_id == HYPRE_WARP_SIZE-1)
    {
       in = 0;
    }
 
 #pragma unroll
-   for (hypre_int d = 16; d > 0; d >>= 1)
+   for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
    {
       T t = __shfl_xor_sync(HYPRE_WARP_FULL_MASK, in, d);
 
@@ -454,7 +454,7 @@ static __device__ __forceinline__
 T warp_reduce_sum(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in += __shfl_down_sync(HYPRE_WARP_FULL_MASK, in, d);
   }
@@ -466,7 +466,7 @@ static __device__ __forceinline__
 T warp_allreduce_sum(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in += __shfl_xor_sync(HYPRE_WARP_FULL_MASK, in, d);
   }
@@ -478,7 +478,7 @@ static __device__ __forceinline__
 T warp_reduce_max(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in = max(in, __shfl_down_sync(HYPRE_WARP_FULL_MASK, in, d));
   }
@@ -490,7 +490,7 @@ static __device__ __forceinline__
 T warp_allreduce_max(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in = max(in, __shfl_xor_sync(HYPRE_WARP_FULL_MASK, in, d));
   }
@@ -502,7 +502,7 @@ static __device__ __forceinline__
 T warp_reduce_min(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in = min(in, __shfl_down_sync(HYPRE_WARP_FULL_MASK, in, d));
   }
@@ -514,7 +514,7 @@ static __device__ __forceinline__
 T warp_allreduce_min(T in)
 {
 #pragma unroll
-  for (hypre_int d = 16; d > 0; d >>= 1)
+  for (hypre_int d = HYPRE_WARP_SIZE/2; d > 0; d >>= 1)
   {
     in = min(in, __shfl_xor_sync(HYPRE_WARP_FULL_MASK, in, d));
   }

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -416,7 +416,7 @@ T warp_prefix_sum(hypre_int lane_id, T in, T &all_sum)
    for (hypre_int d = 2; d <=HYPRE_WARP_SIZE; d <<= 1)
    {
       T t = __shfl_up_sync(HYPRE_WARP_FULL_MASK, in, d >> 1);
-      if ( (lane_id & (d - 1)) == d - 1 )
+      if ( (lane_id & (d - 1)) == (d - 1) )
       {
          in += t;
       }
@@ -434,7 +434,7 @@ T warp_prefix_sum(hypre_int lane_id, T in, T &all_sum)
    {
       T t = __shfl_xor_sync(HYPRE_WARP_FULL_MASK, in, d);
 
-      if ( (lane_id & (d - 1)) == d - 1)
+      if ( (lane_id & (d - 1)) == (d - 1))
       {
         if ( (lane_id & ((d << 1) - 1)) == ((d << 1) - 1) )
          {


### PR DESCRIPTION
This PR includes some fixes and updates to help improve portability.

950a747 and 2f51e75 are updates to use `HYPRE_WARP_SIZE` instead of hardcoded 32, 31, or 16.  26a1a8a in an update for readability.

2e5ccb6 is an important fix to a sneaky issue. It turns out, `clang` and `nvcc` assign different precedence between `>>` and `-`. Indeed, the code before that commit elicited a warning from clang about the precedence. The code as it was would behave differently on clang than on nvcc. So those extra parentheses are critical. This commit merits close examination to make sure I understood the original intent of the code correctly.

26a1a8a is another fix for clang. This function would not compile without `result_type` being defined. (Alternatively, the functor could subclass `unary_functor`.)

I've been using the `ij` test with the following to exercise GPU support without managed memory:

`./ij -n 48 48 48 -pmis -keepT 1 -rlx 18 -rap 1 -mod_rap2 1 -mm_cusparse 1 -solver 1 -agg_nl 0 -exec_device`

and with managed memory:

`./ij -n 48 48 48 -pmis -keepT 1 -rlx 18 -rap 1 -mod_rap2 1 -mm_cusparse 1 -solver 1 -agg_nl 1 -exec_device`

Both of these tests are passing (in the sense that the solver converges) using CUDA 10.2 on V100.

These changes will be important for HIP support as the HIP compiler is based on clang. Thank you.