### PR TITLE
Fix hopscotch

### DIFF
--- a/AUTOTEST/machine-tux.sh
+++ b/AUTOTEST/machine-tux.sh
@@ -120,6 +120,11 @@ RO="-ams -ij -sstruct -struct -lobpcg -rt -D HYPRE_NO_SAVED -nthreads 2"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $RO
 ./renametest.sh basic $output_dir/basic--with-openmp
 
+co="--with-openmp --enable-hopscotch"
+RO="-ij -sstruct -struct -lobpcg -rt -D HYPRE_NO_SAVED -nthreads 2"
+./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $RO
+./renametest.sh basic $output_dir/basic--with-concurrent-hopscotch
+
 co="--enable-single --enable-debug"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: -single
 ./renametest.sh basic $output_dir/basic--enable-single

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1381,30 +1381,6 @@ void hypre_prefix_sum_triple(HYPRE_Int *in_out1, HYPRE_Int *sum1, HYPRE_Int *in_
  */
 void hypre_prefix_sum_multiple(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int n, HYPRE_Int *workspace);
 
-/* hypre_merge_sort.c */
-/**
- * Why merge sort?
- * 1) Merge sort can take advantage of eliminating duplicates.
- * 2) Merge sort is more efficiently parallelizable than qsort
- */
-
-/**
- * Out of place merge sort with duplicate elimination
- * @ret number of unique elements
- */
-HYPRE_Int hypre_merge_sort_unique(HYPRE_Int *in, HYPRE_Int *out, HYPRE_Int len);
-/**
- * Out of place merge sort with duplicate elimination
- *
- * @param out pointer to output can be in or temp
- * @ret number of unique elements
- */
-HYPRE_Int hypre_merge_sort_unique2(HYPRE_Int *in, HYPRE_Int *temp, HYPRE_Int len, HYPRE_Int **out);
-
-void hypre_merge_sort(HYPRE_Int *in, HYPRE_Int *temp, HYPRE_Int len, HYPRE_Int **sorted);
-
-void hypre_union2(HYPRE_Int n1, HYPRE_BigInt *arr1, HYPRE_Int n2, HYPRE_BigInt *arr2, HYPRE_Int *n3, HYPRE_BigInt *arr3, HYPRE_Int *map1, HYPRE_Int *map2);
-
 /* hypre_hopscotch_hash.c */
 
 #ifdef HYPRE_USING_OPENMP
@@ -1513,18 +1489,18 @@ typedef struct
    hypre_BigHopscotchBucket* volatile table;
 } hypre_UnorderedBigIntMap;
 
+/* hypre_merge_sort.c */
 /**
- * Sort array "in" with length len and put result in array "out"
- * "in" will be deallocated unless in == *out
- * inverse_map is an inverse hash table s.t. inverse_map[i] = j iff (*out)[j] = i
+ * Why merge sort?
+ * 1) Merge sort can take advantage of eliminating duplicates.
+ * 2) Merge sort is more efficiently parallelizable than qsort
  */
-void hypre_sort_and_create_inverse_map(
-  HYPRE_Int *in, HYPRE_Int len, HYPRE_Int **out, hypre_UnorderedIntMap *inverse_map);
-
-#ifdef HYPRE_CONCURRENT_HOPSCOTCH
+void hypre_union2(HYPRE_Int n1, HYPRE_BigInt *arr1, HYPRE_Int n2, HYPRE_BigInt *arr2, HYPRE_Int *n3, HYPRE_BigInt *arr3, HYPRE_Int *map1, HYPRE_Int *map2);
+void hypre_merge_sort(HYPRE_Int *in, HYPRE_Int *temp, HYPRE_Int len, HYPRE_Int **sorted);
 void hypre_big_merge_sort(HYPRE_BigInt *in, HYPRE_BigInt *temp, HYPRE_Int len, HYPRE_BigInt **sorted);
+void hypre_sort_and_create_inverse_map(HYPRE_Int *in, HYPRE_Int len, HYPRE_Int **out, hypre_UnorderedIntMap *inverse_map);
 void hypre_big_sort_and_create_inverse_map(HYPRE_BigInt *in, HYPRE_Int len, HYPRE_BigInt **out, hypre_UnorderedBigIntMap *inverse_map);
-#endif
+
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 HYPRE_Int hypre_SyncCudaComputeStream(hypre_Handle *hypre_handle);
@@ -1539,9 +1515,9 @@ void hypre_NvtxPushRangeColor(const char *name, HYPRE_Int cid);
 void hypre_NvtxPushRange(const char *name);
 void hypre_NvtxPopRange();
 
-
 #ifdef __cplusplus
 }
 #endif
 
 #endif
+

--- a/src/utilities/hypre_hopscotch_hash.h
+++ b/src/utilities/hypre_hopscotch_hash.h
@@ -31,7 +31,7 @@
 //  Moran Tzafrir
 //  Tel-Aviv University
 //
-//  Date: July 15, 2008.  
+//  Date: July 15, 2008.
 //
 ////////////////////////////////////////////////////////////////////////////////
 // Programmer : Moran Tzafrir (MoranTza@gmail.com)
@@ -70,7 +70,8 @@ extern "C" {
  ******************************************************************************/
 
 #ifdef HYPRE_USING_ATOMIC
-static inline HYPRE_Int hypre_compare_and_swap(HYPRE_Int *ptr, HYPRE_Int oldval, HYPRE_Int newval)
+static inline HYPRE_Int
+hypre_compare_and_swap( HYPRE_Int *ptr, HYPRE_Int oldval, HYPRE_Int newval )
 {
 #if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) && (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) > 40100
   return __sync_val_compare_and_swap(ptr, oldval, newval);
@@ -84,7 +85,8 @@ static inline HYPRE_Int hypre_compare_and_swap(HYPRE_Int *ptr, HYPRE_Int oldval,
 #endif
 }
 
-static inline HYPRE_Int hypre_fetch_and_add(HYPRE_Int *ptr, HYPRE_Int value)
+static inline HYPRE_Int
+hypre_fetch_and_add( HYPRE_Int *ptr, HYPRE_Int value )
 {
 #if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) && (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) > 40100
   return __sync_fetch_and_add(ptr, value);
@@ -97,7 +99,8 @@ static inline HYPRE_Int hypre_fetch_and_add(HYPRE_Int *ptr, HYPRE_Int value)
 #endif
 }
 #else // !HYPRE_USING_ATOMIC
-static inline HYPRE_Int hypre_compare_and_swap(HYPRE_Int *ptr, HYPRE_Int oldval, HYPRE_Int newval)
+static inline HYPRE_Int
+hypre_compare_and_swap( HYPRE_Int *ptr, HYPRE_Int oldval, HYPRE_Int newval )
 {
    if (*ptr == oldval)
    {
@@ -107,7 +110,8 @@ static inline HYPRE_Int hypre_compare_and_swap(HYPRE_Int *ptr, HYPRE_Int oldval,
    else return *ptr;
 }
 
-static inline HYPRE_Int hypre_fetch_and_add(HYPRE_Int *ptr, HYPRE_Int value)
+static inline HYPRE_Int
+hypre_fetch_and_add( HYPRE_Int *ptr, HYPRE_Int value )
 {
    HYPRE_Int oldval = *ptr;
    *ptr += value;
@@ -125,12 +129,11 @@ static inline HYPRE_Int hypre_fetch_and_add(HYPRE_Int *ptr, HYPRE_Int value)
 #define HYPRE_HOPSCOTCH_HASH_BUSY  (1)
 
 // Small Utilities ..........................................................
-#ifdef HYPRE_CONCURRENT_HOPSCOTCH
-static inline HYPRE_Int first_lsb_bit_indx(hypre_uint x) 
+static inline HYPRE_Int
+first_lsb_bit_indx( hypre_uint x )
 {
   return ffs(x) - 1;
 }
-#endif
 /**
  * hypre_Hash is adapted from xxHash with the following license.
  */
@@ -183,11 +186,12 @@ static inline HYPRE_Int first_lsb_bit_indx(hypre_uint x)
 #define HYPRE_XXH_PRIME64_4  9650029242287828579ULL
 #define HYPRE_XXH_PRIME64_5  2870177450012600261ULL
 
-#  define HYPRE_XXH_rotl32(x,r) ((x << r) | (x >> (32 - r)))
-#  define HYPRE_XXH_rotl64(x,r) ((x << r) | (x >> (64 - r)))
+#define HYPRE_XXH_rotl32(x,r) ((x << r) | (x >> (32 - r)))
+#define HYPRE_XXH_rotl64(x,r) ((x << r) | (x >> (64 - r)))
 
 #if defined(HYPRE_MIXEDINT) || defined(HYPRE_BIGINT)
-static inline HYPRE_BigInt hypre_BigHash(HYPRE_BigInt input)
+static inline HYPRE_BigInt
+hypre_BigHash( HYPRE_BigInt input )
 {
     hypre_ulongint h64 = HYPRE_XXH_PRIME64_5 + sizeof(input);
 
@@ -209,13 +213,14 @@ static inline HYPRE_BigInt hypre_BigHash(HYPRE_BigInt input)
       hypre_printf("hash(%lld) = %d\n", h64, HYPRE_HOPSCOTCH_HASH_EMPTY);
       hypre_assert(HYPRE_HOPSCOTCH_HASH_EMPTY != h64);
     }
-#endif 
+#endif
 
     return h64;
 }
 
 #else
-static inline HYPRE_Int hypre_BigHash(HYPRE_Int input)
+static inline HYPRE_Int
+hypre_BigHash(HYPRE_Int input)
 {
     hypre_uint h32 = HYPRE_XXH_PRIME32_5 + sizeof(input);
 
@@ -238,7 +243,8 @@ static inline HYPRE_Int hypre_BigHash(HYPRE_Int input)
 #endif
 
 #ifdef HYPRE_BIGINT
-static inline HYPRE_Int hypre_Hash(HYPRE_Int input)
+static inline HYPRE_Int
+hypre_Hash(HYPRE_Int input)
 {
     hypre_ulongint h64 = HYPRE_XXH_PRIME64_5 + sizeof(input);
 
@@ -260,13 +266,14 @@ static inline HYPRE_Int hypre_Hash(HYPRE_Int input)
       hypre_printf("hash(%lld) = %d\n", h64, HYPRE_HOPSCOTCH_HASH_EMPTY);
       hypre_assert(HYPRE_HOPSCOTCH_HASH_EMPTY != h64);
     }
-#endif 
+#endif
 
     return h64;
 }
 
 #else
-static inline HYPRE_Int hypre_Hash(HYPRE_Int input)
+static inline HYPRE_Int
+hypre_Hash(HYPRE_Int input)
 {
     hypre_uint h32 = HYPRE_XXH_PRIME32_5 + sizeof(input);
 
@@ -288,12 +295,13 @@ static inline HYPRE_Int hypre_Hash(HYPRE_Int input)
 }
 #endif
 
-static inline void hypre_UnorderedIntSetFindCloserFreeBucket( hypre_UnorderedIntSet *s,
+static inline void
+ hypre_UnorderedIntSetFindCloserFreeBucket( hypre_UnorderedIntSet *s,
 #ifdef HYPRE_CONCURRENT_HOPSCOTCH
-                            hypre_HopscotchSegment* start_seg,
+                                            hypre_HopscotchSegment *start_seg,
 #endif
-                            HYPRE_Int *free_bucket,
-                            HYPRE_Int *free_dist )
+                                            HYPRE_Int *free_bucket,
+                                            HYPRE_Int *free_dist )
 {
   HYPRE_Int move_bucket = *free_bucket - (HYPRE_HOPSCOTCH_HASH_HOP_RANGE - 1);
   HYPRE_Int move_free_dist;
@@ -315,7 +323,7 @@ static inline void hypre_UnorderedIntSetFindCloserFreeBucket( hypre_UnorderedInt
     {
 #ifdef HYPRE_CONCURRENT_HOPSCOTCH
       hypre_HopscotchSegment*  move_segment = &(s->segments[move_bucket & s->segmentMask]);
-      
+
       if(start_seg != move_segment)
         omp_set_lock(&move_segment->lock);
 #endif
@@ -352,16 +360,17 @@ static inline void hypre_UnorderedIntSetFindCloserFreeBucket( hypre_UnorderedInt
     }
     ++move_bucket;
   }
-  *free_bucket = -1; 
+  *free_bucket = -1;
   *free_dist = 0;
 }
 
-static inline void hypre_UnorderedBigIntSetFindCloserFreeBucket( hypre_UnorderedBigIntSet *s,
+static inline void
+hypre_UnorderedBigIntSetFindCloserFreeBucket( hypre_UnorderedBigIntSet *s,
 #ifdef HYPRE_CONCURRENT_HOPSCOTCH
-                             hypre_HopscotchSegment* start_seg,
+                                              hypre_HopscotchSegment   *start_seg,
 #endif
-                             HYPRE_Int *free_bucket,
-                             HYPRE_Int *free_dist )
+                                              HYPRE_Int *free_bucket,
+                                              HYPRE_Int *free_dist )
 {
   HYPRE_Int move_bucket = *free_bucket - (HYPRE_HOPSCOTCH_HASH_HOP_RANGE - 1);
   HYPRE_Int move_free_dist;
@@ -383,7 +392,7 @@ static inline void hypre_UnorderedBigIntSetFindCloserFreeBucket( hypre_Unordered
     {
 #ifdef HYPRE_CONCURRENT_HOPSCOTCH
       hypre_HopscotchSegment*  move_segment = &(s->segments[move_bucket & s->segmentMask]);
-      
+
       if(start_seg != move_segment)
         omp_set_lock(&move_segment->lock);
 #endif
@@ -420,16 +429,17 @@ static inline void hypre_UnorderedBigIntSetFindCloserFreeBucket( hypre_Unordered
     }
     ++move_bucket;
   }
-  *free_bucket = -1; 
+  *free_bucket = -1;
   *free_dist = 0;
 }
 
-static inline void hypre_UnorderedIntMapFindCloserFreeBucket( hypre_UnorderedIntMap *m,
+static inline void
+hypre_UnorderedIntMapFindCloserFreeBucket( hypre_UnorderedIntMap  *m,
 #ifdef HYPRE_CONCURRENT_HOPSCOTCH
-                            hypre_HopscotchSegment* start_seg,
+                                           hypre_HopscotchSegment *start_seg,
 #endif
-                            hypre_HopscotchBucket** free_bucket,
-                            HYPRE_Int* free_dist)
+                                           hypre_HopscotchBucket **free_bucket,
+                                           HYPRE_Int *free_dist)
 {
   hypre_HopscotchBucket* move_bucket = *free_bucket - (HYPRE_HOPSCOTCH_HASH_HOP_RANGE - 1);
   HYPRE_Int move_free_dist;
@@ -451,7 +461,7 @@ static inline void hypre_UnorderedIntMapFindCloserFreeBucket( hypre_UnorderedInt
     {
 #ifdef HYPRE_CONCURRENT_HOPSCOTCH
       hypre_HopscotchSegment* move_segment = &(m->segments[(move_bucket - m->table) & m->segmentMask]);
-      
+
       if (start_seg != move_segment)
         omp_set_lock(&move_segment->lock);
 #endif
@@ -489,16 +499,17 @@ static inline void hypre_UnorderedIntMapFindCloserFreeBucket( hypre_UnorderedInt
     }
     ++move_bucket;
   }
-  *free_bucket = NULL; 
+  *free_bucket = NULL;
   *free_dist = 0;
 }
 
-static inline void hypre_UnorderedBigIntMapFindCloserFreeBucket( hypre_UnorderedBigIntMap *m,
+static inline void
+hypre_UnorderedBigIntMapFindCloserFreeBucket( hypre_UnorderedBigIntMap   *m,
 #ifdef HYPRE_CONCURRENT_HOPSCOTCH
-                            hypre_HopscotchSegment* start_seg,
+                                              hypre_HopscotchSegment     *start_seg,
 #endif
-                            hypre_BigHopscotchBucket** free_bucket,
-                            HYPRE_Int* free_dist)
+                                              hypre_BigHopscotchBucket **free_bucket,
+                                              HYPRE_Int *free_dist)
 {
   hypre_BigHopscotchBucket* move_bucket = *free_bucket - (HYPRE_HOPSCOTCH_HASH_HOP_RANGE - 1);
   HYPRE_Int move_free_dist;
@@ -520,7 +531,7 @@ static inline void hypre_UnorderedBigIntMapFindCloserFreeBucket( hypre_Unordered
     {
 #ifdef HYPRE_CONCURRENT_HOPSCOTCH
       hypre_HopscotchSegment* move_segment = &(m->segments[(move_bucket - m->table) & m->segmentMask]);
-      
+
       if (start_seg != move_segment)
         omp_set_lock(&move_segment->lock);
 #endif
@@ -558,7 +569,7 @@ static inline void hypre_UnorderedBigIntMapFindCloserFreeBucket( hypre_Unordered
     }
     ++move_bucket;
   }
-  *free_bucket = NULL; 
+  *free_bucket = NULL;
   *free_dist = 0;
 }
 
@@ -581,9 +592,9 @@ void hypre_UnorderedIntMapDestroy( hypre_UnorderedIntMap *m );
 void hypre_UnorderedBigIntMapDestroy( hypre_UnorderedBigIntMap *m );
 
 // Query Operations .........................................................
-#ifdef HYPRE_CONCURRENT_HOPSCOTCH
-static inline HYPRE_Int hypre_UnorderedIntSetContains( hypre_UnorderedIntSet *s,
-                                                HYPRE_Int key )
+static inline HYPRE_Int
+hypre_UnorderedIntSetContains( hypre_UnorderedIntSet *s,
+                               HYPRE_Int              key )
 {
   //CALCULATE HASH ..........................
 #ifdef HYPRE_BIGINT
@@ -593,7 +604,9 @@ static inline HYPRE_Int hypre_UnorderedIntSetContains( hypre_UnorderedIntSet *s,
 #endif
 
   //CHECK IF ALREADY CONTAIN ................
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   hypre_HopscotchSegment *segment = &s->segments[hash & s->segmentMask];
+#endif
   HYPRE_Int bucket = hash & s->bucketMask;
   hypre_uint hopInfo = s->hopInfo[bucket];
 
@@ -606,7 +619,9 @@ static inline HYPRE_Int hypre_UnorderedIntSetContains( hypre_UnorderedIntSet *s,
     else return 0;
   }
 
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   HYPRE_Int startTimestamp = segment->timestamp;
+#endif
   while (0 != hopInfo)
   {
     HYPRE_Int i = first_lsb_bit_indx(hopInfo);
@@ -615,10 +630,12 @@ static inline HYPRE_Int hypre_UnorderedIntSetContains( hypre_UnorderedIntSet *s,
     if (hash == s->hash[currElm] && key == s->key[currElm])
       return 1;
     hopInfo &= ~(1U << i);
-  } 
+  }
 
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   if (segment->timestamp == startTimestamp)
     return 0;
+#endif
 
   HYPRE_Int i;
   for (i = 0; i< HYPRE_HOPSCOTCH_HASH_HOP_RANGE; ++i)
@@ -629,8 +646,9 @@ static inline HYPRE_Int hypre_UnorderedIntSetContains( hypre_UnorderedIntSet *s,
   return 0;
 }
 
-static inline HYPRE_Int hypre_UnorderedBigIntSetContains( hypre_UnorderedBigIntSet *s,
-                                                HYPRE_BigInt key )
+static inline HYPRE_Int
+hypre_UnorderedBigIntSetContains( hypre_UnorderedBigIntSet *s,
+                                  HYPRE_BigInt key )
 {
   //CALCULATE HASH ..........................
 #if defined(HYPRE_BIGINT) || defined(HYPRE_MIXEDINT)
@@ -640,7 +658,9 @@ static inline HYPRE_Int hypre_UnorderedBigIntSetContains( hypre_UnorderedBigIntS
 #endif
 
   //CHECK IF ALREADY CONTAIN ................
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   hypre_HopscotchSegment *segment = &s->segments[(HYPRE_Int)(hash & s->segmentMask)];
+#endif
   HYPRE_Int bucket = (HYPRE_Int)(hash & s->bucketMask);
   hypre_uint hopInfo = s->hopInfo[bucket];
 
@@ -653,7 +673,9 @@ static inline HYPRE_Int hypre_UnorderedBigIntSetContains( hypre_UnorderedBigIntS
     else return 0;
   }
 
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   HYPRE_Int startTimestamp = segment->timestamp;
+#endif
   while (0 != hopInfo)
   {
     HYPRE_Int i = first_lsb_bit_indx(hopInfo);
@@ -662,10 +684,12 @@ static inline HYPRE_Int hypre_UnorderedBigIntSetContains( hypre_UnorderedBigIntS
     if (hash == s->hash[currElm] && key == s->key[currElm])
       return 1;
     hopInfo &= ~(1U << i);
-  } 
+  }
 
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   if (segment->timestamp == startTimestamp)
     return 0;
+#endif
 
   HYPRE_Int i;
   for (i = 0; i< HYPRE_HOPSCOTCH_HASH_HOP_RANGE; ++i)
@@ -679,8 +703,9 @@ static inline HYPRE_Int hypre_UnorderedBigIntSetContains( hypre_UnorderedBigIntS
 /**
  * @ret -1 if key doesn't exist
  */
-static inline HYPRE_Int hypre_UnorderedIntMapGet( hypre_UnorderedIntMap *m,
-                                           HYPRE_Int key)
+static inline HYPRE_Int
+hypre_UnorderedIntMapGet( hypre_UnorderedIntMap *m,
+                          HYPRE_Int key )
 {
   //CALCULATE HASH ..........................
 #ifdef HYPRE_BIGINT
@@ -690,7 +715,9 @@ static inline HYPRE_Int hypre_UnorderedIntMapGet( hypre_UnorderedIntMap *m,
 #endif
 
   //CHECK IF ALREADY CONTAIN ................
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   hypre_HopscotchSegment *segment = &m->segments[hash & m->segmentMask];
+#endif
   hypre_HopscotchBucket *elmAry = &(m->table[hash & m->bucketMask]);
   hypre_uint hopInfo = elmAry->hopInfo;
   if (0 == hopInfo)
@@ -702,7 +729,9 @@ static inline HYPRE_Int hypre_UnorderedIntMapGet( hypre_UnorderedIntMap *m,
     else return -1;
   }
 
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   HYPRE_Int startTimestamp = segment->timestamp;
+#endif
   while (0 != hopInfo)
   {
     HYPRE_Int i = first_lsb_bit_indx(hopInfo);
@@ -710,10 +739,12 @@ static inline HYPRE_Int hypre_UnorderedIntMapGet( hypre_UnorderedIntMap *m,
     if (hash == currElm->hash && key == currElm->key)
       return currElm->data;
     hopInfo &= ~(1U << i);
-  } 
+  }
 
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   if (segment->timestamp == startTimestamp)
     return -1;
+#endif
 
   hypre_HopscotchBucket *currBucket = &(m->table[hash & m->bucketMask]);
   HYPRE_Int i;
@@ -725,8 +756,9 @@ static inline HYPRE_Int hypre_UnorderedIntMapGet( hypre_UnorderedIntMap *m,
   return -1;
 }
 
-static inline HYPRE_Int hypre_UnorderedBigIntMapGet( hypre_UnorderedBigIntMap *m,
-                                           HYPRE_BigInt key)
+static inline
+HYPRE_Int hypre_UnorderedBigIntMapGet( hypre_UnorderedBigIntMap *m,
+                                       HYPRE_BigInt key )
 {
   //CALCULATE HASH ..........................
 #if defined(HYPRE_BIGINT) || defined(HYPRE_MIXEDINT)
@@ -736,7 +768,9 @@ static inline HYPRE_Int hypre_UnorderedBigIntMapGet( hypre_UnorderedBigIntMap *m
 #endif
 
   //CHECK IF ALREADY CONTAIN ................
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   hypre_HopscotchSegment *segment = &m->segments[(HYPRE_Int)(hash & m->segmentMask)];
+#endif
   hypre_BigHopscotchBucket *elmAry = &(m->table[(HYPRE_Int)(hash & m->bucketMask)]);
   hypre_uint hopInfo = elmAry->hopInfo;
   if (0 == hopInfo)
@@ -748,7 +782,9 @@ static inline HYPRE_Int hypre_UnorderedBigIntMapGet( hypre_UnorderedBigIntMap *m
     else return -1;
   }
 
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   HYPRE_Int startTimestamp = segment->timestamp;
+#endif
   while (0 != hopInfo)
   {
     HYPRE_Int i = first_lsb_bit_indx(hopInfo);
@@ -756,10 +792,12 @@ static inline HYPRE_Int hypre_UnorderedBigIntMapGet( hypre_UnorderedBigIntMap *m
     if (hash == currElm->hash && key == currElm->key)
       return currElm->data;
     hopInfo &= ~(1U << i);
-  } 
+  }
 
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   if (segment->timestamp == startTimestamp)
     return -1;
+#endif
 
   hypre_BigHopscotchBucket *currBucket = &(m->table[hash & m->bucketMask]);
   HYPRE_Int i;
@@ -770,10 +808,10 @@ static inline HYPRE_Int hypre_UnorderedBigIntMapGet( hypre_UnorderedBigIntMap *m
   }
   return -1;
 }
-#endif
 
 //status Operations .........................................................
-static inline HYPRE_Int hypre_UnorderedIntSetSize(hypre_UnorderedIntSet *s)
+static inline
+HYPRE_Int hypre_UnorderedIntSetSize( hypre_UnorderedIntSet *s )
 {
   HYPRE_Int counter = 0;
   HYPRE_Int n = s->bucketMask + HYPRE_HOPSCOTCH_HASH_INSERT_RANGE;
@@ -786,9 +824,10 @@ static inline HYPRE_Int hypre_UnorderedIntSetSize(hypre_UnorderedIntSet *s)
     }
   }
   return counter;
-}   
+}
 
-static inline HYPRE_Int hypre_UnorderedBigIntSetSize(hypre_UnorderedBigIntSet *s)
+static inline
+HYPRE_Int hypre_UnorderedBigIntSetSize( hypre_UnorderedBigIntSet *s )
 {
   HYPRE_Int counter = 0;
   HYPRE_BigInt n = s->bucketMask + HYPRE_HOPSCOTCH_HASH_INSERT_RANGE;
@@ -801,9 +840,10 @@ static inline HYPRE_Int hypre_UnorderedBigIntSetSize(hypre_UnorderedBigIntSet *s
     }
   }
   return counter;
-}   
+}
 
-static inline HYPRE_Int hypre_UnorderedIntMapSize(hypre_UnorderedIntMap *m)
+static inline HYPRE_Int
+hypre_UnorderedIntMapSize( hypre_UnorderedIntMap *m )
 {
   HYPRE_Int counter = 0;
   HYPRE_Int n = m->bucketMask + HYPRE_HOPSCOTCH_HASH_INSERT_RANGE;
@@ -818,7 +858,8 @@ static inline HYPRE_Int hypre_UnorderedIntMapSize(hypre_UnorderedIntMap *m)
   return counter;
 }
 
-static inline HYPRE_Int hypre_UnorderedBigIntMapSize(hypre_UnorderedBigIntMap *m)
+static inline HYPRE_Int
+hypre_UnorderedBigIntMapSize( hypre_UnorderedBigIntMap *m )
 {
   HYPRE_Int counter = 0;
   HYPRE_Int n = m->bucketMask + HYPRE_HOPSCOTCH_HASH_INSERT_RANGE;
@@ -837,9 +878,9 @@ HYPRE_Int *hypre_UnorderedIntSetCopyToArray( hypre_UnorderedIntSet *s, HYPRE_Int
 HYPRE_BigInt *hypre_UnorderedBigIntSetCopyToArray( hypre_UnorderedBigIntSet *s, HYPRE_Int *len );
 
 //modification Operations ...................................................
-#ifdef HYPRE_CONCURRENT_HOPSCOTCH
-static inline void hypre_UnorderedIntSetPut( hypre_UnorderedIntSet *s,
-                                      HYPRE_Int key )
+static inline void
+hypre_UnorderedIntSetPut( hypre_UnorderedIntSet *s,
+                          HYPRE_Int key )
 {
   //CALCULATE HASH ..........................
 #ifdef HYPRE_BIGINT
@@ -849,8 +890,10 @@ static inline void hypre_UnorderedIntSetPut( hypre_UnorderedIntSet *s,
 #endif
 
   //LOCK KEY HASH ENTERY ....................
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   hypre_HopscotchSegment  *segment = &s->segments[hash & s->segmentMask];
   omp_set_lock(&segment->lock);
+#endif
   HYPRE_Int bucket = hash&s->bucketMask;
 
   //CHECK IF ALREADY CONTAIN ................
@@ -862,7 +905,9 @@ static inline void hypre_UnorderedIntSetPut( hypre_UnorderedIntSet *s,
 
     if(hash == s->hash[currElm] && key == s->key[currElm])
     {
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
       omp_unset_lock(&segment->lock);
+#endif
       return;
     }
     hopInfo &= ~(1U << i);
@@ -873,7 +918,11 @@ static inline void hypre_UnorderedIntSetPut( hypre_UnorderedIntSet *s,
   HYPRE_Int free_dist = 0;
   for ( ; free_dist < HYPRE_HOPSCOTCH_HASH_INSERT_RANGE; ++free_dist, ++free_bucket)
   {
-    if( (HYPRE_HOPSCOTCH_HASH_EMPTY == s->hash[free_bucket]) && (HYPRE_HOPSCOTCH_HASH_EMPTY == hypre_compare_and_swap((HYPRE_Int *)&s->hash[free_bucket], (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_EMPTY, (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_BUSY)) )
+    if( (HYPRE_HOPSCOTCH_HASH_EMPTY == s->hash[free_bucket]) &&
+        (HYPRE_HOPSCOTCH_HASH_EMPTY ==
+           hypre_compare_and_swap((HYPRE_Int *)&s->hash[free_bucket],
+                                  (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_EMPTY,
+                                  (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_BUSY)) )
       break;
   }
 
@@ -888,11 +937,15 @@ static inline void hypre_UnorderedIntSetPut( hypre_UnorderedIntSet *s,
         s->hash[free_bucket] = hash;
         s->hopInfo[bucket]  |= 1U << free_dist;
 
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
         omp_unset_lock(&segment->lock);
+#endif
         return;
       }
       hypre_UnorderedIntSetFindCloserFreeBucket(s,
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
                                                 segment,
+#endif
                                                 &free_bucket, &free_dist);
     } while (-1 != free_bucket);
   }
@@ -904,8 +957,9 @@ static inline void hypre_UnorderedIntSetPut( hypre_UnorderedIntSet *s,
   return;
 }
 
-static inline void hypre_UnorderedBigIntSetPut( hypre_UnorderedBigIntSet *s,
-                                      HYPRE_BigInt key )
+static inline void
+hypre_UnorderedBigIntSetPut( hypre_UnorderedBigIntSet *s,
+                             HYPRE_BigInt key )
 {
   //CALCULATE HASH ..........................
 #if defined(HYPRE_BIGINT) || defined(HYPRE_MIXEDINT)
@@ -915,8 +969,10 @@ static inline void hypre_UnorderedBigIntSetPut( hypre_UnorderedBigIntSet *s,
 #endif
 
   //LOCK KEY HASH ENTERY ....................
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   hypre_HopscotchSegment  *segment = &s->segments[hash & s->segmentMask];
   omp_set_lock(&segment->lock);
+#endif
   HYPRE_Int bucket = (HYPRE_Int)(hash&s->bucketMask);
 
   //CHECK IF ALREADY CONTAIN ................
@@ -928,7 +984,9 @@ static inline void hypre_UnorderedBigIntSetPut( hypre_UnorderedBigIntSet *s,
 
     if(hash == s->hash[currElm] && key == s->key[currElm])
     {
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
       omp_unset_lock(&segment->lock);
+#endif
       return;
     }
     hopInfo &= ~(1U << i);
@@ -939,7 +997,11 @@ static inline void hypre_UnorderedBigIntSetPut( hypre_UnorderedBigIntSet *s,
   HYPRE_Int free_dist = 0;
   for ( ; free_dist < HYPRE_HOPSCOTCH_HASH_INSERT_RANGE; ++free_dist, ++free_bucket)
   {
-    if( (HYPRE_HOPSCOTCH_HASH_EMPTY == s->hash[free_bucket]) && (HYPRE_HOPSCOTCH_HASH_EMPTY == hypre_compare_and_swap((HYPRE_Int *)&s->hash[free_bucket], (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_EMPTY, (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_BUSY)) )
+    if( (HYPRE_HOPSCOTCH_HASH_EMPTY == s->hash[free_bucket]) &&
+        (HYPRE_HOPSCOTCH_HASH_EMPTY ==
+           hypre_compare_and_swap((HYPRE_Int *)&s->hash[free_bucket],
+                                  (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_EMPTY,
+                                  (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_BUSY)) )
       break;
   }
 
@@ -954,12 +1016,16 @@ static inline void hypre_UnorderedBigIntSetPut( hypre_UnorderedBigIntSet *s,
         s->hash[free_bucket] = hash;
         s->hopInfo[bucket]  |= 1U << free_dist;
 
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
         omp_unset_lock(&segment->lock);
+#endif
         return;
       }
       hypre_UnorderedBigIntSetFindCloserFreeBucket(s,
-                                                segment,
-                                                &free_bucket, &free_dist);
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
+                                                   segment,
+#endif
+                                                   &free_bucket, &free_dist);
     } while (-1 != free_bucket);
   }
 
@@ -970,7 +1036,9 @@ static inline void hypre_UnorderedBigIntSetPut( hypre_UnorderedBigIntSet *s,
   return;
 }
 
-static inline HYPRE_Int hypre_UnorderedIntMapPutIfAbsent( hypre_UnorderedIntMap *m, HYPRE_Int key, HYPRE_Int data)
+static inline HYPRE_Int
+hypre_UnorderedIntMapPutIfAbsent( hypre_UnorderedIntMap *m,
+                                  HYPRE_Int key, HYPRE_Int data )
 {
   //CALCULATE HASH ..........................
 #ifdef HYPRE_BIGINT
@@ -980,8 +1048,10 @@ static inline HYPRE_Int hypre_UnorderedIntMapPutIfAbsent( hypre_UnorderedIntMap 
 #endif
 
   //LOCK KEY HASH ENTERY ....................
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   hypre_HopscotchSegment *segment = &m->segments[hash & m->segmentMask];
   omp_set_lock(&segment->lock);
+#endif
   hypre_HopscotchBucket* startBucket = &(m->table[hash & m->bucketMask]);
 
   //CHECK IF ALREADY CONTAIN ................
@@ -993,7 +1063,9 @@ static inline HYPRE_Int hypre_UnorderedIntMapPutIfAbsent( hypre_UnorderedIntMap 
     if (hash == currElm->hash && key == currElm->key)
     {
       HYPRE_Int rc = currElm->data;
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
       omp_unset_lock(&segment->lock);
+#endif
       return rc;
     }
     hopInfo &= ~(1U << i);
@@ -1004,7 +1076,11 @@ static inline HYPRE_Int hypre_UnorderedIntMapPutIfAbsent( hypre_UnorderedIntMap 
   HYPRE_Int free_dist = 0;
   for ( ; free_dist < HYPRE_HOPSCOTCH_HASH_INSERT_RANGE; ++free_dist, ++free_bucket)
   {
-    if( (HYPRE_HOPSCOTCH_HASH_EMPTY == free_bucket->hash) && (HYPRE_HOPSCOTCH_HASH_EMPTY == __sync_val_compare_and_swap((HYPRE_Int *)&free_bucket->hash, (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_EMPTY, (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_BUSY)) )
+    if( (HYPRE_HOPSCOTCH_HASH_EMPTY == free_bucket->hash) &&
+        (HYPRE_HOPSCOTCH_HASH_EMPTY ==
+            hypre_compare_and_swap((HYPRE_Int *)&free_bucket->hash,
+                                   (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_EMPTY,
+                                   (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_BUSY)) )
       break;
   }
 
@@ -1019,11 +1095,15 @@ static inline HYPRE_Int hypre_UnorderedIntMapPutIfAbsent( hypre_UnorderedIntMap 
         free_bucket->key      = key;
         free_bucket->hash     = hash;
         startBucket->hopInfo |= 1U << free_dist;
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
         omp_unset_lock(&segment->lock);
+#endif
         return HYPRE_HOPSCOTCH_HASH_EMPTY;
       }
       hypre_UnorderedIntMapFindCloserFreeBucket(m,
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
                                                 segment,
+#endif
                                                 &free_bucket, &free_dist);
     } while (NULL != free_bucket);
   }
@@ -1035,7 +1115,9 @@ static inline HYPRE_Int hypre_UnorderedIntMapPutIfAbsent( hypre_UnorderedIntMap 
   return HYPRE_HOPSCOTCH_HASH_EMPTY;
 }
 
-static inline HYPRE_Int hypre_UnorderedBigIntMapPutIfAbsent( hypre_UnorderedBigIntMap *m, HYPRE_BigInt key, HYPRE_Int data)
+static inline HYPRE_Int
+hypre_UnorderedBigIntMapPutIfAbsent( hypre_UnorderedBigIntMap *m,
+                                     HYPRE_BigInt key, HYPRE_Int data)
 {
   //CALCULATE HASH ..........................
 #if defined(HYPRE_BIGINT) || defined(HYPRE_MIXEDINT)
@@ -1045,8 +1127,10 @@ static inline HYPRE_Int hypre_UnorderedBigIntMapPutIfAbsent( hypre_UnorderedBigI
 #endif
 
   //LOCK KEY HASH ENTERY ....................
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
   hypre_HopscotchSegment *segment = &m->segments[hash & m->segmentMask];
   omp_set_lock(&segment->lock);
+#endif
   hypre_BigHopscotchBucket* startBucket = &(m->table[hash & m->bucketMask]);
 
   //CHECK IF ALREADY CONTAIN ................
@@ -1058,7 +1142,9 @@ static inline HYPRE_Int hypre_UnorderedBigIntMapPutIfAbsent( hypre_UnorderedBigI
     if (hash == currElm->hash && key == currElm->key)
     {
       HYPRE_Int rc = currElm->data;
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
       omp_unset_lock(&segment->lock);
+#endif
       return rc;
     }
     hopInfo &= ~(1U << i);
@@ -1069,7 +1155,11 @@ static inline HYPRE_Int hypre_UnorderedBigIntMapPutIfAbsent( hypre_UnorderedBigI
   HYPRE_Int free_dist = 0;
   for ( ; free_dist < HYPRE_HOPSCOTCH_HASH_INSERT_RANGE; ++free_dist, ++free_bucket)
   {
-    if( (HYPRE_HOPSCOTCH_HASH_EMPTY == free_bucket->hash) && (HYPRE_HOPSCOTCH_HASH_EMPTY == __sync_val_compare_and_swap((HYPRE_Int *)&free_bucket->hash, (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_EMPTY, (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_BUSY)) )
+    if( (HYPRE_HOPSCOTCH_HASH_EMPTY == free_bucket->hash) &&
+        (HYPRE_HOPSCOTCH_HASH_EMPTY ==
+           hypre_compare_and_swap((HYPRE_Int *)&free_bucket->hash,
+                                  (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_EMPTY,
+                                  (HYPRE_Int)HYPRE_HOPSCOTCH_HASH_BUSY)) )
       break;
   }
 
@@ -1084,12 +1174,16 @@ static inline HYPRE_Int hypre_UnorderedBigIntMapPutIfAbsent( hypre_UnorderedBigI
         free_bucket->key      = key;
         free_bucket->hash     = hash;
         startBucket->hopInfo |= 1U << free_dist;
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
         omp_unset_lock(&segment->lock);
+#endif
         return HYPRE_HOPSCOTCH_HASH_EMPTY;
       }
       hypre_UnorderedBigIntMapFindCloserFreeBucket(m,
-                                                segment,
-                                                &free_bucket, &free_dist);
+#ifdef HYPRE_CONCURRENT_HOPSCOTCH
+                                                   segment,
+#endif
+                                                   &free_bucket, &free_dist);
     } while (NULL != free_bucket);
   }
 
@@ -1099,7 +1193,6 @@ static inline HYPRE_Int hypre_UnorderedBigIntMapPutIfAbsent( hypre_UnorderedBigI
   exit(1);
   return HYPRE_HOPSCOTCH_HASH_EMPTY;
 }
-#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/utilities/hypre_merge_sort.c
+++ b/src/utilities/hypre_merge_sort.c
@@ -590,6 +590,11 @@ void hypre_merge_sort( HYPRE_Int *in, HYPRE_Int *temp, HYPRE_Int len, HYPRE_Int 
 
 /*--------------------------------------------------------------------------
  * hypre_sort_and_create_inverse_map
+ *
+ * Sort array "in" with length len and put result in array "out"
+ *   "in" will be deallocated unless in == *out
+ *   inverse_map is an inverse hash table s.t.
+ *      inverse_map[i] = j iff (*out)[j] = i
  *--------------------------------------------------------------------------*/
 
 void hypre_sort_and_create_inverse_map(HYPRE_Int *in, HYPRE_Int len, HYPRE_Int **out,

--- a/src/utilities/hypre_merge_sort.c
+++ b/src/utilities/hypre_merge_sort.c
@@ -613,7 +613,9 @@ void hypre_sort_and_create_inverse_map(HYPRE_Int *in, HYPRE_Int len, HYPRE_Int *
    hypre_merge_sort(in, temp, len, out);
    hypre_UnorderedIntMapCreate(inverse_map, 2*len, 16*hypre_NumThreads());
    HYPRE_Int i;
+#ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for HYPRE_SMP_SCHEDULE
+#endif
    for (i = 0; i < len; i++)
    {
       HYPRE_Int old = hypre_UnorderedIntMapPutIfAbsent(inverse_map, (*out)[i], i);
@@ -760,7 +762,9 @@ void hypre_big_sort_and_create_inverse_map(HYPRE_BigInt *in, HYPRE_Int len, HYPR
    hypre_big_merge_sort(in, temp, len, out);
    hypre_UnorderedBigIntMapCreate(inverse_map, 2*len, 16*hypre_NumThreads());
    HYPRE_Int i;
+#ifdef HYPRE_USING_OPENMP
 #pragma omp parallel for HYPRE_SMP_SCHEDULE
+#endif
    for (i = 0; i < len; i++)
    {
       HYPRE_Int old = hypre_UnorderedBigIntMapPutIfAbsent(inverse_map, (*out)[i], i);

--- a/src/utilities/hypre_merge_sort.c
+++ b/src/utilities/hypre_merge_sort.c
@@ -16,12 +16,20 @@
 
 #define SWAP(T, a, b) do { T tmp = a; a = b; b = tmp; } while (0)
 
-/* union of two sorted (in ascending order) array arr1 and arr2 into arr3
- * Assumption: no duplicates in arr1 and arr2
- * arr3 should have enough space on entry 
- * map1 and map2 map arr1 and arr2 to arr3 */
-void hypre_union2(HYPRE_Int n1, HYPRE_BigInt *arr1, HYPRE_Int n2, HYPRE_BigInt *arr2, HYPRE_Int *n3, HYPRE_BigInt *arr3,
-                  HYPRE_Int *map1, HYPRE_Int *map2)
+/*--------------------------------------------------------------------------
+ * hypre_union2
+ *
+ * Union of two sorted (in ascending order) array arr1 and arr2 into arr3
+ *
+ * Assumptions:
+ *              1) no duplicates in arr1 and arr2
+ *              2) arr3 should have enough space on entry
+ *              3) map1 and map2 map arr1 and arr2 to arr3
+ *--------------------------------------------------------------------------*/
+void hypre_union2( HYPRE_Int n1,  HYPRE_BigInt *arr1,
+                   HYPRE_Int n2,  HYPRE_BigInt *arr2,
+                   HYPRE_Int *n3, HYPRE_BigInt *arr3,
+                   HYPRE_Int *map1, HYPRE_Int *map2 )
 {
    HYPRE_Int i = 0, j = 0, k = 0;
    while (i < n1 && j < n2)
@@ -57,7 +65,12 @@ void hypre_union2(HYPRE_Int n1, HYPRE_BigInt *arr1, HYPRE_Int n2, HYPRE_BigInt *
    *n3 = k;
 }
 
-static void hypre_merge(HYPRE_Int *first1, HYPRE_Int *last1, HYPRE_Int *first2, HYPRE_Int *last2, HYPRE_Int *out)
+/*--------------------------------------------------------------------------
+ * hypre_merge
+ *--------------------------------------------------------------------------*/
+static void hypre_merge( HYPRE_Int *first1, HYPRE_Int *last1,
+                         HYPRE_Int *first2, HYPRE_Int *last2,
+                         HYPRE_Int *out )
 {
    for ( ; first1 != last1; ++out)
    {
@@ -85,41 +98,50 @@ static void hypre_merge(HYPRE_Int *first1, HYPRE_Int *last1, HYPRE_Int *first2, 
       *out = *first2;
    }
 }
-#ifdef HYPRE_CONCURRENT_HOPSCOTCH
-static void hypre_big_merge(HYPRE_BigInt *first1, HYPRE_BigInt *last1, HYPRE_BigInt *first2, HYPRE_BigInt *last2, HYPRE_BigInt *out)
-{
-   for ( ; first1 != last1; ++out)
-   {
-      if (first2 == last2)
-      {
-         for ( ; first1 != last1; ++first1, ++out)
-         {
-            *out = *first1;
-         }
-         return;
-      }
-      if (*first2 < *first1)
-      {
-         *out = *first2;
-         ++first2;
-      }
-      else
-      {
-         *out = *first1;
-         ++first1;
-      }
-   }
-   for ( ; first2 != last2; ++first2, ++out)
-   {
-      *out = *first2;
-   }
-}
-#endif
 
-static void kth_element_(
-   HYPRE_Int *out1, HYPRE_Int *out2,
-   HYPRE_Int *a1, HYPRE_Int *a2,
-   HYPRE_Int left, HYPRE_Int right, HYPRE_Int n1, HYPRE_Int n2, HYPRE_Int k)
+/*--------------------------------------------------------------------------
+ * hypre_big_merge
+ *--------------------------------------------------------------------------*/
+
+static void hypre_big_merge( HYPRE_BigInt *first1, HYPRE_BigInt *last1,
+                             HYPRE_BigInt *first2, HYPRE_BigInt *last2,
+                             HYPRE_BigInt *out )
+{
+   for ( ; first1 != last1; ++out)
+   {
+      if (first2 == last2)
+      {
+         for ( ; first1 != last1; ++first1, ++out)
+         {
+            *out = *first1;
+         }
+         return;
+      }
+      if (*first2 < *first1)
+      {
+         *out = *first2;
+         ++first2;
+      }
+      else
+      {
+         *out = *first1;
+         ++first1;
+      }
+   }
+   for ( ; first2 != last2; ++first2, ++out)
+   {
+      *out = *first2;
+   }
+}
+
+/*--------------------------------------------------------------------------
+ * kth_element_
+ *--------------------------------------------------------------------------*/
+
+static void kth_element_( HYPRE_Int *out1, HYPRE_Int *out2,
+                          HYPRE_Int *a1, HYPRE_Int *a2,
+                          HYPRE_Int left, HYPRE_Int right,
+                          HYPRE_Int n1, HYPRE_Int n2, HYPRE_Int k)
 {
    while (1)
    {
@@ -158,9 +180,17 @@ static void kth_element_(
  * Partition the input so that
  * a1[0:*out1) and a2[0:*out2) contain the smallest k elements
  */
-static void kth_element(
-   HYPRE_Int *out1, HYPRE_Int *out2,
-   HYPRE_Int *a1, HYPRE_Int *a2, HYPRE_Int n1, HYPRE_Int n2, HYPRE_Int k)
+
+/*--------------------------------------------------------------------------
+ * kth_element
+ *
+ * Partition the input so that
+ * a1[0:*out1) and a2[0:*out2) contain the smallest k elements
+ *--------------------------------------------------------------------------*/
+
+static void kth_element( HYPRE_Int *out1, HYPRE_Int *out2,
+                         HYPRE_Int *a1, HYPRE_Int *a2,
+                         HYPRE_Int n1, HYPRE_Int n2, HYPRE_Int k)
 {
    // either of the inputs is empty
    if (n1 == 0)
@@ -232,11 +262,14 @@ static void kth_element(
 #endif
 }
 
-#ifdef HYPRE_CONCURRENT_HOPSCOTCH
-static void big_kth_element_(
-   HYPRE_Int *out1, HYPRE_Int *out2,
-   HYPRE_BigInt *a1, HYPRE_BigInt *a2,
-   HYPRE_Int left, HYPRE_Int right, HYPRE_Int n1, HYPRE_Int n2, HYPRE_Int k)
+/*--------------------------------------------------------------------------
+ * big_kth_element_
+ *--------------------------------------------------------------------------*/
+
+static void big_kth_element_( HYPRE_Int *out1, HYPRE_Int *out2,
+                              HYPRE_BigInt *a1, HYPRE_BigInt *a2,
+                              HYPRE_Int left, HYPRE_Int right,
+                              HYPRE_Int n1, HYPRE_Int n2, HYPRE_Int k)
 {
    while (1)
    {
@@ -271,13 +304,16 @@ static void big_kth_element_(
    }
 }
 
-/**
+/*--------------------------------------------------------------------------
+ * big_kth_element
+ *
  * Partition the input so that
  * a1[0:*out1) and a2[0:*out2) contain the smallest k elements
- */
-static void big_kth_element(
-   HYPRE_Int *out1, HYPRE_Int *out2,
-   HYPRE_BigInt *a1, HYPRE_BigInt *a2, HYPRE_Int n1, HYPRE_Int n2, HYPRE_Int k)
+ *--------------------------------------------------------------------------*/
+
+static void big_kth_element( HYPRE_Int *out1, HYPRE_Int *out2,
+                             HYPRE_BigInt *a1, HYPRE_BigInt *a2,
+                             HYPRE_Int n1, HYPRE_Int n2, HYPRE_Int k)
 {
    // either of the inputs is empty
    if (n1 == 0)
@@ -348,16 +384,19 @@ static void big_kth_element(
    hypre_assert(*out1 + *out2 == k);
 #endif
 }
-#endif
 
-/**
+/*--------------------------------------------------------------------------
+ * hypre_parallel_merge
+ *
  * @param num_threads number of threads that participate in this merge
- * @param my_thread_num thread id (zeor-based) among the threads that participate in this merge
- */
-static void hypre_parallel_merge(
-   HYPRE_Int *first1, HYPRE_Int *last1, HYPRE_Int *first2, HYPRE_Int *last2,
-   HYPRE_Int *out,
-   HYPRE_Int num_threads, HYPRE_Int my_thread_num)
+ * @param my_thread_num thread id (zer0-based) among the threads that
+ *                      participate in this merge
+ *--------------------------------------------------------------------------*/
+
+static void hypre_parallel_merge( HYPRE_Int *first1, HYPRE_Int *last1,
+                                  HYPRE_Int *first2, HYPRE_Int *last2,
+                                  HYPRE_Int *out, HYPRE_Int num_threads,
+                                  HYPRE_Int my_thread_num )
 {
    HYPRE_Int n1 = last1 - first1;
    HYPRE_Int n2 = last2 - first2;
@@ -380,7 +419,7 @@ static void hypre_parallel_merge(
 #ifdef DBG_MERGE_SORT
       printf("%s:%d\n", __FILE__, __LINE__);
 #endif
-      begin1--; begin2++; 
+      begin1--; begin2++;
    }
    while (begin2 > end2 && end1 > 0 && end2 < n2 && first1[end1 - 1] == first2[end2])
    {
@@ -405,11 +444,14 @@ static void hypre_parallel_merge(
 #endif
 }
 
-#ifdef HYPRE_CONCURRENT_HOPSCOTCH
-/**
+/*--------------------------------------------------------------------------
+ * hypre_big_parallel_merge
+ *
  * @param num_threads number of threads that participate in this merge
- * @param my_thread_num thread id (zeor-based) among the threads that participate in this merge
- */
+ * @param my_thread_num thread id (zero-based) among the threads that
+ *                      participate in this merge
+ *--------------------------------------------------------------------------*/
+
 static void hypre_big_parallel_merge(
    HYPRE_BigInt *first1, HYPRE_BigInt *last1, HYPRE_BigInt *first2, HYPRE_BigInt *last2,
    HYPRE_BigInt *out,
@@ -436,7 +478,7 @@ static void hypre_big_parallel_merge(
 #ifdef DBG_MERGE_SORT
       printf("%s:%d\n", __FILE__, __LINE__);
 #endif
-      begin1--; begin2++; 
+      begin1--; begin2++;
    }
    while (begin2 > end2 && end1 > 0 && end2 < n2 && first1[end1 - 1] == first2[end2])
    {
@@ -460,9 +502,12 @@ static void hypre_big_parallel_merge(
    hypre_assert(std::is_sorted(out + begin1 + begin2, out + end1 + end2));
 #endif
 }
-#endif
 
-void hypre_merge_sort(HYPRE_Int *in, HYPRE_Int *temp, HYPRE_Int len, HYPRE_Int **out)
+/*--------------------------------------------------------------------------
+ * hypre_merge_sort
+ *--------------------------------------------------------------------------*/
+
+void hypre_merge_sort( HYPRE_Int *in, HYPRE_Int *temp, HYPRE_Int len, HYPRE_Int **out )
 {
    if (0 == len) return;
 
@@ -543,9 +588,12 @@ void hypre_merge_sort(HYPRE_Int *in, HYPRE_Int *temp, HYPRE_Int len, HYPRE_Int *
 #endif
 }
 
-#ifdef HYPRE_CONCURRENT_HOPSCOTCH
-void hypre_sort_and_create_inverse_map(
-  HYPRE_Int *in, HYPRE_Int len, HYPRE_Int **out, hypre_UnorderedIntMap *inverse_map)
+/*--------------------------------------------------------------------------
+ * hypre_sort_and_create_inverse_map
+ *--------------------------------------------------------------------------*/
+
+void hypre_sort_and_create_inverse_map(HYPRE_Int *in, HYPRE_Int len, HYPRE_Int **out,
+                                       hypre_UnorderedIntMap *inverse_map)
 {
    if (len == 0)
    {
@@ -601,8 +649,12 @@ void hypre_sort_and_create_inverse_map(
 #endif
 }
 
-#ifdef HYPRE_CONCURRENT_HOPSCOTCH
-void hypre_big_merge_sort(HYPRE_BigInt *in, HYPRE_BigInt *temp, HYPRE_Int len, HYPRE_BigInt **out)
+/*--------------------------------------------------------------------------
+ * hypre_big_merge_sort
+ *--------------------------------------------------------------------------*/
+
+void hypre_big_merge_sort(HYPRE_BigInt *in, HYPRE_BigInt *temp, HYPRE_Int len,
+                          HYPRE_BigInt **out)
 {
    if (0 == len) return;
 
@@ -683,9 +735,12 @@ void hypre_big_merge_sort(HYPRE_BigInt *in, HYPRE_BigInt *temp, HYPRE_Int len, H
 #endif
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_big_sort_and_create_inverse_map
+ *--------------------------------------------------------------------------*/
 
-void hypre_big_sort_and_create_inverse_map(
-  HYPRE_BigInt *in, HYPRE_Int len, HYPRE_BigInt **out, hypre_UnorderedBigIntMap *inverse_map)
+void hypre_big_sort_and_create_inverse_map(HYPRE_BigInt *in, HYPRE_Int len, HYPRE_BigInt **out,
+                                           hypre_UnorderedBigIntMap *inverse_map)
 {
    if (len == 0)
    {
@@ -740,7 +795,5 @@ void hypre_big_sort_and_create_inverse_map(
    hypre_profile_times[HYPRE_TIMER_ID_MERGE] += hypre_MPI_Wtime();
 #endif
 }
-#endif
-#endif
 
 /* vim: set tabstop=8 softtabstop=3 sw=3 expandtab: */

--- a/src/utilities/protos.h
+++ b/src/utilities/protos.h
@@ -119,32 +119,7 @@ void hypre_prefix_sum_triple(HYPRE_Int *in_out1, HYPRE_Int *sum1, HYPRE_Int *in_
  */
 void hypre_prefix_sum_multiple(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int n, HYPRE_Int *workspace);
 
-/* hypre_merge_sort.c */
-/**
- * Why merge sort?
- * 1) Merge sort can take advantage of eliminating duplicates.
- * 2) Merge sort is more efficiently parallelizable than qsort
- */
-
-/**
- * Out of place merge sort with duplicate elimination
- * @ret number of unique elements
- */
-HYPRE_Int hypre_merge_sort_unique(HYPRE_Int *in, HYPRE_Int *out, HYPRE_Int len);
-/**
- * Out of place merge sort with duplicate elimination
- *
- * @param out pointer to output can be in or temp
- * @ret number of unique elements
- */
-HYPRE_Int hypre_merge_sort_unique2(HYPRE_Int *in, HYPRE_Int *temp, HYPRE_Int len, HYPRE_Int **out);
-
-void hypre_merge_sort(HYPRE_Int *in, HYPRE_Int *temp, HYPRE_Int len, HYPRE_Int **sorted);
-
-void hypre_union2(HYPRE_Int n1, HYPRE_BigInt *arr1, HYPRE_Int n2, HYPRE_BigInt *arr2, HYPRE_Int *n3, HYPRE_BigInt *arr3, HYPRE_Int *map1, HYPRE_Int *map2);
-
 /* hypre_hopscotch_hash.c */
-
 #ifdef HYPRE_USING_OPENMP
 
 /* Check if atomic operations are available to use concurrent hopscotch hash table */
@@ -251,18 +226,18 @@ typedef struct
    hypre_BigHopscotchBucket* volatile table;
 } hypre_UnorderedBigIntMap;
 
+/* hypre_merge_sort.c */
 /**
- * Sort array "in" with length len and put result in array "out"
- * "in" will be deallocated unless in == *out
- * inverse_map is an inverse hash table s.t. inverse_map[i] = j iff (*out)[j] = i
+ * Why merge sort?
+ * 1) Merge sort can take advantage of eliminating duplicates.
+ * 2) Merge sort is more efficiently parallelizable than qsort
  */
-void hypre_sort_and_create_inverse_map(
-  HYPRE_Int *in, HYPRE_Int len, HYPRE_Int **out, hypre_UnorderedIntMap *inverse_map);
-
-#ifdef HYPRE_CONCURRENT_HOPSCOTCH
+void hypre_union2(HYPRE_Int n1, HYPRE_BigInt *arr1, HYPRE_Int n2, HYPRE_BigInt *arr2, HYPRE_Int *n3, HYPRE_BigInt *arr3, HYPRE_Int *map1, HYPRE_Int *map2);
+void hypre_merge_sort(HYPRE_Int *in, HYPRE_Int *temp, HYPRE_Int len, HYPRE_Int **sorted);
 void hypre_big_merge_sort(HYPRE_BigInt *in, HYPRE_BigInt *temp, HYPRE_Int len, HYPRE_BigInt **sorted);
+void hypre_sort_and_create_inverse_map(HYPRE_Int *in, HYPRE_Int len, HYPRE_Int **out, hypre_UnorderedIntMap *inverse_map);
 void hypre_big_sort_and_create_inverse_map(HYPRE_BigInt *in, HYPRE_Int len, HYPRE_BigInt **out, hypre_UnorderedBigIntMap *inverse_map);
-#endif
+
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 HYPRE_Int hypre_SyncCudaComputeStream(hypre_Handle *hypre_handle);
@@ -276,4 +251,3 @@ HYPRE_Int hypreDevice_BigIntFilln(HYPRE_BigInt *d_x, size_t n, HYPRE_BigInt v);
 void hypre_NvtxPushRangeColor(const char *name, HYPRE_Int cid);
 void hypre_NvtxPushRange(const char *name);
 void hypre_NvtxPopRange();
-


### PR DESCRIPTION
This PR extends the implementation of a few functions in `hypre_hopscotch.h` to the case when `HYPRE_USING_OPENMP` is undefined (and consequently `HYPRE_CONCURRENT_HOPSCOTCH`). Now, one can use `Unordered[Int,BigInt][Set,Map]` capabilities without having to enable OpenMP.  