### PR TITLE
PETSc fix

### DIFF
--- a/AUTOTEST/machine-lassen.sh
+++ b/AUTOTEST/machine-lassen.sh
@@ -44,14 +44,14 @@ rost="-struct -rt -mpibind -rtol 1e-8 -atol 1e-8"
 rocuda="-cuda_lassen -rt -mpibind"
 
 # CUDA with UM
-co="--with-cuda --enable-unified-memory --enable-persistent --enable-cub --enable-debug --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' HYPRE_CUDA_SM=70"
+co="--with-cuda --enable-unified-memory --enable-persistent --enable-cub --enable-debug --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' HYPRE_CUDA_SM=70"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij
 ./renametest.sh basic $output_dir/basic-cuda-um-ij
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ross
 ./renametest.sh basic $output_dir/basic-cuda-um-struct-sstruct
 
 # CUDA with UM [shared library]
-co="--with-cuda --enable-unified-memory --with-openmp --enable-hopscotch --enable-shared --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' HYPRE_CUDA_SM=70"
+co="--with-cuda --enable-unified-memory --with-openmp --enable-hopscotch --enable-shared --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' HYPRE_CUDA_SM=70"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rocuda
 ./renametest.sh basic $output_dir/basic-cuda-um-shared
 #./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij

--- a/AUTOTEST/machine-ray.sh
+++ b/AUTOTEST/machine-ray.sh
@@ -44,14 +44,14 @@ rost="-struct -rt -mpibind -rtol 1e-8 -atol 1e-8"
 rocuda="-cuda_ray -rt -mpibind"
 
 # CUDA with UM
-co="--with-cuda --enable-unified-memory --enable-persistent --enable-cub --enable-debug --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\'"
+co="--with-cuda --enable-unified-memory --enable-persistent --enable-cub --enable-debug --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\'"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij
 ./renametest.sh basic $output_dir/basic-cuda-um-ij
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ross
 ./renametest.sh basic $output_dir/basic-cuda-um-struct-sstruct
 
 # CUDA with UM [shared library]
-co="--with-cuda --enable-unified-memory --with-openmp --enable-hopscotch --enable-shared --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\'"
+co="--with-cuda --enable-unified-memory --with-openmp --enable-hopscotch --enable-shared --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\'"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rocuda
 ./renametest.sh basic $output_dir/basic-cuda-um-shared
 #./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -1888,12 +1888,11 @@ then
    then
       SHARED_SET_SONAME="-Xlinker=-soname,"
       SHARED_OPTIONS="-Xlinker=-z,defs"
-      SHARED_COMPILE_FLAG="-Xcompiler \"-fPIC\""
    else
       SHARED_SET_SONAME="-Wl,-soname,"
       SHARED_OPTIONS="-Wl,-z,defs"
-      SHARED_COMPILE_FLAG="-fPIC"
    fi
+   SHARED_COMPILE_FLAG="-fPIC"
    case $hypre_platform in
       AIX* | aix* | Aix*) SHARED_COMPILE_FLAG="-qmkshrobj"
                           SHARED_BUILD_FLAG="-G"
@@ -1911,7 +1910,7 @@ dnl                          LINK_F77="${F77} -brtl"
    FFLAGS="${FFLAGS} ${SHARED_COMPILE_FLAG}"
    CFLAGS="${CFLAGS} ${SHARED_COMPILE_FLAG}"
    CXXFLAGS="${CXXFLAGS} ${SHARED_COMPILE_FLAG}"
-   CUFLAGS="${CUFLAGS} ${SHARED_COMPILE_FLAG}"
+   CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
 dnl   BUILD_F77_SHARED="${F77} ${SHARED_BUILD_FLAG}"
    BUILD_FC_SHARED="${FC} ${SHARED_BUILD_FLAG}"
    if test "$hypre_using_fei" = "yes"

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -1771,7 +1771,7 @@ then
 
    CUFLAGS="${CUFLAGS} -Xcompiler \"${CXXFLAGS}\""
 
-   CFLAGS=${CXXFLAGS}
+   dnl CFLAGS=${CXXFLAGS}
    LDFLAGS="-ccbin=$NVCCBIN ${HYPRE_CUDA_GENCODE} -Xcompiler \"${LDFLAGS}\""
    HYPRE_CUDA_INCL="-I${HYPRE_CUDA_PATH}/include"
    HYPRE_CUDA_LIBS="-L${HYPRE_CUDA_PATH}/lib64 -lcudart"

--- a/src/configure
+++ b/src/configure
@@ -738,7 +738,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -888,7 +887,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1141,15 +1139,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1287,7 +1276,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1440,7 +1429,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -8626,12 +8614,11 @@ then
    then
       SHARED_SET_SONAME="-Xlinker=-soname,"
       SHARED_OPTIONS="-Xlinker=-z,defs"
-      SHARED_COMPILE_FLAG="-Xcompiler \"-fPIC\""
    else
       SHARED_SET_SONAME="-Wl,-soname,"
       SHARED_OPTIONS="-Wl,-z,defs"
-      SHARED_COMPILE_FLAG="-fPIC"
    fi
+   SHARED_COMPILE_FLAG="-fPIC"
    case $hypre_platform in
       AIX* | aix* | Aix*) SHARED_COMPILE_FLAG="-qmkshrobj"
                           SHARED_BUILD_FLAG="-G"
@@ -8648,7 +8635,7 @@ then
    FFLAGS="${FFLAGS} ${SHARED_COMPILE_FLAG}"
    CFLAGS="${CFLAGS} ${SHARED_COMPILE_FLAG}"
    CXXFLAGS="${CXXFLAGS} ${SHARED_COMPILE_FLAG}"
-   CUFLAGS="${CUFLAGS} ${SHARED_COMPILE_FLAG}"
+   CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
    BUILD_FC_SHARED="${FC} ${SHARED_BUILD_FLAG}"
    if test "$hypre_using_fei" = "yes"
    then

--- a/src/configure
+++ b/src/configure
@@ -8496,8 +8496,7 @@ done
 
    CUFLAGS="${CUFLAGS} -Xcompiler \"${CXXFLAGS}\""
 
-   CFLAGS=${CXXFLAGS}
-   LDFLAGS="-ccbin=$NVCCBIN ${HYPRE_CUDA_GENCODE} -Xcompiler \"${LDFLAGS}\""
+      LDFLAGS="-ccbin=$NVCCBIN ${HYPRE_CUDA_GENCODE} -Xcompiler \"${LDFLAGS}\""
    HYPRE_CUDA_INCL="-I${HYPRE_CUDA_PATH}/include"
    HYPRE_CUDA_LIBS="-L${HYPRE_CUDA_PATH}/lib64 -lcudart"
    if test "$hypre_using_nvtx" = "yes"

--- a/src/parcsr_ls/par_cycle.c
+++ b/src/parcsr_ls/par_cycle.c
@@ -411,13 +411,13 @@ hypre_BoomerAMGCycle( void              *amg_vdata,
                   hypre_ParVectorAxpy(relax_weight[level],Utemp,Aux_U);
                }
                else if (smooth_num_levels > level &&
-	               (smooth_type == 5 || smooth_type == 15))
-	       {
+                       (smooth_type == 5 || smooth_type == 15))
+               {
                   HYPRE_ILUSolve(smoother[level],
                                  (HYPRE_ParCSRMatrix) A_array[level],
                                  (HYPRE_ParVector) Aux_F,
                                  (HYPRE_ParVector) Aux_U);
-	       }
+               }
                else if (smooth_num_levels > level &&
                         (smooth_type == 6 || smooth_type == 16))
                {

--- a/src/seq_mv/csr_matvec_device.c
+++ b/src/seq_mv/csr_matvec_device.c
@@ -15,6 +15,7 @@
 #include "_hypre_utilities.hpp"
 
 #if defined(HYPRE_USING_CUDA)
+/* y = alpha * A * x + beta * b */
 HYPRE_Int
 hypre_CSRMatrixMatvecDevice( HYPRE_Int        trans,
                              HYPRE_Complex    alpha,
@@ -29,13 +30,32 @@ hypre_CSRMatrixMatvecDevice( HYPRE_Int        trans,
    hypre_error_w_msg(HYPRE_ERROR_GENERIC,"ERROR: hypre_CSRMatvecDevice should not be called when bigint is enabled!");
 #else
 
-   cusparseHandle_t handle = hypre_HandleCusparseHandle(hypre_handle());
-   cusparseMatDescr_t descr = hypre_HandleCusparseMatDescr(hypre_handle());
+   // TODO
+   hypre_assert(offset == 0);
+
+   if (x == y)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC,"ERROR::x and y are the same pointer in hypre_CSRMatrixMatvecDevice\n");
+   }
+
+   if (trans)
+   {
+      hypre_assert(hypre_CSRMatrixNumCols(A) == hypre_VectorSize(y));
+      hypre_assert(hypre_CSRMatrixNumRows(A) == hypre_VectorSize(x));
+   }
+   else
+   {
+      hypre_assert(hypre_CSRMatrixNumCols(A) == hypre_VectorSize(x));
+      hypre_assert(hypre_CSRMatrixNumRows(A) == hypre_VectorSize(y));
+   }
+   hypre_assert(hypre_VectorSize(y) == hypre_VectorSize(b));
+
+   cusparseHandle_t   handle = hypre_HandleCusparseHandle(hypre_handle());
+   cusparseMatDescr_t descr  = hypre_HandleCusparseMatDescr(hypre_handle());
 
    //hypre_CSRMatrixPrefetch(A, HYPRE_MEMORY_DEVICE);
    //hypre_SeqVectorPrefetch(x, HYPRE_MEMORY_DEVICE);
    //hypre_SeqVectorPrefetch(b, HYPRE_MEMORY_DEVICE);
-
 
    //if (b != y)
    //{
@@ -44,37 +64,36 @@ hypre_CSRMatrixMatvecDevice( HYPRE_Int        trans,
 
    if (b != y)
    {
-      HYPRE_THRUST_CALL( copy_n, b->data, y->size-offset, y->data );
+      HYPRE_THRUST_CALL( copy_n,
+                         hypre_VectorData(b),
+                         hypre_VectorSize(y) - offset,
+                         hypre_VectorData(y) );
    }
 
-   if (x == y)
+   if (hypre_CSRMatrixNumNonzeros(A) <= 0)
    {
-      hypre_error_w_msg(HYPRE_ERROR_GENERIC,"ERROR::x and y are the same pointer in hypre_CSRMatrixMatvecDevice\n");
-   }
+      hypre_SeqVectorScale(beta, y);
 
-   // TODO
-   if (offset != 0)
-   {
-      hypre_printf("WARNING:: Offset is not zero in hypre_CSRMatrixMatvecDevice :: \n");
+      return hypre_error_flag;
    }
-
-   hypre_assert(offset == 0);
 
    if (trans)
    {
-      HYPRE_Complex *csc_a = hypre_TAlloc(HYPRE_Complex, A->num_nonzeros, HYPRE_MEMORY_DEVICE);
-      HYPRE_Int     *csc_j = hypre_TAlloc(HYPRE_Int,     A->num_nonzeros, HYPRE_MEMORY_DEVICE);
-      HYPRE_Int     *csc_i = hypre_TAlloc(HYPRE_Int,     A->num_cols+1,   HYPRE_MEMORY_DEVICE);
+      HYPRE_Complex *csc_a = hypre_TAlloc(HYPRE_Complex, hypre_CSRMatrixNumNonzeros(A), HYPRE_MEMORY_DEVICE);
+      HYPRE_Int     *csc_j = hypre_TAlloc(HYPRE_Int,     hypre_CSRMatrixNumNonzeros(A), HYPRE_MEMORY_DEVICE);
+      HYPRE_Int     *csc_i = hypre_TAlloc(HYPRE_Int,     hypre_CSRMatrixNumCols(A)+1,   HYPRE_MEMORY_DEVICE);
 
-      HYPRE_CUSPARSE_CALL( cusparseDcsr2csc(handle, A->num_rows, A->num_cols, A->num_nonzeros,
-                           A->data, A->i, A->j, csc_a, csc_j, csc_i,
-                           CUSPARSE_ACTION_NUMERIC, CUSPARSE_INDEX_BASE_ZERO) );
+      HYPRE_CUSPARSE_CALL( cusparseDcsr2csc(handle, hypre_CSRMatrixNumRows(A), hypre_CSRMatrixNumCols(A),
+                                            hypre_CSRMatrixNumNonzeros(A), hypre_CSRMatrixData(A),
+                                            hypre_CSRMatrixI(A), hypre_CSRMatrixJ(A), csc_a, csc_j, csc_i,
+                                            CUSPARSE_ACTION_NUMERIC, CUSPARSE_INDEX_BASE_ZERO) );
 
       HYPRE_CUSPARSE_CALL( cusparseDcsrmv(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                           A->num_cols, A->num_rows, A->num_nonzeros,
-                           &alpha, descr,
-                           csc_a, csc_i, csc_j,
-                           x->data, &beta, y->data) );
+                                          hypre_CSRMatrixNumCols(A), hypre_CSRMatrixNumRows(A),
+                                          hypre_CSRMatrixNumNonzeros(A),
+                                          &alpha, descr,
+                                          csc_a, csc_i, csc_j,
+                                          hypre_VectorData(x), &beta, hypre_VectorData(y)) );
 
       hypre_TFree(csc_a, HYPRE_MEMORY_DEVICE);
       hypre_TFree(csc_i, HYPRE_MEMORY_DEVICE);
@@ -83,10 +102,11 @@ hypre_CSRMatrixMatvecDevice( HYPRE_Int        trans,
    else
    {
       HYPRE_CUSPARSE_CALL( cusparseDcsrmv(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                           A->num_rows-offset, A->num_cols, A->num_nonzeros,
-                           &alpha, descr,
-                           A->data, A->i+offset, A->j,
-                           x->data, &beta, y->data+offset) );
+                                          hypre_CSRMatrixNumRows(A) - offset, hypre_CSRMatrixNumCols(A),
+                                          hypre_CSRMatrixNumNonzeros(A),
+                                          &alpha, descr,
+                                          hypre_CSRMatrixData(A), hypre_CSRMatrixI(A) + offset, hypre_CSRMatrixJ(A),
+                                          hypre_VectorData(x), &beta, hypre_VectorData(y) + offset) );
    }
 
    hypre_SyncCudaComputeStream(hypre_handle());
@@ -97,12 +117,12 @@ hypre_CSRMatrixMatvecDevice( HYPRE_Int        trans,
 
 HYPRE_Int
 hypre_CSRMatrixMatvecDeviceBIGINT( HYPRE_Complex    alpha,
-                       hypre_CSRMatrix *A,
-                       hypre_Vector    *x,
-                       HYPRE_Complex    beta,
-                       hypre_Vector    *b,
-                       hypre_Vector    *y,
-                       HYPRE_Int offset )
+                                   hypre_CSRMatrix *A,
+                                   hypre_Vector    *x,
+                                   HYPRE_Complex    beta,
+                                   hypre_Vector    *b,
+                                   hypre_Vector    *y,
+                                   HYPRE_Int offset )
 {
 #ifdef HYPRE_BIGINT
 #error "TODO BigInt"

--- a/src/seq_mv/vector.c
+++ b/src/seq_mv/vector.c
@@ -440,6 +440,17 @@ HYPRE_Int
 hypre_SeqVectorScale( HYPRE_Complex alpha,
                       hypre_Vector *y )
 {
+   /* special cases */
+   if (alpha == 1.0)
+   {
+      return 0;
+   }
+
+   if (alpha == 0.0)
+   {
+      return hypre_SeqVectorSetConstantValues(y, 0.0);
+   }
+
 #ifdef HYPRE_PROFILE
    hypre_profile_times[HYPRE_TIMER_ID_BLAS1] -= hypre_MPI_Wtime();
 #endif
@@ -447,11 +458,6 @@ hypre_SeqVectorScale( HYPRE_Complex alpha,
    HYPRE_Complex *y_data = hypre_VectorData(y);
    HYPRE_Int      size   = hypre_VectorSize(y);
    HYPRE_Int      ierr = 0;
-
-   if (alpha == 1.0)
-   {
-      return ierr;
-   }
 
    size *= hypre_VectorNumVectors(y);
 

--- a/src/seq_mv/vector.c
+++ b/src/seq_mv/vector.c
@@ -448,6 +448,11 @@ hypre_SeqVectorScale( HYPRE_Complex alpha,
    HYPRE_Int      size   = hypre_VectorSize(y);
    HYPRE_Int      ierr = 0;
 
+   if (alpha == 1.0)
+   {
+      return ierr;
+   }
+
    size *= hypre_VectorNumVectors(y);
 
    //hypre_SeqVectorPrefetch(y, HYPRE_MEMORY_DEVICE);

--- a/src/struct_mv/_hypre_struct_mv.h
+++ b/src/struct_mv/_hypre_struct_mv.h
@@ -1556,11 +1556,11 @@ typedef struct hypre_StructVector_struct
                                           the data array.  data_indices[b]
                                           is the starting index of vector
                                           data corresponding to box b. */
-                      
+
    HYPRE_Int             num_ghost[2*HYPRE_MAXDIM]; /* Num ghost layers in each
                                                      * direction */
    HYPRE_Int             bghost_not_clear; /* Are boundary ghosts clear? */
-                      
+
    HYPRE_BigInt          global_size;  /* Total number coefficients */
 
    HYPRE_Int             ref_count;
@@ -1582,16 +1582,16 @@ typedef struct hypre_StructVector_struct
 #define hypre_StructVectorBGhostNotClear(vector)((vector) -> bghost_not_clear)
 #define hypre_StructVectorGlobalSize(vector)    ((vector) -> global_size)
 #define hypre_StructVectorRefCount(vector)      ((vector) -> ref_count)
- 
+
 #define hypre_StructVectorNDim(vector) \
 hypre_StructGridNDim(hypre_StructVectorGrid(vector))
 
 #define hypre_StructVectorBox(vector, b) \
 hypre_BoxArrayBox(hypre_StructVectorDataSpace(vector), b)
- 
+
 #define hypre_StructVectorBoxData(vector, b) \
 (hypre_StructVectorData(vector) + hypre_StructVectorDataIndices(vector)[b])
- 
+
 #define hypre_StructVectorBoxDataValue(vector, b, index) \
 (hypre_StructVectorBoxData(vector, b) + \
  hypre_BoxIndexRank(hypre_StructVectorBox(vector, b), index))

--- a/src/struct_mv/_hypre_struct_mv.hpp
+++ b/src/struct_mv/_hypre_struct_mv.hpp
@@ -763,7 +763,7 @@ typedef struct hypre_Boxloop_struct
     printf("\n ERROR hypre_newBoxLoop: %s in %s(%d) function %s\n",cudaGetErrorString(err),__FILE__,__LINE__,__FUNCTION__); \
     /* HYPRE_Int *p = NULL; *p = 1; */                                                                                      \
   }                                                                                                                         \
-  hypre_CheckErrorDevice(cudaDeviceSynchronize());                                                                          \
+  HYPRE_CUDA_CALL( cudaDeviceSynchronize() );                                                                               \
 }
 #endif
 

--- a/src/struct_mv/boxloop_cuda.h
+++ b/src/struct_mv/boxloop_cuda.h
@@ -41,7 +41,7 @@ typedef struct hypre_Boxloop_struct
     printf("\n ERROR hypre_newBoxLoop: %s in %s(%d) function %s\n",cudaGetErrorString(err),__FILE__,__LINE__,__FUNCTION__); \
     /* HYPRE_Int *p = NULL; *p = 1; */                                                                                      \
   }                                                                                                                         \
-  hypre_CheckErrorDevice(cudaDeviceSynchronize());                                                                          \
+  HYPRE_CUDA_CALL( cudaDeviceSynchronize() );                                                                               \
 }
 #endif
 

--- a/src/struct_mv/struct_vector.h
+++ b/src/struct_mv/struct_vector.h
@@ -33,11 +33,11 @@ typedef struct hypre_StructVector_struct
                                           the data array.  data_indices[b]
                                           is the starting index of vector
                                           data corresponding to box b. */
-                      
+
    HYPRE_Int             num_ghost[2*HYPRE_MAXDIM]; /* Num ghost layers in each
                                                      * direction */
    HYPRE_Int             bghost_not_clear; /* Are boundary ghosts clear? */
-                      
+
    HYPRE_BigInt          global_size;  /* Total number coefficients */
 
    HYPRE_Int             ref_count;
@@ -59,16 +59,16 @@ typedef struct hypre_StructVector_struct
 #define hypre_StructVectorBGhostNotClear(vector)((vector) -> bghost_not_clear)
 #define hypre_StructVectorGlobalSize(vector)    ((vector) -> global_size)
 #define hypre_StructVectorRefCount(vector)      ((vector) -> ref_count)
- 
+
 #define hypre_StructVectorNDim(vector) \
 hypre_StructGridNDim(hypre_StructVectorGrid(vector))
 
 #define hypre_StructVectorBox(vector, b) \
 hypre_BoxArrayBox(hypre_StructVectorDataSpace(vector), b)
- 
+
 #define hypre_StructVectorBoxData(vector, b) \
 (hypre_StructVectorData(vector) + hypre_StructVectorDataIndices(vector)[b])
- 
+
 #define hypre_StructVectorBoxDataValue(vector, b, index) \
 (hypre_StructVectorBoxData(vector, b) + \
  hypre_BoxIndexRank(hypre_StructVectorBox(vector, b), index))

--- a/src/utilities/hypre_general.c
+++ b/src/utilities/hypre_general.c
@@ -175,10 +175,7 @@ HYPRE_Init()
    /* Keep this check here at the end of HYPRE_Init()
     * Make sure that CUB Allocator has not been setup in HYPRE_Init,
     * otherwise users are not able to set the parameters of CUB
-    * Note: hypre_HandleCubCachingDeviceAllocator and
-    *       hypre_HandleCubCachingManagedAllocator
-    *       are not used, since allocation would happen therein,
-    *       which is not wanted here */
+    */
    if ( hypre_HandleCubDevAllocator(_hypre_handle) ||
         hypre_HandleCubUvmAllocator(_hypre_handle) )
    {


### PR DESCRIPTION
1. Fixing compile, build issues with CUDA in #151 
2. Fixing a case where Cusparse cannot properly do matvec with m-by-0 matrix
3. Adding a special case for `hypre_SeqVectorScale` with scale = 1.0