### PR TITLE
aggressive coarsening and 2s interp on GPUs

### DIFF
--- a/AUTOTEST/machine-lassen.sh
+++ b/AUTOTEST/machine-lassen.sh
@@ -61,8 +61,8 @@ co="--with-cuda --enable-unified-memory --with-openmp --enable-hopscotch --enabl
 
 # OMP 4.5 with UM
 co="--with-device-openmp --enable-unified-memory --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' HYPRE_CUDA_SM=70"
-./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij
-./renametest.sh basic $output_dir/basic-deviceomp-um-ij
+#./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij
+#./renametest.sh basic $output_dir/basic-deviceomp-um-ij
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ross
 ./renametest.sh basic $output_dir/basic-deviceomp-um-struct-sstruct
 

--- a/AUTOTEST/machine-lassen.sh
+++ b/AUTOTEST/machine-lassen.sh
@@ -50,9 +50,9 @@ co="--with-cuda --enable-unified-memory --enable-persistent --enable-cub --enabl
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ross
 ./renametest.sh basic $output_dir/basic-cuda-um-struct-sstruct
 
-# CUDA with UM [shared library]
+# CUDA with UM [shared library, no run]
 co="--with-cuda --enable-unified-memory --with-openmp --enable-hopscotch --enable-shared --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' HYPRE_CUDA_SM=70"
-./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rocuda
+./test.sh basic.sh $src_dir -co: $co -mo: $mo
 ./renametest.sh basic $output_dir/basic-cuda-um-shared
 #./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij
 #./renametest.sh basic $output_dir/basic-cuda-um-shared-ij
@@ -82,10 +82,13 @@ co="--with-device-openmp --enable-unified-memory --enable-shared --with-extra-CF
 #./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ross
 #./renametest.sh basic $output_dir/basic-deviceomp-um-debug-struct-sstruct
 
-# CUDA w.o UM, only struct
-#co="--with-cuda --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' HYPRE_CUDA_SM=70"
-#./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rost
-#./renametest.sh basic $output_dir/basic-cuda-nonum-struct
+# CUDA w.o UM
+co="--with-cuda --enable-debug --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' HYPRE_CUDA_SM=70"
+./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rost
+./renametest.sh basic $output_dir/basic-cuda-nonum-struct
+./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rocuda
+./renametest.sh basic $output_dir/basic-cuda-nonum-cuda
+
 
 # OMP4.5 w.o UM, only struct [in debug mode]
 co="--with-device-openmp --enable-debug --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' HYPRE_CUDA_SM=70"

--- a/AUTOTEST/machine-lassen.sh
+++ b/AUTOTEST/machine-lassen.sh
@@ -67,9 +67,9 @@ co="--with-device-openmp --enable-unified-memory --with-extra-CFLAGS=\\'-qmaxmem
 ./renametest.sh basic $output_dir/basic-deviceomp-um-struct-sstruct
 
 # OMP 4.5 with UM [shared library, no run]
-co="--with-device-openmp --enable-unified-memory --enable-shared --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029:1500-030:1501-308\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029:1500-030:1501-308\\' HYPRE_CUDA_SM=70"
-./test.sh basic.sh $src_dir -co: $co -mo: $mo
-./renametest.sh basic $output_dir/basic-deviceomp-um-shared
+#co="--with-device-openmp --enable-unified-memory --enable-shared --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029:1500-030:1501-308\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029:1500-030:1501-308\\' HYPRE_CUDA_SM=70"
+#./test.sh basic.sh $src_dir -co: $co -mo: $mo
+#./renametest.sh basic $output_dir/basic-deviceomp-um-shared
 #./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij
 #./renametest.sh basic $output_dir/basic-deviceomp-um-shared-ij
 #./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ross
@@ -90,7 +90,7 @@ co="--with-cuda --enable-debug --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=150
 ./renametest.sh basic $output_dir/basic-cuda-nonum-cuda
 
 
-# OMP4.5 w.o UM, only struct [in debug mode]
+# OMP 4.5 w.o UM, only struct [in debug mode]
 co="--with-device-openmp --enable-debug --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' HYPRE_CUDA_SM=70"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rost
 ./renametest.sh basic $output_dir/basic-deviceomp-nonum-debug-struct
@@ -105,5 +105,4 @@ for errfile in $( find $output_dir ! -size 0 -name "*.err" )
 do
    echo $errfile >&2
 done
-
 

--- a/AUTOTEST/machine-ray.sh
+++ b/AUTOTEST/machine-ray.sh
@@ -61,8 +61,8 @@ co="--with-cuda --enable-unified-memory --with-openmp --enable-hopscotch --enabl
 
 # OMP 4.5 with UM
 co="--with-device-openmp --enable-unified-memory --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\'"
-./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij
-./renametest.sh basic $output_dir/basic-deviceomp-um-ij
+#./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij
+#./renametest.sh basic $output_dir/basic-deviceomp-um-ij
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ross
 ./renametest.sh basic $output_dir/basic-deviceomp-um-struct-sstruct
 

--- a/AUTOTEST/machine-ray.sh
+++ b/AUTOTEST/machine-ray.sh
@@ -50,9 +50,9 @@ co="--with-cuda --enable-unified-memory --enable-persistent --enable-cub --enabl
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ross
 ./renametest.sh basic $output_dir/basic-cuda-um-struct-sstruct
 
-# CUDA with UM [shared library]
+# CUDA with UM [shared library, no run]
 co="--with-cuda --enable-unified-memory --with-openmp --enable-hopscotch --enable-shared --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\'"
-./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rocuda
+./test.sh basic.sh $src_dir -co: $co -mo: $mo
 ./renametest.sh basic $output_dir/basic-cuda-um-shared
 #./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij
 #./renametest.sh basic $output_dir/basic-cuda-um-shared-ij
@@ -82,10 +82,13 @@ co="--with-device-openmp --enable-unified-memory --enable-shared --with-extra-CF
 #./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ross
 #./renametest.sh basic $output_dir/basic-deviceomp-um-debug-struct-sstruct
 
-# CUDA w.o UM, only struct
-#co="--with-cuda --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\'"
-#./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rost
-#./renametest.sh basic $output_dir/basic-cuda-nonum-struct
+# CUDA w.o UM
+co="--with-cuda --enable-debug --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\'"
+./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rost
+./renametest.sh basic $output_dir/basic-cuda-nonum-struct
+./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rocuda
+./renametest.sh basic $output_dir/basic-cuda-nonum-cuda
+
 
 # OMP4.5 w.o UM, only struct [in debug mode]
 co="--with-device-openmp --enable-debug --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\'"

--- a/AUTOTEST/machine-ray.sh
+++ b/AUTOTEST/machine-ray.sh
@@ -67,9 +67,9 @@ co="--with-device-openmp --enable-unified-memory --with-extra-CFLAGS=\\'-qmaxmem
 ./renametest.sh basic $output_dir/basic-deviceomp-um-struct-sstruct
 
 # OMP 4.5 with UM [shared library, no run]
-co="--with-device-openmp --enable-unified-memory --enable-shared --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029:1500-030:1501-308\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029:1500-030:1501-308\\'"
-./test.sh basic.sh $src_dir -co: $co -mo: $mo
-./renametest.sh basic $output_dir/basic-deviceomp-um-shared
+#co="--with-device-openmp --enable-unified-memory --enable-shared --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029:1500-030:1501-308\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029:1500-030:1501-308\\'"
+#./test.sh basic.sh $src_dir -co: $co -mo: $mo
+#./renametest.sh basic $output_dir/basic-deviceomp-um-shared
 #./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $roij
 #./renametest.sh basic $output_dir/basic-deviceomp-um-shared-ij
 #./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ross
@@ -90,7 +90,7 @@ co="--with-cuda --enable-debug --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=150
 ./renametest.sh basic $output_dir/basic-cuda-nonum-cuda
 
 
-# OMP4.5 w.o UM, only struct [in debug mode]
+# OMP 4.5 w.o UM, only struct [in debug mode]
 co="--with-device-openmp --enable-debug --with-extra-CFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\' --with-extra-CXXFLAGS=\\'-qmaxmem=-1 -qsuppress=1500-029\\'"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $rost
 ./renametest.sh basic $output_dir/basic-deviceomp-nonum-debug-struct
@@ -105,5 +105,4 @@ for errfile in $( find $output_dir ! -size 0 -name "*.err" )
 do
    echo $errfile >&2
 done
-
 

--- a/src/parcsr_ls/Makefile
+++ b/src/parcsr_ls/Makefile
@@ -154,7 +154,7 @@ CUFILES =\
  par_lr_interp_device.c\
  par_strength_device.c\
  par_strength2nd_device.c\
- par_amgdd_fac_cycle_device.c
+ par_amgdd_fac_cycle_device.c\
  par_2s_interp_device.c
 
 COBJS = ${FILES:.c=.o}

--- a/src/parcsr_ls/Makefile
+++ b/src/parcsr_ls/Makefile
@@ -153,7 +153,8 @@ CUFILES =\
  par_interp_trunc_device.c\
  par_lr_interp_device.c\
  par_strength_device.c\
- par_amgdd_fac_cycle_device.c
+ par_amgdd_fac_cycle_device.c\
+ par_2s_interp_device.c
 
 COBJS = ${FILES:.c=.o}
 CUOBJS = ${CUFILES:.c=.obj}

--- a/src/parcsr_ls/Makefile
+++ b/src/parcsr_ls/Makefile
@@ -153,6 +153,7 @@ CUFILES =\
  par_interp_trunc_device.c\
  par_lr_interp_device.c\
  par_strength_device.c\
+ par_strength2nd_device.c\
  par_amgdd_fac_cycle_device.c
 
 COBJS = ${FILES:.c=.o}

--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -1951,6 +1951,8 @@ HYPRE_Int hypre_BoomerAMGCreate2ndS ( hypre_ParCSRMatrix *S , HYPRE_Int *CF_mark
 HYPRE_Int hypre_BoomerAMGCorrectCFMarker ( HYPRE_Int *CF_marker , HYPRE_Int num_var , HYPRE_Int *new_CF_marker );
 HYPRE_Int hypre_BoomerAMGCorrectCFMarker2 ( HYPRE_Int *CF_marker , HYPRE_Int num_var , HYPRE_Int *new_CF_marker );
 HYPRE_Int hypre_BoomerAMGCreateSDevice(hypre_ParCSRMatrix *A, HYPRE_Real strength_threshold, HYPRE_Real max_row_sum, HYPRE_Int num_functions, HYPRE_Int *dof_func, hypre_ParCSRMatrix **S_ptr);
+HYPRE_Int hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix *S, HYPRE_Int *CF_marker, HYPRE_Int num_paths, HYPRE_BigInt *coarse_row_starts, hypre_ParCSRMatrix **C_ptr);
+
 
 /* par_sv_interp.c */
 HYPRE_Int hypre_BoomerAMGSmoothInterpVectors ( hypre_ParCSRMatrix *A , HYPRE_Int num_smooth_vecs , hypre_ParVector **smooth_vecs , HYPRE_Int smooth_steps );

--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -1862,7 +1862,11 @@ HYPRE_Int hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix *A, HYPRE_Int *C
 HYPRE_Int hypre_BoomerAMGBuildModExtPEInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker, hypre_ParCSRMatrix *S, HYPRE_BigInt *num_cpts_global, HYPRE_Int debug_flag, HYPRE_Real trunc_factor, HYPRE_Int max_elmts, HYPRE_Int *col_offd_S_to_A, hypre_ParCSRMatrix **P_ptr);
 
 /* par_2s_interp.c */
+HYPRE_Int hypre_BoomerAMGBuildModPartialExtInterpHost ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
+HYPRE_Int hypre_BoomerAMGBuildModPartialExtInterpDevice ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
 HYPRE_Int hypre_BoomerAMGBuildModPartialExtInterp ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
+HYPRE_Int hypre_BoomerAMGBuildModPartialExtPEInterpHost ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
+HYPRE_Int hypre_BoomerAMGBuildModPartialExtPEInterpDevice ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
 HYPRE_Int hypre_BoomerAMGBuildModPartialExtPEInterp ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
 
 /* par_multi_interp.c */

--- a/src/parcsr_ls/par_2s_interp_device.c
+++ b/src/parcsr_ls/par_2s_interp_device.c
@@ -1,0 +1,791 @@
+/******************************************************************************
+ * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+
+#include "_hypre_parcsr_ls.h"
+#include "_hypre_utilities.hpp"
+
+#if defined(HYPRE_USING_CUDA)
+
+__global__ void hypreCUDAKernel_compute_weak_rowsums( HYPRE_Int nr_of_rows, bool has_offd, HYPRE_Int *CF_marker, HYPRE_Int *A_diag_i, HYPRE_Complex *A_diag_a, HYPRE_Int *S_diag_j, HYPRE_Int *A_offd_i, HYPRE_Complex *A_offd_a, HYPRE_Int *S_offd_j, HYPRE_Real *rs, HYPRE_Int flag );
+
+__global__ void hypreCUDAKernel_MMInterpScaleAFF( HYPRE_Int AFF_nrows, HYPRE_Int *AFF_diag_i, HYPRE_Int *AFF_diag_j, HYPRE_Complex *AFF_diag_a, HYPRE_Int *AFF_offd_i, HYPRE_Int *AFF_offd_j, HYPRE_Complex *AFF_offd_a, HYPRE_Complex *beta_diag, HYPRE_Complex *beta_offd, HYPRE_Int *F2_to_F, HYPRE_Real *rsW );
+
+__global__ void hypreCUDAKernel_compute_dlam_dtmp( HYPRE_Int nr_of_rows, HYPRE_Int *AFF_diag_i, HYPRE_Int *AFF_diag_j, HYPRE_Complex *AFF_diag_data, HYPRE_Int *AFF_offd_i, HYPRE_Complex *AFF_offd_data, HYPRE_Complex *rsFC, HYPRE_Complex *dlam, HYPRE_Complex *dtmp );
+
+__global__ void hypreCUDAKernel_MMPEInterpScaleAFF( HYPRE_Int AFF_nrows, HYPRE_Int *AFF_diag_i, HYPRE_Int *AFF_diag_j, HYPRE_Complex *AFF_diag_a, HYPRE_Int *AFF_offd_i, HYPRE_Int *AFF_offd_j, HYPRE_Complex *AFF_offd_a, HYPRE_Complex *tmp_diag, HYPRE_Complex *tmp_offd, HYPRE_Complex *lam_diag, HYPRE_Complex *lam_offd, HYPRE_Int *F2_to_F, HYPRE_Real *rsW );
+
+void hypreDevice_extendWtoP( HYPRE_Int P_nr_of_rows, HYPRE_Int W_nr_of_rows, HYPRE_Int W_nr_of_cols, HYPRE_Int *CF_marker, HYPRE_Int W_diag_nnz, HYPRE_Int *W_diag_i, HYPRE_Int *W_diag_j, HYPRE_Complex *W_diag_data, HYPRE_Int *P_diag_i, HYPRE_Int *P_diag_j, HYPRE_Complex *P_diag_data, HYPRE_Int *W_offd_i, HYPRE_Int *P_offd_i );
+
+/*--------------------------------------------------------------------------------------*/
+HYPRE_Int
+hypre_BoomerAMGBuildModPartialExtInterpDevice( hypre_ParCSRMatrix  *A,
+                                               HYPRE_Int           *CF_marker,
+                                               hypre_ParCSRMatrix  *S,
+                                               HYPRE_BigInt        *num_cpts_global,     /* C2 */
+                                               HYPRE_BigInt        *num_old_cpts_global, /* C2 + F2 */
+                                               HYPRE_Int            debug_flag,
+                                               HYPRE_Real           trunc_factor,
+                                               HYPRE_Int            max_elmts,
+                                               HYPRE_Int           *col_offd_S_to_A,
+                                               hypre_ParCSRMatrix **P_ptr )
+{
+   HYPRE_Int           A_nr_local   = hypre_ParCSRMatrixNumRows(A);
+   hypre_CSRMatrix    *A_diag       = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Complex      *A_diag_data  = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int          *A_diag_i     = hypre_CSRMatrixI(A_diag);
+   hypre_CSRMatrix    *A_offd       = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Complex      *A_offd_data  = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int          *A_offd_i     = hypre_CSRMatrixI(A_offd);
+   HYPRE_Int           A_offd_nnz   = hypre_CSRMatrixNumNonzeros(A_offd);
+   HYPRE_Int          *Soc_diag_j   = hypre_ParCSRMatrixSocDiagJ(S);
+   HYPRE_Int          *Soc_offd_j   = hypre_ParCSRMatrixSocOffdJ(S);
+   HYPRE_Int          *CF_marker_dev;
+   HYPRE_Complex      *Dbeta, *Dbeta_offd, *rsWA, *rsW;
+   hypre_ParCSRMatrix *As_FF, *As_FC, *W, *P;
+
+   CF_marker_dev = hypre_TAlloc(HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE);
+   hypre_TMemcpy(CF_marker_dev, CF_marker, HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+
+   //TODO use CF_marker_dev
+   /* As_FF = As_{F2, F}, As_FC = As_{F, C2} */
+   hypre_ParCSRMatrixGenerateFFFC3Device(A, CF_marker, num_cpts_global, S, &As_FC, &As_FF);
+
+   HYPRE_Int AFC_nr_local = hypre_ParCSRMatrixNumRows(As_FC);
+   HYPRE_Int AFF_nr_local = hypre_ParCSRMatrixNumRows(As_FF);
+
+   /* row sum of AFC, i.e., D_beta */
+   Dbeta = hypre_TAlloc(HYPRE_Complex, AFC_nr_local, HYPRE_MEMORY_DEVICE);
+   hypre_CSRMatrixComputeRowSumDevice(hypre_ParCSRMatrixDiag(As_FC), NULL, NULL, Dbeta, 0, 1.0, "set");
+   hypre_CSRMatrixComputeRowSumDevice(hypre_ParCSRMatrixOffd(As_FC), NULL, NULL, Dbeta, 0, 1.0, "add");
+
+   /* collect off-processor D_beta */
+   hypre_ParCSRCommPkg    *comm_pkg = hypre_ParCSRMatrixCommPkg(As_FF);
+   hypre_ParCSRCommHandle *comm_handle;
+   if (!comm_pkg)
+   {
+      hypre_MatvecCommPkgCreate(As_FF);
+      comm_pkg = hypre_ParCSRMatrixCommPkg(As_FF);
+   }
+   Dbeta_offd = hypre_TAlloc(HYPRE_Complex, hypre_CSRMatrixNumCols(hypre_ParCSRMatrixOffd(As_FF)), HYPRE_MEMORY_DEVICE);
+   HYPRE_Int num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+   HYPRE_Int num_elmts_send = hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends);
+   HYPRE_Complex *send_buf = hypre_TAlloc(HYPRE_Complex, num_elmts_send, HYPRE_MEMORY_DEVICE);
+   hypre_ParCSRCommPkgCopySendMapElmtsToDevice(comm_pkg);
+   HYPRE_THRUST_CALL( gather,
+                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg),
+                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg) + num_elmts_send,
+                      Dbeta,
+                      send_buf );
+   comm_handle = hypre_ParCSRCommHandleCreate_v2(1, comm_pkg, HYPRE_MEMORY_DEVICE, send_buf, HYPRE_MEMORY_DEVICE, Dbeta_offd);
+   hypre_ParCSRCommHandleDestroy(comm_handle);
+   hypre_TFree(send_buf, HYPRE_MEMORY_DEVICE);
+
+   /* weak row sum and diagonal, i.e., DFF + Dgamma */
+   rsWA = hypre_TAlloc(HYPRE_Complex, A_nr_local, HYPRE_MEMORY_DEVICE);
+
+   dim3 bDim = hypre_GetDefaultCUDABlockDimension();
+   dim3 gDim = hypre_GetDefaultCUDAGridDimension(A_nr_local, "warp", bDim);
+
+   /* only for rows corresponding to F2 (notice flag == -1) */
+   HYPRE_CUDA_LAUNCH( hypreCUDAKernel_compute_weak_rowsums,
+                      gDim, bDim,
+                      A_nr_local,
+                      A_offd_nnz > 0,
+                      CF_marker_dev,
+                      A_diag_i,
+                      A_diag_data,
+                      Soc_diag_j,
+                      A_offd_i,
+                      A_offd_data,
+                      Soc_offd_j,
+                      rsWA,
+                      -1 );
+
+   rsW = hypre_TAlloc(HYPRE_Complex, AFF_nr_local, HYPRE_MEMORY_DEVICE);
+   HYPRE_Complex *new_end = HYPRE_THRUST_CALL( copy_if,
+                                               rsWA,
+                                               rsWA + A_nr_local,
+                                               CF_marker_dev,
+                                               rsW,
+                                               equal<HYPRE_Int>(-2) );
+
+   hypre_assert(new_end - rsW == AFF_nr_local);
+
+   hypre_TFree(rsWA, HYPRE_MEMORY_DEVICE);
+
+   /* map from F2 to F */
+   HYPRE_Int *map_to_F = hypre_TAlloc(HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE);
+   HYPRE_THRUST_CALL( exclusive_scan,
+                      thrust::make_transform_iterator(CF_marker_dev,              is_negative<HYPRE_Int>()),
+                      thrust::make_transform_iterator(CF_marker_dev + A_nr_local, is_negative<HYPRE_Int>()),
+                      map_to_F );
+   HYPRE_Int *map_F2_to_F = hypre_TAlloc(HYPRE_Int, AFF_nr_local, HYPRE_MEMORY_DEVICE);
+
+   HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( copy_if,
+                                           map_to_F,
+                                           map_to_F + A_nr_local,
+                                           CF_marker_dev,
+                                           map_F2_to_F,
+                                           equal<HYPRE_Int>(-2) );
+
+   hypre_assert(tmp_end - map_F2_to_F == AFF_nr_local);
+
+   hypre_TFree(map_to_F, HYPRE_MEMORY_DEVICE);
+
+   /* add to rsW those in AFF that correspond to Dbeta == 0
+    * diagnoally scale As_FF (from both sides) and replace the diagonal */
+   gDim = hypre_GetDefaultCUDAGridDimension(AFF_nr_local, "warp", bDim);
+
+   HYPRE_CUDA_LAUNCH( hypreCUDAKernel_MMInterpScaleAFF,
+                      gDim, bDim,
+                      AFF_nr_local,
+                      hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(As_FF)),
+                      hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(As_FF)),
+                      hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(As_FF)),
+                      hypre_CSRMatrixI(hypre_ParCSRMatrixOffd(As_FF)),
+                      hypre_CSRMatrixJ(hypre_ParCSRMatrixOffd(As_FF)),
+                      hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(As_FF)),
+                      Dbeta,
+                      Dbeta_offd,
+                      map_F2_to_F,
+                      rsW );
+
+   hypre_TFree(Dbeta, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(Dbeta_offd, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(map_F2_to_F, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(rsW, HYPRE_MEMORY_DEVICE);
+
+   /* Perform matrix-matrix multiplication */
+   W = hypre_ParCSRMatMatDevice(As_FF, As_FC);
+
+   hypre_ParCSRMatrixDestroy(As_FF);
+   hypre_ParCSRMatrixDestroy(As_FC);
+
+   /* Construct P from matrix product W */
+   HYPRE_Int          *P_diag_i, *P_diag_j, *P_offd_i;
+   HYPRE_Complex      *P_diag_data;
+   HYPRE_Int           P_nr_local = A_nr_local - (AFC_nr_local - AFF_nr_local);
+   HYPRE_Int           P_diag_nnz = hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(W)) +
+                                    hypre_ParCSRMatrixNumCols(W);
+
+   hypre_assert(P_nr_local == hypre_ParCSRMatrixNumRows(W) + hypre_ParCSRMatrixNumCols(W));
+
+   P_diag_i    = hypre_TAlloc(HYPRE_Int,     P_nr_local + 1, HYPRE_MEMORY_DEVICE);
+   P_diag_j    = hypre_TAlloc(HYPRE_Int,     P_diag_nnz,     HYPRE_MEMORY_DEVICE);
+   P_diag_data = hypre_TAlloc(HYPRE_Complex, P_diag_nnz,     HYPRE_MEMORY_DEVICE);
+   P_offd_i    = hypre_TAlloc(HYPRE_Int,     P_nr_local + 1, HYPRE_MEMORY_DEVICE);
+
+   HYPRE_Int *C2F2_marker = hypre_TAlloc(HYPRE_Int, P_nr_local, HYPRE_MEMORY_DEVICE);
+   tmp_end = HYPRE_THRUST_CALL( copy_if,
+                                CF_marker_dev,
+                                CF_marker_dev + A_nr_local,
+                                CF_marker_dev,
+                                C2F2_marker,
+                                out_of_range<HYPRE_Int>(-1, 0) /* -2 or 1 */ );
+
+   hypre_assert(tmp_end - C2F2_marker == P_nr_local);
+
+   hypre_TFree(CF_marker_dev, HYPRE_MEMORY_DEVICE);
+
+   hypreDevice_extendWtoP( P_nr_local,
+                           AFF_nr_local,
+                           hypre_ParCSRMatrixNumCols(W),
+                           C2F2_marker,
+                           hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(W)),
+                           hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(W)),
+                           hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(W)),
+                           hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(W)),
+                           P_diag_i,
+                           P_diag_j,
+                           P_diag_data,
+                           hypre_CSRMatrixI(hypre_ParCSRMatrixOffd(W)),
+                           P_offd_i );
+
+   hypre_TFree(C2F2_marker, HYPRE_MEMORY_DEVICE);
+
+   // final P
+   P = hypre_ParCSRMatrixCreate(hypre_ParCSRMatrixComm(A),
+                                hypre_ParCSRMatrixGlobalNumRows(W) + hypre_ParCSRMatrixGlobalNumCols(W),
+                                hypre_ParCSRMatrixGlobalNumCols(W),
+                                num_old_cpts_global,
+                                num_cpts_global,
+                                hypre_CSRMatrixNumCols(hypre_ParCSRMatrixOffd(W)),
+                                P_diag_nnz,
+                                hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixOffd(W)));
+
+   hypre_ParCSRMatrixOwnsRowStarts(P) = 0;
+   hypre_ParCSRMatrixOwnsColStarts(P) = 0;
+
+   hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(P))    = P_diag_i;
+   hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(P))    = P_diag_j;
+   hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(P)) = P_diag_data;
+
+   hypre_CSRMatrixI(hypre_ParCSRMatrixOffd(P))    = P_offd_i;
+   hypre_CSRMatrixJ(hypre_ParCSRMatrixOffd(P))    = hypre_CSRMatrixJ(hypre_ParCSRMatrixOffd(W));
+   hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(P)) = hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(W));
+   hypre_CSRMatrixJ(hypre_ParCSRMatrixOffd(W))    = NULL;
+   hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(W)) = NULL;
+
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(P)) = HYPRE_MEMORY_DEVICE;
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixOffd(P)) = HYPRE_MEMORY_DEVICE;
+
+   hypre_ParCSRMatrixDeviceColMapOffd(P) = hypre_ParCSRMatrixDeviceColMapOffd(W);
+   hypre_ParCSRMatrixColMapOffd(P)       = hypre_ParCSRMatrixColMapOffd(W);
+   hypre_ParCSRMatrixDeviceColMapOffd(W) = NULL;
+   hypre_ParCSRMatrixColMapOffd(W)       = NULL;
+
+   hypre_ParCSRMatrixNumNonzeros(P)  = hypre_ParCSRMatrixNumNonzeros(W) +
+                                       hypre_ParCSRMatrixGlobalNumCols(W);
+   hypre_ParCSRMatrixDNumNonzeros(P) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(P);
+
+   hypre_ParCSRMatrixDestroy(W);
+
+   if (trunc_factor != 0.0 || max_elmts > 0)
+   {
+      hypre_BoomerAMGInterpTruncationDevice(P, trunc_factor, max_elmts );
+   }
+
+   *P_ptr = P;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------------------*/
+HYPRE_Int
+hypre_BoomerAMGBuildModPartialExtPEInterpDevice( hypre_ParCSRMatrix  *A,
+                                                 HYPRE_Int           *CF_marker,
+                                                 hypre_ParCSRMatrix  *S,
+                                                 HYPRE_BigInt        *num_cpts_global,     /* C2 */
+                                                 HYPRE_BigInt        *num_old_cpts_global, /* C2 + F2 */
+                                                 HYPRE_Int            debug_flag,
+                                                 HYPRE_Real           trunc_factor,
+                                                 HYPRE_Int            max_elmts,
+                                                 HYPRE_Int           *col_offd_S_to_A,
+                                                 hypre_ParCSRMatrix **P_ptr )
+{
+   HYPRE_Int           A_nr_local   = hypre_ParCSRMatrixNumRows(A);
+   hypre_CSRMatrix    *A_diag       = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Complex      *A_diag_data  = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int          *A_diag_i     = hypre_CSRMatrixI(A_diag);
+   hypre_CSRMatrix    *A_offd       = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Complex      *A_offd_data  = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int          *A_offd_i     = hypre_CSRMatrixI(A_offd);
+   HYPRE_Int           A_offd_nnz   = hypre_CSRMatrixNumNonzeros(A_offd);
+   HYPRE_Int          *Soc_diag_j   = hypre_ParCSRMatrixSocDiagJ(S);
+   HYPRE_Int          *Soc_offd_j   = hypre_ParCSRMatrixSocOffdJ(S);
+   HYPRE_Int          *CF_marker_dev;
+   HYPRE_Complex      *Dbeta, *rsWA, *rsW, *dlam, *dlam_offd, *dtmp, *dtmp_offd;
+   hypre_ParCSRMatrix *As_F2F, *As_FF, *As_FC, *W, *P;
+
+   CF_marker_dev = hypre_TAlloc(HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE);
+   hypre_TMemcpy(CF_marker_dev, CF_marker, HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+
+   //TODO use CF_marker_dev
+   /* As_F2F = As_{F2, F}, As_FC = As_{F, C2} */
+   hypre_ParCSRMatrixGenerateFFFC3Device(A, CF_marker, num_cpts_global, S, &As_FC, &As_F2F);
+
+   HYPRE_Int AFC_nr_local = hypre_ParCSRMatrixNumRows(As_FC);
+   HYPRE_Int AF2F_nr_local = hypre_ParCSRMatrixNumRows(As_F2F);
+
+   /* row sum of AFC, i.e., D_beta */
+   Dbeta = hypre_TAlloc(HYPRE_Complex, AFC_nr_local, HYPRE_MEMORY_DEVICE);
+   hypre_CSRMatrixComputeRowSumDevice(hypre_ParCSRMatrixDiag(As_FC), NULL, NULL, Dbeta, 0, 1.0, "set");
+   hypre_CSRMatrixComputeRowSumDevice(hypre_ParCSRMatrixOffd(As_FC), NULL, NULL, Dbeta, 0, 1.0, "add");
+
+   /* As_FF = As_{F,F} */
+   hypre_ParCSRMatrixGenerateFFFCDevice(A, CF_marker, num_cpts_global, S, NULL, &As_FF);
+
+   hypre_assert(AFC_nr_local = hypre_ParCSRMatrixNumRows(As_FF));
+
+   dim3 bDim = hypre_GetDefaultCUDABlockDimension();
+   dim3 gDim = hypre_GetDefaultCUDAGridDimension(AFC_nr_local, "warp", bDim);
+
+   /* Generate D_lambda in the paper: D_beta + (row sum of AFF without diagonal elements / row_nnz) */
+   /* Generate D_tmp, i.e., D_mu / D_lambda */
+   dlam = hypre_TAlloc(HYPRE_Complex, AFC_nr_local, HYPRE_MEMORY_DEVICE);
+   dtmp = hypre_TAlloc(HYPRE_Complex, AFC_nr_local, HYPRE_MEMORY_DEVICE);
+
+   HYPRE_CUDA_LAUNCH( hypreCUDAKernel_compute_dlam_dtmp,
+                      gDim, bDim,
+                      AFC_nr_local,
+                      hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(As_FF)),
+                      hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(As_FF)),
+                      hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(As_FF)),
+                      hypre_CSRMatrixI(hypre_ParCSRMatrixOffd(As_FF)),
+                      hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(As_FF)),
+                      Dbeta,
+                      dlam,
+                      dtmp );
+
+   hypre_ParCSRMatrixDestroy(As_FF);
+   hypre_TFree(Dbeta, HYPRE_MEMORY_DEVICE);
+
+   /* collect off-processor dtmp and dlam*/
+   dtmp_offd = hypre_TAlloc(HYPRE_Complex, hypre_CSRMatrixNumCols(hypre_ParCSRMatrixOffd(As_F2F)), HYPRE_MEMORY_DEVICE);
+   dlam_offd = hypre_TAlloc(HYPRE_Complex, hypre_CSRMatrixNumCols(hypre_ParCSRMatrixOffd(As_F2F)), HYPRE_MEMORY_DEVICE);
+
+   hypre_ParCSRCommPkg    *comm_pkg = hypre_ParCSRMatrixCommPkg(As_F2F);
+   hypre_ParCSRCommHandle *comm_handle;
+   if (!comm_pkg)
+   {
+      hypre_MatvecCommPkgCreate(As_F2F);
+      comm_pkg = hypre_ParCSRMatrixCommPkg(As_F2F);
+   }
+   HYPRE_Int num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+   HYPRE_Int num_elmts_send = hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends);
+   HYPRE_Complex *send_buf = hypre_TAlloc(HYPRE_Complex, num_elmts_send, HYPRE_MEMORY_DEVICE);
+   hypre_ParCSRCommPkgCopySendMapElmtsToDevice(comm_pkg);
+
+   HYPRE_THRUST_CALL( gather,
+                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg),
+                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg) + num_elmts_send,
+                      dtmp,
+                      send_buf );
+   comm_handle = hypre_ParCSRCommHandleCreate_v2(1, comm_pkg, HYPRE_MEMORY_DEVICE, send_buf, HYPRE_MEMORY_DEVICE, dtmp_offd);
+   hypre_ParCSRCommHandleDestroy(comm_handle);
+
+   HYPRE_THRUST_CALL( gather,
+                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg),
+                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg) + num_elmts_send,
+                      dlam,
+                      send_buf );
+   comm_handle = hypre_ParCSRCommHandleCreate_v2(1, comm_pkg, HYPRE_MEMORY_DEVICE, send_buf, HYPRE_MEMORY_DEVICE, dlam_offd);
+   hypre_ParCSRCommHandleDestroy(comm_handle);
+
+   hypre_TFree(send_buf, HYPRE_MEMORY_DEVICE);
+
+   /* weak row sum and diagonal, i.e., DFF + Dgamma */
+   rsWA = hypre_TAlloc(HYPRE_Complex, A_nr_local, HYPRE_MEMORY_DEVICE);
+
+   bDim = hypre_GetDefaultCUDABlockDimension();
+   gDim = hypre_GetDefaultCUDAGridDimension(A_nr_local, "warp", bDim);
+
+   /* only for rows corresponding to F2 (notice flag == -1) */
+   HYPRE_CUDA_LAUNCH( hypreCUDAKernel_compute_weak_rowsums,
+                      gDim, bDim,
+                      A_nr_local,
+                      A_offd_nnz > 0,
+                      CF_marker_dev,
+                      A_diag_i,
+                      A_diag_data,
+                      Soc_diag_j,
+                      A_offd_i,
+                      A_offd_data,
+                      Soc_offd_j,
+                      rsWA,
+                      -1 );
+
+   rsW = hypre_TAlloc(HYPRE_Complex, AF2F_nr_local, HYPRE_MEMORY_DEVICE);
+   HYPRE_Complex *new_end = HYPRE_THRUST_CALL( copy_if,
+                                               rsWA,
+                                               rsWA + A_nr_local,
+                                               CF_marker_dev,
+                                               rsW,
+                                               equal<HYPRE_Int>(-2) );
+
+   hypre_assert(new_end - rsW == AF2F_nr_local);
+
+   hypre_TFree(rsWA, HYPRE_MEMORY_DEVICE);
+
+   /* map from F2 to F */
+   HYPRE_Int *map_to_F = hypre_TAlloc(HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE);
+   HYPRE_THRUST_CALL( exclusive_scan,
+                      thrust::make_transform_iterator(CF_marker_dev,              is_negative<HYPRE_Int>()),
+                      thrust::make_transform_iterator(CF_marker_dev + A_nr_local, is_negative<HYPRE_Int>()),
+                      map_to_F );
+   HYPRE_Int *map_F2_to_F = hypre_TAlloc(HYPRE_Int, AF2F_nr_local, HYPRE_MEMORY_DEVICE);
+
+   HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( copy_if,
+                                           map_to_F,
+                                           map_to_F + A_nr_local,
+                                           CF_marker_dev,
+                                           map_F2_to_F,
+                                           equal<HYPRE_Int>(-2) );
+
+   hypre_assert(tmp_end - map_F2_to_F == AF2F_nr_local);
+
+   hypre_TFree(map_to_F, HYPRE_MEMORY_DEVICE);
+
+   /* add to rsW those in AFF that correspond to lam == 0
+    * diagnoally scale As_F2F (from both sides) and replace the diagonal */
+   gDim = hypre_GetDefaultCUDAGridDimension(AF2F_nr_local, "warp", bDim);
+
+   HYPRE_CUDA_LAUNCH( hypreCUDAKernel_MMPEInterpScaleAFF,
+                      gDim, bDim,
+                      AF2F_nr_local,
+                      hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(As_F2F)),
+                      hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(As_F2F)),
+                      hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(As_F2F)),
+                      hypre_CSRMatrixI(hypre_ParCSRMatrixOffd(As_F2F)),
+                      hypre_CSRMatrixJ(hypre_ParCSRMatrixOffd(As_F2F)),
+                      hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(As_F2F)),
+                      dtmp,
+                      dtmp_offd,
+                      dlam,
+                      dlam_offd,
+                      map_F2_to_F,
+                      rsW );
+
+   hypre_TFree(dlam,        HYPRE_MEMORY_DEVICE);
+   hypre_TFree(dlam_offd,   HYPRE_MEMORY_DEVICE);
+   hypre_TFree(dtmp,        HYPRE_MEMORY_DEVICE);
+   hypre_TFree(dtmp_offd,   HYPRE_MEMORY_DEVICE);
+   hypre_TFree(map_F2_to_F, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(rsW,         HYPRE_MEMORY_DEVICE);
+
+   /* Perform matrix-matrix multiplication */
+   W = hypre_ParCSRMatMatDevice(As_F2F, As_FC);
+
+   hypre_ParCSRMatrixDestroy(As_F2F);
+   hypre_ParCSRMatrixDestroy(As_FC);
+
+   /* Construct P from matrix product W */
+   HYPRE_Int          *P_diag_i, *P_diag_j, *P_offd_i;
+   HYPRE_Complex      *P_diag_data;
+   HYPRE_Int           P_nr_local = A_nr_local - (AFC_nr_local - AF2F_nr_local);
+   HYPRE_Int           P_diag_nnz = hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(W)) +
+                                    hypre_ParCSRMatrixNumCols(W);
+
+   hypre_assert(P_nr_local == hypre_ParCSRMatrixNumRows(W) + hypre_ParCSRMatrixNumCols(W));
+
+   P_diag_i    = hypre_TAlloc(HYPRE_Int,     P_nr_local + 1, HYPRE_MEMORY_DEVICE);
+   P_diag_j    = hypre_TAlloc(HYPRE_Int,     P_diag_nnz,     HYPRE_MEMORY_DEVICE);
+   P_diag_data = hypre_TAlloc(HYPRE_Complex, P_diag_nnz,     HYPRE_MEMORY_DEVICE);
+   P_offd_i    = hypre_TAlloc(HYPRE_Int,     P_nr_local + 1, HYPRE_MEMORY_DEVICE);
+
+   HYPRE_Int *C2F2_marker = hypre_TAlloc(HYPRE_Int, P_nr_local, HYPRE_MEMORY_DEVICE);
+   tmp_end = HYPRE_THRUST_CALL( copy_if,
+                                CF_marker_dev,
+                                CF_marker_dev + A_nr_local,
+                                CF_marker_dev,
+                                C2F2_marker,
+                                out_of_range<HYPRE_Int>(-1, 0) /* -2 or 1 */ );
+
+   hypre_assert(tmp_end - C2F2_marker == P_nr_local);
+
+   hypre_TFree(CF_marker_dev, HYPRE_MEMORY_DEVICE);
+
+   hypreDevice_extendWtoP( P_nr_local,
+                           AF2F_nr_local,
+                           hypre_ParCSRMatrixNumCols(W),
+                           C2F2_marker,
+                           hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(W)),
+                           hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(W)),
+                           hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(W)),
+                           hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(W)),
+                           P_diag_i,
+                           P_diag_j,
+                           P_diag_data,
+                           hypre_CSRMatrixI(hypre_ParCSRMatrixOffd(W)),
+                           P_offd_i );
+
+   hypre_TFree(C2F2_marker, HYPRE_MEMORY_DEVICE);
+
+   // final P
+   P = hypre_ParCSRMatrixCreate(hypre_ParCSRMatrixComm(A),
+                                hypre_ParCSRMatrixGlobalNumRows(W) + hypre_ParCSRMatrixGlobalNumCols(W),
+                                hypre_ParCSRMatrixGlobalNumCols(W),
+                                num_old_cpts_global,
+                                num_cpts_global,
+                                hypre_CSRMatrixNumCols(hypre_ParCSRMatrixOffd(W)),
+                                P_diag_nnz,
+                                hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixOffd(W)));
+
+   hypre_ParCSRMatrixOwnsRowStarts(P) = 0;
+   hypre_ParCSRMatrixOwnsColStarts(P) = 0;
+
+   hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(P))    = P_diag_i;
+   hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(P))    = P_diag_j;
+   hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(P)) = P_diag_data;
+
+   hypre_CSRMatrixI(hypre_ParCSRMatrixOffd(P))    = P_offd_i;
+   hypre_CSRMatrixJ(hypre_ParCSRMatrixOffd(P))    = hypre_CSRMatrixJ(hypre_ParCSRMatrixOffd(W));
+   hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(P)) = hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(W));
+   hypre_CSRMatrixJ(hypre_ParCSRMatrixOffd(W))    = NULL;
+   hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(W)) = NULL;
+
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(P)) = HYPRE_MEMORY_DEVICE;
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixOffd(P)) = HYPRE_MEMORY_DEVICE;
+
+   hypre_ParCSRMatrixDeviceColMapOffd(P) = hypre_ParCSRMatrixDeviceColMapOffd(W);
+   hypre_ParCSRMatrixColMapOffd(P)       = hypre_ParCSRMatrixColMapOffd(W);
+   hypre_ParCSRMatrixDeviceColMapOffd(W) = NULL;
+   hypre_ParCSRMatrixColMapOffd(W)       = NULL;
+
+   hypre_ParCSRMatrixNumNonzeros(P)  = hypre_ParCSRMatrixNumNonzeros(W) +
+                                       hypre_ParCSRMatrixGlobalNumCols(W);
+   hypre_ParCSRMatrixDNumNonzeros(P) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(P);
+
+   hypre_ParCSRMatrixDestroy(W);
+
+   if (trunc_factor != 0.0 || max_elmts > 0)
+   {
+      hypre_BoomerAMGInterpTruncationDevice(P, trunc_factor, max_elmts );
+   }
+
+   *P_ptr = P;
+
+   return hypre_error_flag;
+}
+
+//-----------------------------------------------------------------------
+__global__
+void hypreCUDAKernel_MMInterpScaleAFF( HYPRE_Int      AFF_nrows,
+                                       HYPRE_Int     *AFF_diag_i,
+                                       HYPRE_Int     *AFF_diag_j,
+                                       HYPRE_Complex *AFF_diag_a,
+                                       HYPRE_Int     *AFF_offd_i,
+                                       HYPRE_Int     *AFF_offd_j,
+                                       HYPRE_Complex *AFF_offd_a,
+                                       HYPRE_Complex *beta_diag,
+                                       HYPRE_Complex *beta_offd,
+                                       HYPRE_Int     *F2_to_F,
+                                       HYPRE_Real    *rsW )
+{
+   HYPRE_Int row = hypre_cuda_get_grid_warp_id<1,1>();
+
+   if (row >= AFF_nrows)
+   {
+      return;
+   }
+
+   HYPRE_Int lane = hypre_cuda_get_lane_id<1>();
+   HYPRE_Int ib_diag, ie_diag;
+   HYPRE_Int rowF;
+
+   if (lane == 0)
+   {
+      rowF= read_only_load(&F2_to_F[row]);
+   }
+   rowF = __shfl_sync(HYPRE_WARP_FULL_MASK, rowF, 0);
+
+   if (lane < 2)
+   {
+      ib_diag = read_only_load(AFF_diag_i + row + lane);
+   }
+   ie_diag = __shfl_sync(HYPRE_WARP_FULL_MASK, ib_diag, 1);
+   ib_diag = __shfl_sync(HYPRE_WARP_FULL_MASK, ib_diag, 0);
+
+   HYPRE_Complex rl = 0.0;
+
+   for (HYPRE_Int i = ib_diag + lane; __any_sync(HYPRE_WARP_FULL_MASK, i < ie_diag); i += HYPRE_WARP_SIZE)
+   {
+      if (i < ie_diag)
+      {
+         HYPRE_Int j = read_only_load(&AFF_diag_j[i]);
+
+         if (j == rowF)
+         {
+            /* diagonal */
+            AFF_diag_a[i] = 1.0;
+         }
+         else
+         {
+            /* off-diagonal */
+            HYPRE_Complex beta = read_only_load(&beta_diag[j]);
+            HYPRE_Complex val = AFF_diag_a[i];
+
+            if (beta == 0.0)
+            {
+               rl += val;
+               AFF_diag_a[i] = 0.0;
+            }
+            else
+            {
+               AFF_diag_a[i] = val / beta;
+            }
+         }
+      }
+   }
+
+   HYPRE_Int ib_offd, ie_offd;
+
+   if (lane < 2)
+   {
+      ib_offd = read_only_load(AFF_offd_i + row + lane);
+   }
+   ie_offd = __shfl_sync(HYPRE_WARP_FULL_MASK, ib_offd, 1);
+   ib_offd = __shfl_sync(HYPRE_WARP_FULL_MASK, ib_offd, 0);
+
+   for (HYPRE_Int i = ib_offd + lane; __any_sync(HYPRE_WARP_FULL_MASK, i < ie_offd); i += HYPRE_WARP_SIZE)
+   {
+      if (i < ie_offd)
+      {
+         HYPRE_Int j = read_only_load(&AFF_offd_j[i]);
+         HYPRE_Complex beta = read_only_load(&beta_offd[j]);
+         HYPRE_Complex val = AFF_offd_a[i];
+
+         if (beta == 0.0)
+         {
+            rl += val;
+            AFF_offd_a[i] = 0.0;
+         }
+         else
+         {
+            AFF_offd_a[i] = val / beta;
+         }
+      }
+   }
+
+   rl = warp_reduce_sum(rl);
+
+   if (lane == 0)
+   {
+      rl += read_only_load(&rsW[row]);
+      rl = rl == 0.0 ? 0.0 : -1.0 / rl;
+   }
+
+   rl = __shfl_sync(HYPRE_WARP_FULL_MASK, rl, 0);
+
+   for (HYPRE_Int i = ib_diag + lane; __any_sync(HYPRE_WARP_FULL_MASK, i < ie_diag); i += HYPRE_WARP_SIZE)
+   {
+      if (i < ie_diag)
+      {
+         AFF_diag_a[i] *= rl;
+      }
+   }
+
+   for (HYPRE_Int i = ib_offd + lane; __any_sync(HYPRE_WARP_FULL_MASK, i < ie_offd); i += HYPRE_WARP_SIZE)
+   {
+      if (i < ie_offd)
+      {
+         AFF_offd_a[i] *= rl;
+      }
+   }
+}
+
+//-----------------------------------------------------------------------
+__global__
+void hypreCUDAKernel_MMPEInterpScaleAFF( HYPRE_Int      AFF_nrows,
+                                         HYPRE_Int     *AFF_diag_i,
+                                         HYPRE_Int     *AFF_diag_j,
+                                         HYPRE_Complex *AFF_diag_a,
+                                         HYPRE_Int     *AFF_offd_i,
+                                         HYPRE_Int     *AFF_offd_j,
+                                         HYPRE_Complex *AFF_offd_a,
+                                         HYPRE_Complex *tmp_diag,
+                                         HYPRE_Complex *tmp_offd,
+                                         HYPRE_Complex *lam_diag,
+                                         HYPRE_Complex *lam_offd,
+                                         HYPRE_Int     *F2_to_F,
+                                         HYPRE_Real    *rsW )
+{
+   HYPRE_Int row = hypre_cuda_get_grid_warp_id<1,1>();
+
+   if (row >= AFF_nrows)
+   {
+      return;
+   }
+
+   HYPRE_Int lane = hypre_cuda_get_lane_id<1>();
+   HYPRE_Int ib_diag, ie_diag;
+   HYPRE_Int rowF;
+
+   if (lane == 0)
+   {
+      rowF= read_only_load(&F2_to_F[row]);
+   }
+   rowF = __shfl_sync(HYPRE_WARP_FULL_MASK, rowF, 0);
+
+   if (lane < 2)
+   {
+      ib_diag = read_only_load(AFF_diag_i + row + lane);
+   }
+   ie_diag = __shfl_sync(HYPRE_WARP_FULL_MASK, ib_diag, 1);
+   ib_diag = __shfl_sync(HYPRE_WARP_FULL_MASK, ib_diag, 0);
+
+   HYPRE_Complex rl = 0.0;
+
+   for (HYPRE_Int i = ib_diag + lane; __any_sync(HYPRE_WARP_FULL_MASK, i < ie_diag); i += HYPRE_WARP_SIZE)
+   {
+      if (i < ie_diag)
+      {
+         HYPRE_Int j = read_only_load(&AFF_diag_j[i]);
+
+         if (j == rowF)
+         {
+            /* diagonal */
+            AFF_diag_a[i] = 1.0;
+         }
+         else
+         {
+            /* off-diagonal */
+            HYPRE_Complex lam = read_only_load(&lam_diag[j]);
+            HYPRE_Complex val = AFF_diag_a[i];
+
+            if (lam == 0.0)
+            {
+               rl += val;
+               AFF_diag_a[i] = 0.0;
+            }
+            else
+            {
+               rl += val * read_only_load(&tmp_diag[j]);
+               AFF_diag_a[i] = val / lam;
+            }
+         }
+      }
+   }
+
+   HYPRE_Int ib_offd, ie_offd;
+
+   if (lane < 2)
+   {
+      ib_offd = read_only_load(AFF_offd_i + row + lane);
+   }
+   ie_offd = __shfl_sync(HYPRE_WARP_FULL_MASK, ib_offd, 1);
+   ib_offd = __shfl_sync(HYPRE_WARP_FULL_MASK, ib_offd, 0);
+
+   for (HYPRE_Int i = ib_offd + lane; __any_sync(HYPRE_WARP_FULL_MASK, i < ie_offd); i += HYPRE_WARP_SIZE)
+   {
+      if (i < ie_offd)
+      {
+         HYPRE_Int j = read_only_load(&AFF_offd_j[i]);
+         HYPRE_Complex lam = read_only_load(&lam_offd[j]);
+         HYPRE_Complex val = AFF_offd_a[i];
+
+         if (lam == 0.0)
+         {
+            rl += val;
+            AFF_offd_a[i] = 0.0;
+         }
+         else
+         {
+            rl += val * read_only_load(&tmp_offd[j]);
+            AFF_offd_a[i] = val / lam;
+         }
+      }
+   }
+
+   rl = warp_reduce_sum(rl);
+
+   if (lane == 0)
+   {
+      rl += read_only_load(&rsW[row]);
+      rl = rl == 0.0 ? 0.0 : -1.0 / rl;
+   }
+
+   rl = __shfl_sync(HYPRE_WARP_FULL_MASK, rl, 0);
+
+   for (HYPRE_Int i = ib_diag + lane; __any_sync(HYPRE_WARP_FULL_MASK, i < ie_diag); i += HYPRE_WARP_SIZE)
+   {
+      if (i < ie_diag)
+      {
+         AFF_diag_a[i] *= rl;
+      }
+   }
+
+   for (HYPRE_Int i = ib_offd + lane; __any_sync(HYPRE_WARP_FULL_MASK, i < ie_offd); i += HYPRE_WARP_SIZE)
+   {
+      if (i < ie_offd)
+      {
+         AFF_offd_a[i] *= rl;
+      }
+   }
+}
+
+#endif /* #if defined(HYPRE_USING_CUDA) */

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -1230,27 +1230,43 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                hypre_BoomerAMGCreate2ndS(S, CF_marker, num_paths,
                                          coarse_pnts_global1, &S2);
                if (coarsen_type == 10)
+               {
                   hypre_BoomerAMGCoarsenHMIS(S2, S2, measure_type+3, coarsen_cut_factor,
                                              debug_flag, &CFN_marker);
+               }
                else if (coarsen_type == 8)
+               {
                   hypre_BoomerAMGCoarsenPMIS(S2, S2, 3,
                                              debug_flag, &CFN_marker);
+               }
                else if (coarsen_type == 9)
+               {
                   hypre_BoomerAMGCoarsenPMIS(S2, S2, 4,
                                              debug_flag, &CFN_marker);
+               }
                else if (coarsen_type == 6)
+               {
                   hypre_BoomerAMGCoarsenFalgout(S2, S2, measure_type, coarsen_cut_factor,
                                                 debug_flag, &CFN_marker);
+               }
                else if (coarsen_type == 21 || coarsen_type == 22)
+               {
                   hypre_BoomerAMGCoarsenCGCb(S2, S2, measure_type,
                                              coarsen_type, cgc_its, debug_flag, &CFN_marker);
+               }
                else if (coarsen_type == 7)
+               {
                   hypre_BoomerAMGCoarsen(S2, S2, 2, debug_flag, &CFN_marker);
+               }
                else if (coarsen_type)
+               {
                   hypre_BoomerAMGCoarsenRuge(S2, S2, measure_type, coarsen_type,
                                              coarsen_cut_factor, debug_flag, &CFN_marker);
+               }
                else
+               {
                   hypre_BoomerAMGCoarsen(S2, S2, 0, debug_flag, &CFN_marker);
+               }
 
                hypre_ParCSRMatrixDestroy(S2);
             }
@@ -1312,27 +1328,43 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                hypre_BoomerAMGCreate2ndS(SN, CFN_marker, num_paths,
                                          coarse_pnts_global1, &S2);
                if (coarsen_type == 10)
+               {
                   hypre_BoomerAMGCoarsenHMIS(S2, S2, measure_type+3, coarsen_cut_factor,
                                              debug_flag, &CF2_marker);
+               }
                else if (coarsen_type == 8)
+               {
                   hypre_BoomerAMGCoarsenPMIS(S2, S2, 3,
                                              debug_flag, &CF2_marker);
+               }
                else if (coarsen_type == 9)
+               {
                   hypre_BoomerAMGCoarsenPMIS(S2, S2, 4,
                                              debug_flag, &CF2_marker);
+               }
                else if (coarsen_type == 6)
+               {
                   hypre_BoomerAMGCoarsenFalgout(S2, S2, measure_type, coarsen_cut_factor,
                                                 debug_flag, &CF2_marker);
+               }
                else if (coarsen_type == 21 || coarsen_type == 22)
+               {
                   hypre_BoomerAMGCoarsenCGCb(S2, S2, measure_type,
                                              coarsen_type, cgc_its, debug_flag, &CF2_marker);
+               }
                else if (coarsen_type == 7)
+               {
                   hypre_BoomerAMGCoarsen(S2, S2, 2, debug_flag, &CF2_marker);
+               }
                else if (coarsen_type)
+               {
                   hypre_BoomerAMGCoarsenRuge(S2, S2, measure_type, coarsen_type,
                                              coarsen_cut_factor, debug_flag, &CF2_marker);
+               }
                else
+               {
                   hypre_BoomerAMGCoarsen(S2, S2, 0, debug_flag, &CF2_marker);
+               }
 
                hypre_ParCSRMatrixDestroy(S2);
                S2 = NULL;
@@ -1598,16 +1630,18 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                   else if (agg_interp_type == 5)
                   {
                      hypre_BoomerAMGBuildModPartialExtInterp(A_array[level],
-                                                CF_marker, S, coarse_pnts_global, coarse_pnts_global1,
-                                                debug_flag,
-                                                agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P2);
+                                                             CF_marker, S, coarse_pnts_global,
+                                                             coarse_pnts_global1,
+                                                             debug_flag,
+                                                             agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P2);
                   }
                   else if (agg_interp_type == 7)
                   {
                      hypre_BoomerAMGBuildModPartialExtPEInterp(A_array[level],
-                                                CF_marker, S, coarse_pnts_global, coarse_pnts_global1,
-                                                debug_flag,
-                                                agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P2);
+                                                               CF_marker, S, coarse_pnts_global,
+                                                               coarse_pnts_global1,
+                                                               debug_flag,
+                                                               agg_P12_trunc_factor, agg_P12_max_elmts, col_offd_S_to_A, &P2);
                   }
 
 

--- a/src/parcsr_ls/par_coarsen_device.c
+++ b/src/parcsr_ls/par_coarsen_device.c
@@ -164,9 +164,11 @@ hypre_BoomerAMGCoarsenPMISDevice( hypre_ParCSRMatrix    *S,
    /*---------------------------------------------------
     * Clean up and return
     *---------------------------------------------------*/
-   if( *CF_marker_ptr == NULL )
+   if (*CF_marker_ptr == NULL)
+   {
       *CF_marker_ptr = hypre_CTAlloc(HYPRE_Int, num_cols_diag, HYPRE_MEMORY_HOST);
-   
+   }
+
    hypre_TMemcpy( *CF_marker_ptr, CF_marker_diag, HYPRE_Int, num_cols_diag, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE );
    hypre_TFree(CF_marker_diag, HYPRE_MEMORY_DEVICE);
 

--- a/src/parcsr_ls/par_interp_trunc_device.c
+++ b/src/parcsr_ls/par_interp_trunc_device.c
@@ -60,7 +60,7 @@ hypreCUDAKernel_InterpTruncation( HYPRE_Int   nrows,
       if (i < q)
       {
          HYPRE_Real v;
-         cond = cond_prev && i < p + max_elmts;
+         cond = cond_prev && (max_elmts == 0 || i < p + max_elmts);
          if (cond)
          {
             v = read_only_load(&P_a[i]);
@@ -88,7 +88,9 @@ hypreCUDAKernel_InterpTruncation( HYPRE_Int   nrows,
    }
 }
 
-/*-----------------------------------------------------------------------*/
+/*-----------------------------------------------------------------------*
+ * RL: To be consistent with the CPU version, max_elmts == 0 means no limit on rownnz
+ */
 HYPRE_Int
 hypre_BoomerAMGInterpTruncationDevice( hypre_ParCSRMatrix *P, HYPRE_Real trunc_factor, HYPRE_Int max_elmts )
 {

--- a/src/parcsr_ls/par_lr_interp_device.c
+++ b/src/parcsr_ls/par_lr_interp_device.c
@@ -16,13 +16,13 @@
 
 __global__ void hypreCUDAKernel_compute_weak_rowsums( HYPRE_Int nr_of_rows, bool has_offd, HYPRE_Int *CF_marker, HYPRE_Int *A_diag_i, HYPRE_Complex *A_diag_a, HYPRE_Int *S_diag_j, HYPRE_Int *A_offd_i, HYPRE_Complex *A_offd_a, HYPRE_Int *S_offd_j, HYPRE_Real *rs, HYPRE_Int flag );
 
-__global__ void compute_aff_afc( HYPRE_Int nr_of_rows, HYPRE_Int *AFF_diag_i, HYPRE_Int *AFF_diag_j, HYPRE_Complex *AFF_diag_data, HYPRE_Int *AFF_offd_i, HYPRE_Complex *AFF_offd_data, HYPRE_Int *AFC_diag_i, HYPRE_Complex *AFC_diag_data, HYPRE_Int *AFC_offd_i, HYPRE_Complex *AFC_offd_data, HYPRE_Complex *rsW, HYPRE_Complex *rsFC );
+__global__ void hypreCUDAKernel_compute_aff_afc( HYPRE_Int nr_of_rows, HYPRE_Int *AFF_diag_i, HYPRE_Int *AFF_diag_j, HYPRE_Complex *AFF_diag_data, HYPRE_Int *AFF_offd_i, HYPRE_Complex *AFF_offd_data, HYPRE_Int *AFC_diag_i, HYPRE_Complex *AFC_diag_data, HYPRE_Int *AFC_offd_i, HYPRE_Complex *AFC_offd_data, HYPRE_Complex *rsW, HYPRE_Complex *rsFC );
 
 void hypreDevice_extendWtoP( HYPRE_Int P_nr_of_rows, HYPRE_Int W_nr_of_rows, HYPRE_Int W_nr_of_cols, HYPRE_Int *CF_marker, HYPRE_Int W_diag_nnz, HYPRE_Int *W_diag_i, HYPRE_Int *W_diag_j, HYPRE_Complex *W_diag_data, HYPRE_Int *P_diag_i, HYPRE_Int *P_diag_j, HYPRE_Complex *P_diag_data, HYPRE_Int *W_offd_i, HYPRE_Int *P_offd_i );
 
-__global__ void compute_twiaff_w( HYPRE_Int nr_of_rows, HYPRE_BigInt first_index, HYPRE_Int *AFF_diag_i, HYPRE_Int *AFF_diag_j, HYPRE_Complex *AFF_diag_data, HYPRE_Complex *AFF_diag_data_old, HYPRE_Int *AFF_offd_i, HYPRE_Int *AFF_offd_j, HYPRE_Complex *AFF_offd_data, HYPRE_Int *AFF_ext_i, HYPRE_BigInt *AFF_ext_j, HYPRE_Complex *AFF_ext_data, HYPRE_Complex *rsW, HYPRE_Complex *rsFC, HYPRE_Complex *rsFC_offd );
+__global__ void hypreCUDAKernel_compute_twiaff_w( HYPRE_Int nr_of_rows, HYPRE_BigInt first_index, HYPRE_Int *AFF_diag_i, HYPRE_Int *AFF_diag_j, HYPRE_Complex *AFF_diag_data, HYPRE_Complex *AFF_diag_data_old, HYPRE_Int *AFF_offd_i, HYPRE_Int *AFF_offd_j, HYPRE_Complex *AFF_offd_data, HYPRE_Int *AFF_ext_i, HYPRE_BigInt *AFF_ext_j, HYPRE_Complex *AFF_ext_data, HYPRE_Complex *rsW, HYPRE_Complex *rsFC, HYPRE_Complex *rsFC_offd );
 
-__global__ void compute_aff_afc_epe( HYPRE_Int nr_of_rows, HYPRE_Int *AFF_diag_i, HYPRE_Int *AFF_diag_j, HYPRE_Complex *AFF_diag_data, HYPRE_Int *AFF_offd_i, HYPRE_Int *AFF_offd_j, HYPRE_Complex *AFF_offd_data, HYPRE_Int *AFC_diag_i, HYPRE_Complex *AFC_diag_data, HYPRE_Int *AFC_offd_i, HYPRE_Complex *AFC_offd_data, HYPRE_Complex *rsW, HYPRE_Complex *dlam, HYPRE_Complex *d_tmp, HYPRE_Complex *dtmp_offd );
+__global__ void hypreCUDAKernel_compute_aff_afc_epe( HYPRE_Int nr_of_rows, HYPRE_Int *AFF_diag_i, HYPRE_Int *AFF_diag_j, HYPRE_Complex *AFF_diag_data, HYPRE_Int *AFF_offd_i, HYPRE_Int *AFF_offd_j, HYPRE_Complex *AFF_offd_data, HYPRE_Int *AFC_diag_i, HYPRE_Complex *AFC_diag_data, HYPRE_Int *AFC_offd_i, HYPRE_Complex *AFC_offd_data, HYPRE_Complex *rsW, HYPRE_Complex *dlam, HYPRE_Complex *d_tmp, HYPRE_Complex *dtmp_offd );
 
 __global__ void hypreCUDAKernel_compute_dlam_dtmp( HYPRE_Int nr_of_rows, HYPRE_Int *AFF_diag_i, HYPRE_Int *AFF_diag_j, HYPRE_Complex *AFF_diag_data, HYPRE_Int *AFF_offd_i, HYPRE_Complex *AFF_offd_data, HYPRE_Complex *rsFC, HYPRE_Complex *dlam, HYPRE_Complex *dtmp );
 
@@ -112,7 +112,7 @@ hypre_BoomerAMGBuildExtInterpDevice(hypre_ParCSRMatrix  *A,
    /* 6. Form matrix ~{A_FC}, (return twAFC in AFC data structure) */
    hypre_NvtxPushRangeColor("Compute interp matrix", 4);
    gDim = hypre_GetDefaultCUDAGridDimension(W_nr_of_rows, "warp", bDim);
-   HYPRE_CUDA_LAUNCH( compute_aff_afc,
+   HYPRE_CUDA_LAUNCH( hypreCUDAKernel_compute_aff_afc,
                       gDim, bDim,
                       W_nr_of_rows,
                       hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(AFF)),
@@ -344,7 +344,7 @@ hypre_BoomerAMGBuildExtPIInterpDevice( hypre_ParCSRMatrix  *A,
 
    hypre_NvtxPushRangeColor("Compute interp matrix", 4);
    gDim = hypre_GetDefaultCUDAGridDimension(W_nr_of_rows, "warp", bDim);
-   HYPRE_CUDA_LAUNCH( compute_twiaff_w,
+   HYPRE_CUDA_LAUNCH( hypreCUDAKernel_compute_twiaff_w,
                       gDim, bDim,
                       W_nr_of_rows,
                       hypre_ParCSRMatrixFirstRowIndex(AFF),
@@ -589,7 +589,7 @@ hypre_BoomerAMGBuildExtPEInterpDevice(hypre_ParCSRMatrix  *A,
    /* 6. Form matrix ~{A_FC}, (return twAFC in AFC data structure) */
    hypre_NvtxPushRangeColor("Compute interp matrix", 4);
    gDim = hypre_GetDefaultCUDAGridDimension(W_nr_of_rows, "warp", bDim);
-   HYPRE_CUDA_LAUNCH( compute_aff_afc_epe,
+   HYPRE_CUDA_LAUNCH( hypreCUDAKernel_compute_aff_afc_epe,
                       gDim, bDim,
                       W_nr_of_rows,
                       hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(AFF)),
@@ -790,18 +790,18 @@ void hypreCUDAKernel_compute_weak_rowsums( HYPRE_Int      nr_of_rows,
 
 //-----------------------------------------------------------------------
 __global__
-void compute_aff_afc( HYPRE_Int      nr_of_rows,
-                      HYPRE_Int     *AFF_diag_i,
-                      HYPRE_Int     *AFF_diag_j,
-                      HYPRE_Complex *AFF_diag_data,
-                      HYPRE_Int     *AFF_offd_i,
-                      HYPRE_Complex *AFF_offd_data,
-                      HYPRE_Int     *AFC_diag_i,
-                      HYPRE_Complex *AFC_diag_data,
-                      HYPRE_Int     *AFC_offd_i,
-                      HYPRE_Complex *AFC_offd_data,
-                      HYPRE_Complex *rsW,
-                      HYPRE_Complex *rsFC )
+void hypreCUDAKernel_compute_aff_afc( HYPRE_Int      nr_of_rows,
+                                      HYPRE_Int     *AFF_diag_i,
+                                      HYPRE_Int     *AFF_diag_j,
+                                      HYPRE_Complex *AFF_diag_data,
+                                      HYPRE_Int     *AFF_offd_i,
+                                      HYPRE_Complex *AFF_offd_data,
+                                      HYPRE_Int     *AFC_diag_i,
+                                      HYPRE_Complex *AFC_diag_data,
+                                      HYPRE_Int     *AFC_offd_i,
+                                      HYPRE_Complex *AFC_offd_data,
+                                      HYPRE_Complex *rsW,
+                                      HYPRE_Complex *rsFC )
 {
    HYPRE_Int row = hypre_cuda_get_grid_warp_id<1,1>();
 
@@ -1029,21 +1029,21 @@ hypreDevice_extendWtoP( HYPRE_Int      P_nr_of_rows,
 //-----------------------------------------------------------------------
 // For Ext+i Interp, scale AFF from the left and the right
 __global__
-void compute_twiaff_w( HYPRE_Int      nr_of_rows,
-                       HYPRE_BigInt   first_index,
-                       HYPRE_Int     *AFF_diag_i,
-                       HYPRE_Int     *AFF_diag_j,
-                       HYPRE_Complex *AFF_diag_data,
-                       HYPRE_Complex *AFF_diag_data_old,
-                       HYPRE_Int     *AFF_offd_i,
-                       HYPRE_Int     *AFF_offd_j,
-                       HYPRE_Complex *AFF_offd_data,
-                       HYPRE_Int     *AFF_ext_i,
-                       HYPRE_BigInt  *AFF_ext_j,
-                       HYPRE_Complex *AFF_ext_data,
-                       HYPRE_Complex *rsW,
-                       HYPRE_Complex *rsFC,
-                       HYPRE_Complex *rsFC_offd )
+void hypreCUDAKernel_compute_twiaff_w( HYPRE_Int      nr_of_rows,
+                                       HYPRE_BigInt   first_index,
+                                       HYPRE_Int     *AFF_diag_i,
+                                       HYPRE_Int     *AFF_diag_j,
+                                       HYPRE_Complex *AFF_diag_data,
+                                       HYPRE_Complex *AFF_diag_data_old,
+                                       HYPRE_Int     *AFF_offd_i,
+                                       HYPRE_Int     *AFF_offd_j,
+                                       HYPRE_Complex *AFF_offd_data,
+                                       HYPRE_Int     *AFF_ext_i,
+                                       HYPRE_BigInt  *AFF_ext_j,
+                                       HYPRE_Complex *AFF_ext_data,
+                                       HYPRE_Complex *rsW,
+                                       HYPRE_Complex *rsFC,
+                                       HYPRE_Complex *rsFC_offd )
 {
    HYPRE_Int row = hypre_cuda_get_grid_warp_id<1,1>();
 
@@ -1202,21 +1202,21 @@ void compute_twiaff_w( HYPRE_Int      nr_of_rows,
 
 //-----------------------------------------------------------------------
 __global__
-void compute_aff_afc_epe( HYPRE_Int      nr_of_rows,
-                          HYPRE_Int     *AFF_diag_i,
-                          HYPRE_Int     *AFF_diag_j,
-                          HYPRE_Complex *AFF_diag_data,
-                          HYPRE_Int     *AFF_offd_i,
-                          HYPRE_Int     *AFF_offd_j,
-                          HYPRE_Complex *AFF_offd_data,
-                          HYPRE_Int     *AFC_diag_i,
-                          HYPRE_Complex *AFC_diag_data,
-                          HYPRE_Int     *AFC_offd_i,
-                          HYPRE_Complex *AFC_offd_data,
-                          HYPRE_Complex *rsW,
-                          HYPRE_Complex *dlam,
-                          HYPRE_Complex *dtmp,
-                          HYPRE_Complex *dtmp_offd )
+void hypreCUDAKernel_compute_aff_afc_epe( HYPRE_Int      nr_of_rows,
+                                          HYPRE_Int     *AFF_diag_i,
+                                          HYPRE_Int     *AFF_diag_j,
+                                          HYPRE_Complex *AFF_diag_data,
+                                          HYPRE_Int     *AFF_offd_i,
+                                          HYPRE_Int     *AFF_offd_j,
+                                          HYPRE_Complex *AFF_offd_data,
+                                          HYPRE_Int     *AFC_diag_i,
+                                          HYPRE_Complex *AFC_diag_data,
+                                          HYPRE_Int     *AFC_offd_i,
+                                          HYPRE_Complex *AFC_offd_data,
+                                          HYPRE_Complex *rsW,
+                                          HYPRE_Complex *dlam,
+                                          HYPRE_Complex *dtmp,
+                                          HYPRE_Complex *dtmp_offd )
 {
    HYPRE_Int row = hypre_cuda_get_grid_warp_id<1,1>();
 

--- a/src/parcsr_ls/par_strength2nd_device.c
+++ b/src/parcsr_ls/par_strength2nd_device.c
@@ -269,7 +269,7 @@ __global__ void hypre_CUDAKernel_MarkDiagonal_w( HYPRE_Int nr_of_rows, HYPRE_Int
 struct is_false
 {
    __host__ __device__
-   bool operator()(const int x)
+   bool operator()(const HYPRE_Int x)
    {
       return x==0;
    }
@@ -305,7 +305,7 @@ void remove_diagonal( hypre_ParCSRMatrix* S )
       hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(S)) = S_diag_a_new;
    }
    thrust::exclusive_scan(dmp,dmp+nr_of_rows+1,dmp);
-   thrust::minus<int> op;
+   thrust::minus<HYPRE_Int> op;
    thrust::device_ptr<HYPRE_Int> S_diag_ip(S_diag_i);
    thrust::transform( S_diag_ip, S_diag_ip+nr_of_rows+1, dmp, S_diag_ip, op );
    hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(S)) = nnz-ndiag;
@@ -371,7 +371,7 @@ void truncate( hypre_ParCSRMatrix* S, HYPRE_Complex trunc_level )
    hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(S)) = S_diag_a_new;
 
    thrust::exclusive_scan(dmp,dmp+nr_of_rows+1,dmp);
-   thrust::minus<int> op;
+   thrust::minus<HYPRE_Int> op;
    thrust::device_ptr<HYPRE_Int> S_diag_ip(S_diag_i);
    thrust::transform( S_diag_ip, S_diag_ip+nr_of_rows+1, dmp, S_diag_ip, op );
    hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(S)) = nnz-no_remove;
@@ -402,7 +402,7 @@ void truncate( hypre_ParCSRMatrix* S, HYPRE_Complex trunc_level )
    hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(S)) = S_offd_a_new;
 
    thrust::exclusive_scan(dmp,dmp+nr_of_rows+1,dmp);
-   //   thrust::minus<int> op;
+   //   thrust::minus<HYPRE_Int> op;
    thrust::device_ptr<HYPRE_Int> S_offd_ip(S_offd_i);
    thrust::transform( S_offd_ip, S_offd_ip+nr_of_rows+1, dmp, S_offd_ip, op );
    hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixOffd(S)) = nnz-no_remove;
@@ -444,7 +444,7 @@ __global__  void hypre_CUDAKernel_AddDiagJ( HYPRE_Int nr_of_rows, HYPRE_Int* SI_
    ib = SI_diag_i[row];
    ie = SI_diag_i[row+1];
    SI_diag_jnew[ib] = row;
-   for( int ind=ib+1; ind < ie; ind++ )
+   for( HYPRE_Int ind=ib+1; ind < ie; ind++ )
       SI_diag_jnew[ind] = SI_diag_j[ind-row-1];
 }
 
@@ -456,7 +456,7 @@ __global__ void hypre_CUDAKernel_MarkDiagonal( HYPRE_Int nr_of_rows, HYPRE_Int* 
    if( row >= nr_of_rows )
       return;
    dm[row]=0;
-   for( int ind=S_diag_i[row]; ind < S_diag_i[row+1]; ind++ )
+   for( HYPRE_Int ind=S_diag_i[row]; ind < S_diag_i[row+1]; ind++ )
    {
       dmj[ind]=0;
       if( S_diag_j[ind]==row )
@@ -631,7 +631,7 @@ HYPRE_Int hypre_BoomerAMGExtractCCDev( hypre_ParCSRMatrix  *A,
 
    HYPRE_Int *ACC_offd_i = hypre_CTAlloc(HYPRE_Int,nrofcoarserows+1,HYPRE_MEMORY_DEVICE);
    thrust::device_ptr<HYPRE_Int> ACC_offd_i_dev(ACC_offd_i);
-   thrust::copy_if( ACC_tmp_dev, ACC_tmp_dev+nrofrows, CF_marker_dev, ACC_offd_i_dev, is_positive<int>() );
+   thrust::copy_if( ACC_tmp_dev, ACC_tmp_dev+nrofrows, CF_marker_dev, ACC_offd_i_dev, is_positive<HYPRE_Int>() );
    thrust::exclusive_scan( ACC_offd_i_dev, ACC_offd_i_dev+nrofcoarserows+1, ACC_offd_i_dev );
    HYPRE_Int ACC_offd_nnz = ACC_offd_i[nrofcoarserows];
 
@@ -642,17 +642,17 @@ HYPRE_Int hypre_BoomerAMGExtractCCDev( hypre_ParCSRMatrix  *A,
       ACC_offd_j= hypre_CTAlloc(HYPRE_Int, ACC_offd_nnz, HYPRE_MEMORY_DEVICE);
       thrust::device_ptr<HYPRE_Int> ACC_offd_j_dev(ACC_offd_j), CF_array_offd_dev(CF_array_offd);
       thrust::device_ptr<HYPRE_Int> A_offd_j_dev(A_offd_j);
-      thrust::copy_if( A_offd_j_dev, A_offd_j_dev+A_offd_nnz, CF_array_offd_dev, ACC_offd_j_dev, is_positive<int>() );
+      thrust::copy_if( A_offd_j_dev, A_offd_j_dev+A_offd_nnz, CF_array_offd_dev, ACC_offd_j_dev, is_positive<HYPRE_Int>() );
       ACC_offd_a = hypre_CTAlloc( HYPRE_Complex, ACC_offd_nnz, HYPRE_MEMORY_DEVICE);
       thrust::device_ptr<HYPRE_Complex> A_offd_a_dev(A_offd_a), ACC_offd_a_dev(ACC_offd_a);
-      thrust::copy_if( A_offd_a_dev, A_offd_a_dev+A_offd_nnz, CF_array_offd_dev, ACC_offd_a_dev, is_positive<int>() );
+      thrust::copy_if( A_offd_a_dev, A_offd_a_dev+A_offd_nnz, CF_array_offd_dev, ACC_offd_a_dev, is_positive<HYPRE_Int>() );
    }
    hypre_TFree(ACC_tmp,HYPRE_MEMORY_DEVICE);
    hypre_TFree(CF_array_offd,HYPRE_MEMORY_DEVICE);
    // 3. Transform diagonal submatrix column index (F,C) to (C)
    HYPRE_Int* fine_to_coarse = hypre_CTAlloc(HYPRE_Int,nrofrows, HYPRE_MEMORY_DEVICE);
    thrust::device_ptr<HYPRE_Int> fine_to_coarse_dev(fine_to_coarse);
-   thrust::transform( CF_marker_dev, CF_marker_dev+nrofrows, fine_to_coarse_dev, is_positive<int>());
+   thrust::transform( CF_marker_dev, CF_marker_dev+nrofrows, fine_to_coarse_dev, is_positive<HYPRE_Int>());
    thrust::exclusive_scan( fine_to_coarse_dev, fine_to_coarse_dev+nrofrows, fine_to_coarse_dev );
    if( ACC_diag_nnz > 0 )
    {
@@ -717,7 +717,7 @@ __global__ void hypre_CUDAKernel_GetCfarray( HYPRE_Int nrofrows, HYPRE_Int nnz, 
 {
    HYPRE_Int i=hypre_cuda_get_grid_thread_id<1,1>();
    if( i < nrofrows )
-      for( int ind=A_diag_i[i] ; ind < A_diag_i[i+1] ; ind++ )
+      for( HYPRE_Int ind=A_diag_i[i] ; ind < A_diag_i[i+1] ; ind++ )
          CF_array[ind] = CF_marker[i]>0 && CF_marker[A_diag_j[ind]]>0;
 }
 
@@ -726,9 +726,9 @@ __global__ void hypre_CUDAKernel_GetCfarrayOffd( HYPRE_Int nrofrows, HYPRE_Int n
                                   HYPRE_Int* CF_marker_offd, HYPRE_Int* A_offd_i,
                                   HYPRE_Int* A_offd_j, HYPRE_Int* CF_array )
 {
-   int i=hypre_cuda_get_grid_thread_id<1,1>();
+   HYPRE_Int i=hypre_cuda_get_grid_thread_id<1,1>();
    if( i < nrofrows )
-      for( int ind=A_offd_i[i] ; ind < A_offd_i[i+1] ; ind++ )
+      for( HYPRE_Int ind=A_offd_i[i] ; ind < A_offd_i[i+1] ; ind++ )
          CF_array[ind] = CF_marker[i]>0 && CF_marker_offd[A_offd_j[ind]]>0;
 }
 
@@ -736,7 +736,7 @@ __global__ void hypre_CUDAKernel_GetCfarrayOffd( HYPRE_Int nrofrows, HYPRE_Int n
 __global__ void hypre_CUDAKernel_GetIcarray( HYPRE_Int nrofrows, HYPRE_Int* A_i,
                              HYPRE_Int* CF_marker, HYPRE_Int* CF_array, HYPRE_Int* ACC_tmp )
 {
-   int i = hypre_cuda_get_grid_warp_id<1,1>();
+   HYPRE_Int i = hypre_cuda_get_grid_warp_id<1,1>();
    if( i >= nrofrows )
    {
       return;
@@ -753,7 +753,7 @@ __global__ void hypre_CUDAKernel_GetIcarray( HYPRE_Int nrofrows, HYPRE_Int* A_i,
    {
       return;
    }
-   int ncl=0;
+   HYPRE_Int ncl=0;
    if (lane < 2)
    {
       ib = read_only_load(A_i + i + lane);
@@ -823,7 +823,7 @@ void restrict_colmap_to_cpts( HYPRE_Int ACC_offd_size, HYPRE_Int* ACC_offd_j,
       new_col_map = hypre_CTAlloc( HYPRE_Int, ncpts, HYPRE_MEMORY_DEVICE );
       thrust::device_ptr<HYPRE_Int> new_col_map_dev(new_col_map), col_map_A_dev(col_map_A);
       thrust::copy_if( col_map_A_dev, col_map_A_dev+nr_cols_A, fine_to_coarse_dev,
-                    new_col_map_dev, is_positive<int>() );
+                    new_col_map_dev, is_positive<HYPRE_Int>() );
 
    /* Map A_offd_j to new local indices */
       thrust::exclusive_scan( fine_to_coarse_dev, &fine_to_coarse_dev[nr_cols_A+1], fine_to_coarse_dev );
@@ -839,7 +839,7 @@ void restrict_colmap_to_cpts( HYPRE_Int ACC_offd_size, HYPRE_Int* ACC_offd_j,
 
 
 /*-----------------------------------------------------------------------*/
-int getSendInfo( HYPRE_Int nr_cols_P, HYPRE_Int* col_map_P,
+HYPRE_Int getSendInfo( HYPRE_Int nr_cols_P, HYPRE_Int* col_map_P,
                  HYPRE_Int* num_cpts, HYPRE_Int num_proc,
                  HYPRE_Int global_nr_of_rows,
                  HYPRE_Int** nrec, HYPRE_Int** recprocs )

--- a/src/parcsr_ls/par_strength2nd_device.c
+++ b/src/parcsr_ls/par_strength2nd_device.c
@@ -1,0 +1,927 @@
+#include "HYPRE.h"
+#include "HYPRE_parcsr_mv.h"
+#include "HYPRE_IJ_mv.h"
+#include "_hypre_utilities.h"
+#include "_hypre_utilities.hpp"
+
+#include "HYPRE_parcsr_ls.h"
+#include "_hypre_parcsr_ls.h"
+#include "_hypre_parcsr_mv.h"
+#include "HYPRE_utilities.h"
+
+#if defined(HYPRE_USING_CUDA)
+
+//-----------------------------------------------------------------------
+HYPRE_Int hypre_BoomerAMGExtractCCDev( hypre_ParCSRMatrix  *A,
+                                       HYPRE_Int           *CF_marker,
+                                       HYPRE_BigInt        *coarse_row_starts,
+                                       hypre_ParCSRMatrix **ACC_ptr);
+
+void truncate( hypre_ParCSRMatrix* S, HYPRE_Complex trunc_level );
+void add_diagonal( hypre_ParCSRMatrix* S );
+void add_unit_data( hypre_ParCSRMatrix* S );
+void remove_diagonal( hypre_ParCSRMatrix* S );
+
+__global__ void hypre_CUDAKernel_ScaleDiag( HYPRE_Int nr_of_rows, HYPRE_Int* SI_diag_i,
+                        HYPRE_Complex* SI_diag_a, HYPRE_Complex coeff );
+
+//-----------------------------------------------------------------------
+HYPRE_Int hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix  *S,
+                                           HYPRE_Int           *CF_marker,
+                                           HYPRE_Int            num_paths,
+                                           HYPRE_BigInt        *coarse_row_starts,
+                                           hypre_ParCSRMatrix **C_ptr)
+{
+   HYPRE_Int nr_of_rows hypre_CSRMatrixNumRows(hypre_ParCSRMatrixDiag(S));
+   HYPRE_Complex coeff=1;
+
+   MPI_Comm comm = hypre_ParCSRMatrixComm(S);
+   HYPRE_Int num_proc, myid;
+   hypre_MPI_Comm_size(comm, &num_proc);
+   hypre_MPI_Comm_rank(comm, &myid);
+
+   // 1. Create new matrix with added diagonal, S+coeff*I, for coeff=1 or 2.
+   hypre_NvtxPushRangeColor("Setup", 1);
+   add_unit_data( S );
+   hypre_ParCSRMatrix* SI = hypre_ParCSRMatrixClone( S, 1 );
+   add_diagonal( SI );
+
+   // 2. Add a data array to the strength matrix, needed in order 
+   //    to use matrix-matrix multiplication.
+   add_unit_data( SI );
+   hypre_NvtxPopRange();
+
+   // 2b. Scale diagonal by coeff   
+   if( coeff != 1 )
+   {
+      HYPRE_Int* SI_diag_i=hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(SI));
+      HYPRE_Complex* SI_diag_a=hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(SI));
+      dim3 bDim   = hypre_GetDefaultCUDABlockDimension();
+      dim3 gDim   = hypre_GetDefaultCUDAGridDimension(nr_of_rows, "thread",   bDim);
+      hypre_CUDAKernel_ScaleDiag<<<gDim,bDim>>>( nr_of_rows, SI_diag_i, SI_diag_a, coeff );
+      HYPRE_CUDA_CALL(cudaDeviceSynchronize());
+   }
+
+   // 3. Perform matrix-matrix multiplication
+   //   HYPRE_CUDA_CALL(cudaDeviceSynchronize());
+   //   hypre_MPI_Barrier(comm);
+   hypre_NvtxPushRangeColor("Matrix-matrix mult", 3);
+   hypre_ParCSRMatrix *SIS = hypre_ParCSRMatMatDevice( SI, S );
+   hypre_NvtxPopRange();
+
+   // 4. Extract CC parts of the matrices
+   hypre_ParCSRMatrix *SCC;
+   HYPRE_CUDA_CALL(cudaDeviceSynchronize());
+   hypre_MPI_Barrier(comm);
+   hypre_NvtxPushRangeColor("ExtractCCDev", 4);
+   hypre_BoomerAMGExtractCCDev( SIS, CF_marker, coarse_row_starts, &SCC );
+   hypre_NvtxPopRange();
+   if( num_paths == 2 )
+   {
+      // 5. If num_paths =2, prune elements < 2.
+      truncate(SCC,1.5);
+   }
+   // 6. Clean up matrix before returning it.
+   remove_diagonal( SCC );
+   hypre_TFree( hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(SCC)),hypre_ParCSRMatrixMemoryLocation(SCC));
+   hypre_TFree( hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(SCC)),hypre_ParCSRMatrixMemoryLocation(SCC));
+
+   *C_ptr = SCC;
+   return 0;
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_AddDiagI( HYPRE_Int nr_of_rows, HYPRE_Int* SI_diag_i );
+__global__ void hypre_CUDAKernel_AddDiagJ( HYPRE_Int nr_of_rows, HYPRE_Int* SI_diag_i, 
+                            HYPRE_Int* SI_diag_j, HYPRE_Int* SI_diag_jnew );
+
+//-----------------------------------------------------------------------
+void add_diagonal( hypre_ParCSRMatrix* SI )
+{
+   // It is assumed that the input SI is a strenght matrix, i.e., it has no diagonal
+   // elements and no data array. This function computes SI := SI+I, where the
+   // resulting matrix is still without a data array.
+   HYPRE_MemoryLocation ml = hypre_ParCSRMatrixMemoryLocation(SI);
+   HYPRE_Int nr_of_rows = hypre_CSRMatrixNumRows(hypre_ParCSRMatrixDiag(SI));
+   HYPRE_Int* SI_diag_i = hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(SI));
+   HYPRE_Int nnz        = hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(SI));
+   dim3 bDim = hypre_GetDefaultCUDABlockDimension();
+   dim3 gDim = hypre_GetDefaultCUDAGridDimension(nr_of_rows+1, "thread",   bDim);
+   hypre_CUDAKernel_AddDiagI<<<gDim,bDim>>>( nr_of_rows, SI_diag_i );
+   HYPRE_Int* SI_diag_j     = hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(SI));
+   HYPRE_Int* SI_diag_j_new = hypre_CTAlloc( HYPRE_Int, nnz+nr_of_rows, ml);
+   cudaDeviceSynchronize();
+   dim3 gDim2=hypre_GetDefaultCUDAGridDimension(nr_of_rows, "thread",   bDim);
+   hypre_CUDAKernel_AddDiagJ<<<gDim2,bDim>>>( nr_of_rows, SI_diag_i, SI_diag_j, SI_diag_j_new );
+   cudaDeviceSynchronize();
+   hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(SI)) = SI_diag_j_new;
+   hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(SI)) = nnz+nr_of_rows;
+   hypre_TFree(SI_diag_j,ml);
+   hypre_MatvecCommPkgCreate(SI);
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_MarkDiagonal( HYPRE_Int nr_of_rows, HYPRE_Int* S_diag_i,
+                               HYPRE_Int* S_diag_j, HYPRE_Int* dm, HYPRE_Int* dmj );
+__global__ void hypre_CUDAKernel_MarkDiagonal_w( HYPRE_Int nr_of_rows, HYPRE_Int* S_diag_i,
+                                 HYPRE_Int* S_diag_j, HYPRE_Int* dm, HYPRE_Int* dmj );
+struct is_false
+{
+   __host__ __device__
+   bool operator()(const int x)
+   {
+      return x==0;
+   }
+};
+
+//-----------------------------------------------------------------------
+void remove_diagonal( hypre_ParCSRMatrix* S )
+{
+   HYPRE_MemoryLocation ml = hypre_ParCSRMatrixMemoryLocation(S);
+   HYPRE_Int nr_of_rows = hypre_CSRMatrixNumRows(hypre_ParCSRMatrixDiag(S));
+   HYPRE_Int* S_diag_i = hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(S));
+   HYPRE_Int* S_diag_j = hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(S));
+   HYPRE_Int nnz        = hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(S));
+   dim3 bDim = hypre_GetDefaultCUDABlockDimension();
+   dim3 gDim = hypre_GetDefaultCUDAGridDimension(nr_of_rows, "warp",   bDim);
+   HYPRE_Int* dm =hypre_CTAlloc(HYPRE_Int, nr_of_rows+1, HYPRE_MEMORY_DEVICE);
+   HYPRE_Int* dmj=hypre_CTAlloc(HYPRE_Int, nnz, HYPRE_MEMORY_DEVICE);
+   hypre_CUDAKernel_MarkDiagonal_w<<<gDim,bDim>>>( nr_of_rows, S_diag_i, S_diag_j, dm, dmj );
+   thrust::device_ptr<HYPRE_Int>  dmp(dm), dmjp(dmj);
+   HYPRE_Int ndiag=thrust::reduce(dmp,dmp+nr_of_rows);
+   HYPRE_Int* S_diag_j_new = hypre_CTAlloc( HYPRE_Int, nnz-ndiag, ml);
+   thrust::device_ptr<HYPRE_Int> S_diag_jp(S_diag_j), S_diag_j_newp(S_diag_j_new);
+   thrust::copy_if(S_diag_jp,S_diag_jp+nnz,dmjp,S_diag_j_newp,is_false());
+   hypre_TFree(S_diag_j,ml);
+   hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(S)) = S_diag_j_new;      
+   HYPRE_Complex* S_diag_a = hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(S));
+   if( S_diag_a != NULL )
+   {
+      HYPRE_Complex* S_diag_a_new = hypre_CTAlloc( HYPRE_Complex, nnz-ndiag, ml);
+      thrust::device_ptr<HYPRE_Complex> S_diag_ap(S_diag_a), S_diag_a_newp(S_diag_a_new);
+      thrust::copy_if(S_diag_ap,S_diag_ap+nnz,dmjp,S_diag_a_newp,is_false());
+      hypre_TFree(S_diag_a,ml);
+      hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(S)) = S_diag_a_new;
+   }
+   thrust::exclusive_scan(dmp,dmp+nr_of_rows+1,dmp);
+   thrust::minus<int> op;
+   thrust::device_ptr<HYPRE_Int> S_diag_ip(S_diag_i);
+   thrust::transform( S_diag_ip, S_diag_ip+nr_of_rows+1, dmp, S_diag_ip, op );
+   hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(S)) = nnz-ndiag;
+   hypre_MatvecCommPkgCreate(S);
+
+   hypre_TFree( dm, HYPRE_MEMORY_DEVICE);
+   hypre_TFree( dmj, HYPRE_MEMORY_DEVICE);
+}
+
+//-----------------------------------------------------------------------
+void add_unit_data( hypre_ParCSRMatrix* S )
+{
+   HYPRE_MemoryLocation ml = hypre_ParCSRMatrixMemoryLocation(S);
+   HYPRE_Int nnzd = hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(S));
+   HYPRE_Int nnzo = hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixOffd(S));
+   // In case data exists, remove old arrays, might have wrong size.
+   hypre_TFree(hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(S)),ml);
+   hypre_TFree(hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(S)),ml);
+   // Create new data arrays 
+   HYPRE_Complex* S_diag_a = hypre_CTAlloc( HYPRE_Complex, nnzd, ml );
+   HYPRE_Complex* S_offd_a = hypre_CTAlloc( HYPRE_Complex, nnzo, ml );
+   thrust::device_ptr<HYPRE_Complex>  S_diag_a_dev(S_diag_a);
+   thrust::fill(S_diag_a_dev,S_diag_a_dev+nnzd,1.0);
+   thrust::device_ptr<HYPRE_Complex>  S_offd_a_dev(S_offd_a);
+   thrust::fill(S_offd_a_dev,S_offd_a_dev+nnzo,1.0);
+   hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(S)) = S_diag_a;
+   hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(S)) = S_offd_a;
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_MarkTrunc_w( HYPRE_Int nr_of_rows, HYPRE_Int* S_diag_i,
+                              HYPRE_Complex* S_diag_a, HYPRE_Complex trunc_level,
+                              HYPRE_Int* dm, HYPRE_Int* dmj );
+//-----------------------------------------------------------------------
+void truncate( hypre_ParCSRMatrix* S, HYPRE_Complex trunc_level )
+{
+   HYPRE_MemoryLocation ml = hypre_ParCSRMatrixMemoryLocation(S);
+   HYPRE_Int nr_of_rows = hypre_CSRMatrixNumRows(hypre_ParCSRMatrixDiag(S));
+   HYPRE_Int*     S_diag_i = hypre_CSRMatrixI(   hypre_ParCSRMatrixDiag(S));
+   HYPRE_Int*     S_diag_j = hypre_CSRMatrixJ(   hypre_ParCSRMatrixDiag(S));
+   HYPRE_Complex* S_diag_a = hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(S));
+   HYPRE_Int nnz = hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(S));
+   dim3 bDim = hypre_GetDefaultCUDABlockDimension();
+   dim3 gDim = hypre_GetDefaultCUDAGridDimension(nr_of_rows, "warp",   bDim);
+   HYPRE_Int* dm =hypre_CTAlloc(HYPRE_Int, nr_of_rows+1, HYPRE_MEMORY_DEVICE);
+   HYPRE_Int* dmj=hypre_CTAlloc(HYPRE_Int, nnz, HYPRE_MEMORY_DEVICE);
+   hypre_CUDAKernel_MarkTrunc_w<<<gDim,bDim>>>( nr_of_rows, S_diag_i, S_diag_a, trunc_level, dm, dmj );
+   thrust::device_ptr<HYPRE_Int>  dmp(dm), dmjp(dmj);
+   HYPRE_Int no_remove=thrust::reduce(dmp,dmp+nr_of_rows);
+
+   // New col index array
+   HYPRE_Int* S_diag_j_new = hypre_CTAlloc( HYPRE_Int, nnz-no_remove, ml);
+   thrust::device_ptr<HYPRE_Int> S_diag_jp(S_diag_j), S_diag_j_newp(S_diag_j_new);
+   thrust::copy_if(S_diag_jp,S_diag_jp+nnz,dmjp,S_diag_j_newp,is_false());
+   hypre_TFree(S_diag_j,ml);
+   hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(S)) = S_diag_j_new;      
+
+   // New data array
+   HYPRE_Complex* S_diag_a_new = hypre_CTAlloc( HYPRE_Complex, nnz-no_remove, ml);
+   thrust::device_ptr<HYPRE_Complex> S_diag_ap(S_diag_a), S_diag_a_newp(S_diag_a_new);
+   thrust::copy_if(S_diag_ap,S_diag_ap+nnz,dmjp,S_diag_a_newp,is_false());
+   hypre_TFree(S_diag_a,ml);
+   hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(S)) = S_diag_a_new;
+
+   thrust::exclusive_scan(dmp,dmp+nr_of_rows+1,dmp);
+   thrust::minus<int> op;
+   thrust::device_ptr<HYPRE_Int> S_diag_ip(S_diag_i);
+   thrust::transform( S_diag_ip, S_diag_ip+nr_of_rows+1, dmp, S_diag_ip, op );
+   hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(S)) = nnz-no_remove;
+
+   // Off diagonal part
+   hypre_TFree( dmj, HYPRE_MEMORY_DEVICE);
+
+   HYPRE_Int*     S_offd_i = hypre_CSRMatrixI(hypre_ParCSRMatrixOffd(S));
+   HYPRE_Int*     S_offd_j = hypre_CSRMatrixJ(hypre_ParCSRMatrixOffd(S));
+   HYPRE_Complex* S_offd_a = hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(S));
+   nnz = hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixOffd(S));
+   dmj=hypre_CTAlloc(HYPRE_Int, nnz, HYPRE_MEMORY_DEVICE);
+   hypre_CUDAKernel_MarkTrunc_w<<<gDim,bDim>>>( nr_of_rows, S_offd_i, S_offd_a, trunc_level, dm, dmj );
+   no_remove=thrust::reduce(dmp,dmp+nr_of_rows);
+   
+   // New col index array
+   HYPRE_Int* S_offd_j_new = hypre_CTAlloc( HYPRE_Int, nnz-no_remove, ml);
+   thrust::device_ptr<HYPRE_Int> S_offd_jp(S_offd_j), S_offd_j_newp(S_offd_j_new);
+   thrust::device_ptr<HYPRE_Int> dmjp2(dmj);
+   thrust::copy_if(S_offd_jp,S_offd_jp+nnz,dmjp2,S_offd_j_newp,is_false());
+   hypre_TFree(S_offd_j,ml);
+   hypre_CSRMatrixJ(hypre_ParCSRMatrixOffd(S)) = S_offd_j_new;      
+   // New data array
+   HYPRE_Complex* S_offd_a_new = hypre_CTAlloc( HYPRE_Complex, nnz-no_remove, ml);
+   thrust::device_ptr<HYPRE_Complex> S_offd_ap(S_offd_a), S_offd_a_newp(S_offd_a_new);
+   thrust::copy_if(S_offd_ap,S_offd_ap+nnz,dmjp2,S_offd_a_newp,is_false());
+   hypre_TFree(S_offd_a,ml);
+   hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(S)) = S_offd_a_new;
+
+   thrust::exclusive_scan(dmp,dmp+nr_of_rows+1,dmp);
+   //   thrust::minus<int> op;
+   thrust::device_ptr<HYPRE_Int> S_offd_ip(S_offd_i);
+   thrust::transform( S_offd_ip, S_offd_ip+nr_of_rows+1, dmp, S_offd_ip, op );
+   hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixOffd(S)) = nnz-no_remove;
+
+
+// Should compress local index in offd, but the routine will likely work without doing it
+   hypre_TFree( dm, HYPRE_MEMORY_DEVICE);
+   hypre_TFree( dmj, HYPRE_MEMORY_DEVICE);
+
+   hypre_MatvecCommPkgCreate(S);
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_ScaleDiag( HYPRE_Int nr_of_rows, HYPRE_Int* SI_diag_i,
+                        HYPRE_Complex* SI_diag_a, HYPRE_Complex coeff )
+{
+   HYPRE_Int row = hypre_cuda_get_grid_thread_id<1,1>();
+   if( row < nr_of_rows )
+      SI_diag_a[SI_diag_i[row]] *= coeff;
+ // Assuming each row has a diagonal element, that occurs first in the row.
+}
+
+//-----------------------------------------------------------------------
+__global__  void hypre_CUDAKernel_AddDiagI( HYPRE_Int nr_of_rows, HYPRE_Int* SI_diag_i )
+{
+   HYPRE_Int row = hypre_cuda_get_grid_thread_id<1,1>();
+   if( row <= nr_of_rows )
+      SI_diag_i[row] += row;
+  //Adding one element per row, assumes that no row has a diagonal element initially.
+}
+
+//-----------------------------------------------------------------------
+__global__  void hypre_CUDAKernel_AddDiagJ( HYPRE_Int nr_of_rows, HYPRE_Int* SI_diag_i, 
+                        HYPRE_Int* SI_diag_j, HYPRE_Int* SI_diag_jnew )
+{
+   HYPRE_Int row = hypre_cuda_get_grid_thread_id<1,1>(), ib, ie;
+   if( row >= nr_of_rows )
+      return;
+   ib = SI_diag_i[row];
+   ie = SI_diag_i[row+1];
+   SI_diag_jnew[ib] = row;
+   for( int ind=ib+1; ind < ie; ind++ )
+      SI_diag_jnew[ind] = SI_diag_j[ind-row-1];
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_MarkDiagonal( HYPRE_Int nr_of_rows, HYPRE_Int* S_diag_i,
+                               HYPRE_Int* S_diag_j, HYPRE_Int* dm, HYPRE_Int* dmj )
+{
+   HYPRE_Int row = hypre_cuda_get_grid_thread_id<1,1>();//, ib, ie;
+   if( row >= nr_of_rows )
+      return;
+   dm[row]=0;
+   for( int ind=S_diag_i[row]; ind < S_diag_i[row+1]; ind++ )
+   {
+      dmj[ind]=0;
+      if( S_diag_j[ind]==row )
+      {
+         dm[row]=1;
+         dmj[ind]=1;
+      }
+   }
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_MarkDiagonal_w( HYPRE_Int nr_of_rows, HYPRE_Int* S_diag_i,
+                                 HYPRE_Int* S_diag_j, HYPRE_Int* dm, HYPRE_Int* dmj )
+{
+   HYPRE_Int row = hypre_cuda_get_grid_warp_id<1,1>(), ib, ie, sj, hd;
+   if( row >= nr_of_rows )
+   {
+      return;
+   }
+   HYPRE_Int lane = hypre_cuda_get_lane_id<1>();
+   if (lane < 2)
+   {
+      ib = read_only_load(S_diag_i + row + lane);
+   }
+   ie = __shfl_sync(HYPRE_WARP_FULL_MASK, ib, 1);
+   ib = __shfl_sync(HYPRE_WARP_FULL_MASK, ib, 0);
+   hd = 0;
+   for (HYPRE_Int ind = ib + lane; __any_sync(HYPRE_WARP_FULL_MASK, ind < ie); ind += HYPRE_WARP_SIZE)
+   {
+      if( ind < ie )
+      {
+         sj = read_only_load(S_diag_j + ind);
+         hd= (sj==row||hd==1);
+         dmj[ind] = sj==row;
+      }
+   }
+   dm[row]=warp_allreduce_max(hd);
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_MarkTrunc_w( HYPRE_Int nr_of_rows, HYPRE_Int* S_diag_i,
+                                   HYPRE_Complex* S_diag_a,
+                                   HYPRE_Complex trunc_level,
+                                   HYPRE_Int* dm, HYPRE_Int* dmj )
+{
+   HYPRE_Int row = hypre_cuda_get_grid_warp_id<1,1>(), ib, ie, hd;
+   HYPRE_Complex sa;
+   if( row >= nr_of_rows )
+   {
+      return;
+   }
+   HYPRE_Int lane = hypre_cuda_get_lane_id<1>();
+   if (lane < 2)
+   {
+      ib = read_only_load(S_diag_i + row + lane);
+   }
+   ie = __shfl_sync(HYPRE_WARP_FULL_MASK, ib, 1);
+   ib = __shfl_sync(HYPRE_WARP_FULL_MASK, ib, 0);
+   hd = 0;
+   for (HYPRE_Int ind = ib + lane; __any_sync(HYPRE_WARP_FULL_MASK, ind < ie); ind += HYPRE_WARP_SIZE)
+   {
+      if( ind < ie )
+      {
+         sa = read_only_load(S_diag_a + ind);
+         hd += (sa <= trunc_level);
+         dmj[ind] = sa <= trunc_level; // 1--> remove, 0--> keep
+      }
+   }
+   dm[row]=warp_allreduce_sum(hd); // Number of elements to remove in `row'
+}
+
+//-----------------------------------------------------------------------
+
+__global__ void hypre_CUDAKernel_GetCfarray( HYPRE_Int nrofrows, HYPRE_Int nnz,  HYPRE_Int* CF_marker,
+                                             HYPRE_Int* A_diag_i, HYPRE_Int* A_diag_j, HYPRE_Int* CF_array );
+__global__ void hypre_CUDAKernel_GetCfarrayOffd( HYPRE_Int nrofrows, HYPRE_Int nnz,  HYPRE_Int* CF_marker,
+                                                 HYPRE_Int* CF_marker_offd, HYPRE_Int* A_offd_i,
+                                                 HYPRE_Int* A_offd_j, HYPRE_Int* CF_array );
+__global__ void hypre_CUDAKernel_GetIcarray( HYPRE_Int nrofrows,  HYPRE_Int* A_diag_i, HYPRE_Int* CF_marker,
+                                             HYPRE_Int* CF_array, HYPRE_Int* ACC_tmp );
+__global__ void hypre_CUDAKernel_TransformColindDiag( HYPRE_Int nnz, HYPRE_Int* fine_to_coarse,
+                                                      HYPRE_Int* A_diag_j );
+void restrict_colmap_to_cpts( HYPRE_Int ACC_offd_size, HYPRE_Int* ACC_offd_j,
+                              HYPRE_Int nr_cols_A, HYPRE_Int* col_map_A,
+                              HYPRE_Int* nr_cols_ACC, HYPRE_Int** col_map_ACC );
+void CoarseToFine_comm( MPI_Comm comm, HYPRE_Int nr_cols_P, HYPRE_Int* col_map_P,
+                        HYPRE_Int* fine_to_coarse, HYPRE_Int first_diagonal,
+                        HYPRE_Int nr_of_rows, HYPRE_Int* num_cpts, HYPRE_Int global_nr_of_rows );
+void getcfmoffd( hypre_ParCSRMatrix* A, HYPRE_Int* CF_marker, HYPRE_Int** CF_marker_offd );
+
+
+HYPRE_Int hypre_BoomerAMGExtractCCDev( hypre_ParCSRMatrix  *A,
+                                       HYPRE_Int           *CF_marker,
+                                       HYPRE_BigInt        *coarse_row_starts,
+                                       hypre_ParCSRMatrix **ACC_ptr)
+{
+   hypre_CSRMatrix    *A_diag     = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Complex      *A_diag_a   = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int          *A_diag_i   = hypre_CSRMatrixI(A_diag);
+   HYPRE_Int          *A_diag_j   = hypre_CSRMatrixJ(A_diag);
+   HYPRE_Int           A_diag_nnz = hypre_CSRMatrixNumNonzeros(A_diag);
+
+   hypre_CSRMatrix    *A_offd     = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Complex      *A_offd_a   = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int          *A_offd_i   = hypre_CSRMatrixI(A_offd);
+   HYPRE_Int          *A_offd_j   = hypre_CSRMatrixJ(A_offd);
+   HYPRE_Int           A_offd_nnz = hypre_CSRMatrixNumNonzeros(A_offd);
+
+   // 0. Information on coarse dimensions
+   MPI_Comm comm = hypre_ParCSRMatrixComm(A);
+   HYPRE_Int num_procs, my_id;
+   HYPRE_Int my_first_cpt, my_last_cpt, global_num_coarse;
+   hypre_MPI_Comm_size(comm, &num_procs);
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+   my_first_cpt = coarse_row_starts[0];
+   my_last_cpt  = coarse_row_starts[1]-1;
+   if (my_id == (num_procs -1)) global_num_coarse = coarse_row_starts[1];
+   hypre_MPI_Bcast(&global_num_coarse, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+#else
+   my_first_cpt = coarse_row_starts[my_id];
+   my_last_cpt  = coarse_row_starts[my_id+1]-1;
+   global_num_coarse = coarse_row_starts[num_procs];
+#endif
+
+   // 1. diagonal part of ACC
+   HYPRE_Int nrofrows = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Int *CF_array= hypre_CTAlloc(HYPRE_Int,A_diag_nnz,HYPRE_MEMORY_DEVICE);
+   thrust::device_ptr<HYPRE_Int> CF_array_dev(CF_array);
+   thrust::fill(CF_array_dev,CF_array_dev+A_diag_nnz,0);
+   dim3 bDim   = hypre_GetDefaultCUDABlockDimension();
+   dim3 gDim   = hypre_GetDefaultCUDAGridDimension( nrofrows, "thread",   bDim);
+   dim3 gDimw  = hypre_GetDefaultCUDAGridDimension( nrofrows, "warp",   bDim);
+   hypre_CUDAKernel_GetCfarray<<<gDim,bDim>>>( nrofrows, A_diag_nnz, CF_marker, A_diag_i, A_diag_j, CF_array );
+
+   HYPRE_Int *ACC_tmp = hypre_CTAlloc( HYPRE_Int, nrofrows, HYPRE_MEMORY_DEVICE );
+   hypre_CUDAKernel_GetIcarray<<<gDimw,bDim>>>( nrofrows, A_diag_i, CF_marker, CF_array, ACC_tmp );
+
+   HYPRE_Int nrofcoarserows = my_last_cpt-my_first_cpt+1;
+   //   HYPRE_Int nrofcoarserows = thrust::count_if( CF_marker, CF_marker+nrofrows, is_positive() );
+
+   HYPRE_Int *ACC_diag_i = hypre_CTAlloc( HYPRE_Int, nrofcoarserows+1, HYPRE_MEMORY_DEVICE);
+   thrust::device_ptr<HYPRE_Int> ACC_tmp_dev(ACC_tmp), CF_marker_dev(CF_marker), ACC_diag_i_dev(ACC_diag_i);
+   thrust::copy_if( ACC_tmp_dev, ACC_tmp_dev+nrofrows, CF_marker_dev, ACC_diag_i_dev, is_positive<HYPRE_Int>() );
+   thrust::exclusive_scan( ACC_diag_i_dev, ACC_diag_i_dev+nrofcoarserows+1, ACC_diag_i_dev );
+   HYPRE_Int ACC_diag_nnz = ACC_diag_i[nrofcoarserows]; // Should do this on device
+   
+   HYPRE_Int *ACC_diag_j    = NULL;
+   HYPRE_Complex *ACC_diag_a= NULL;
+   if( ACC_diag_nnz > 0 )
+   {
+      ACC_diag_j = hypre_CTAlloc(HYPRE_Int, ACC_diag_nnz, HYPRE_MEMORY_DEVICE);
+
+      thrust::device_ptr<HYPRE_Int> A_diag_j_dev(A_diag_j), ACC_diag_j_dev(ACC_diag_j);
+      thrust::device_ptr<HYPRE_Int> CF_array_dev(CF_array);
+      thrust::copy_if( A_diag_j_dev, A_diag_j_dev+A_diag_nnz, CF_array_dev, ACC_diag_j_dev, is_positive<HYPRE_Int>() );
+      ACC_diag_a = hypre_CTAlloc( HYPRE_Complex, ACC_diag_nnz, HYPRE_MEMORY_DEVICE);
+      thrust::device_ptr<HYPRE_Complex> A_diag_a_dev(A_diag_a), ACC_diag_a_dev(ACC_diag_a);
+      thrust::copy_if( A_diag_a_dev, A_diag_a_dev+A_diag_nnz, CF_array_dev, ACC_diag_a_dev, is_positive<HYPRE_Int>() );
+   }
+   hypre_TFree(CF_array,HYPRE_MEMORY_DEVICE);
+
+   // 2. off-diagonal part of ACC  
+   HYPRE_Int* CF_marker_offd;
+   getcfmoffd( A, CF_marker, &CF_marker_offd );
+
+   HYPRE_Int *CF_array_offd = hypre_CTAlloc(HYPRE_Int,A_offd_nnz,HYPRE_MEMORY_DEVICE);
+   hypre_CUDAKernel_GetCfarrayOffd<<<gDim,bDim>>>( nrofrows, A_offd_nnz, CF_marker, CF_marker_offd, A_offd_i, A_offd_j, CF_array_offd );
+
+   hypre_CUDAKernel_GetIcarray<<<gDimw,bDim>>>( nrofrows, A_offd_i, CF_marker, CF_array_offd, ACC_tmp );
+
+   HYPRE_Int *ACC_offd_i = hypre_CTAlloc(HYPRE_Int,nrofcoarserows+1,HYPRE_MEMORY_DEVICE);
+   thrust::device_ptr<HYPRE_Int> ACC_offd_i_dev(ACC_offd_i);
+   thrust::copy_if( ACC_tmp_dev, ACC_tmp_dev+nrofrows, CF_marker_dev, ACC_offd_i_dev, is_positive<int>() );
+   thrust::exclusive_scan( ACC_offd_i_dev, ACC_offd_i_dev+nrofcoarserows+1, ACC_offd_i_dev );
+   HYPRE_Int ACC_offd_nnz = ACC_offd_i[nrofcoarserows];
+
+   HYPRE_Int *ACC_offd_j    = NULL;
+   HYPRE_Complex *ACC_offd_a= NULL;
+   if( ACC_offd_nnz > 0 )
+   {
+      ACC_offd_j= hypre_CTAlloc(HYPRE_Int, ACC_offd_nnz, HYPRE_MEMORY_DEVICE);
+      thrust::device_ptr<HYPRE_Int> ACC_offd_j_dev(ACC_offd_j), CF_array_offd_dev(CF_array_offd);
+      thrust::device_ptr<HYPRE_Int> A_offd_j_dev(A_offd_j);
+      thrust::copy_if( A_offd_j_dev, A_offd_j_dev+A_offd_nnz, CF_array_offd_dev, ACC_offd_j_dev, is_positive<int>() );
+      ACC_offd_a = hypre_CTAlloc( HYPRE_Complex, ACC_offd_nnz, HYPRE_MEMORY_DEVICE);
+      thrust::device_ptr<HYPRE_Complex> A_offd_a_dev(A_offd_a), ACC_offd_a_dev(ACC_offd_a);
+      thrust::copy_if( A_offd_a_dev, A_offd_a_dev+A_offd_nnz, CF_array_offd_dev, ACC_offd_a_dev, is_positive<int>() );
+   }
+   hypre_TFree(ACC_tmp,HYPRE_MEMORY_DEVICE);
+   hypre_TFree(CF_array_offd,HYPRE_MEMORY_DEVICE);
+   // 3. Transform diagonal submatrix column index (F,C) to (C)  
+   HYPRE_Int* fine_to_coarse = hypre_CTAlloc(HYPRE_Int,nrofrows, HYPRE_MEMORY_DEVICE);
+   thrust::device_ptr<HYPRE_Int> fine_to_coarse_dev(fine_to_coarse);
+   thrust::transform( CF_marker_dev, CF_marker_dev+nrofrows, fine_to_coarse_dev, is_positive<int>());
+   thrust::exclusive_scan( fine_to_coarse_dev, fine_to_coarse_dev+nrofrows, fine_to_coarse_dev );
+   if( ACC_diag_nnz > 0 )
+   {
+      gDim   = hypre_GetDefaultCUDAGridDimension( ACC_diag_nnz, "thread",   bDim);
+      hypre_CUDAKernel_TransformColindDiag<<<gDim,bDim>>>( ACC_diag_nnz, fine_to_coarse, ACC_diag_j );
+      cudaDeviceSynchronize();
+   }
+
+   // 4. Transform off-diagonal submatrix column index (F,C) to (C)
+   HYPRE_Int* col_map_A_dev = hypre_ParCSRMatrixDeviceColMapOffd(A);
+   //   HYPRE_Int* col_map_A     = hypre_ParCSRMatrixColMapOffd(A);
+   HYPRE_Int nr_cols_A  = hypre_CSRMatrixNumCols(hypre_ParCSRMatrixOffd(A));
+   HYPRE_Int nr_cols_ACC=0;
+   HYPRE_Int* col_map_ACC=NULL, *col_map_ACC_h=NULL;
+   if( nr_cols_A > 0 )
+   {
+      restrict_colmap_to_cpts( ACC_offd_nnz, ACC_offd_j, nr_cols_A, col_map_A_dev,
+                               &nr_cols_ACC, &col_map_ACC );
+      //      cudaDeviceSynchronize();
+      HYPRE_Int  first_diagonal = hypre_ParCSRMatrixFirstColDiag(A);
+      HYPRE_Int  global_nr_of_rows = hypre_ParCSRMatrixGlobalNumRows(A);
+      col_map_ACC_h = hypre_CTAlloc( HYPRE_Int, nr_cols_ACC, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy( col_map_ACC_h, col_map_ACC, HYPRE_Int, nr_cols_ACC, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+      CoarseToFine_comm( comm, nr_cols_ACC, col_map_ACC_h, fine_to_coarse, first_diagonal, nrofrows,
+                         coarse_row_starts, global_nr_of_rows );
+      hypre_TMemcpy( col_map_ACC, col_map_ACC_h, HYPRE_Int, nr_cols_ACC, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+   }
+   hypre_TFree(fine_to_coarse,HYPRE_MEMORY_DEVICE);
+   // 5. Create ParCSRMatrix structure and return it
+   hypre_ParCSRMatrix* ACC = hypre_ParCSRMatrixCreate(comm, global_num_coarse,
+         global_num_coarse, coarse_row_starts,
+         coarse_row_starts, nr_cols_ACC, ACC_diag_i[nrofcoarserows], ACC_offd_i[nrofcoarserows]);
+
+   hypre_ParCSRMatrixOwnsRowStarts(ACC) = 0;
+
+   hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(ACC)) = ACC_diag_i;
+   if (ACC_diag_i[nrofcoarserows])
+   {
+      hypre_CSRMatrixJ(hypre_ParCSRMatrixDiag(ACC))    = ACC_diag_j;
+      hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(ACC)) = ACC_diag_a;
+   }
+   
+   hypre_CSRMatrixI(hypre_ParCSRMatrixOffd(ACC)) = ACC_offd_i;
+   if (nr_cols_ACC)
+   {
+      if (ACC_offd_i[nrofcoarserows])
+      {
+         hypre_CSRMatrixJ(hypre_ParCSRMatrixOffd(ACC))    = ACC_offd_j;
+         hypre_CSRMatrixData(hypre_ParCSRMatrixOffd(ACC)) = ACC_offd_a;
+      }
+      hypre_ParCSRMatrixColMapOffd(ACC)       = col_map_ACC_h;
+      hypre_ParCSRMatrixDeviceColMapOffd(ACC) = col_map_ACC;
+   }
+   hypre_ParCSRMatrixCommPkg(ACC) = NULL;
+   *ACC_ptr = ACC;
+   return 0;
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_GetCfarray( HYPRE_Int nrofrows, HYPRE_Int nnz,  HYPRE_Int* CF_marker,
+                             HYPRE_Int* A_diag_i, HYPRE_Int* A_diag_j, HYPRE_Int* CF_array )
+{
+   HYPRE_Int i=hypre_cuda_get_grid_thread_id<1,1>();
+   if( i < nrofrows )
+      for( int ind=A_diag_i[i] ; ind < A_diag_i[i+1] ; ind++ )
+         CF_array[ind] = CF_marker[i]>0 && CF_marker[A_diag_j[ind]]>0;
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_GetCfarrayOffd( HYPRE_Int nrofrows, HYPRE_Int nnz,  HYPRE_Int* CF_marker,
+                                  HYPRE_Int* CF_marker_offd, HYPRE_Int* A_offd_i,
+                                  HYPRE_Int* A_offd_j, HYPRE_Int* CF_array )
+{
+   int i=hypre_cuda_get_grid_thread_id<1,1>();
+   if( i < nrofrows )
+      for( int ind=A_offd_i[i] ; ind < A_offd_i[i+1] ; ind++ )
+         CF_array[ind] = CF_marker[i]>0 && CF_marker_offd[A_offd_j[ind]]>0;
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_GetIcarray( HYPRE_Int nrofrows, HYPRE_Int* A_i,
+                             HYPRE_Int* CF_marker, HYPRE_Int* CF_array, HYPRE_Int* ACC_tmp )
+{
+   int i = hypre_cuda_get_grid_warp_id<1,1>();
+   if( i >= nrofrows )
+   {
+      return;
+   }
+   HYPRE_Int lane = hypre_cuda_get_lane_id<1>();
+   HYPRE_Int ib, ie;
+   ACC_tmp[i] = 0;
+   if (lane == 0)
+   {
+      ib = read_only_load(CF_marker + i);
+   }
+   ib = __shfl_sync(HYPRE_WARP_FULL_MASK, ib, 0);
+   if (ib <= 0)
+   {
+      return;
+   }
+   int ncl=0;
+   if (lane < 2)
+   {
+      ib = read_only_load(A_i + i + lane);
+   }
+   ie = __shfl_sync(HYPRE_WARP_FULL_MASK, ib, 1);
+   ib = __shfl_sync(HYPRE_WARP_FULL_MASK, ib, 0);
+   for (HYPRE_Int ind = ib + lane; __any_sync(HYPRE_WARP_FULL_MASK, ind < ie); ind += HYPRE_WARP_SIZE)
+   {
+      if( ind < ie )
+         ncl += CF_array[ind]==1;
+
+   }
+   ncl=warp_reduce_sum(ncl);
+   if( lane == 0 )
+      ACC_tmp[i]= ncl;
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_TransformColindDiag( HYPRE_Int nnz, HYPRE_Int* fine_to_coarse,
+                                       HYPRE_Int* A_diag_j )
+{
+   HYPRE_Int i=hypre_cuda_get_grid_thread_id<1,1>();
+   if( i < nnz )
+      A_diag_j[i] = fine_to_coarse[A_diag_j[i]];
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_MarkCpts( HYPRE_Int P_offd_size, HYPRE_Int *P_offd_j,
+                           HYPRE_Int* fine_to_coarse )
+{
+   HYPRE_Int myid=hypre_cuda_get_grid_thread_id<1,1>();
+   if( myid < P_offd_size )
+         atomicOr(&fine_to_coarse[P_offd_j[myid]],1);
+}
+
+//-----------------------------------------------------------------------
+__global__ void hypre_CUDAKernel_RemapOffd( HYPRE_Int P_offd_size, HYPRE_Int *P_offd_j,
+                            HYPRE_Int* fine_to_coarse )
+{
+   HYPRE_Int myid = hypre_cuda_get_grid_thread_id<1,1>();
+   if( myid < P_offd_size )
+      P_offd_j[myid] = fine_to_coarse[P_offd_j[myid]];
+}
+
+//-----------------------------------------------------------------------
+void restrict_colmap_to_cpts( HYPRE_Int ACC_offd_size, HYPRE_Int* ACC_offd_j,
+                              HYPRE_Int nr_cols_A, HYPRE_Int* col_map_A,
+                              HYPRE_Int* nr_cols_ACC, HYPRE_Int** col_map_ACC )
+{
+   /* Remove F-pts and unused values from column map colmap_P. Re-enumerate P_off_j to the
+      new, compressed, local index space */
+   HYPRE_Int *new_col_map;
+   HYPRE_Int* fine_to_coarse;
+   HYPRE_Int ncpts=0;
+   if( ACC_offd_size > 0 )
+   {
+      dim3 block = hypre_GetDefaultCUDABlockDimension();
+      dim3 grid  = hypre_GetDefaultCUDAGridDimension( ACC_offd_size, "thread",   block);
+      fine_to_coarse = hypre_CTAlloc(HYPRE_Int, nr_cols_A+1, HYPRE_MEMORY_DEVICE);
+      grid   = hypre_GetDefaultCUDAGridDimension( ACC_offd_size, "thread",   block);
+      thrust::device_ptr<HYPRE_Int> fine_to_coarse_dev(fine_to_coarse);
+      thrust::fill(fine_to_coarse_dev,fine_to_coarse_dev+nr_cols_A+1,0);
+      hypre_CUDAKernel_MarkCpts<<<grid,block>>>( ACC_offd_size, ACC_offd_j, fine_to_coarse );
+      ncpts = thrust::reduce(fine_to_coarse_dev,fine_to_coarse_dev+nr_cols_A);   
+
+   /* Construct new column map */
+      new_col_map = hypre_CTAlloc( HYPRE_Int, ncpts, HYPRE_MEMORY_DEVICE );
+      thrust::device_ptr<HYPRE_Int> new_col_map_dev(new_col_map), col_map_A_dev(col_map_A);
+      thrust::copy_if( col_map_A_dev, col_map_A_dev+nr_cols_A, fine_to_coarse_dev,
+                    new_col_map_dev, is_positive<int>() );
+
+   /* Map A_offd_j to new local indices */
+      thrust::exclusive_scan( fine_to_coarse_dev, &fine_to_coarse_dev[nr_cols_A+1], fine_to_coarse_dev );
+      hypre_CUDAKernel_RemapOffd<<<grid,block>>>( ACC_offd_size, ACC_offd_j, fine_to_coarse );
+      cudaDeviceSynchronize();
+   /* Give back memory and return result */ 
+      //      hypre_TFree(*col_map_P,HYPRE_MEMORY_SHARED);
+      hypre_TFree(fine_to_coarse,HYPRE_MEMORY_DEVICE);
+      *nr_cols_ACC = ncpts;
+      *col_map_ACC = new_col_map;
+   }
+}
+
+
+/*-----------------------------------------------------------------------*/
+int getSendInfo( HYPRE_Int nr_cols_P, HYPRE_Int* col_map_P, 
+                 HYPRE_Int* num_cpts, HYPRE_Int num_proc,
+                 HYPRE_Int global_nr_of_rows,
+                 HYPRE_Int** nrec, HYPRE_Int** recprocs )
+{
+   /* Collect information about owners of coarse points */
+   /* Input: nr_cols_P - size of col_map_P              */
+   /*        col_map_P - Global index of columns of P in the total array enumeration 0..n-1 */
+   /*        nr_of_rows - Number of rows in proc               */
+   /*        num_cpts - first fine grid point index for each processor */
+   /*        num_proc - Number of  processors */
+   /* Output: nrec - nrec[p] is the number of elements to receive from processor p */
+   /*         recprocs - recprocs[i] is the processor id of the value of element i of col_map_P */
+
+   HYPRE_Int i, toolow, toohigh, fail, proc;
+   fail = 0;
+   for( i=0 ; i < nr_cols_P ; i++ )
+   {
+      /* Initial guess */
+      toolow=toohigh=0;
+      proc = (HYPRE_Int)trunc(((HYPRE_Real)col_map_P[i]/global_nr_of_rows)*num_proc);
+      if( num_cpts[proc] <= col_map_P[i] )
+      {
+         if( col_map_P[i] < num_cpts[proc+1] )
+         {
+            (*nrec)[proc]++;
+            (*recprocs)[i]=proc;
+         }
+         else
+            toolow=1;
+      }
+      else
+         toohigh = 1;
+      /* Adjust if guess not correct */
+      if( toohigh )
+      {
+         while( proc >= 0 && (num_cpts[proc] > col_map_P[i]) )
+            proc--;
+         if( proc < 0 )
+            fail = 1;
+         else
+         {
+            (*nrec)[proc]++;
+            (*recprocs)[i]=proc;
+         }
+      }
+      if( toolow )
+      {
+         while( (proc <= num_proc) && num_cpts[proc] < col_map_P[i] )
+            proc++;
+         if( proc > num_proc )
+            fail = 2;
+         else
+         {
+            (*nrec)[proc]++;
+            (*recprocs)[i]=proc;
+         }
+      }
+   }
+   return fail;
+}
+
+/*-----------------------------------------------------------------------*/
+void CoarseToFine_comm( MPI_Comm comm, HYPRE_Int nr_cols_P, HYPRE_Int* col_map_P,
+                        HYPRE_Int* fine_to_coarse, HYPRE_Int first_diagonal,
+                        HYPRE_Int nr_of_rows, HYPRE_Int* num_cpts, HYPRE_Int global_nr_of_rows )
+{
+   /* Translate the indices of the column map col_map_P to a coarse point enumeration */
+   /* It is assumed that col_map_P holds indices in the range 0..n-1, where n is the gobal number */
+   /* of columns. Furthermore, nc of the n colums correspond to coarse point indices.  */
+   /* The elements in col_map_P are assumed to be coarse point indices. This routine transforms */
+   /* them from the 0..n-1 enumeration to a 0..nc-1 enumeration */
+
+   HYPRE_Int** buf, **sbuf;
+   HYPRE_Int* el, *nrec, *nsend, *recprocs;
+   HYPRE_Int num_proc, p, i, fail, tag, tag2, tag3;
+   hypre_MPI_Request* req, *req2, *req3;
+   hypre_MPI_Status status;
+   HYPRE_Int* first_fine_pr, *fine_to_coarse_h;
+   HYPRE_Int first_coarse, myid;
+   
+   hypre_MPI_Comm_size(comm, &num_proc);
+   hypre_MPI_Comm_rank(comm, &myid);
+   fine_to_coarse_h = hypre_CTAlloc(HYPRE_Int, nr_of_rows, HYPRE_MEMORY_HOST ); 
+   hypre_TMemcpy( fine_to_coarse_h, fine_to_coarse, HYPRE_Int, nr_of_rows, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+   nrec     = hypre_CTAlloc(HYPRE_Int, num_proc, HYPRE_MEMORY_HOST ); /* receive this number of elements from proc p */
+   recprocs = hypre_CTAlloc(HYPRE_Int, nr_cols_P, HYPRE_MEMORY_HOST );
+   nsend    = hypre_CTAlloc(HYPRE_Int, num_proc, HYPRE_MEMORY_HOST ); /* send this number of elements to proc p      */
+   el       = hypre_CTAlloc(HYPRE_Int, num_proc, HYPRE_MEMORY_HOST );
+
+   first_fine_pr = hypre_CTAlloc(HYPRE_Int, num_proc+1, HYPRE_MEMORY_HOST );
+   hypre_MPI_Allgather( &first_diagonal, 1, HYPRE_MPI_INT, first_fine_pr, 1, HYPRE_MPI_INT, comm ); 
+   first_fine_pr[num_proc]=global_nr_of_rows;
+
+   fail = getSendInfo( nr_cols_P, col_map_P, first_fine_pr, num_proc, global_nr_of_rows, &nrec, &recprocs );
+   hypre_TFree(first_fine_pr,HYPRE_MEMORY_HOST);
+
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+   first_coarse = num_cpts[0];
+#else
+   first_coarse = num_cpts[myid];
+#endif
+   if( fail == 0 )
+   {
+      req   = hypre_CTAlloc(hypre_MPI_Request,num_proc,HYPRE_MEMORY_HOST);
+      req2  = hypre_CTAlloc(hypre_MPI_Request,num_proc,HYPRE_MEMORY_HOST);
+      req3  = hypre_CTAlloc(hypre_MPI_Request,num_proc,HYPRE_MEMORY_HOST);
+
+      tag = 305;
+      tag2= 306;
+      tag3= 307;
+      
+      /* Receive wanted number of elements */
+      for( p=0 ; p < num_proc ; p++ )
+         hypre_MPI_Irecv( &nsend[p], 1, HYPRE_MPI_INT, p, tag, comm, &req[p] );
+
+      buf  = hypre_CTAlloc( HYPRE_Int*, num_proc, HYPRE_MEMORY_HOST);
+      sbuf = hypre_CTAlloc( HYPRE_Int*, num_proc, HYPRE_MEMORY_HOST);
+
+      /* Send wanted number of elements */
+      for( p=0 ; p < num_proc ; p++ )
+      {
+         hypre_MPI_Isend(&nrec[p], 1, HYPRE_MPI_INT,  p, tag, comm, &req2[p] );   
+         el[p]  = 0;
+         buf[p] = hypre_CTAlloc( HYPRE_Int, nrec[p], HYPRE_MEMORY_HOST);
+      }
+      /* Pack the indices for which transformation is wanted */
+      for( i=0 ; i < nr_cols_P ; i++ )
+      {
+         p=recprocs[i];
+         buf[p][el[p]++] = col_map_P[i];
+      }
+      /* finish size receive, and post receive for the data */
+      for( p=0 ; p < num_proc ; p++ )
+      {
+         hypre_MPI_Wait( &req[p], &status );
+         sbuf[p] = hypre_CTAlloc(HYPRE_Int, nsend[p], HYPRE_MEMORY_HOST );
+         hypre_MPI_Irecv( sbuf[p], nsend[p], HYPRE_MPI_INT, p, tag2, comm, &req[p] );
+      }
+      /* Send the packed indices */
+      for( p=0 ; p < num_proc ; p++ )
+         hypre_MPI_Isend( buf[p], nrec[p], HYPRE_MPI_INT, p, tag2, comm, &req2[p] );
+
+      //      /* Post receive for last send */
+      //      for( p=0 ; p < num_proc ; p++ )
+      //         hypre_MPI_Irecv( buf[p], nrec[p], HYPRE_MPI_INT, p, tag3, comm, &req3[p] );
+
+      /* Transform indices and send them back to their destinations */
+      for( p=0 ; p < num_proc ; p++ )
+      {
+         hypre_MPI_Wait( &req[p], &status );
+         for( i=0 ; i < nsend[p]; i++ )
+            sbuf[p][i] = fine_to_coarse_h[sbuf[p][i]-first_diagonal]+first_coarse;
+         hypre_MPI_Isend( sbuf[p], nsend[p], HYPRE_MPI_INT, p, tag3, comm, &req2[p] );
+      }
+      /* Post receive for last send */
+      for( p=0 ; p < num_proc ; p++ )
+         hypre_MPI_Irecv( buf[p], nrec[p], HYPRE_MPI_INT, p, tag3, comm, &req3[p] );
+
+      /* Wait for last irecv */
+      for( p=0 ; p < num_proc ; p++ )
+      {
+         hypre_MPI_Wait( &req3[p], &status );
+         el[p] = 0;
+      }
+      /* store the transformed indices */
+      for( i=0 ; i < nr_cols_P ; i++ )
+         col_map_P[i] = buf[recprocs[i]][el[recprocs[i]]++];
+
+      hypre_TFree(req,  HYPRE_MEMORY_HOST);
+      hypre_TFree(req2, HYPRE_MEMORY_HOST);
+      hypre_TFree(req3, HYPRE_MEMORY_HOST);
+      for( p=0 ; p < num_proc ; p++ )
+      {
+         hypre_TFree( buf[p], HYPRE_MEMORY_HOST);
+         hypre_TFree(sbuf[p], HYPRE_MEMORY_HOST);
+      }
+      hypre_TFree( buf, HYPRE_MEMORY_HOST);
+      hypre_TFree(sbuf, HYPRE_MEMORY_HOST);
+   }
+   else
+      printf("ERROR: fail = %d in CoarseToFine, proc %d \n",fail,myid);
+   hypre_TFree(fine_to_coarse_h, HYPRE_MEMORY_HOST);
+   hypre_TFree(nrec,    HYPRE_MEMORY_HOST);
+   hypre_TFree(nsend,   HYPRE_MEMORY_HOST);
+   hypre_TFree(recprocs,HYPRE_MEMORY_HOST);
+   hypre_TFree(el,      HYPRE_MEMORY_HOST);
+}
+
+//-----------------------------------------------------------------------
+void getcfmoffd( hypre_ParCSRMatrix* A, HYPRE_Int* CF_marker, HYPRE_Int** CF_marker_offd )
+{
+   hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
+   hypre_ParCSRCommHandle  *comm_handle;
+   HYPRE_Int index, num_sends, *int_buf_data, i, j, start;
+   HYPRE_Int num_cols_A_offd = hypre_CSRMatrixNumCols(hypre_ParCSRMatrixOffd(A));
+   
+   if (num_cols_A_offd > 0) 
+      *CF_marker_offd = hypre_CTAlloc(HYPRE_Int,  num_cols_A_offd, HYPRE_MEMORY_DEVICE);
+   else
+   {
+      *CF_marker_offd = NULL;
+      return;
+   }
+   if (!comm_pkg)
+   {
+	hypre_MatvecCommPkgCreate(A);
+	comm_pkg = hypre_ParCSRMatrixCommPkg(A); 
+   }
+   num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+   int_buf_data = hypre_CTAlloc(HYPRE_Int, hypre_ParCSRCommPkgSendMapStart(comm_pkg, 
+						num_sends), HYPRE_MEMORY_HOST);
+   index = 0;
+   for (i = 0; i < num_sends; i++)
+   {
+	start = hypre_ParCSRCommPkgSendMapStart(comm_pkg, i);
+	for (j = start; j < hypre_ParCSRCommPkgSendMapStart(comm_pkg, i+1); j++)
+		int_buf_data[index++] 
+		 = CF_marker[hypre_ParCSRCommPkgSendMapElmt(comm_pkg,j)];
+   }
+   comm_handle = hypre_ParCSRCommHandleCreate( 11, comm_pkg, int_buf_data, 
+	*CF_marker_offd);
+   hypre_ParCSRCommHandleDestroy(comm_handle);   
+   hypre_TFree(int_buf_data,HYPRE_MEMORY_HOST);
+}
+
+#endif /* #if defined(HYPRE_USING_CUDA) */

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -1086,7 +1086,11 @@ HYPRE_Int hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix *A, HYPRE_Int *C
 HYPRE_Int hypre_BoomerAMGBuildModExtPEInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker, hypre_ParCSRMatrix *S, HYPRE_BigInt *num_cpts_global, HYPRE_Int debug_flag, HYPRE_Real trunc_factor, HYPRE_Int max_elmts, HYPRE_Int *col_offd_S_to_A, hypre_ParCSRMatrix **P_ptr);
 
 /* par_2s_interp.c */
+HYPRE_Int hypre_BoomerAMGBuildModPartialExtInterpHost ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
+HYPRE_Int hypre_BoomerAMGBuildModPartialExtInterpDevice ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
 HYPRE_Int hypre_BoomerAMGBuildModPartialExtInterp ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
+HYPRE_Int hypre_BoomerAMGBuildModPartialExtPEInterpHost ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
+HYPRE_Int hypre_BoomerAMGBuildModPartialExtPEInterpDevice ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
 HYPRE_Int hypre_BoomerAMGBuildModPartialExtPEInterp ( hypre_ParCSRMatrix *A , HYPRE_Int *CF_marker , hypre_ParCSRMatrix *S , HYPRE_BigInt *num_cpts_global , HYPRE_BigInt *num_old_cpts_global , HYPRE_Int debug_flag , HYPRE_Real trunc_factor , HYPRE_Int max_elmts , HYPRE_Int *col_offd_S_to_A , hypre_ParCSRMatrix **P_ptr );
 
 /* par_multi_interp.c */

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -1175,6 +1175,8 @@ HYPRE_Int hypre_BoomerAMGCreate2ndS ( hypre_ParCSRMatrix *S , HYPRE_Int *CF_mark
 HYPRE_Int hypre_BoomerAMGCorrectCFMarker ( HYPRE_Int *CF_marker , HYPRE_Int num_var , HYPRE_Int *new_CF_marker );
 HYPRE_Int hypre_BoomerAMGCorrectCFMarker2 ( HYPRE_Int *CF_marker , HYPRE_Int num_var , HYPRE_Int *new_CF_marker );
 HYPRE_Int hypre_BoomerAMGCreateSDevice(hypre_ParCSRMatrix *A, HYPRE_Real strength_threshold, HYPRE_Real max_row_sum, HYPRE_Int num_functions, HYPRE_Int *dof_func, hypre_ParCSRMatrix **S_ptr);
+HYPRE_Int hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix *S, HYPRE_Int *CF_marker, HYPRE_Int num_paths, HYPRE_BigInt *coarse_row_starts, hypre_ParCSRMatrix **C_ptr);
+
 
 /* par_sv_interp.c */
 HYPRE_Int hypre_BoomerAMGSmoothInterpVectors ( hypre_ParCSRMatrix *A , HYPRE_Int num_smooth_vecs , hypre_ParVector **smooth_vecs , HYPRE_Int smooth_steps );

--- a/src/parcsr_mv/Makefile
+++ b/src/parcsr_mv/Makefile
@@ -52,6 +52,7 @@ FILES =\
 
 CUFILES =\
  par_csr_matvec.c\
+ par_csr_fffc_device.c\
  par_csr_matop_device.c\
  par_csr_triplemat_device.c
 

--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -712,6 +712,9 @@ HYPRE_Int hypre_ParCSRMatrixGenerateFFFC(hypre_ParCSRMatrix *A, HYPRE_Int *CF_ma
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFC3(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFCD3(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr , HYPRE_Real **D_lambda_ptr ) ;
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFC3Device(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
+HYPRE_Int hypre_ParCSRMatrixGenerateCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host, HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACF_ptr) ;
+HYPRE_Int hypre_ParCSRMatrixGenerateCCDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host, HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACC_ptr) ;
+HYPRE_Int hypre_ParCSRMatrixGenerate1DCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host, HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACX_ptr, hypre_ParCSRMatrix **AXC_ptr ) ;
 
 /* new_commpkg.c */
 HYPRE_Int hypre_PrintCommpkg ( hypre_ParCSRMatrix *A , const char *file_name );
@@ -821,6 +824,7 @@ hypre_CSRMatrix* hypre_ConcatDiagAndOffdDevice(hypre_ParCSRMatrix *A);
 HYPRE_Int hypre_ConcatDiagOffdAndExtDevice(hypre_ParCSRMatrix *A, hypre_CSRMatrix *E, hypre_CSRMatrix **B_ptr, HYPRE_Int *num_cols_offd_ptr, HYPRE_BigInt **cols_map_offd_ptr);
 HYPRE_Int hypre_ParCSRMatrixGetRowDevice( hypre_ParCSRMatrix *mat, HYPRE_BigInt row, HYPRE_Int *size, HYPRE_BigInt **col_ind, HYPRE_Complex **values );
 HYPRE_Int hypre_ParCSRDiagScale( HYPRE_ParCSRMatrix HA, HYPRE_ParVector Hy, HYPRE_ParVector Hx );
+HYPRE_Int hypre_ParCSRMatrixDropSmallEntriesDevice( hypre_ParCSRMatrix *A, HYPRE_Complex tol, HYPRE_Int abs, HYPRE_Int option);
 
 #ifdef HYPRE_USING_PERSISTENT_COMM
 hypre_ParCSRPersistentCommHandle* hypre_ParCSRPersistentCommHandleCreate(HYPRE_Int job, hypre_ParCSRCommPkg *comm_pkg);

--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -711,6 +711,7 @@ HYPRE_Int HYPRE_ParVectorGetValues ( HYPRE_ParVector vector, HYPRE_Int num_value
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFC(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFC3(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFCD3(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr , HYPRE_Real **D_lambda_ptr ) ;
+HYPRE_Int hypre_ParCSRMatrixGenerateFFFC3Device(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
 
 /* new_commpkg.c */
 HYPRE_Int hypre_PrintCommpkg ( hypre_ParCSRMatrix *A , const char *file_name );

--- a/src/parcsr_mv/gen_fffc.c
+++ b/src/parcsr_mv/gen_fffc.c
@@ -503,12 +503,12 @@ hypre_ParCSRMatrixGenerateFFFC( hypre_ParCSRMatrix  *A,
  * ----------------------------------------------------------------------------- */
 
 HYPRE_Int
-hypre_ParCSRMatrixGenerateFFFC3( hypre_ParCSRMatrix *A,
-                                HYPRE_Int           *CF_marker,
-                                HYPRE_BigInt        *cpts_starts,
-                                hypre_ParCSRMatrix  *S,
-                                hypre_ParCSRMatrix **A_FC_ptr,
-                                hypre_ParCSRMatrix **A_FF_ptr)
+hypre_ParCSRMatrixGenerateFFFC3( hypre_ParCSRMatrix  *A,
+                                 HYPRE_Int           *CF_marker,
+                                 HYPRE_BigInt        *cpts_starts,
+                                 hypre_ParCSRMatrix  *S,
+                                 hypre_ParCSRMatrix **A_FC_ptr,
+                                 hypre_ParCSRMatrix **A_FF_ptr)
 {
    MPI_Comm                 comm     = hypre_ParCSRMatrixComm(A);
    HYPRE_MemoryLocation memory_location_P = hypre_ParCSRMatrixMemoryLocation(A);
@@ -1054,12 +1054,12 @@ hypre_ParCSRMatrixGenerateFFFC3( hypre_ParCSRMatrix *A,
 
 HYPRE_Int
 hypre_ParCSRMatrixGenerateFFFCD3( hypre_ParCSRMatrix *A,
-                                HYPRE_Int           *CF_marker,
-                                HYPRE_BigInt        *cpts_starts,
-                                hypre_ParCSRMatrix  *S,
-                                hypre_ParCSRMatrix **A_FC_ptr,
-                                hypre_ParCSRMatrix **A_FF_ptr,
-                                HYPRE_Real         **D_lambda_ptr)
+                                  HYPRE_Int           *CF_marker,
+                                  HYPRE_BigInt        *cpts_starts,
+                                  hypre_ParCSRMatrix  *S,
+                                  hypre_ParCSRMatrix **A_FC_ptr,
+                                  hypre_ParCSRMatrix **A_FF_ptr,
+                                  HYPRE_Real         **D_lambda_ptr)
 {
    MPI_Comm                 comm     = hypre_ParCSRMatrixComm(A);
    HYPRE_MemoryLocation memory_location_P = hypre_ParCSRMatrixMemoryLocation(A);

--- a/src/parcsr_mv/par_csr_fffc_device.c
+++ b/src/parcsr_mv/par_csr_fffc_device.c
@@ -1,0 +1,1445 @@
+/******************************************************************************
+ * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+
+#include "_hypre_utilities.h"
+#include "_hypre_parcsr_mv.h"
+#include "_hypre_utilities.hpp"
+
+#if defined(HYPRE_USING_CUDA)
+
+typedef thrust::tuple<HYPRE_Int, HYPRE_Int> Tuple;
+//typedef thrust::tuple<HYPRE_Int, HYPRE_Int, HYPRe_Int> Tuple3;
+
+/* transform from local F/C index to global F/C index,
+ * where F index "x" are saved as "-x-1"
+ */
+struct FFFC_functor : public thrust::unary_function<Tuple, HYPRE_BigInt>
+{
+   HYPRE_BigInt CF_first[2];
+
+   FFFC_functor(HYPRE_BigInt F_first_, HYPRE_BigInt C_first_)
+   {
+      CF_first[1] = F_first_;
+      CF_first[0] = C_first_;
+   }
+
+   __host__ __device__
+   HYPRE_BigInt operator()(const Tuple& t) const
+   {
+      const HYPRE_Int local_idx = thrust::get<0>(t);
+      const HYPRE_Int cf_marker = thrust::get<1>(t);
+      const HYPRE_Int s = cf_marker < 0;
+      const HYPRE_Int m = 1 - 2*s;
+      return m*(local_idx + CF_first[s] + s);
+   }
+};
+
+/* this predicate selects A^s_{FF} */
+template<typename T>
+struct FF_pred : public thrust::unary_function<Tuple, bool>
+{
+   HYPRE_Int  option;
+   HYPRE_Int *row_CF_marker;
+   T         *col_CF_marker;
+
+   FF_pred(HYPRE_Int option_, HYPRE_Int *row_CF_marker_, T *col_CF_marker_)
+   {
+      option = option_;
+      row_CF_marker = row_CF_marker_;
+      col_CF_marker = col_CF_marker_;
+   }
+
+   __host__ __device__
+   bool operator()(const Tuple& t) const
+   {
+      const HYPRE_Int i = thrust::get<0>(t);
+      const HYPRE_Int j = thrust::get<1>(t);
+
+      if (option == 1)
+      {
+         /* A_{F,F} */
+         return row_CF_marker[i] <   0 && (j == -2 || j >= 0 && col_CF_marker[j] < 0);
+      }
+      else
+      {
+         /* A_{F2, F} */
+         return row_CF_marker[i] == -2 && (j == -2 || j >= 0 && col_CF_marker[j] < 0);
+      }
+   }
+};
+
+/* this predicate selects A^s_{FC} */
+template<typename T>
+struct FC_pred : public thrust::unary_function<Tuple, bool>
+{
+   HYPRE_Int *row_CF_marker;
+   T         *col_CF_marker;
+
+   FC_pred(HYPRE_Int *row_CF_marker_, T *col_CF_marker_)
+   {
+      row_CF_marker = row_CF_marker_;
+      col_CF_marker = col_CF_marker_;
+   }
+
+   __host__ __device__
+   bool operator()(const Tuple& t) const
+   {
+      const HYPRE_Int i = thrust::get<0>(t);
+      const HYPRE_Int j = thrust::get<1>(t);
+
+      return row_CF_marker[i] < 0 && (j >= 0 && col_CF_marker[j] >= 0);
+   }
+};
+
+/* this predicate selects A^s_{CF} */
+template<typename T>
+struct CF_pred : public thrust::unary_function<Tuple, bool>
+{
+   HYPRE_Int *row_CF_marker;
+   T         *col_CF_marker;
+
+   CF_pred(HYPRE_Int *row_CF_marker_, T *col_CF_marker_)
+   {
+      row_CF_marker = row_CF_marker_;
+      col_CF_marker = col_CF_marker_;
+   }
+
+   __host__ __device__
+   bool operator()(const Tuple& t) const
+   {
+      const HYPRE_Int i = thrust::get<0>(t);
+      const HYPRE_Int j = thrust::get<1>(t);
+
+      return row_CF_marker[i] >= 0 && (j >= 0 && col_CF_marker[j] < 0);
+   }
+};
+
+/* this predicate selects A^s_{CC} */
+template<typename T>
+struct CC_pred : public thrust::unary_function<Tuple, bool>
+{
+   HYPRE_Int *row_CF_marker;
+   T         *col_CF_marker;
+
+   CC_pred(HYPRE_Int *row_CF_marker_, T *col_CF_marker_)
+   {
+      row_CF_marker = row_CF_marker_;
+      col_CF_marker = col_CF_marker_;
+   }
+
+   __host__ __device__
+   bool operator()(const Tuple& t) const
+   {
+      const HYPRE_Int i = thrust::get<0>(t);
+      const HYPRE_Int j = thrust::get<1>(t);
+
+      return row_CF_marker[i] >= 0 && (j == -2 || j >= 0 && col_CF_marker[j] >= 0);
+   }
+};
+
+/* this predicate selects A^s_{C,:} */
+struct CX_pred : public thrust::unary_function<Tuple, bool>
+{
+   HYPRE_Int *row_CF_marker;
+
+   CX_pred(HYPRE_Int *row_CF_marker_)
+   {
+      row_CF_marker = row_CF_marker_;
+   }
+
+   __host__ __device__
+   bool operator()(const Tuple& t) const
+   {
+      const HYPRE_Int i = thrust::get<0>(t);
+      const HYPRE_Int j = thrust::get<1>(t);
+
+      return row_CF_marker[i] >= 0 && (j == -2 || j >= 0);
+   }
+};
+
+/* this predicate selects A^s_{:,C} */
+template<typename T>
+struct XC_pred : public thrust::unary_function<Tuple, bool>
+{
+   T         *col_CF_marker;
+
+   XC_pred(T *col_CF_marker_)
+   {
+      col_CF_marker = col_CF_marker_;
+   }
+
+   __host__ __device__
+   bool operator()(const Tuple& t) const
+   {
+      const HYPRE_Int i = thrust::get<0>(t);
+      const HYPRE_Int j = thrust::get<1>(t);
+
+      return (j == -2 && col_CF_marker[i] >= 0) || (j >= 0 && col_CF_marker[j] >= 0);
+   }
+};
+
+/* Option = 1:
+ *    F is marked as -1, C is +1
+ *    | AFF AFC |
+ *    | ACF ACC |
+ *
+ * Option = 2 (for aggressive coarsening):
+ *    F_2 is marked as -2 in CF_marker, F_1 as -1, and C_2 as +1
+ *    | AF1F1 AF1F2 AF1C2 |
+ *    | AF2F1 AF2F2 AF2C2 |
+ *    | AC2F1 AC2F2 AC2C2 |
+ *    F = F1 + F2
+ *    AFC: A_{F, C2}
+ *    AFF: A_{F2, F}
+ *    ACF: A_{C2, F}
+ *    ACC: A_{C2, C2}
+ */
+
+HYPRE_Int
+hypre_ParCSRMatrixGenerateFFFCDevice_core( hypre_ParCSRMatrix  *A,
+                                           HYPRE_Int           *CF_marker_host,
+                                           HYPRE_BigInt        *cpts_starts,
+                                           hypre_ParCSRMatrix  *S,
+                                           hypre_ParCSRMatrix **AFC_ptr,
+                                           hypre_ParCSRMatrix **AFF_ptr,
+                                           hypre_ParCSRMatrix **ACF_ptr,
+                                           hypre_ParCSRMatrix **ACC_ptr,
+                                           HYPRE_Int            option )
+{
+   MPI_Comm                 comm     = hypre_ParCSRMatrixComm(A);
+   hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
+   hypre_ParCSRCommHandle  *comm_handle;
+   HYPRE_Int                num_sends     = hypre_ParCSRCommPkgNumSends(comm_pkg);
+   HYPRE_Int                num_elem_send = hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends);
+   //HYPRE_MemoryLocation     memory_location = hypre_ParCSRMatrixMemoryLocation(A);
+   /* diag part of A */
+   hypre_CSRMatrix    *A_diag   = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Complex      *A_diag_a = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int          *A_diag_i = hypre_CSRMatrixI(A_diag);
+   HYPRE_Int          *A_diag_j = hypre_CSRMatrixJ(A_diag);
+   HYPRE_Int           A_diag_nnz = hypre_CSRMatrixNumNonzeros(A_diag);
+   /* offd part of A */
+   hypre_CSRMatrix    *A_offd   = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Complex      *A_offd_a = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int          *A_offd_i = hypre_CSRMatrixI(A_offd);
+   HYPRE_Int          *A_offd_j = hypre_CSRMatrixJ(A_offd);
+   HYPRE_Int           A_offd_nnz = hypre_CSRMatrixNumNonzeros(A_offd);
+   HYPRE_Int           num_cols_A_offd = hypre_CSRMatrixNumCols(A_offd);
+   /* SoC */
+   HYPRE_Int          *Soc_diag_j = S ? hypre_ParCSRMatrixSocDiagJ(S) : A_diag_j;
+   HYPRE_Int          *Soc_offd_j = S ? hypre_ParCSRMatrixSocOffdJ(S) : A_offd_j;
+   /* MPI size and rank */
+   HYPRE_Int           my_id, num_procs;
+   /* nF and nC */
+   HYPRE_Int           n_local, nF_local, nC_local, nF2_local = 0;
+   HYPRE_BigInt       *fpts_starts, *row_starts, *f2pts_starts = NULL;
+   HYPRE_BigInt        nF_global, nC_global, nF2_global = 0;
+   HYPRE_BigInt        F_first, C_first;
+   HYPRE_Int          *CF_marker;
+   /* work arrays */
+   HYPRE_Int          *map2FC, *map2F2 = NULL, *itmp, *A_diag_ii, *A_offd_ii, *offd_mark;
+   HYPRE_BigInt       *send_buf, *recv_buf;
+
+   hypre_MPI_Comm_size(comm, &num_procs);
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+   n_local    = hypre_ParCSRMatrixNumRows(A);
+   row_starts = hypre_ParCSRMatrixRowStarts(A);
+
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+   if (my_id == (num_procs -1))
+   {
+      nC_global = cpts_starts[1];
+   }
+   hypre_MPI_Bcast(&nC_global, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+   nC_local = (HYPRE_Int) (cpts_starts[1] - cpts_starts[0]);
+   fpts_starts = hypre_TAlloc(HYPRE_BigInt, 2, HYPRE_MEMORY_HOST);
+   fpts_starts[0] = row_starts[0] - cpts_starts[0];
+   fpts_starts[1] = row_starts[1] - cpts_starts[1];
+   F_first = fpts_starts[0];
+   C_first = cpts_starts[0];
+#else
+   nC_global = cpts_starts[num_procs];
+   nC_local = (HYPRE_Int)(cpts_starts[my_id+1] - cpts_starts[my_id]);
+   fpts_starts = hypre_TAlloc(HYPRE_BigInt, num_procs+1, HYPRE_MEMORY_HOST);
+   for (i = 0; i <= num_procs; i++)
+   {
+      fpts_starts[i] = row_starts[i] - cpts_starts[i];
+   }
+   F_first = fpts_starts[myid];
+   C_first = cpts_starts[myid];
+#endif
+   nF_local = n_local - nC_local;
+   nF_global = hypre_ParCSRMatrixGlobalNumRows(A) - nC_global;
+
+   CF_marker  = hypre_TAlloc(HYPRE_Int,    n_local,         HYPRE_MEMORY_DEVICE);
+   map2FC     = hypre_TAlloc(HYPRE_Int,    n_local,         HYPRE_MEMORY_DEVICE);
+   itmp       = hypre_TAlloc(HYPRE_Int,    n_local,         HYPRE_MEMORY_DEVICE);
+   recv_buf   = hypre_TAlloc(HYPRE_BigInt, num_cols_A_offd, HYPRE_MEMORY_DEVICE);
+
+   hypre_TMemcpy(CF_marker, CF_marker_host, HYPRE_Int, n_local, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+
+   if (option == 2)
+   {
+      nF2_local = HYPRE_THRUST_CALL( count,
+                                     CF_marker,
+                                     CF_marker + n_local,
+                                     -2 );
+
+      HYPRE_BigInt nF2_local_big = nF2_local;
+
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+      f2pts_starts = hypre_TAlloc(HYPRE_BigInt, 2, HYPRE_MEMORY_HOST);
+      hypre_MPI_Scan(&nF2_local_big, f2pts_starts + 1, 1, HYPRE_MPI_BIG_INT, hypre_MPI_SUM, comm);
+      f2pts_starts[0] = f2pts_starts[1] - nF2_local_big;
+      if (my_id == (num_procs -1))
+      {
+         nF2_global = f2pts_starts[1];
+      }
+      hypre_MPI_Bcast(&nF2_global, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+#else
+      f2pts_starts = hypre_TAlloc(HYPRE_BigInt, num_procs + 1, HYPRE_MEMORY_HOST);
+      hypre_MPI_Allgather(&nF2_local_big, 1, HYPRE_MPI_BIG_INT, f2pts_starts + 1, 1, HYPRE_MPI_BIG_INT, comm);
+      f2pts_starts[0] = 0;
+      for (i = 2; i < num_procs + 1; i++)
+      {
+         f2pts_starts[i] += f2pts_starts[i-1];
+      }
+      nF2_global = f2pts_starts[num_procs];
+#endif
+   }
+
+   /* map from all points (i.e, F+C) to F/C indices */
+   HYPRE_THRUST_CALL( exclusive_scan,
+                      thrust::make_transform_iterator(CF_marker,           is_negative<HYPRE_Int>()),
+                      thrust::make_transform_iterator(CF_marker + n_local, is_negative<HYPRE_Int>()),
+                      map2FC ); /* F */
+
+   HYPRE_THRUST_CALL( exclusive_scan,
+                      thrust::make_transform_iterator(CF_marker,           is_nonnegative<HYPRE_Int>()),
+                      thrust::make_transform_iterator(CF_marker + n_local, is_nonnegative<HYPRE_Int>()),
+                      itmp ); /* C */
+
+   HYPRE_THRUST_CALL( scatter_if,
+                      itmp,
+                      itmp + n_local,
+                      thrust::counting_iterator<HYPRE_Int>(0),
+                      thrust::make_transform_iterator(CF_marker, is_nonnegative<HYPRE_Int>()),
+                      map2FC ); /* FC combined */
+
+   hypre_TFree(itmp, HYPRE_MEMORY_DEVICE);
+
+   if (option == 2)
+   {
+      map2F2 = hypre_TAlloc(HYPRE_Int, n_local, HYPRE_MEMORY_DEVICE);
+      HYPRE_THRUST_CALL( exclusive_scan,
+                         thrust::make_transform_iterator(CF_marker,           equal<HYPRE_Int>(-2)),
+                         thrust::make_transform_iterator(CF_marker + n_local, equal<HYPRE_Int>(-2)),
+                         map2F2 ); /* F2 */
+   }
+
+   /* send_buf: global F/C indices. Note F-pts "x" are saved as "-x-1" */
+   send_buf = hypre_TAlloc(HYPRE_BigInt, num_elem_send, HYPRE_MEMORY_DEVICE);
+
+   hypre_ParCSRCommPkgCopySendMapElmtsToDevice(comm_pkg);
+
+   FFFC_functor functor(F_first, C_first);
+   HYPRE_THRUST_CALL( gather,
+                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg),
+                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg) + num_elem_send,
+                      thrust::make_transform_iterator(thrust::make_zip_iterator(thrust::make_tuple(map2FC, CF_marker)), functor),
+                      send_buf );
+
+   comm_handle = hypre_ParCSRCommHandleCreate_v2(21, comm_pkg, HYPRE_MEMORY_DEVICE, send_buf, HYPRE_MEMORY_DEVICE, recv_buf);
+   hypre_ParCSRCommHandleDestroy(comm_handle);
+
+   hypre_TFree(send_buf, HYPRE_MEMORY_DEVICE);
+
+   thrust::zip_iterator< thrust::tuple<HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*> > new_end;
+
+   A_diag_ii = hypre_TAlloc(HYPRE_Int, A_diag_nnz,      HYPRE_MEMORY_DEVICE);
+   A_offd_ii = hypre_TAlloc(HYPRE_Int, A_offd_nnz,      HYPRE_MEMORY_DEVICE);
+   offd_mark = hypre_TAlloc(HYPRE_Int, num_cols_A_offd, HYPRE_MEMORY_DEVICE);
+
+   hypreDevice_CsrRowPtrsToIndices_v2(n_local, A_diag_nnz, A_diag_i, A_diag_ii);
+   hypreDevice_CsrRowPtrsToIndices_v2(n_local, A_offd_nnz, A_offd_i, A_offd_ii);
+
+   if (AFF_ptr)
+   {
+      HYPRE_Int           AFF_diag_nnz, AFF_offd_nnz;
+      HYPRE_Int          *AFF_diag_ii, *AFF_diag_i, *AFF_diag_j;
+      HYPRE_Complex      *AFF_diag_a;
+      HYPRE_Int          *AFF_offd_ii, *AFF_offd_i, *AFF_offd_j;
+      HYPRE_Complex      *AFF_offd_a;
+      hypre_ParCSRMatrix *AFF;
+      hypre_CSRMatrix    *AFF_diag, *AFF_offd;
+      HYPRE_BigInt       *col_map_offd_AFF;
+      HYPRE_Int           num_cols_AFF_offd;
+
+      /* AFF Diag */
+      FF_pred<HYPRE_Int> AFF_pred_diag(option, CF_marker, CF_marker);
+      AFF_diag_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)) + A_diag_nnz,
+                                        AFF_pred_diag );
+
+      AFF_diag_ii = hypre_TAlloc(HYPRE_Int,     AFF_diag_nnz, HYPRE_MEMORY_DEVICE);
+      AFF_diag_j  = hypre_TAlloc(HYPRE_Int,     AFF_diag_nnz, HYPRE_MEMORY_DEVICE);
+      AFF_diag_a  = hypre_TAlloc(HYPRE_Complex, AFF_diag_nnz, HYPRE_MEMORY_DEVICE);
+
+      /* Notice that we cannot use Soc_diag_j in the first two arguments since the diagonal is marked as -2 */
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, A_diag_j, A_diag_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, A_diag_j, A_diag_a)) + A_diag_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(AFF_diag_ii, AFF_diag_j, AFF_diag_a)),
+                                   AFF_pred_diag );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == AFF_diag_ii + AFF_diag_nnz );
+
+      HYPRE_THRUST_CALL ( gather,
+                          AFF_diag_j,
+                          AFF_diag_j + AFF_diag_nnz,
+                          map2FC,
+                          AFF_diag_j );
+
+      HYPRE_THRUST_CALL ( gather,
+                          AFF_diag_ii,
+                          AFF_diag_ii + AFF_diag_nnz,
+                          option == 1 ? map2FC : map2F2,
+                          AFF_diag_ii );
+
+      AFF_diag_i = hypreDevice_CsrRowIndicesToPtrs(option == 1 ? nF_local : nF2_local, AFF_diag_nnz, AFF_diag_ii);
+      hypre_TFree(AFF_diag_ii, HYPRE_MEMORY_DEVICE);
+
+      /* AFF Offd */
+      FF_pred<HYPRE_BigInt> AFF_pred_offd(option, CF_marker, recv_buf);
+      AFF_offd_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)) + A_offd_nnz,
+                                        AFF_pred_offd );
+
+      AFF_offd_ii = hypre_TAlloc(HYPRE_Int,     AFF_offd_nnz, HYPRE_MEMORY_DEVICE);
+      AFF_offd_j  = hypre_TAlloc(HYPRE_Int,     AFF_offd_nnz, HYPRE_MEMORY_DEVICE);
+      AFF_offd_a  = hypre_TAlloc(HYPRE_Complex, AFF_offd_nnz, HYPRE_MEMORY_DEVICE);
+
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)) + A_offd_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(AFF_offd_ii, AFF_offd_j, AFF_offd_a)),
+                                   AFF_pred_offd );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == AFF_offd_ii + AFF_offd_nnz );
+
+      HYPRE_THRUST_CALL ( gather,
+                          AFF_offd_ii,
+                          AFF_offd_ii + AFF_offd_nnz,
+                          option == 1 ? map2FC : map2F2,
+                          AFF_offd_ii );
+
+      AFF_offd_i = hypreDevice_CsrRowIndicesToPtrs(option == 1 ? nF_local : nF2_local, AFF_offd_nnz, AFF_offd_ii);
+      hypre_TFree(AFF_offd_ii, HYPRE_MEMORY_DEVICE);
+
+      /* col_map_offd_AFF */
+      HYPRE_Int *tmp_j = hypre_TAlloc(HYPRE_Int, hypre_max(AFF_offd_nnz, num_cols_A_offd), HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(tmp_j, AFF_offd_j, HYPRE_Int, AFF_offd_nnz, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+      HYPRE_THRUST_CALL( sort,
+                         tmp_j,
+                         tmp_j + AFF_offd_nnz );
+      HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( unique,
+                                              tmp_j,
+                                              tmp_j + AFF_offd_nnz );
+      num_cols_AFF_offd = tmp_end - tmp_j;
+      HYPRE_THRUST_CALL( fill_n,
+                         offd_mark,
+                         num_cols_A_offd,
+                         0 );
+      hypreDevice_ScatterConstant(offd_mark, num_cols_AFF_offd, tmp_j, 1);
+      HYPRE_THRUST_CALL( exclusive_scan,
+                         offd_mark,
+                         offd_mark + num_cols_A_offd,
+                         tmp_j );
+      HYPRE_THRUST_CALL( gather,
+                         AFF_offd_j,
+                         AFF_offd_j + AFF_offd_nnz,
+                         tmp_j,
+                         AFF_offd_j );
+      col_map_offd_AFF = hypre_TAlloc(HYPRE_BigInt, num_cols_AFF_offd, HYPRE_MEMORY_DEVICE);
+      tmp_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_transform_iterator(recv_buf, -_1-1),
+                                   thrust::make_transform_iterator(recv_buf, -_1-1) + num_cols_A_offd,
+                                   offd_mark,
+                                   col_map_offd_AFF,
+                                   thrust::identity<HYPRE_Int>() );
+      hypre_assert(tmp_end - col_map_offd_AFF == num_cols_AFF_offd);
+      hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
+
+      AFF = hypre_ParCSRMatrixCreate(comm,
+                                     option == 1 ? nF_global : nF2_global,
+                                     nF_global,
+                                     option == 1 ? fpts_starts : f2pts_starts,
+                                     fpts_starts,
+                                     num_cols_AFF_offd,
+                                     AFF_diag_nnz,
+                                     AFF_offd_nnz);
+
+      hypre_ParCSRMatrixOwnsRowStarts(AFF) = 1;
+      hypre_ParCSRMatrixOwnsColStarts(AFF) = option == 1 ? 0 : 1;
+
+      AFF_diag = hypre_ParCSRMatrixDiag(AFF);
+      hypre_CSRMatrixData(AFF_diag) = AFF_diag_a;
+      hypre_CSRMatrixI(AFF_diag)    = AFF_diag_i;
+      hypre_CSRMatrixJ(AFF_diag)    = AFF_diag_j;
+
+      AFF_offd = hypre_ParCSRMatrixOffd(AFF);
+      hypre_CSRMatrixData(AFF_offd) = AFF_offd_a;
+      hypre_CSRMatrixI(AFF_offd)    = AFF_offd_i;
+      hypre_CSRMatrixJ(AFF_offd)    = AFF_offd_j;
+
+      hypre_CSRMatrixMemoryLocation(AFF_diag) = HYPRE_MEMORY_DEVICE;
+      hypre_CSRMatrixMemoryLocation(AFF_offd) = HYPRE_MEMORY_DEVICE;
+
+      hypre_ParCSRMatrixDeviceColMapOffd(AFF) = col_map_offd_AFF;
+      hypre_ParCSRMatrixColMapOffd(AFF) = hypre_TAlloc(HYPRE_BigInt, num_cols_AFF_offd, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(hypre_ParCSRMatrixColMapOffd(AFF), col_map_offd_AFF, HYPRE_BigInt, num_cols_AFF_offd,
+                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+
+      hypre_ParCSRMatrixSetNumNonzeros(AFF);
+      hypre_ParCSRMatrixDNumNonzeros(AFF) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(AFF);
+      hypre_MatvecCommPkgCreate(AFF);
+
+      *AFF_ptr = AFF;
+   }
+
+   if (AFC_ptr)
+   {
+      HYPRE_Int           AFC_diag_nnz, AFC_offd_nnz;
+      HYPRE_Int          *AFC_diag_ii, *AFC_diag_i, *AFC_diag_j;
+      HYPRE_Complex      *AFC_diag_a;
+      HYPRE_Int          *AFC_offd_ii, *AFC_offd_i, *AFC_offd_j;
+      HYPRE_Complex      *AFC_offd_a;
+      hypre_ParCSRMatrix *AFC;
+      hypre_CSRMatrix    *AFC_diag, *AFC_offd;
+      HYPRE_BigInt       *col_map_offd_AFC;
+      HYPRE_Int           num_cols_AFC_offd;
+
+      /* AFC Diag */
+      FC_pred<HYPRE_Int> AFC_pred_diag(CF_marker, CF_marker);
+      AFC_diag_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)) + A_diag_nnz,
+                                        AFC_pred_diag );
+
+      AFC_diag_ii = hypre_TAlloc(HYPRE_Int,     AFC_diag_nnz, HYPRE_MEMORY_DEVICE);
+      AFC_diag_j  = hypre_TAlloc(HYPRE_Int,     AFC_diag_nnz, HYPRE_MEMORY_DEVICE);
+      AFC_diag_a  = hypre_TAlloc(HYPRE_Complex, AFC_diag_nnz, HYPRE_MEMORY_DEVICE);
+
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j, A_diag_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j, A_diag_a)) + A_diag_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(AFC_diag_ii, AFC_diag_j, AFC_diag_a)),
+                                   AFC_pred_diag );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == AFC_diag_ii + AFC_diag_nnz );
+
+      HYPRE_THRUST_CALL ( gather,
+                          AFC_diag_j,
+                          AFC_diag_j + AFC_diag_nnz,
+                          map2FC,
+                          AFC_diag_j );
+
+      HYPRE_THRUST_CALL ( gather,
+                          AFC_diag_ii,
+                          AFC_diag_ii + AFC_diag_nnz,
+                          map2FC,
+                          AFC_diag_ii );
+
+      AFC_diag_i = hypreDevice_CsrRowIndicesToPtrs(nF_local, AFC_diag_nnz, AFC_diag_ii);
+      hypre_TFree(AFC_diag_ii, HYPRE_MEMORY_DEVICE);
+
+      /* AFC Offd */
+      FC_pred<HYPRE_BigInt> AFC_pred_offd(CF_marker, recv_buf);
+      AFC_offd_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)) + A_offd_nnz,
+                                        AFC_pred_offd );
+
+      AFC_offd_ii = hypre_TAlloc(HYPRE_Int,     AFC_offd_nnz, HYPRE_MEMORY_DEVICE);
+      AFC_offd_j  = hypre_TAlloc(HYPRE_Int,     AFC_offd_nnz, HYPRE_MEMORY_DEVICE);
+      AFC_offd_a  = hypre_TAlloc(HYPRE_Complex, AFC_offd_nnz, HYPRE_MEMORY_DEVICE);
+
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)) + A_offd_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(AFC_offd_ii, AFC_offd_j, AFC_offd_a)),
+                                   AFC_pred_offd );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == AFC_offd_ii + AFC_offd_nnz );
+
+      HYPRE_THRUST_CALL ( gather,
+                          AFC_offd_ii,
+                          AFC_offd_ii + AFC_offd_nnz,
+                          map2FC,
+                          AFC_offd_ii );
+
+      AFC_offd_i = hypreDevice_CsrRowIndicesToPtrs(nF_local, AFC_offd_nnz, AFC_offd_ii);
+      hypre_TFree(AFC_offd_ii, HYPRE_MEMORY_DEVICE);
+
+      /* col_map_offd_AFC */
+      HYPRE_Int *tmp_j = hypre_TAlloc(HYPRE_Int, hypre_max(AFC_offd_nnz, num_cols_A_offd), HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(tmp_j, AFC_offd_j, HYPRE_Int, AFC_offd_nnz, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+      HYPRE_THRUST_CALL( sort,
+                         tmp_j,
+                         tmp_j + AFC_offd_nnz );
+      HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( unique,
+                                              tmp_j,
+                                              tmp_j + AFC_offd_nnz );
+      num_cols_AFC_offd = tmp_end - tmp_j;
+      HYPRE_THRUST_CALL( fill_n,
+                         offd_mark,
+                         num_cols_A_offd,
+                         0 );
+      hypreDevice_ScatterConstant(offd_mark, num_cols_AFC_offd, tmp_j, 1);
+      HYPRE_THRUST_CALL( exclusive_scan,
+                         offd_mark,
+                         offd_mark + num_cols_A_offd,
+                         tmp_j);
+      HYPRE_THRUST_CALL( gather,
+                         AFC_offd_j,
+                         AFC_offd_j + AFC_offd_nnz,
+                         tmp_j,
+                         AFC_offd_j );
+      col_map_offd_AFC = hypre_TAlloc(HYPRE_BigInt, num_cols_AFC_offd, HYPRE_MEMORY_DEVICE);
+      tmp_end = HYPRE_THRUST_CALL( copy_if,
+                                   recv_buf,
+                                   recv_buf + num_cols_A_offd,
+                                   offd_mark,
+                                   col_map_offd_AFC,
+                                   thrust::identity<HYPRE_Int>());
+      hypre_assert(tmp_end - col_map_offd_AFC == num_cols_AFC_offd);
+      hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
+
+      /* AFC */
+      AFC = hypre_ParCSRMatrixCreate(comm,
+                                     nF_global,
+                                     nC_global,
+                                     fpts_starts,
+                                     cpts_starts,
+                                     num_cols_AFC_offd,
+                                     AFC_diag_nnz,
+                                     AFC_offd_nnz);
+
+      hypre_ParCSRMatrixOwnsRowStarts(AFC) = AFF_ptr ? 0 : 1;
+      hypre_ParCSRMatrixOwnsColStarts(AFC) = 0;
+
+      AFC_diag = hypre_ParCSRMatrixDiag(AFC);
+      hypre_CSRMatrixData(AFC_diag) = AFC_diag_a;
+      hypre_CSRMatrixI(AFC_diag)    = AFC_diag_i;
+      hypre_CSRMatrixJ(AFC_diag)    = AFC_diag_j;
+
+      AFC_offd = hypre_ParCSRMatrixOffd(AFC);
+      hypre_CSRMatrixData(AFC_offd) = AFC_offd_a;
+      hypre_CSRMatrixI(AFC_offd)    = AFC_offd_i;
+      hypre_CSRMatrixJ(AFC_offd)    = AFC_offd_j;
+
+      hypre_CSRMatrixMemoryLocation(AFC_diag) = HYPRE_MEMORY_DEVICE;
+      hypre_CSRMatrixMemoryLocation(AFC_offd) = HYPRE_MEMORY_DEVICE;
+
+      hypre_ParCSRMatrixDeviceColMapOffd(AFC) = col_map_offd_AFC;
+      hypre_ParCSRMatrixColMapOffd(AFC) = hypre_TAlloc(HYPRE_BigInt, num_cols_AFC_offd, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(hypre_ParCSRMatrixColMapOffd(AFC), col_map_offd_AFC, HYPRE_BigInt, num_cols_AFC_offd,
+                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+
+      hypre_ParCSRMatrixSetNumNonzeros(AFC);
+      hypre_ParCSRMatrixDNumNonzeros(AFC) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(AFC);
+      hypre_MatvecCommPkgCreate(AFC);
+
+      *AFC_ptr = AFC;
+   }
+
+   if (ACF_ptr)
+   {
+      HYPRE_Int           ACF_diag_nnz, ACF_offd_nnz;
+      HYPRE_Int          *ACF_diag_ii, *ACF_diag_i, *ACF_diag_j;
+      HYPRE_Complex      *ACF_diag_a;
+      HYPRE_Int          *ACF_offd_ii, *ACF_offd_i, *ACF_offd_j;
+      HYPRE_Complex      *ACF_offd_a;
+      hypre_ParCSRMatrix *ACF;
+      hypre_CSRMatrix    *ACF_diag, *ACF_offd;
+      HYPRE_BigInt       *col_map_offd_ACF;
+      HYPRE_Int           num_cols_ACF_offd;
+
+      /* ACF Diag */
+      CF_pred<HYPRE_Int> ACF_pred_diag(CF_marker, CF_marker);
+      ACF_diag_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)) + A_diag_nnz,
+                                        ACF_pred_diag );
+
+      ACF_diag_ii = hypre_TAlloc(HYPRE_Int,     ACF_diag_nnz, HYPRE_MEMORY_DEVICE);
+      ACF_diag_j  = hypre_TAlloc(HYPRE_Int,     ACF_diag_nnz, HYPRE_MEMORY_DEVICE);
+      ACF_diag_a  = hypre_TAlloc(HYPRE_Complex, ACF_diag_nnz, HYPRE_MEMORY_DEVICE);
+
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j, A_diag_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j, A_diag_a)) + A_diag_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(ACF_diag_ii, ACF_diag_j, ACF_diag_a)),
+                                   ACF_pred_diag );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == ACF_diag_ii + ACF_diag_nnz );
+
+      HYPRE_THRUST_CALL ( gather,
+                          ACF_diag_j,
+                          ACF_diag_j + ACF_diag_nnz,
+                          map2FC,
+                          ACF_diag_j );
+
+      HYPRE_THRUST_CALL ( gather,
+                          ACF_diag_ii,
+                          ACF_diag_ii + ACF_diag_nnz,
+                          map2FC,
+                          ACF_diag_ii );
+
+      ACF_diag_i = hypreDevice_CsrRowIndicesToPtrs(nC_local, ACF_diag_nnz, ACF_diag_ii);
+      hypre_TFree(ACF_diag_ii, HYPRE_MEMORY_DEVICE);
+
+      /* ACF Offd */
+      CF_pred<HYPRE_BigInt> ACF_pred_offd(CF_marker, recv_buf);
+      ACF_offd_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)) + A_offd_nnz,
+                                        ACF_pred_offd );
+
+      ACF_offd_ii = hypre_TAlloc(HYPRE_Int,     ACF_offd_nnz, HYPRE_MEMORY_DEVICE);
+      ACF_offd_j  = hypre_TAlloc(HYPRE_Int,     ACF_offd_nnz, HYPRE_MEMORY_DEVICE);
+      ACF_offd_a  = hypre_TAlloc(HYPRE_Complex, ACF_offd_nnz, HYPRE_MEMORY_DEVICE);
+
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)) + A_offd_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(ACF_offd_ii, ACF_offd_j, ACF_offd_a)),
+                                   ACF_pred_offd );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == ACF_offd_ii + ACF_offd_nnz );
+
+      HYPRE_THRUST_CALL ( gather,
+                          ACF_offd_ii,
+                          ACF_offd_ii + ACF_offd_nnz,
+                          map2FC,
+                          ACF_offd_ii );
+
+      ACF_offd_i = hypreDevice_CsrRowIndicesToPtrs(nC_local, ACF_offd_nnz, ACF_offd_ii);
+      hypre_TFree(ACF_offd_ii, HYPRE_MEMORY_DEVICE);
+
+      /* col_map_offd_ACF */
+      HYPRE_Int *tmp_j = hypre_TAlloc(HYPRE_Int, hypre_max(ACF_offd_nnz, num_cols_A_offd), HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(tmp_j, ACF_offd_j, HYPRE_Int, ACF_offd_nnz, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+      HYPRE_THRUST_CALL( sort,
+                         tmp_j,
+                         tmp_j + ACF_offd_nnz );
+      HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( unique,
+                                              tmp_j,
+                                              tmp_j + ACF_offd_nnz );
+      num_cols_ACF_offd = tmp_end - tmp_j;
+      HYPRE_THRUST_CALL( fill_n,
+                         offd_mark,
+                         num_cols_A_offd,
+                         0 );
+      hypreDevice_ScatterConstant(offd_mark, num_cols_ACF_offd, tmp_j, 1);
+      HYPRE_THRUST_CALL( exclusive_scan,
+                         offd_mark,
+                         offd_mark + num_cols_A_offd,
+                         tmp_j);
+      HYPRE_THRUST_CALL( gather,
+                         ACF_offd_j,
+                         ACF_offd_j + ACF_offd_nnz,
+                         tmp_j,
+                         ACF_offd_j );
+      col_map_offd_ACF = hypre_TAlloc(HYPRE_BigInt, num_cols_ACF_offd, HYPRE_MEMORY_DEVICE);
+      tmp_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_transform_iterator(recv_buf, -_1-1),
+                                   thrust::make_transform_iterator(recv_buf, -_1-1) + num_cols_A_offd,
+                                   offd_mark,
+                                   col_map_offd_ACF,
+                                   thrust::identity<HYPRE_Int>());
+      hypre_assert(tmp_end - col_map_offd_ACF == num_cols_ACF_offd);
+      hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
+
+      /* ACF */
+      ACF = hypre_ParCSRMatrixCreate(comm,
+                                     nC_global,
+                                     nF_global,
+                                     cpts_starts,
+                                     fpts_starts,
+                                     num_cols_ACF_offd,
+                                     ACF_diag_nnz,
+                                     ACF_offd_nnz);
+
+      hypre_ParCSRMatrixOwnsRowStarts(ACF) = 0;
+      hypre_ParCSRMatrixOwnsColStarts(ACF) = (AFF_ptr || AFC_ptr) ? 0 : 1;
+
+      ACF_diag = hypre_ParCSRMatrixDiag(ACF);
+      hypre_CSRMatrixData(ACF_diag) = ACF_diag_a;
+      hypre_CSRMatrixI(ACF_diag)    = ACF_diag_i;
+      hypre_CSRMatrixJ(ACF_diag)    = ACF_diag_j;
+
+      ACF_offd = hypre_ParCSRMatrixOffd(ACF);
+      hypre_CSRMatrixData(ACF_offd) = ACF_offd_a;
+      hypre_CSRMatrixI(ACF_offd)    = ACF_offd_i;
+      hypre_CSRMatrixJ(ACF_offd)    = ACF_offd_j;
+
+      hypre_CSRMatrixMemoryLocation(ACF_diag) = HYPRE_MEMORY_DEVICE;
+      hypre_CSRMatrixMemoryLocation(ACF_offd) = HYPRE_MEMORY_DEVICE;
+
+      hypre_ParCSRMatrixDeviceColMapOffd(ACF) = col_map_offd_ACF;
+      hypre_ParCSRMatrixColMapOffd(ACF) = hypre_TAlloc(HYPRE_BigInt, num_cols_ACF_offd, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(hypre_ParCSRMatrixColMapOffd(ACF), col_map_offd_ACF, HYPRE_BigInt, num_cols_ACF_offd,
+                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+
+      hypre_ParCSRMatrixSetNumNonzeros(ACF);
+      hypre_ParCSRMatrixDNumNonzeros(ACF) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(ACF);
+      hypre_MatvecCommPkgCreate(ACF);
+
+      *ACF_ptr = ACF;
+   }
+
+   if (ACC_ptr)
+   {
+      HYPRE_Int           ACC_diag_nnz, ACC_offd_nnz;
+      HYPRE_Int          *ACC_diag_ii, *ACC_diag_i, *ACC_diag_j;
+      HYPRE_Complex      *ACC_diag_a;
+      HYPRE_Int          *ACC_offd_ii, *ACC_offd_i, *ACC_offd_j;
+      HYPRE_Complex      *ACC_offd_a;
+      hypre_ParCSRMatrix *ACC;
+      hypre_CSRMatrix    *ACC_diag, *ACC_offd;
+      HYPRE_BigInt       *col_map_offd_ACC;
+      HYPRE_Int           num_cols_ACC_offd;
+
+      /* ACC Diag */
+      CC_pred<HYPRE_Int> ACC_pred_diag(CF_marker, CF_marker);
+      ACC_diag_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)) + A_diag_nnz,
+                                        ACC_pred_diag );
+
+      ACC_diag_ii = hypre_TAlloc(HYPRE_Int,     ACC_diag_nnz, HYPRE_MEMORY_DEVICE);
+      ACC_diag_j  = hypre_TAlloc(HYPRE_Int,     ACC_diag_nnz, HYPRE_MEMORY_DEVICE);
+      ACC_diag_a  = hypre_TAlloc(HYPRE_Complex, ACC_diag_nnz, HYPRE_MEMORY_DEVICE);
+
+      /* Notice that we cannot use Soc_diag_j in the first two arguments since the diagonal is marked as -2 */
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, A_diag_j, A_diag_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, A_diag_j, A_diag_a)) + A_diag_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(ACC_diag_ii, ACC_diag_j, ACC_diag_a)),
+                                   ACC_pred_diag );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == ACC_diag_ii + ACC_diag_nnz );
+
+      HYPRE_THRUST_CALL ( gather,
+                          ACC_diag_j,
+                          ACC_diag_j + ACC_diag_nnz,
+                          map2FC,
+                          ACC_diag_j );
+
+      HYPRE_THRUST_CALL ( gather,
+                          ACC_diag_ii,
+                          ACC_diag_ii + ACC_diag_nnz,
+                          map2FC,
+                          ACC_diag_ii );
+
+      ACC_diag_i = hypreDevice_CsrRowIndicesToPtrs(nC_local, ACC_diag_nnz, ACC_diag_ii);
+      hypre_TFree(ACC_diag_ii, HYPRE_MEMORY_DEVICE);
+
+      /* ACC Offd */
+      CC_pred<HYPRE_BigInt> ACC_pred_offd(CF_marker, recv_buf);
+      ACC_offd_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)) + A_offd_nnz,
+                                        ACC_pred_offd );
+
+      ACC_offd_ii = hypre_TAlloc(HYPRE_Int,     ACC_offd_nnz, HYPRE_MEMORY_DEVICE);
+      ACC_offd_j  = hypre_TAlloc(HYPRE_Int,     ACC_offd_nnz, HYPRE_MEMORY_DEVICE);
+      ACC_offd_a  = hypre_TAlloc(HYPRE_Complex, ACC_offd_nnz, HYPRE_MEMORY_DEVICE);
+
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)) + A_offd_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(ACC_offd_ii, ACC_offd_j, ACC_offd_a)),
+                                   ACC_pred_offd );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == ACC_offd_ii + ACC_offd_nnz );
+
+      HYPRE_THRUST_CALL ( gather,
+                          ACC_offd_ii,
+                          ACC_offd_ii + ACC_offd_nnz,
+                          map2FC,
+                          ACC_offd_ii );
+
+      ACC_offd_i = hypreDevice_CsrRowIndicesToPtrs(nC_local, ACC_offd_nnz, ACC_offd_ii);
+      hypre_TFree(ACC_offd_ii, HYPRE_MEMORY_DEVICE);
+
+      /* col_map_offd_ACC */
+      HYPRE_Int *tmp_j = hypre_TAlloc(HYPRE_Int, hypre_max(ACC_offd_nnz, num_cols_A_offd), HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(tmp_j, ACC_offd_j, HYPRE_Int, ACC_offd_nnz, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+      HYPRE_THRUST_CALL( sort,
+                         tmp_j,
+                         tmp_j + ACC_offd_nnz );
+      HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( unique,
+                                              tmp_j,
+                                              tmp_j + ACC_offd_nnz );
+      num_cols_ACC_offd = tmp_end - tmp_j;
+      HYPRE_THRUST_CALL( fill_n,
+                         offd_mark,
+                         num_cols_A_offd,
+                         0 );
+      hypreDevice_ScatterConstant(offd_mark, num_cols_ACC_offd, tmp_j, 1);
+      HYPRE_THRUST_CALL( exclusive_scan,
+                         offd_mark,
+                         offd_mark + num_cols_A_offd,
+                         tmp_j);
+      HYPRE_THRUST_CALL( gather,
+                         ACC_offd_j,
+                         ACC_offd_j + ACC_offd_nnz,
+                         tmp_j,
+                         ACC_offd_j );
+      col_map_offd_ACC = hypre_TAlloc(HYPRE_BigInt, num_cols_ACC_offd, HYPRE_MEMORY_DEVICE);
+      tmp_end = HYPRE_THRUST_CALL( copy_if,
+                                   recv_buf,
+                                   recv_buf + num_cols_A_offd,
+                                   offd_mark,
+                                   col_map_offd_ACC,
+                                   thrust::identity<HYPRE_Int>());
+      hypre_assert(tmp_end - col_map_offd_ACC == num_cols_ACC_offd);
+      hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
+
+      /* ACC */
+      ACC = hypre_ParCSRMatrixCreate(comm,
+                                     nC_global,
+                                     nC_global,
+                                     cpts_starts,
+                                     cpts_starts,
+                                     num_cols_ACC_offd,
+                                     ACC_diag_nnz,
+                                     ACC_offd_nnz);
+
+      hypre_ParCSRMatrixOwnsRowStarts(ACC) = 0;
+      hypre_ParCSRMatrixOwnsColStarts(ACC) = 0;
+
+      ACC_diag = hypre_ParCSRMatrixDiag(ACC);
+      hypre_CSRMatrixData(ACC_diag) = ACC_diag_a;
+      hypre_CSRMatrixI(ACC_diag)    = ACC_diag_i;
+      hypre_CSRMatrixJ(ACC_diag)    = ACC_diag_j;
+
+      ACC_offd = hypre_ParCSRMatrixOffd(ACC);
+      hypre_CSRMatrixData(ACC_offd) = ACC_offd_a;
+      hypre_CSRMatrixI(ACC_offd)    = ACC_offd_i;
+      hypre_CSRMatrixJ(ACC_offd)    = ACC_offd_j;
+
+      hypre_CSRMatrixMemoryLocation(ACC_diag) = HYPRE_MEMORY_DEVICE;
+      hypre_CSRMatrixMemoryLocation(ACC_offd) = HYPRE_MEMORY_DEVICE;
+
+      hypre_ParCSRMatrixDeviceColMapOffd(ACC) = col_map_offd_ACC;
+      hypre_ParCSRMatrixColMapOffd(ACC) = hypre_TAlloc(HYPRE_BigInt, num_cols_ACC_offd, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(hypre_ParCSRMatrixColMapOffd(ACC), col_map_offd_ACC, HYPRE_BigInt, num_cols_ACC_offd,
+                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+
+      hypre_ParCSRMatrixSetNumNonzeros(ACC);
+      hypre_ParCSRMatrixDNumNonzeros(ACC) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(ACC);
+      hypre_MatvecCommPkgCreate(ACC);
+
+      *ACC_ptr = ACC;
+   }
+
+   hypre_TFree(A_diag_ii, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(A_offd_ii, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(offd_mark, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(CF_marker, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(map2FC,    HYPRE_MEMORY_DEVICE);
+   hypre_TFree(map2F2,    HYPRE_MEMORY_DEVICE);
+   hypre_TFree(recv_buf,  HYPRE_MEMORY_DEVICE);
+
+   return hypre_error_flag;
+}
+
+HYPRE_Int
+hypre_ParCSRMatrixGenerateFFFCDevice( hypre_ParCSRMatrix  *A,
+                                      HYPRE_Int           *CF_marker_host,
+                                      HYPRE_BigInt        *cpts_starts,
+                                      hypre_ParCSRMatrix  *S,
+                                      hypre_ParCSRMatrix **AFC_ptr,
+                                      hypre_ParCSRMatrix **AFF_ptr )
+{
+   return hypre_ParCSRMatrixGenerateFFFCDevice_core(A, CF_marker_host, cpts_starts, S, AFC_ptr, AFF_ptr, NULL, NULL, 1);
+}
+
+HYPRE_Int
+hypre_ParCSRMatrixGenerateFFFC3Device( hypre_ParCSRMatrix  *A,
+                                       HYPRE_Int           *CF_marker_host,
+                                       HYPRE_BigInt        *cpts_starts,
+                                       hypre_ParCSRMatrix  *S,
+                                       hypre_ParCSRMatrix **AFC_ptr,
+                                       hypre_ParCSRMatrix **AFF_ptr)
+{
+   return hypre_ParCSRMatrixGenerateFFFCDevice_core(A, CF_marker_host, cpts_starts, S, AFC_ptr, AFF_ptr, NULL, NULL, 2);
+}
+
+HYPRE_Int
+hypre_ParCSRMatrixGenerateCFDevice( hypre_ParCSRMatrix  *A,
+                                    HYPRE_Int           *CF_marker_host,
+                                    HYPRE_BigInt        *cpts_starts,
+                                    hypre_ParCSRMatrix  *S,
+                                    hypre_ParCSRMatrix **ACF_ptr)
+{
+   return hypre_ParCSRMatrixGenerateFFFCDevice_core(A, CF_marker_host, cpts_starts, S, NULL, NULL, ACF_ptr, NULL, 1);
+}
+
+HYPRE_Int
+hypre_ParCSRMatrixGenerateCCDevice( hypre_ParCSRMatrix  *A,
+                                    HYPRE_Int           *CF_marker_host,
+                                    HYPRE_BigInt        *cpts_starts,
+                                    hypre_ParCSRMatrix  *S,
+                                    hypre_ParCSRMatrix **ACC_ptr)
+{
+   return hypre_ParCSRMatrixGenerateFFFCDevice_core(A, CF_marker_host, cpts_starts, S, NULL, NULL, NULL, ACC_ptr, 1);
+}
+
+HYPRE_Int
+hypre_ParCSRMatrixGenerate1DCFDevice( hypre_ParCSRMatrix  *A,
+                                      HYPRE_Int           *CF_marker_host,
+                                      HYPRE_BigInt        *cpts_starts,
+                                      hypre_ParCSRMatrix  *S,
+                                      hypre_ParCSRMatrix **ACX_ptr,
+                                      hypre_ParCSRMatrix **AXC_ptr )
+{
+   MPI_Comm                 comm     = hypre_ParCSRMatrixComm(A);
+   hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
+   hypre_ParCSRCommHandle  *comm_handle;
+   HYPRE_Int                num_sends     = hypre_ParCSRCommPkgNumSends(comm_pkg);
+   HYPRE_Int                num_elem_send = hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends);
+   //HYPRE_MemoryLocation     memory_location = hypre_ParCSRMatrixMemoryLocation(A);
+   /* diag part of A */
+   hypre_CSRMatrix    *A_diag   = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Complex      *A_diag_a = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int          *A_diag_i = hypre_CSRMatrixI(A_diag);
+   HYPRE_Int          *A_diag_j = hypre_CSRMatrixJ(A_diag);
+   HYPRE_Int           A_diag_nnz = hypre_CSRMatrixNumNonzeros(A_diag);
+   /* offd part of A */
+   hypre_CSRMatrix    *A_offd   = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Complex      *A_offd_a = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int          *A_offd_i = hypre_CSRMatrixI(A_offd);
+   HYPRE_Int          *A_offd_j = hypre_CSRMatrixJ(A_offd);
+   HYPRE_Int           A_offd_nnz = hypre_CSRMatrixNumNonzeros(A_offd);
+   HYPRE_BigInt       *col_map_offd_A = hypre_ParCSRMatrixDeviceColMapOffd(A);
+   HYPRE_Int           num_cols_A_offd = hypre_CSRMatrixNumCols(A_offd);
+   /* SoC */
+   HYPRE_Int          *Soc_diag_j = S ? hypre_ParCSRMatrixSocDiagJ(S) : A_diag_j;
+   HYPRE_Int          *Soc_offd_j = S ? hypre_ParCSRMatrixSocOffdJ(S) : A_offd_j;
+   /* MPI size and rank */
+   HYPRE_Int           my_id, num_procs;
+   /* nF and nC */
+   HYPRE_Int           n_local, /*nF_local,*/ nC_local;
+   HYPRE_BigInt       *fpts_starts, *row_starts;
+   HYPRE_BigInt        /*nF_global,*/ nC_global;
+   HYPRE_BigInt        F_first, C_first;
+   HYPRE_Int          *CF_marker;
+   /* work arrays */
+   HYPRE_Int          *map2FC, *itmp, *A_diag_ii, *A_offd_ii, *offd_mark;
+   HYPRE_BigInt       *send_buf, *recv_buf;
+
+   hypre_MPI_Comm_size(comm, &num_procs);
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+   n_local    = hypre_ParCSRMatrixNumRows(A);
+   row_starts = hypre_ParCSRMatrixRowStarts(A);
+
+   if (!col_map_offd_A)
+   {
+      col_map_offd_A = hypre_TAlloc(HYPRE_BigInt, num_cols_A_offd, HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(col_map_offd_A, hypre_ParCSRMatrixColMapOffd(A), HYPRE_BigInt, num_cols_A_offd,
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_ParCSRMatrixDeviceColMapOffd(A) = col_map_offd_A;
+   }
+
+#ifdef HYPRE_NO_GLOBAL_PARTITION
+   if (my_id == (num_procs -1))
+   {
+      nC_global = cpts_starts[1];
+   }
+   hypre_MPI_Bcast(&nC_global, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
+   nC_local = (HYPRE_Int) (cpts_starts[1] - cpts_starts[0]);
+   fpts_starts = hypre_TAlloc(HYPRE_BigInt, 2, HYPRE_MEMORY_HOST);
+   fpts_starts[0] = row_starts[0] - cpts_starts[0];
+   fpts_starts[1] = row_starts[1] - cpts_starts[1];
+   F_first = fpts_starts[0];
+   C_first = cpts_starts[0];
+#else
+   nC_global = cpts_starts[num_procs];
+   nC_local = (HYPRE_Int)(cpts_starts[my_id+1] - cpts_starts[my_id]);
+   fpts_starts = hypre_TAlloc(HYPRE_BigInt, num_procs+1, HYPRE_MEMORY_HOST);
+   for (i = 0; i <= num_procs; i++)
+   {
+      fpts_starts[i] = row_starts[i] - cpts_starts[i];
+   }
+   F_first = fpts_starts[myid];
+   C_first = cpts_starts[myid];
+#endif
+   /*
+   nF_local = n_local - nC_local;
+   nF_global = hypre_ParCSRMatrixGlobalNumRows(A) - nC_global;
+   */
+
+   CF_marker  = hypre_TAlloc(HYPRE_Int,    n_local,         HYPRE_MEMORY_DEVICE);
+   map2FC     = hypre_TAlloc(HYPRE_Int,    n_local,         HYPRE_MEMORY_DEVICE);
+   itmp       = hypre_TAlloc(HYPRE_Int,    n_local,         HYPRE_MEMORY_DEVICE);
+   recv_buf   = hypre_TAlloc(HYPRE_BigInt, num_cols_A_offd, HYPRE_MEMORY_DEVICE);
+
+   hypre_TMemcpy(CF_marker, CF_marker_host, HYPRE_Int, n_local, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+
+   /* map from all points (i.e, F+C) to F/C indices */
+   HYPRE_THRUST_CALL( exclusive_scan,
+                      thrust::make_transform_iterator(CF_marker,           is_negative<HYPRE_Int>()),
+                      thrust::make_transform_iterator(CF_marker + n_local, is_negative<HYPRE_Int>()),
+                      map2FC ); /* F */
+
+   HYPRE_THRUST_CALL( exclusive_scan,
+                      thrust::make_transform_iterator(CF_marker,           is_nonnegative<HYPRE_Int>()),
+                      thrust::make_transform_iterator(CF_marker + n_local, is_nonnegative<HYPRE_Int>()),
+                      itmp ); /* C */
+
+   HYPRE_THRUST_CALL( scatter_if,
+                      itmp,
+                      itmp + n_local,
+                      thrust::counting_iterator<HYPRE_Int>(0),
+                      thrust::make_transform_iterator(CF_marker, is_nonnegative<HYPRE_Int>()),
+                      map2FC ); /* FC combined */
+
+   hypre_TFree(itmp, HYPRE_MEMORY_DEVICE);
+
+   /* send_buf: global F/C indices. Note F-pts "x" are saved as "-x-1" */
+   send_buf = hypre_TAlloc(HYPRE_BigInt, num_elem_send, HYPRE_MEMORY_DEVICE);
+
+   hypre_ParCSRCommPkgCopySendMapElmtsToDevice(comm_pkg);
+
+   FFFC_functor functor(F_first, C_first);
+   HYPRE_THRUST_CALL( gather,
+                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg),
+                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg) + num_elem_send,
+                      thrust::make_transform_iterator(thrust::make_zip_iterator(thrust::make_tuple(map2FC, CF_marker)), functor),
+                      send_buf );
+
+   comm_handle = hypre_ParCSRCommHandleCreate_v2(21, comm_pkg, HYPRE_MEMORY_DEVICE, send_buf, HYPRE_MEMORY_DEVICE, recv_buf);
+   hypre_ParCSRCommHandleDestroy(comm_handle);
+
+   hypre_TFree(send_buf, HYPRE_MEMORY_DEVICE);
+
+   thrust::zip_iterator< thrust::tuple<HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*> > new_end;
+
+   A_diag_ii = hypre_TAlloc(HYPRE_Int, A_diag_nnz,      HYPRE_MEMORY_DEVICE);
+   A_offd_ii = hypre_TAlloc(HYPRE_Int, A_offd_nnz,      HYPRE_MEMORY_DEVICE);
+   offd_mark = hypre_TAlloc(HYPRE_Int, num_cols_A_offd, HYPRE_MEMORY_DEVICE);
+
+   hypreDevice_CsrRowPtrsToIndices_v2(n_local, A_diag_nnz, A_diag_i, A_diag_ii);
+   hypreDevice_CsrRowPtrsToIndices_v2(n_local, A_offd_nnz, A_offd_i, A_offd_ii);
+
+   if (ACX_ptr)
+   {
+      HYPRE_Int           ACX_diag_nnz, ACX_offd_nnz;
+      HYPRE_Int          *ACX_diag_ii, *ACX_diag_i, *ACX_diag_j;
+      HYPRE_Complex      *ACX_diag_a;
+      HYPRE_Int          *ACX_offd_ii, *ACX_offd_i, *ACX_offd_j;
+      HYPRE_Complex      *ACX_offd_a;
+      hypre_ParCSRMatrix *ACX;
+      hypre_CSRMatrix    *ACX_diag, *ACX_offd;
+      HYPRE_BigInt       *col_map_offd_ACX;
+      HYPRE_Int           num_cols_ACX_offd;
+
+      /* ACX Diag */
+      CX_pred ACX_pred(CF_marker);
+      ACX_diag_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)) + A_diag_nnz,
+                                        ACX_pred );
+
+      ACX_diag_ii = hypre_TAlloc(HYPRE_Int,     ACX_diag_nnz, HYPRE_MEMORY_DEVICE);
+      ACX_diag_j  = hypre_TAlloc(HYPRE_Int,     ACX_diag_nnz, HYPRE_MEMORY_DEVICE);
+      ACX_diag_a  = hypre_TAlloc(HYPRE_Complex, ACX_diag_nnz, HYPRE_MEMORY_DEVICE);
+
+      /* Notice that we cannot use Soc_diag_j in the first two arguments since the diagonal is marked as -2 */
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, A_diag_j, A_diag_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, A_diag_j, A_diag_a)) + A_diag_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(ACX_diag_ii, ACX_diag_j, ACX_diag_a)),
+                                   ACX_pred );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == ACX_diag_ii + ACX_diag_nnz );
+
+      HYPRE_THRUST_CALL ( gather,
+                          ACX_diag_ii,
+                          ACX_diag_ii + ACX_diag_nnz,
+                          map2FC,
+                          ACX_diag_ii );
+
+      ACX_diag_i = hypreDevice_CsrRowIndicesToPtrs(nC_local, ACX_diag_nnz, ACX_diag_ii);
+      hypre_TFree(ACX_diag_ii, HYPRE_MEMORY_DEVICE);
+
+      /* ACX Offd */
+      ACX_offd_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)) + A_offd_nnz,
+                                        ACX_pred );
+
+      ACX_offd_ii = hypre_TAlloc(HYPRE_Int,     ACX_offd_nnz, HYPRE_MEMORY_DEVICE);
+      ACX_offd_j  = hypre_TAlloc(HYPRE_Int,     ACX_offd_nnz, HYPRE_MEMORY_DEVICE);
+      ACX_offd_a  = hypre_TAlloc(HYPRE_Complex, ACX_offd_nnz, HYPRE_MEMORY_DEVICE);
+
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)) + A_offd_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(ACX_offd_ii, ACX_offd_j, ACX_offd_a)),
+                                   ACX_pred );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == ACX_offd_ii + ACX_offd_nnz );
+
+      HYPRE_THRUST_CALL ( gather,
+                          ACX_offd_ii,
+                          ACX_offd_ii + ACX_offd_nnz,
+                          map2FC,
+                          ACX_offd_ii );
+
+      ACX_offd_i = hypreDevice_CsrRowIndicesToPtrs(nC_local, ACX_offd_nnz, ACX_offd_ii);
+      hypre_TFree(ACX_offd_ii, HYPRE_MEMORY_DEVICE);
+
+      /* col_map_offd_ACX */
+      HYPRE_Int *tmp_j = hypre_TAlloc(HYPRE_Int, hypre_max(ACX_offd_nnz, num_cols_A_offd), HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(tmp_j, ACX_offd_j, HYPRE_Int, ACX_offd_nnz, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+      HYPRE_THRUST_CALL( sort,
+                         tmp_j,
+                         tmp_j + ACX_offd_nnz );
+      HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( unique,
+                                              tmp_j,
+                                              tmp_j + ACX_offd_nnz );
+      num_cols_ACX_offd = tmp_end - tmp_j;
+      HYPRE_THRUST_CALL( fill_n,
+                         offd_mark,
+                         num_cols_A_offd,
+                         0 );
+      hypreDevice_ScatterConstant(offd_mark, num_cols_ACX_offd, tmp_j, 1);
+      HYPRE_THRUST_CALL( exclusive_scan,
+                         offd_mark,
+                         offd_mark + num_cols_A_offd,
+                         tmp_j);
+      HYPRE_THRUST_CALL( gather,
+                         ACX_offd_j,
+                         ACX_offd_j + ACX_offd_nnz,
+                         tmp_j,
+                         ACX_offd_j );
+      col_map_offd_ACX = hypre_TAlloc(HYPRE_BigInt, num_cols_ACX_offd, HYPRE_MEMORY_DEVICE);
+      tmp_end = HYPRE_THRUST_CALL( copy_if,
+                                   col_map_offd_A,
+                                   col_map_offd_A + num_cols_A_offd,
+                                   offd_mark,
+                                   col_map_offd_ACX,
+                                   thrust::identity<HYPRE_Int>());
+      hypre_assert(tmp_end - col_map_offd_ACX == num_cols_ACX_offd);
+      hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
+
+      /* ACX */
+      ACX = hypre_ParCSRMatrixCreate(comm,
+                                     nC_global,
+                                     hypre_ParCSRMatrixGlobalNumCols(A),
+                                     cpts_starts,
+                                     hypre_ParCSRMatrixColStarts(A),
+                                     num_cols_ACX_offd,
+                                     ACX_diag_nnz,
+                                     ACX_offd_nnz);
+
+      hypre_ParCSRMatrixOwnsRowStarts(ACX) = 0;
+      hypre_ParCSRMatrixOwnsColStarts(ACX) = 0;
+
+      ACX_diag = hypre_ParCSRMatrixDiag(ACX);
+      hypre_CSRMatrixData(ACX_diag) = ACX_diag_a;
+      hypre_CSRMatrixI(ACX_diag)    = ACX_diag_i;
+      hypre_CSRMatrixJ(ACX_diag)    = ACX_diag_j;
+
+      ACX_offd = hypre_ParCSRMatrixOffd(ACX);
+      hypre_CSRMatrixData(ACX_offd) = ACX_offd_a;
+      hypre_CSRMatrixI(ACX_offd)    = ACX_offd_i;
+      hypre_CSRMatrixJ(ACX_offd)    = ACX_offd_j;
+
+      hypre_CSRMatrixMemoryLocation(ACX_diag) = HYPRE_MEMORY_DEVICE;
+      hypre_CSRMatrixMemoryLocation(ACX_offd) = HYPRE_MEMORY_DEVICE;
+
+      hypre_ParCSRMatrixDeviceColMapOffd(ACX) = col_map_offd_ACX;
+      hypre_ParCSRMatrixColMapOffd(ACX) = hypre_TAlloc(HYPRE_BigInt, num_cols_ACX_offd, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(hypre_ParCSRMatrixColMapOffd(ACX), col_map_offd_ACX, HYPRE_BigInt, num_cols_ACX_offd,
+                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+
+      hypre_ParCSRMatrixSetNumNonzeros(ACX);
+      hypre_ParCSRMatrixDNumNonzeros(ACX) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(ACX);
+      hypre_MatvecCommPkgCreate(ACX);
+
+      *ACX_ptr = ACX;
+   }
+
+   if (AXC_ptr)
+   {
+      HYPRE_Int           AXC_diag_nnz, AXC_offd_nnz;
+      HYPRE_Int          *AXC_diag_ii, *AXC_diag_i, *AXC_diag_j;
+      HYPRE_Complex      *AXC_diag_a;
+      HYPRE_Int          *AXC_offd_ii, *AXC_offd_i, *AXC_offd_j;
+      HYPRE_Complex      *AXC_offd_a;
+      hypre_ParCSRMatrix *AXC;
+      hypre_CSRMatrix    *AXC_diag, *AXC_offd;
+      HYPRE_BigInt       *col_map_offd_AXC;
+      HYPRE_Int           num_cols_AXC_offd;
+
+      /* AXC Diag */
+      XC_pred<HYPRE_Int> AXC_pred_diag(CF_marker);
+      AXC_diag_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)) + A_diag_nnz,
+                                        AXC_pred_diag );
+
+      AXC_diag_ii = hypre_TAlloc(HYPRE_Int,     AXC_diag_nnz, HYPRE_MEMORY_DEVICE);
+      AXC_diag_j  = hypre_TAlloc(HYPRE_Int,     AXC_diag_nnz, HYPRE_MEMORY_DEVICE);
+      AXC_diag_a  = hypre_TAlloc(HYPRE_Complex, AXC_diag_nnz, HYPRE_MEMORY_DEVICE);
+
+      /* Notice that we cannot use Soc_diag_j in the first two arguments since the diagonal is marked as -2 */
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, A_diag_j, A_diag_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, A_diag_j, A_diag_a)) + A_diag_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(AXC_diag_ii, AXC_diag_j, AXC_diag_a)),
+                                   AXC_pred_diag );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == AXC_diag_ii + AXC_diag_nnz );
+
+      HYPRE_THRUST_CALL ( gather,
+                          AXC_diag_j,
+                          AXC_diag_j + AXC_diag_nnz,
+                          map2FC,
+                          AXC_diag_j );
+
+      AXC_diag_i = hypreDevice_CsrRowIndicesToPtrs(n_local, AXC_diag_nnz, AXC_diag_ii);
+      hypre_TFree(AXC_diag_ii, HYPRE_MEMORY_DEVICE);
+
+      /* AXC Offd */
+      XC_pred<HYPRE_BigInt> AXC_pred_offd(recv_buf);
+      AXC_offd_nnz = HYPRE_THRUST_CALL( count_if,
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)) + A_offd_nnz,
+                                        AXC_pred_offd );
+
+      AXC_offd_ii = hypre_TAlloc(HYPRE_Int,     AXC_offd_nnz, HYPRE_MEMORY_DEVICE);
+      AXC_offd_j  = hypre_TAlloc(HYPRE_Int,     AXC_offd_nnz, HYPRE_MEMORY_DEVICE);
+      AXC_offd_a  = hypre_TAlloc(HYPRE_Complex, AXC_offd_nnz, HYPRE_MEMORY_DEVICE);
+
+      new_end = HYPRE_THRUST_CALL( copy_if,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)) + A_offd_nnz,
+                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
+                                   thrust::make_zip_iterator(thrust::make_tuple(AXC_offd_ii, AXC_offd_j, AXC_offd_a)),
+                                   AXC_pred_offd );
+
+      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == AXC_offd_ii + AXC_offd_nnz );
+
+      AXC_offd_i = hypreDevice_CsrRowIndicesToPtrs(n_local, AXC_offd_nnz, AXC_offd_ii);
+      hypre_TFree(AXC_offd_ii, HYPRE_MEMORY_DEVICE);
+
+      /* col_map_offd_AXC */
+      HYPRE_Int *tmp_j = hypre_TAlloc(HYPRE_Int, hypre_max(AXC_offd_nnz, num_cols_A_offd), HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(tmp_j, AXC_offd_j, HYPRE_Int, AXC_offd_nnz, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+      HYPRE_THRUST_CALL( sort,
+                         tmp_j,
+                         tmp_j + AXC_offd_nnz );
+      HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( unique,
+                                              tmp_j,
+                                              tmp_j + AXC_offd_nnz );
+      num_cols_AXC_offd = tmp_end - tmp_j;
+      HYPRE_THRUST_CALL( fill_n,
+                         offd_mark,
+                         num_cols_A_offd,
+                         0 );
+      hypreDevice_ScatterConstant(offd_mark, num_cols_AXC_offd, tmp_j, 1);
+      HYPRE_THRUST_CALL( exclusive_scan,
+                         offd_mark,
+                         offd_mark + num_cols_A_offd,
+                         tmp_j);
+      HYPRE_THRUST_CALL( gather,
+                         AXC_offd_j,
+                         AXC_offd_j + AXC_offd_nnz,
+                         tmp_j,
+                         AXC_offd_j );
+      col_map_offd_AXC = hypre_TAlloc(HYPRE_BigInt, num_cols_AXC_offd, HYPRE_MEMORY_DEVICE);
+      tmp_end = HYPRE_THRUST_CALL( copy_if,
+                                   recv_buf,
+                                   recv_buf + num_cols_A_offd,
+                                   offd_mark,
+                                   col_map_offd_AXC,
+                                   thrust::identity<HYPRE_Int>());
+      hypre_assert(tmp_end - col_map_offd_AXC == num_cols_AXC_offd);
+      hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
+
+      /* AXC */
+      AXC = hypre_ParCSRMatrixCreate(comm,
+                                     hypre_ParCSRMatrixGlobalNumRows(A),
+                                     nC_global,
+                                     row_starts,
+                                     cpts_starts,
+                                     num_cols_AXC_offd,
+                                     AXC_diag_nnz,
+                                     AXC_offd_nnz);
+
+      hypre_ParCSRMatrixOwnsRowStarts(AXC) = 0;
+      hypre_ParCSRMatrixOwnsColStarts(AXC) = 0;
+
+      AXC_diag = hypre_ParCSRMatrixDiag(AXC);
+      hypre_CSRMatrixData(AXC_diag) = AXC_diag_a;
+      hypre_CSRMatrixI(AXC_diag)    = AXC_diag_i;
+      hypre_CSRMatrixJ(AXC_diag)    = AXC_diag_j;
+
+      AXC_offd = hypre_ParCSRMatrixOffd(AXC);
+      hypre_CSRMatrixData(AXC_offd) = AXC_offd_a;
+      hypre_CSRMatrixI(AXC_offd)    = AXC_offd_i;
+      hypre_CSRMatrixJ(AXC_offd)    = AXC_offd_j;
+
+      hypre_CSRMatrixMemoryLocation(AXC_diag) = HYPRE_MEMORY_DEVICE;
+      hypre_CSRMatrixMemoryLocation(AXC_offd) = HYPRE_MEMORY_DEVICE;
+
+      hypre_ParCSRMatrixDeviceColMapOffd(AXC) = col_map_offd_AXC;
+      hypre_ParCSRMatrixColMapOffd(AXC) = hypre_TAlloc(HYPRE_BigInt, num_cols_AXC_offd, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(hypre_ParCSRMatrixColMapOffd(AXC), col_map_offd_AXC, HYPRE_BigInt, num_cols_AXC_offd,
+                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+
+      hypre_ParCSRMatrixSetNumNonzeros(AXC);
+      hypre_ParCSRMatrixDNumNonzeros(AXC) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(AXC);
+      hypre_MatvecCommPkgCreate(AXC);
+
+      *AXC_ptr = AXC;
+   }
+
+   hypre_TFree(A_diag_ii, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(A_offd_ii, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(offd_mark, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(CF_marker, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(map2FC,    HYPRE_MEMORY_DEVICE);
+   hypre_TFree(recv_buf,  HYPRE_MEMORY_DEVICE);
+
+   return hypre_error_flag;
+}
+
+#endif // #if defined(HYPRE_USING_CUDA)
+

--- a/src/parcsr_mv/par_csr_matop_device.c
+++ b/src/parcsr_mv/par_csr_matop_device.c
@@ -6,10 +6,7 @@
  ******************************************************************************/
 
 #include "_hypre_utilities.h"
-#include "hypre_hopscotch_hash.h"
 #include "_hypre_parcsr_mv.h"
-#include "_hypre_lapack.h"
-#include "_hypre_blas.h"
 #include "_hypre_utilities.hpp"
 
 #if defined(HYPRE_USING_CUDA)
@@ -525,580 +522,6 @@ hypre_ParCSRMatrixExtractBExtDevice( hypre_ParCSRMatrix *B,
    return hypre_ParCSRMatrixExtractBExtDeviceWait(request);
 }
 
-/*---------------------------
- *---------------------------*/
-typedef thrust::tuple<HYPRE_Int, HYPRE_Int> Tuple;
-//typedef thrust::tuple<HYPRE_Int, HYPRE_Int, HYPRe_Int> Tuple3;
-
-/* transform from local F/C index to global F/C index,
- * where F index "x" are saved as "-x-1"
- */
-struct FFFC_functor : public thrust::unary_function<Tuple, HYPRE_BigInt>
-{
-   HYPRE_BigInt CF_first[2];
-
-   FFFC_functor(HYPRE_BigInt F_first_, HYPRE_BigInt C_first_)
-   {
-      CF_first[1] = F_first_;
-      CF_first[0] = C_first_;
-   }
-
-   __host__ __device__
-   HYPRE_BigInt operator()(const Tuple& t) const
-   {
-      const HYPRE_Int local_idx = thrust::get<0>(t);
-      const HYPRE_Int cf_marker = thrust::get<1>(t);
-      const HYPRE_Int s = cf_marker < 0;
-      const HYPRE_Int m = 1 - 2*s;
-      return m*(local_idx + CF_first[s] + s);
-   }
-};
-
-/* this predicate selects A^s_{FF} or A^s_{FC} */
-template<bool FCOL, typename T>
-struct FFFC_pred : public thrust::unary_function<Tuple, bool>
-{
-   HYPRE_Int  option;
-   HYPRE_Int *row_CF_marker;
-   T         *col_CF_marker;
-
-   FFFC_pred(HYPRE_Int option_, HYPRE_Int *row_CF_marker_, T *col_CF_marker_)
-   {
-      option = option_;
-      row_CF_marker = row_CF_marker_;
-      col_CF_marker = col_CF_marker_;
-   }
-
-   __host__ __device__
-   bool operator()(const Tuple& t) const
-   {
-      const HYPRE_Int i = thrust::get<0>(t);
-      const HYPRE_Int j = thrust::get<1>(t);
-      if (FCOL)
-      {
-         if (option == 1)
-         {
-            /* A_{F,F} */
-            return row_CF_marker[i] < 0 && (j == -2 || j >= 0 && col_CF_marker[j] < 0);
-         }
-         else
-         {
-            /* A_{F2, F} */
-            return row_CF_marker[i] == -2 && (j == -2 || j >= 0 && col_CF_marker[j] < 0);
-         }
-      }
-      else
-      {
-         /* A_{F,C} */
-         return row_CF_marker[i] < 0 && (j >= 0 && col_CF_marker[j] >= 0);
-      }
-   }
-};
-
-/* Option = 1
- *    AFC contains the diagonal of F-C block of A
- *    AFF contains the diagonal of F-F block of A
- * Option = 2 (for aggressive coarsening, where C = [F_2, C_2] )
- *    F_2 is marked as -2 in CF_marker, F_1 is -1, and C_2 >= 0
- *    AFC: A_{F, C_2}
- *    AFF: A_{F_2, F}
- */
-HYPRE_Int
-hypre_ParCSRMatrixGenerateFFFCDevice_core( hypre_ParCSRMatrix  *A,
-                                           HYPRE_Int           *CF_marker_host,
-                                           HYPRE_BigInt        *cpts_starts,
-                                           hypre_ParCSRMatrix  *S,
-                                           hypre_ParCSRMatrix **AFC_ptr,
-                                           hypre_ParCSRMatrix **AFF_ptr,
-                                           HYPRE_Int            option )
-{
-   MPI_Comm                 comm     = hypre_ParCSRMatrixComm(A);
-   hypre_ParCSRCommPkg     *comm_pkg = hypre_ParCSRMatrixCommPkg(A);
-   hypre_ParCSRCommHandle  *comm_handle;
-   HYPRE_Int                num_sends     = hypre_ParCSRCommPkgNumSends(comm_pkg);
-   HYPRE_Int                num_elem_send = hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends);
-   //HYPRE_MemoryLocation     memory_location = hypre_ParCSRMatrixMemoryLocation(A);
-   /* diag part of A */
-   hypre_CSRMatrix    *A_diag   = hypre_ParCSRMatrixDiag(A);
-   HYPRE_Complex      *A_diag_a = hypre_CSRMatrixData(A_diag);
-   HYPRE_Int          *A_diag_i = hypre_CSRMatrixI(A_diag);
-   HYPRE_Int          *A_diag_j = hypre_CSRMatrixJ(A_diag);
-   HYPRE_Int           A_diag_nnz = hypre_CSRMatrixNumNonzeros(A_diag);
-   /* offd part of A */
-   hypre_CSRMatrix    *A_offd   = hypre_ParCSRMatrixOffd(A);
-   HYPRE_Complex      *A_offd_a = hypre_CSRMatrixData(A_offd);
-   HYPRE_Int          *A_offd_i = hypre_CSRMatrixI(A_offd);
-   //HYPRE_Int          *A_offd_j = hypre_CSRMatrixJ(A_offd);
-   HYPRE_Int           A_offd_nnz = hypre_CSRMatrixNumNonzeros(A_offd);
-   HYPRE_Int           num_cols_A_offd = hypre_CSRMatrixNumCols(A_offd);
-   /* SoC */
-   HYPRE_Int          *Soc_diag_j = hypre_ParCSRMatrixSocDiagJ(S);
-   HYPRE_Int          *Soc_offd_j = hypre_ParCSRMatrixSocOffdJ(S);
-   /* MPI size and rank */
-   HYPRE_Int           my_id, num_procs;
-   /* nF and nC */
-   HYPRE_Int           n_local, nF_local, nC_local, nF2_local = 0;
-   HYPRE_BigInt       *fpts_starts, *row_starts, *f2pts_starts = NULL;
-   HYPRE_BigInt        n_global, nF_global, nC_global, nF2_global = 0;
-   HYPRE_BigInt        F_first, C_first;
-   HYPRE_Int          *CF_marker;
-   /* work arrays */
-   HYPRE_Int          *map2FC, *map2F2 = NULL, *itmp, *A_diag_ii, *A_offd_ii, *offd_mark;
-   HYPRE_BigInt       *send_buf, *recv_buf;
-
-   hypre_MPI_Comm_size(comm, &num_procs);
-   hypre_MPI_Comm_rank(comm, &my_id);
-
-   n_global   = hypre_ParCSRMatrixGlobalNumRows(A);
-   n_local    = hypre_ParCSRMatrixNumRows(A);
-   row_starts = hypre_ParCSRMatrixRowStarts(A);
-
-#ifdef HYPRE_NO_GLOBAL_PARTITION
-   if (my_id == (num_procs -1))
-   {
-      nC_global = cpts_starts[1];
-   }
-   hypre_MPI_Bcast(&nC_global, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
-   nC_local = (HYPRE_Int) (cpts_starts[1] - cpts_starts[0]);
-   fpts_starts = hypre_TAlloc(HYPRE_BigInt, 2, HYPRE_MEMORY_HOST);
-   fpts_starts[0] = row_starts[0] - cpts_starts[0];
-   fpts_starts[1] = row_starts[1] - cpts_starts[1];
-   F_first = fpts_starts[0];
-   C_first = cpts_starts[0];
-#else
-   nC_global = cpts_starts[num_procs];
-   nC_local = (HYPRE_Int)(cpts_starts[my_id+1] - cpts_starts[my_id]);
-   fpts_starts = hypre_TAlloc(HYPRE_BigInt, num_procs+1, HYPRE_MEMORY_HOST);
-   for (i = 0; i <= num_procs; i++)
-   {
-      fpts_starts[i] = row_starts[i] - cpts_starts[i];
-   }
-   F_first = fpts_starts[myid];
-   C_first = cpts_starts[myid];
-#endif
-   nF_local = n_local - nC_local;
-   nF_global = n_global - nC_global;
-
-   CF_marker  = hypre_TAlloc(HYPRE_Int,    n_local,         HYPRE_MEMORY_DEVICE);
-   map2FC     = hypre_TAlloc(HYPRE_Int,    n_local,         HYPRE_MEMORY_DEVICE);
-   itmp       = hypre_TAlloc(HYPRE_Int,    n_local,         HYPRE_MEMORY_DEVICE);
-   recv_buf   = hypre_TAlloc(HYPRE_BigInt, num_cols_A_offd, HYPRE_MEMORY_DEVICE);
-
-   hypre_TMemcpy(CF_marker, CF_marker_host, HYPRE_Int, n_local, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
-
-   if (option == 2)
-   {
-      nF2_local = HYPRE_THRUST_CALL( count,
-                                     CF_marker,
-                                     CF_marker + n_local,
-                                     -2 );
-
-      HYPRE_BigInt nF2_local_big = nF2_local;
-
-#ifdef HYPRE_NO_GLOBAL_PARTITION
-      f2pts_starts = hypre_TAlloc(HYPRE_BigInt, 2, HYPRE_MEMORY_HOST);
-      hypre_MPI_Scan(&nF2_local_big, f2pts_starts + 1, 1, HYPRE_MPI_BIG_INT, hypre_MPI_SUM, comm);
-      f2pts_starts[0] = f2pts_starts[1] - nF2_local_big;
-      if (my_id == (num_procs -1))
-      {
-         nF2_global = f2pts_starts[1];
-      }
-      hypre_MPI_Bcast(&nF2_global, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
-#else
-      f2pts_starts = hypre_TAlloc(HYPRE_BigInt, num_procs + 1, HYPRE_MEMORY_HOST);
-      hypre_MPI_Allgather(&nF2_local_big, 1, HYPRE_MPI_BIG_INT, f2pts_starts + 1, 1, HYPRE_MPI_BIG_INT, comm);
-      f2pts_starts[0] = 0;
-      for (i = 2; i < num_procs + 1; i++)
-      {
-         f2pts_starts[i] += f2pts_starts[i-1];
-      }
-      nF2_global = f2pts_starts[num_procs];
-#endif
-   }
-
-   /* map from all points (i.e, F+C) to F/C indices */
-   HYPRE_THRUST_CALL( exclusive_scan,
-                      thrust::make_transform_iterator(CF_marker,           is_negative<HYPRE_Int>()),
-                      thrust::make_transform_iterator(CF_marker + n_local, is_negative<HYPRE_Int>()),
-                      map2FC ); /* F */
-
-   HYPRE_THRUST_CALL( exclusive_scan,
-                      thrust::make_transform_iterator(CF_marker,           is_nonnegative<HYPRE_Int>()),
-                      thrust::make_transform_iterator(CF_marker + n_local, is_nonnegative<HYPRE_Int>()),
-                      itmp ); /* C */
-
-   HYPRE_THRUST_CALL( scatter_if,
-                      itmp,
-                      itmp + n_local,
-                      thrust::counting_iterator<HYPRE_Int>(0),
-                      thrust::make_transform_iterator(CF_marker, is_nonnegative<HYPRE_Int>()),
-                      map2FC ); /* FC combined */
-
-   hypre_TFree(itmp, HYPRE_MEMORY_DEVICE);
-
-   if (option == 2)
-   {
-      map2F2 = hypre_TAlloc(HYPRE_Int, n_local, HYPRE_MEMORY_DEVICE);
-      HYPRE_THRUST_CALL( exclusive_scan,
-                         thrust::make_transform_iterator(CF_marker,           equal<HYPRE_Int>(-2)),
-                         thrust::make_transform_iterator(CF_marker + n_local, equal<HYPRE_Int>(-2)),
-                         map2F2 ); /* F2 */
-   }
-
-   /* send_buf: global F/C indices. Note F-pts "x" are saved as "-x-1" */
-   send_buf = hypre_TAlloc(HYPRE_BigInt, num_elem_send, HYPRE_MEMORY_DEVICE);
-
-   hypre_ParCSRCommPkgCopySendMapElmtsToDevice(comm_pkg);
-
-   FFFC_functor functor(F_first, C_first);
-   HYPRE_THRUST_CALL( gather,
-                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg),
-                      hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg) + num_elem_send,
-                      thrust::make_transform_iterator(thrust::make_zip_iterator(thrust::make_tuple(map2FC, CF_marker)), functor),
-                      send_buf );
-
-   comm_handle = hypre_ParCSRCommHandleCreate_v2(21, comm_pkg, HYPRE_MEMORY_DEVICE, send_buf, HYPRE_MEMORY_DEVICE, recv_buf);
-   hypre_ParCSRCommHandleDestroy(comm_handle);
-
-   hypre_TFree(send_buf, HYPRE_MEMORY_DEVICE);
-
-   thrust::zip_iterator< thrust::tuple<HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*> > new_end;
-
-   A_diag_ii = hypre_TAlloc(HYPRE_Int, A_diag_nnz,      HYPRE_MEMORY_DEVICE);
-   A_offd_ii = hypre_TAlloc(HYPRE_Int, A_offd_nnz,      HYPRE_MEMORY_DEVICE);
-   offd_mark = hypre_TAlloc(HYPRE_Int, num_cols_A_offd, HYPRE_MEMORY_DEVICE);
-
-   hypreDevice_CsrRowPtrsToIndices_v2(n_local, A_diag_nnz, A_diag_i, A_diag_ii);
-   hypreDevice_CsrRowPtrsToIndices_v2(n_local, A_offd_nnz, A_offd_i, A_offd_ii);
-
-   if (AFF_ptr)
-   {
-      HYPRE_Int           AFF_diag_nnz, AFF_offd_nnz;
-      HYPRE_Int          *AFF_diag_ii, *AFF_diag_i, *AFF_diag_j;
-      HYPRE_Complex      *AFF_diag_a;
-      HYPRE_Int          *AFF_offd_ii, *AFF_offd_i, *AFF_offd_j;
-      HYPRE_Complex      *AFF_offd_a;
-      hypre_ParCSRMatrix *AFF;
-      hypre_CSRMatrix    *AFF_diag, *AFF_offd;
-      HYPRE_BigInt       *col_map_offd_AFF;
-      HYPRE_Int           num_cols_AFF_offd;
-
-      /* AFF Diag */
-      FFFC_pred<true, HYPRE_Int> AFF_pred_diag(option, CF_marker, CF_marker);
-      AFF_diag_nnz = HYPRE_THRUST_CALL( count_if,
-                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
-                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)) + A_diag_nnz,
-                                        AFF_pred_diag );
-
-      AFF_diag_ii = hypre_TAlloc(HYPRE_Int,     AFF_diag_nnz, HYPRE_MEMORY_DEVICE);
-      AFF_diag_j  = hypre_TAlloc(HYPRE_Int,     AFF_diag_nnz, HYPRE_MEMORY_DEVICE);
-      AFF_diag_a  = hypre_TAlloc(HYPRE_Complex, AFF_diag_nnz, HYPRE_MEMORY_DEVICE);
-
-      new_end = HYPRE_THRUST_CALL( copy_if,
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, A_diag_j, A_diag_a)),
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, A_diag_j, A_diag_a)) + A_diag_nnz,
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
-                                   thrust::make_zip_iterator(thrust::make_tuple(AFF_diag_ii, AFF_diag_j, AFF_diag_a)),
-                                   AFF_pred_diag );
-
-      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == AFF_diag_ii + AFF_diag_nnz );
-
-      HYPRE_THRUST_CALL ( gather,
-                          AFF_diag_j,
-                          AFF_diag_j + AFF_diag_nnz,
-                          map2FC,
-                          AFF_diag_j );
-
-      HYPRE_THRUST_CALL ( gather,
-                          AFF_diag_ii,
-                          AFF_diag_ii + AFF_diag_nnz,
-                          option == 1 ? map2FC : map2F2,
-                          AFF_diag_ii );
-
-      AFF_diag_i = hypreDevice_CsrRowIndicesToPtrs(option == 1 ? nF_local : nF2_local, AFF_diag_nnz, AFF_diag_ii);
-      hypre_TFree(AFF_diag_ii, HYPRE_MEMORY_DEVICE);
-
-      /* AFF Offd */
-      FFFC_pred<true, HYPRE_BigInt> AFF_pred_offd(option, CF_marker, recv_buf);
-      AFF_offd_nnz = HYPRE_THRUST_CALL( count_if,
-                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
-                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)) + A_offd_nnz,
-                                        AFF_pred_offd );
-
-      AFF_offd_ii = hypre_TAlloc(HYPRE_Int,     AFF_offd_nnz, HYPRE_MEMORY_DEVICE);
-      AFF_offd_j  = hypre_TAlloc(HYPRE_Int,     AFF_offd_nnz, HYPRE_MEMORY_DEVICE);
-      AFF_offd_a  = hypre_TAlloc(HYPRE_Complex, AFF_offd_nnz, HYPRE_MEMORY_DEVICE);
-
-      new_end = HYPRE_THRUST_CALL( copy_if,
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)),
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)) + A_offd_nnz,
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
-                                   thrust::make_zip_iterator(thrust::make_tuple(AFF_offd_ii, AFF_offd_j, AFF_offd_a)),
-                                   AFF_pred_offd );
-
-      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == AFF_offd_ii + AFF_offd_nnz );
-
-      HYPRE_THRUST_CALL ( gather,
-                          AFF_offd_ii,
-                          AFF_offd_ii + AFF_offd_nnz,
-                          option == 1 ? map2FC : map2F2,
-                          AFF_offd_ii );
-
-      AFF_offd_i = hypreDevice_CsrRowIndicesToPtrs(option == 1 ? nF_local : nF2_local, AFF_offd_nnz, AFF_offd_ii);
-      hypre_TFree(AFF_offd_ii, HYPRE_MEMORY_DEVICE);
-
-      /* col_map_offd_AFF */
-      HYPRE_Int *tmp_j = hypre_TAlloc(HYPRE_Int, hypre_max(AFF_offd_nnz, num_cols_A_offd), HYPRE_MEMORY_DEVICE);
-      hypre_TMemcpy(tmp_j, AFF_offd_j, HYPRE_Int, AFF_offd_nnz, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
-      HYPRE_THRUST_CALL( sort,
-                         tmp_j,
-                         tmp_j + AFF_offd_nnz );
-      HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( unique,
-                                              tmp_j,
-                                              tmp_j + AFF_offd_nnz );
-      num_cols_AFF_offd = tmp_end - tmp_j;
-      HYPRE_THRUST_CALL( fill_n,
-                         offd_mark,
-                         num_cols_A_offd,
-                         0 );
-      hypreDevice_ScatterConstant(offd_mark, num_cols_AFF_offd, tmp_j, 1);
-      HYPRE_THRUST_CALL( exclusive_scan,
-                         offd_mark,
-                         offd_mark + num_cols_A_offd,
-                         tmp_j );
-      HYPRE_THRUST_CALL( gather,
-                         AFF_offd_j,
-                         AFF_offd_j + AFF_offd_nnz,
-                         tmp_j,
-                         AFF_offd_j );
-      col_map_offd_AFF = hypre_TAlloc(HYPRE_Int, num_cols_AFF_offd, HYPRE_MEMORY_DEVICE);
-      tmp_end = HYPRE_THRUST_CALL( copy_if,
-                                   thrust::make_transform_iterator(recv_buf, -_1-1),
-                                   thrust::make_transform_iterator(recv_buf, -_1-1) + num_cols_A_offd,
-                                   offd_mark,
-                                   col_map_offd_AFF,
-                                   thrust::identity<HYPRE_Int>() );
-      hypre_assert(tmp_end - col_map_offd_AFF == num_cols_AFF_offd);
-      hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
-
-      AFF = hypre_ParCSRMatrixCreate(comm,
-                                     option == 1 ? nF_global : nF2_global,
-                                     nF_global,
-                                     option == 1 ? fpts_starts : f2pts_starts,
-                                     fpts_starts,
-                                     num_cols_AFF_offd,
-                                     AFF_diag_nnz,
-                                     AFF_offd_nnz);
-
-      hypre_ParCSRMatrixOwnsRowStarts(AFF) = 1;
-      hypre_ParCSRMatrixOwnsColStarts(AFF) = option == 1 ? 0 : 1;
-
-      AFF_diag = hypre_ParCSRMatrixDiag(AFF);
-      hypre_CSRMatrixData(AFF_diag) = AFF_diag_a;
-      hypre_CSRMatrixI(AFF_diag)    = AFF_diag_i;
-      hypre_CSRMatrixJ(AFF_diag)    = AFF_diag_j;
-
-      AFF_offd = hypre_ParCSRMatrixOffd(AFF);
-      hypre_CSRMatrixData(AFF_offd) = AFF_offd_a;
-      hypre_CSRMatrixI(AFF_offd)    = AFF_offd_i;
-      hypre_CSRMatrixJ(AFF_offd)    = AFF_offd_j;
-
-      hypre_CSRMatrixMemoryLocation(AFF_diag) = HYPRE_MEMORY_DEVICE;
-      hypre_CSRMatrixMemoryLocation(AFF_offd) = HYPRE_MEMORY_DEVICE;
-
-      hypre_ParCSRMatrixDeviceColMapOffd(AFF) = col_map_offd_AFF;
-      hypre_ParCSRMatrixColMapOffd(AFF) = hypre_TAlloc(HYPRE_BigInt, num_cols_AFF_offd, HYPRE_MEMORY_HOST);
-      hypre_TMemcpy(hypre_ParCSRMatrixColMapOffd(AFF), col_map_offd_AFF, HYPRE_BigInt, num_cols_AFF_offd,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
-
-      hypre_ParCSRMatrixSetNumNonzeros(AFF);
-      hypre_ParCSRMatrixDNumNonzeros(AFF) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(AFF);
-      hypre_MatvecCommPkgCreate(AFF);
-
-      *AFF_ptr = AFF;
-   }
-
-   if (AFC_ptr)
-   {
-      HYPRE_Int           AFC_diag_nnz, AFC_offd_nnz;
-      HYPRE_Int          *AFC_diag_ii, *AFC_diag_i, *AFC_diag_j;
-      HYPRE_Complex      *AFC_diag_a;
-      HYPRE_Int          *AFC_offd_ii, *AFC_offd_i, *AFC_offd_j;
-      HYPRE_Complex      *AFC_offd_a;
-      hypre_ParCSRMatrix *AFC;
-      hypre_CSRMatrix    *AFC_diag, *AFC_offd;
-      HYPRE_BigInt       *col_map_offd_AFC;
-      HYPRE_Int           num_cols_AFC_offd;
-
-      /* AFC Diag */
-      FFFC_pred<false, HYPRE_Int> AFC_pred_diag(option, CF_marker, CF_marker);
-      AFC_diag_nnz = HYPRE_THRUST_CALL( count_if,
-                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
-                                        thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)) + A_diag_nnz,
-                                        AFC_pred_diag );
-
-      AFC_diag_ii = hypre_TAlloc(HYPRE_Int,     AFC_diag_nnz, HYPRE_MEMORY_DEVICE);
-      AFC_diag_j  = hypre_TAlloc(HYPRE_Int,     AFC_diag_nnz, HYPRE_MEMORY_DEVICE);
-      AFC_diag_a  = hypre_TAlloc(HYPRE_Complex, AFC_diag_nnz, HYPRE_MEMORY_DEVICE);
-
-      new_end = HYPRE_THRUST_CALL( copy_if,
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j, A_diag_a)),
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j, A_diag_a)) + A_diag_nnz,
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_diag_ii, Soc_diag_j)),
-                                   thrust::make_zip_iterator(thrust::make_tuple(AFC_diag_ii, AFC_diag_j, AFC_diag_a)),
-                                   AFC_pred_diag );
-
-      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == AFC_diag_ii + AFC_diag_nnz );
-
-      HYPRE_THRUST_CALL ( gather,
-                          AFC_diag_j,
-                          AFC_diag_j + AFC_diag_nnz,
-                          map2FC,
-                          AFC_diag_j );
-
-      HYPRE_THRUST_CALL ( gather,
-                          AFC_diag_ii,
-                          AFC_diag_ii + AFC_diag_nnz,
-                          map2FC,
-                          AFC_diag_ii );
-
-      AFC_diag_i = hypreDevice_CsrRowIndicesToPtrs(nF_local, AFC_diag_nnz, AFC_diag_ii);
-      hypre_TFree(AFC_diag_ii, HYPRE_MEMORY_DEVICE);
-
-      /* AFC Offd */
-      FFFC_pred<false, HYPRE_BigInt> AFC_pred_offd(option, CF_marker, recv_buf);
-      AFC_offd_nnz = HYPRE_THRUST_CALL( count_if,
-                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
-                                        thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)) + A_offd_nnz,
-                                        AFC_pred_offd );
-
-      AFC_offd_ii = hypre_TAlloc(HYPRE_Int,     AFC_offd_nnz, HYPRE_MEMORY_DEVICE);
-      AFC_offd_j  = hypre_TAlloc(HYPRE_Int,     AFC_offd_nnz, HYPRE_MEMORY_DEVICE);
-      AFC_offd_a  = hypre_TAlloc(HYPRE_Complex, AFC_offd_nnz, HYPRE_MEMORY_DEVICE);
-
-      new_end = HYPRE_THRUST_CALL( copy_if,
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)),
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j, A_offd_a)) + A_offd_nnz,
-                                   thrust::make_zip_iterator(thrust::make_tuple(A_offd_ii, Soc_offd_j)),
-                                   thrust::make_zip_iterator(thrust::make_tuple(AFC_offd_ii, AFC_offd_j, AFC_offd_a)),
-                                   AFC_pred_offd );
-
-      hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == AFC_offd_ii + AFC_offd_nnz );
-
-      HYPRE_THRUST_CALL ( gather,
-                          AFC_offd_ii,
-                          AFC_offd_ii + AFC_offd_nnz,
-                          map2FC,
-                          AFC_offd_ii );
-
-      AFC_offd_i = hypreDevice_CsrRowIndicesToPtrs(nF_local, AFC_offd_nnz, AFC_offd_ii);
-      hypre_TFree(AFC_offd_ii, HYPRE_MEMORY_DEVICE);
-
-      /* col_map_offd_AFC */
-      HYPRE_Int *tmp_j = hypre_TAlloc(HYPRE_Int, hypre_max(AFC_offd_nnz, num_cols_A_offd), HYPRE_MEMORY_DEVICE);
-      hypre_TMemcpy(tmp_j, AFC_offd_j, HYPRE_Int, AFC_offd_nnz, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
-      HYPRE_THRUST_CALL( sort,
-                         tmp_j,
-                         tmp_j + AFC_offd_nnz );
-      HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( unique,
-                                              tmp_j,
-                                              tmp_j + AFC_offd_nnz );
-      num_cols_AFC_offd = tmp_end - tmp_j;
-      HYPRE_THRUST_CALL( fill_n,
-                         offd_mark,
-                         num_cols_A_offd,
-                         0 );
-      hypreDevice_ScatterConstant(offd_mark, num_cols_AFC_offd, tmp_j, 1);
-      HYPRE_THRUST_CALL( exclusive_scan,
-                         offd_mark,
-                         offd_mark + num_cols_A_offd,
-                         tmp_j);
-      HYPRE_THRUST_CALL( gather,
-                         AFC_offd_j,
-                         AFC_offd_j + AFC_offd_nnz,
-                         tmp_j,
-                         AFC_offd_j );
-      col_map_offd_AFC = hypre_TAlloc(HYPRE_Int, num_cols_AFC_offd, HYPRE_MEMORY_DEVICE);
-      tmp_end = HYPRE_THRUST_CALL( copy_if,
-                                   recv_buf,
-                                   recv_buf + num_cols_A_offd,
-                                   offd_mark,
-                                   col_map_offd_AFC,
-                                   thrust::identity<HYPRE_Int>());
-      hypre_assert(tmp_end - col_map_offd_AFC == num_cols_AFC_offd);
-      hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
-
-      /* AFC */
-      AFC = hypre_ParCSRMatrixCreate(comm,
-                                     nF_global,
-                                     nC_global,
-                                     fpts_starts,
-                                     cpts_starts,
-                                     num_cols_AFC_offd,
-                                     AFC_diag_nnz,
-                                     AFC_offd_nnz);
-
-      hypre_ParCSRMatrixOwnsRowStarts(AFC) = AFF_ptr ? 0 : 1;
-      hypre_ParCSRMatrixOwnsColStarts(AFC) = 0;
-
-      AFC_diag = hypre_ParCSRMatrixDiag(AFC);
-      hypre_CSRMatrixData(AFC_diag) = AFC_diag_a;
-      hypre_CSRMatrixI(AFC_diag)    = AFC_diag_i;
-      hypre_CSRMatrixJ(AFC_diag)    = AFC_diag_j;
-
-      AFC_offd = hypre_ParCSRMatrixOffd(AFC);
-      hypre_CSRMatrixData(AFC_offd) = AFC_offd_a;
-      hypre_CSRMatrixI(AFC_offd)    = AFC_offd_i;
-      hypre_CSRMatrixJ(AFC_offd)    = AFC_offd_j;
-
-      hypre_CSRMatrixMemoryLocation(AFC_diag) = HYPRE_MEMORY_DEVICE;
-      hypre_CSRMatrixMemoryLocation(AFC_offd) = HYPRE_MEMORY_DEVICE;
-
-      hypre_ParCSRMatrixDeviceColMapOffd(AFC) = col_map_offd_AFC;
-      hypre_ParCSRMatrixColMapOffd(AFC) = hypre_TAlloc(HYPRE_BigInt, num_cols_AFC_offd, HYPRE_MEMORY_HOST);
-      hypre_TMemcpy(hypre_ParCSRMatrixColMapOffd(AFC), col_map_offd_AFC, HYPRE_BigInt, num_cols_AFC_offd,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
-
-      hypre_ParCSRMatrixSetNumNonzeros(AFC);
-      hypre_ParCSRMatrixDNumNonzeros(AFC) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(AFC);
-      hypre_MatvecCommPkgCreate(AFC);
-
-      *AFC_ptr = AFC;
-   }
-
-   hypre_TFree(A_diag_ii, HYPRE_MEMORY_DEVICE);
-   hypre_TFree(A_offd_ii, HYPRE_MEMORY_DEVICE);
-   hypre_TFree(offd_mark, HYPRE_MEMORY_DEVICE);
-   hypre_TFree(CF_marker, HYPRE_MEMORY_DEVICE);
-   hypre_TFree(map2FC,    HYPRE_MEMORY_DEVICE);
-   hypre_TFree(map2F2,    HYPRE_MEMORY_DEVICE);
-   hypre_TFree(recv_buf,  HYPRE_MEMORY_DEVICE);
-
-   return hypre_error_flag;
-}
-
-HYPRE_Int
-hypre_ParCSRMatrixGenerateFFFCDevice( hypre_ParCSRMatrix  *A,
-                                      HYPRE_Int           *CF_marker_host,
-                                      HYPRE_BigInt        *cpts_starts,
-                                      hypre_ParCSRMatrix  *S,
-                                      hypre_ParCSRMatrix **AFC_ptr,
-                                      hypre_ParCSRMatrix **AFF_ptr )
-{
-   return hypre_ParCSRMatrixGenerateFFFCDevice_core(A, CF_marker_host, cpts_starts, S, AFC_ptr, AFF_ptr, 1);
-}
-
-HYPRE_Int
-hypre_ParCSRMatrixGenerateFFFC3Device( hypre_ParCSRMatrix  *A,
-                                       HYPRE_Int           *CF_marker_host,
-                                       HYPRE_BigInt        *cpts_starts,
-                                       hypre_ParCSRMatrix  *S,
-                                       hypre_ParCSRMatrix **AFC_ptr,
-                                       hypre_ParCSRMatrix **AFF_ptr)
-{
-   return hypre_ParCSRMatrixGenerateFFFCDevice_core(A, CF_marker_host, cpts_starts, S, AFC_ptr, AFF_ptr, 2);
-}
-
 /* return B = [Adiag, Aoffd] */
 #if 1
 __global__ void
@@ -1597,6 +1020,89 @@ hypre_ParCSRMatrixGetRowDevice( hypre_ParCSRMatrix  *mat,
    }
 
    hypre_SyncCudaComputeStream(hypre_handle());
+
+   return hypre_error_flag;
+}
+
+/* abs    == 1, use absolute values
+ * option == 0, drop all the entries that are smaller than tol
+ * TODO more options
+ */
+HYPRE_Int
+hypre_ParCSRMatrixDropSmallEntriesDevice( hypre_ParCSRMatrix *A,
+                                          HYPRE_Complex       tol,
+                                          HYPRE_Int           abs,
+                                          HYPRE_Int           option)
+{
+   hypre_CSRMatrix *A_diag   = hypre_ParCSRMatrixDiag(A);
+   hypre_CSRMatrix *A_offd   = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Int        num_cols_A_offd  = hypre_CSRMatrixNumCols(A_offd);
+   HYPRE_BigInt    *h_col_map_offd_A = hypre_ParCSRMatrixColMapOffd(A);
+   HYPRE_BigInt    *col_map_offd_A = hypre_ParCSRMatrixDeviceColMapOffd(A);
+
+   if (col_map_offd_A == NULL)
+   {
+      col_map_offd_A = hypre_TAlloc(HYPRE_BigInt, num_cols_A_offd, HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(col_map_offd_A, h_col_map_offd_A, HYPRE_BigInt, num_cols_A_offd,
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_ParCSRMatrixDeviceColMapOffd(A) = col_map_offd_A;
+   }
+
+   hypre_CSRMatrixDropSmallEntriesDevice(A_diag, tol, abs, option);
+   hypre_CSRMatrixDropSmallEntriesDevice(A_offd, tol, abs, option);
+
+   hypre_ParCSRMatrixSetNumNonzeros(A);
+   hypre_ParCSRMatrixDNumNonzeros(A) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(A);
+
+   /* squeeze out zero columns of A_offd */
+   HYPRE_Int *tmp_j, *tmp_end, num_cols_A_offd_new;
+   tmp_j = hypre_TAlloc(HYPRE_Int, hypre_CSRMatrixNumNonzeros(A_offd), HYPRE_MEMORY_DEVICE);
+   hypre_TMemcpy(tmp_j, hypre_CSRMatrixJ(A_offd), HYPRE_Int, hypre_CSRMatrixNumNonzeros(A_offd),
+                 HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+   HYPRE_THRUST_CALL( sort,
+                      tmp_j,
+                      tmp_j + hypre_CSRMatrixNumNonzeros(A_offd) );
+   tmp_end = HYPRE_THRUST_CALL( unique,
+                                tmp_j,
+                                tmp_j + hypre_CSRMatrixNumNonzeros(A_offd) );
+   num_cols_A_offd_new = tmp_end - tmp_j;
+
+   hypre_assert(num_cols_A_offd_new <= num_cols_A_offd);
+
+   if (num_cols_A_offd_new < num_cols_A_offd)
+   {
+      hypre_CSRMatrixNumCols(A_offd) = num_cols_A_offd_new;
+
+      HYPRE_Int *offd_mark = hypre_CTAlloc(HYPRE_Int, num_cols_A_offd, HYPRE_MEMORY_DEVICE);
+      HYPRE_BigInt *col_map_offd_A_new = hypre_TAlloc(HYPRE_BigInt, num_cols_A_offd_new, HYPRE_MEMORY_DEVICE);
+
+      HYPRE_THRUST_CALL( scatter,
+                         thrust::counting_iterator<HYPRE_Int>(0),
+                         thrust::counting_iterator<HYPRE_Int>(num_cols_A_offd_new),
+                         tmp_j,
+                         offd_mark );
+      HYPRE_THRUST_CALL( gather,
+                         hypre_CSRMatrixJ(A_offd),
+                         hypre_CSRMatrixJ(A_offd) + hypre_CSRMatrixNumNonzeros(A_offd),
+                         offd_mark,
+                         hypre_CSRMatrixJ(A_offd) );
+      HYPRE_THRUST_CALL( gather,
+                         tmp_j,
+                         tmp_j + num_cols_A_offd_new,
+                         col_map_offd_A,
+                         col_map_offd_A_new );
+
+      hypre_TFree(offd_mark, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(col_map_offd_A, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(h_col_map_offd_A, HYPRE_MEMORY_HOST);
+
+      hypre_ParCSRMatrixDeviceColMapOffd(A) = col_map_offd_A_new;
+      hypre_ParCSRMatrixColMapOffd(A) = hypre_TAlloc(HYPRE_BigInt, num_cols_A_offd_new, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(hypre_ParCSRMatrixColMapOffd(A), col_map_offd_A_new, HYPRE_BigInt, num_cols_A_offd_new,
+                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+   }
+
+   hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
 
    return hypre_error_flag;
 }

--- a/src/parcsr_mv/par_csr_triplemat_device.c
+++ b/src/parcsr_mv/par_csr_triplemat_device.c
@@ -172,8 +172,8 @@ hypre_ParCSRMatMatDevice( hypre_ParCSRMatrix  *A,
                                 hypre_ParCSRMatrixRowStarts(A),
                                 hypre_ParCSRMatrixColStarts(B),
                                 num_cols_offd_C,
-                                hypre_ParCSRMatrixNumNonzeros(C_diag),
-                                hypre_ParCSRMatrixNumNonzeros(C_offd));
+                                hypre_CSRMatrixNumNonzeros(C_diag),
+                                hypre_CSRMatrixNumNonzeros(C_offd));
 
    /* Note that C does not own the partitionings */
    hypre_ParCSRMatrixSetRowStartsOwner(C, 0);
@@ -464,8 +464,8 @@ hypre_ParCSRTMatMatKTDevice( hypre_ParCSRMatrix  *A,
                                 hypre_ParCSRMatrixColStarts(A),
                                 hypre_ParCSRMatrixColStarts(B),
                                 num_cols_offd_C,
-                                hypre_ParCSRMatrixNumNonzeros(C_diag),
-                                hypre_ParCSRMatrixNumNonzeros(C_offd));
+                                hypre_CSRMatrixNumNonzeros(C_diag),
+                                hypre_CSRMatrixNumNonzeros(C_offd));
 
    /* Note that C does not own the partitionings */
    hypre_ParCSRMatrixSetRowStartsOwner(C, 0);
@@ -780,8 +780,8 @@ hypre_ParCSRMatrixRAPKTDevice( hypre_ParCSRMatrix *R,
                                 hypre_ParCSRMatrixColStarts(R),
                                 hypre_ParCSRMatrixColStarts(P),
                                 num_cols_offd_C,
-                                hypre_ParCSRMatrixNumNonzeros(C_diag),
-                                hypre_ParCSRMatrixNumNonzeros(C_offd));
+                                hypre_CSRMatrixNumNonzeros(C_diag),
+                                hypre_CSRMatrixNumNonzeros(C_offd));
 
    /* Note that C does not own the partitionings */
    hypre_ParCSRMatrixSetRowStartsOwner(C, 0);

--- a/src/parcsr_mv/protos.h
+++ b/src/parcsr_mv/protos.h
@@ -69,6 +69,9 @@ HYPRE_Int hypre_ParCSRMatrixGenerateFFFC(hypre_ParCSRMatrix *A, HYPRE_Int *CF_ma
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFC3(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFCD3(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr , HYPRE_Real **D_lambda_ptr ) ;
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFC3Device(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
+HYPRE_Int hypre_ParCSRMatrixGenerateCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host, HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACF_ptr) ;
+HYPRE_Int hypre_ParCSRMatrixGenerateCCDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host, HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACC_ptr) ;
+HYPRE_Int hypre_ParCSRMatrixGenerate1DCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host, HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACX_ptr, hypre_ParCSRMatrix **AXC_ptr ) ;
 
 /* new_commpkg.c */
 HYPRE_Int hypre_PrintCommpkg ( hypre_ParCSRMatrix *A , const char *file_name );
@@ -178,6 +181,7 @@ hypre_CSRMatrix* hypre_ConcatDiagAndOffdDevice(hypre_ParCSRMatrix *A);
 HYPRE_Int hypre_ConcatDiagOffdAndExtDevice(hypre_ParCSRMatrix *A, hypre_CSRMatrix *E, hypre_CSRMatrix **B_ptr, HYPRE_Int *num_cols_offd_ptr, HYPRE_BigInt **cols_map_offd_ptr);
 HYPRE_Int hypre_ParCSRMatrixGetRowDevice( hypre_ParCSRMatrix *mat, HYPRE_BigInt row, HYPRE_Int *size, HYPRE_BigInt **col_ind, HYPRE_Complex **values );
 HYPRE_Int hypre_ParCSRDiagScale( HYPRE_ParCSRMatrix HA, HYPRE_ParVector Hy, HYPRE_ParVector Hx );
+HYPRE_Int hypre_ParCSRMatrixDropSmallEntriesDevice( hypre_ParCSRMatrix *A, HYPRE_Complex tol, HYPRE_Int abs, HYPRE_Int option);
 
 #ifdef HYPRE_USING_PERSISTENT_COMM
 hypre_ParCSRPersistentCommHandle* hypre_ParCSRPersistentCommHandleCreate(HYPRE_Int job, hypre_ParCSRCommPkg *comm_pkg);

--- a/src/parcsr_mv/protos.h
+++ b/src/parcsr_mv/protos.h
@@ -68,6 +68,7 @@ HYPRE_Int HYPRE_ParVectorGetValues ( HYPRE_ParVector vector, HYPRE_Int num_value
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFC(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFC3(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFCD3(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr , HYPRE_Real **D_lambda_ptr ) ;
+HYPRE_Int hypre_ParCSRMatrixGenerateFFFC3Device(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker , HYPRE_BigInt *cpts_starts , hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr , hypre_ParCSRMatrix **A_FF_ptr ) ;
 
 /* new_commpkg.c */
 HYPRE_Int hypre_PrintCommpkg ( hypre_ParCSRMatrix *A , const char *file_name );

--- a/src/seq_mv/csr_matrix.c
+++ b/src/seq_mv/csr_matrix.c
@@ -149,13 +149,13 @@ hypre_CSRMatrixInitialize( hypre_CSRMatrix *matrix )
  * hypre_CSRMatrixResize
  *--------------------------------------------------------------------------*/
 
-HYPRE_Int 
+HYPRE_Int
 hypre_CSRMatrixResize( hypre_CSRMatrix *matrix, HYPRE_Int new_num_rows, HYPRE_Int new_num_cols, HYPRE_Int new_num_nonzeros )
 {
    HYPRE_MemoryLocation memory_location = hypre_CSRMatrixMemoryLocation(matrix);
    HYPRE_Int old_num_nonzeros = hypre_CSRMatrixNumNonzeros(matrix);
    HYPRE_Int old_num_rows = hypre_CSRMatrixNumRows(matrix);
-  
+
    if (!hypre_CSRMatrixOwnsData(matrix))
    {
       hypre_error_w_msg(HYPRE_ERROR_GENERIC,"Error: called hypre_CSRMatrixResize on a matrix that doesn't own the data\n");
@@ -166,7 +166,7 @@ hypre_CSRMatrixResize( hypre_CSRMatrix *matrix, HYPRE_Int new_num_rows, HYPRE_In
    if (new_num_nonzeros != hypre_CSRMatrixNumNonzeros(matrix))
    {
       hypre_CSRMatrixNumNonzeros(matrix) = new_num_nonzeros;
-      
+
       if (!hypre_CSRMatrixData(matrix))
          hypre_CSRMatrixData(matrix) = hypre_CTAlloc(HYPRE_Complex, new_num_nonzeros, memory_location);
       else
@@ -181,7 +181,7 @@ hypre_CSRMatrixResize( hypre_CSRMatrix *matrix, HYPRE_Int new_num_rows, HYPRE_In
    if (new_num_rows != hypre_CSRMatrixNumRows(matrix))
    {
       hypre_CSRMatrixNumRows(matrix) = new_num_rows;
-      
+
       if (!hypre_CSRMatrixI(matrix))
          hypre_CSRMatrixI(matrix) = hypre_CTAlloc(HYPRE_Int, new_num_rows + 1, memory_location);
       else

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -38,6 +38,9 @@ HYPRE_Int hypre_CSRMatrixCheckDiagFirstDevice( hypre_CSRMatrix  *A );
 void hypre_CSRMatrixComputeRowSumDevice( hypre_CSRMatrix *A, HYPRE_Int *CF_i, HYPRE_Int *CF_j, HYPRE_Complex *row_sum, HYPRE_Int type, HYPRE_Complex scal, const char *set_or_add);
 void hypre_CSRMatrixExtractDiagonalDevice( hypre_CSRMatrix *A, HYPRE_Complex *d, HYPRE_Int type);
 hypre_CSRMatrix* hypre_CSRMatrixStack2Device(hypre_CSRMatrix *A, hypre_CSRMatrix *B);
+hypre_CSRMatrix* hypre_CSRMatrixIdentityDevice(HYPRE_Int n, HYPRE_Complex alp);
+HYPRE_Int hypre_CSRMatrixRemoveDiagonalDevice(hypre_CSRMatrix *A);
+HYPRE_Int hypre_CSRMatrixDropSmallEntriesDevice( hypre_CSRMatrix *A, HYPRE_Complex tol, HYPRE_Int abs, HYPRE_Int option);
 #endif
 
 /* csr_matrix.c */

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -295,6 +295,9 @@ HYPRE_Int hypre_CSRMatrixCheckDiagFirstDevice( hypre_CSRMatrix  *A );
 void hypre_CSRMatrixComputeRowSumDevice( hypre_CSRMatrix *A, HYPRE_Int *CF_i, HYPRE_Int *CF_j, HYPRE_Complex *row_sum, HYPRE_Int type, HYPRE_Complex scal, const char *set_or_add);
 void hypre_CSRMatrixExtractDiagonalDevice( hypre_CSRMatrix *A, HYPRE_Complex *d, HYPRE_Int type);
 hypre_CSRMatrix* hypre_CSRMatrixStack2Device(hypre_CSRMatrix *A, hypre_CSRMatrix *B);
+hypre_CSRMatrix* hypre_CSRMatrixIdentityDevice(HYPRE_Int n, HYPRE_Complex alp);
+HYPRE_Int hypre_CSRMatrixRemoveDiagonalDevice(hypre_CSRMatrix *A);
+HYPRE_Int hypre_CSRMatrixDropSmallEntriesDevice( hypre_CSRMatrix *A, HYPRE_Complex tol, HYPRE_Int abs, HYPRE_Int option);
 #endif
 
 /* csr_matrix.c */

--- a/src/test/TEST_cuda_lassen/gpu_boomer.jobs
+++ b/src/test/TEST_cuda_lassen/gpu_boomer.jobs
@@ -27,29 +27,49 @@ mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 18        -e
 mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype 15 -solver 1 \
  >> gpu_boomer.out.6
 
+mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype 18 -solver 1 \
+ >> gpu_boomer.out.7
+
 # RAP 0
 mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 \
- > gpu_boomer.out.7
+ > gpu_boomer.out.8
 
 mpirun -np 3 ./ij -n 128 128 384 -P 1 1 3       -pmis -keepT 1 -rlx 7 -w 0.85 -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 \
- >> gpu_boomer.out.8
-
-mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 \
  >> gpu_boomer.out.9
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 14 -solver 1 \
+mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 \
  >> gpu_boomer.out.10
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  6 -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 14 -solver 1 \
  >> gpu_boomer.out.11
 
-mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 15 -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  6 -solver 1 \
  >> gpu_boomer.out.12
+
+mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 15 -solver 1 \
+ >> gpu_boomer.out.13
 
 
 mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype  6 -solver 1 \
- >> gpu_boomer.out.13
-
-mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 14 -solver 1 \
  >> gpu_boomer.out.14
 
+mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 14 -solver 1 \
+ >> gpu_boomer.out.15
+
+mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 18 -solver 1 \
+ >> gpu_boomer.out.16
+
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 7 -w 0.85        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -solver 1 \
+ >> gpu_boomer.out.17
+
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.85        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 7 -agg_P12_mx 4 -solver 1 \
+ >> gpu_boomer.out.18
+
+mpirun -np 4 ./ij -n 128 128 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.5        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_mx 4 -interptype 18 -solver 1 -sysL 3 -nf 3 \
+ >> gpu_boomer.out.19
+
+mpirun -np 2 ./ij -n 200 128 128 -P 2 1 1       -pmis -keepT 1 -rlx 7 -w 0.7        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_Pmx 4 -interptype 18 -solver 1 -vardifconv -eps 1 \
+ >> gpu_boomer.out.20
+
+mpirun -np 4 ./ij -n 200 200 200 -P 2 2 1       -pmis -keepT 1 -rlx 18 -ns 2        -exec_device -mm_cusparse 0 -agg_nl 3 -agg_interp 7 -agg_P12_mx 6 -interptype 6 -solver 1 \
+ >> gpu_boomer.out.21

--- a/src/test/TEST_cuda_lassen/gpu_boomer.jobs
+++ b/src/test/TEST_cuda_lassen/gpu_boomer.jobs
@@ -65,7 +65,7 @@ mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 7 -w 0.85   
 mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.85        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 7 -agg_P12_mx 4 -solver 1 \
  >> gpu_boomer.out.18
 
-mpirun -np 4 ./ij -n 128 128 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.5        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_mx 4 -interptype 18 -solver 1 -sysL 3 -nf 3 \
+mpirun -np 4 ./ij -n 128 128 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.5        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_Pmx 4 -interptype 18 -solver 1 -sysL 3 -nf 3 \
  >> gpu_boomer.out.19
 
 mpirun -np 2 ./ij -n 200 128 128 -P 2 1 1       -pmis -keepT 1 -rlx 7 -w 0.7        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_Pmx 4 -interptype 18 -solver 1 -vardifconv -eps 1 \

--- a/src/test/TEST_cuda_lassen/gpu_boomer.saved
+++ b/src/test/TEST_cuda_lassen/gpu_boomer.saved
@@ -47,6 +47,14 @@ Iterations = 87
 Final Relative Residual Norm = 9.959863e-09
 
 # Output file: gpu_boomer.out.7
+     Complexity:    grid = 1.223652
+                operator = 1.527126
+                memory = 1.986829
+
+Iterations = 20
+Final Relative Residual Norm = 6.988736e-09
+
+# Output file: gpu_boomer.out.8
      Complexity:    grid = 1.386321
                 operator = 2.317880
                 memory = 2.741283
@@ -54,7 +62,7 @@ Final Relative Residual Norm = 9.959863e-09
 Iterations = 56
 Final Relative Residual Norm = 9.241976e-09
 
-# Output file: gpu_boomer.out.8
+# Output file: gpu_boomer.out.9
      Complexity:    grid = 1.386759
                 operator = 2.315614
                 memory = 2.739425
@@ -62,7 +70,7 @@ Final Relative Residual Norm = 9.241976e-09
 Iterations = 46
 Final Relative Residual Norm = 7.251191e-09
 
-# Output file: gpu_boomer.out.9
+# Output file: gpu_boomer.out.10
      Complexity:    grid = 1.233960
                 operator = 1.239477
                 memory = 1.468463
@@ -70,7 +78,7 @@ Final Relative Residual Norm = 7.251191e-09
 Iterations = 94
 Final Relative Residual Norm = 8.880872e-09
 
-# Output file: gpu_boomer.out.10
+# Output file: gpu_boomer.out.11
      Complexity:    grid = 1.363906
                 operator = 2.852999
                 memory = 3.479160
@@ -78,7 +86,7 @@ Final Relative Residual Norm = 8.880872e-09
 Iterations = 20
 Final Relative Residual Norm = 9.805896e-09
 
-# Output file: gpu_boomer.out.11
+# Output file: gpu_boomer.out.12
      Complexity:    grid = 1.091816
                 operator = 1.219636
                 memory = 1.372748
@@ -86,7 +94,7 @@ Final Relative Residual Norm = 9.805896e-09
 Iterations = 18
 Final Relative Residual Norm = 6.742504e-09
 
-# Output file: gpu_boomer.out.12
+# Output file: gpu_boomer.out.13
      Complexity:    grid = 1.233954
                 operator = 1.239495
                 memory = 1.468522
@@ -94,7 +102,7 @@ Final Relative Residual Norm = 6.742504e-09
 Iterations = 85
 Final Relative Residual Norm = 9.135451e-09
 
-# Output file: gpu_boomer.out.13
+# Output file: gpu_boomer.out.14
      Complexity:    grid = 1.353532
                 operator = 2.780726
                 memory = 3.404736
@@ -102,11 +110,59 @@ Final Relative Residual Norm = 9.135451e-09
 Iterations = 21
 Final Relative Residual Norm = 3.935099e-09
 
-# Output file: gpu_boomer.out.14
+# Output file: gpu_boomer.out.15
      Complexity:    grid = 1.363166
                 operator = 2.857169
                 memory = 3.482528
 
 Iterations = 22
 Final Relative Residual Norm = 4.471627e-09
+
+# Output file: gpu_boomer.out.16
+     Complexity:    grid = 1.353558
+                operator = 2.783221
+                memory = 3.407235
+
+Iterations = 21
+Final Relative Residual Norm = 3.802953e-09
+
+# Output file: gpu_boomer.out.17
+     Complexity:    grid = 1.015720
+                operator = 1.046367
+                memory = 1.316703
+
+Iterations = 19
+Final Relative Residual Norm = 9.102494e-09
+
+# Output file: gpu_boomer.out.18
+     Complexity:    grid = 1.070965
+                operator = 1.448836
+                memory = 1.990060
+
+Iterations = 20
+Final Relative Residual Norm = 4.969910e-09
+
+# Output file: gpu_boomer.out.19
+     Complexity:    grid = 1.079817
+                operator = 1.704510
+                memory = 1.932945
+
+Iterations = 42
+Final Relative Residual Norm = 6.128329e-09
+
+# Output file: gpu_boomer.out.20
+     Complexity:    grid = 1.082234
+                operator = 1.552184
+                memory = 2.055915
+
+Iterations = 37
+Final Relative Residual Norm = 9.506091e-09
+
+# Output file: gpu_boomer.out.21
+     Complexity:    grid = 1.061732
+                operator = 1.424712
+                memory = 2.084116
+
+Iterations = 27
+Final Relative Residual Norm = 4.626767e-09
 

--- a/src/test/TEST_cuda_lassen/gpu_boomer.saved
+++ b/src/test/TEST_cuda_lassen/gpu_boomer.saved
@@ -143,20 +143,20 @@ Iterations = 20
 Final Relative Residual Norm = 4.969910e-09
 
 # Output file: gpu_boomer.out.19
-     Complexity:    grid = 1.079817
-                operator = 1.704510
-                memory = 1.932945
+     Complexity:    grid = 1.080017
+                operator = 1.534680
+                memory = 1.702916
 
-Iterations = 42
-Final Relative Residual Norm = 6.128329e-09
+Iterations = 43
+Final Relative Residual Norm = 6.535032e-09
 
 # Output file: gpu_boomer.out.20
-     Complexity:    grid = 1.082234
-                operator = 1.552184
-                memory = 2.055915
+     Complexity:    grid = 1.082213
+                operator = 1.551688
+                memory = 2.055413
 
-Iterations = 37
-Final Relative Residual Norm = 9.506091e-09
+Iterations = 38
+Final Relative Residual Norm = 5.790962e-09
 
 # Output file: gpu_boomer.out.21
      Complexity:    grid = 1.061732

--- a/src/test/TEST_cuda_lassen/gpu_boomer.sh
+++ b/src/test/TEST_cuda_lassen/gpu_boomer.sh
@@ -27,6 +27,13 @@ FILES="\
  ${TNAME}.out.12\
  ${TNAME}.out.13\
  ${TNAME}.out.14\
+ ${TNAME}.out.15\
+ ${TNAME}.out.16\
+ ${TNAME}.out.17\
+ ${TNAME}.out.18\
+ ${TNAME}.out.19\
+ ${TNAME}.out.20\
+ ${TNAME}.out.21\
 "
 
 for i in $FILES

--- a/src/test/TEST_cuda_ray/gpu_boomer.jobs
+++ b/src/test/TEST_cuda_ray/gpu_boomer.jobs
@@ -58,3 +58,18 @@ mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -e
 
 mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 18 -solver 1 \
  >> gpu_boomer.out.16
+
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 7 -w 0.85        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -solver 1 \
+ >> gpu_boomer.out.17
+
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.85        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 7 -agg_P12_mx 4 -solver 1 \
+ >> gpu_boomer.out.18
+
+mpirun -np 4 ./ij -n 128 128 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.5        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_mx 4 -interptype 18 -solver 1 -sysL 3 -nf 3 \
+ >> gpu_boomer.out.19
+
+mpirun -np 2 ./ij -n 200 128 128 -P 2 1 1       -pmis -keepT 1 -rlx 7 -w 0.7        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_Pmx 4 -interptype 18 -solver 1 -vardifconv -eps 1 \
+ >> gpu_boomer.out.20
+
+mpirun -np 4 ./ij -n 200 200 200 -P 2 2 1       -pmis -keepT 1 -rlx 18 -ns 2        -exec_device -mm_cusparse 0 -agg_nl 3 -agg_interp 7 -agg_P12_mx 6 -interptype 6 -solver 1 \
+ >> gpu_boomer.out.21

--- a/src/test/TEST_cuda_ray/gpu_boomer.jobs
+++ b/src/test/TEST_cuda_ray/gpu_boomer.jobs
@@ -65,7 +65,7 @@ mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 7 -w 0.85   
 mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.85        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 7 -agg_P12_mx 4 -solver 1 \
  >> gpu_boomer.out.18
 
-mpirun -np 4 ./ij -n 128 128 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.5        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_mx 4 -interptype 18 -solver 1 -sysL 3 -nf 3 \
+mpirun -np 4 ./ij -n 128 128 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.5        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_Pmx 4 -interptype 18 -solver 1 -sysL 3 -nf 3 \
  >> gpu_boomer.out.19
 
 mpirun -np 2 ./ij -n 200 128 128 -P 2 1 1       -pmis -keepT 1 -rlx 7 -w 0.7        -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_Pmx 4 -interptype 18 -solver 1 -vardifconv -eps 1 \

--- a/src/test/TEST_cuda_ray/gpu_boomer.saved
+++ b/src/test/TEST_cuda_ray/gpu_boomer.saved
@@ -1,168 +1,168 @@
 # Output file: gpu_boomer.out.1
-     Complexity:    grid = 1.386668
-                operator = 2.319415
-                memory = 2.742907
+     Complexity:    grid = 1.386318
+                operator = 2.317868
+                memory = 2.741269
 
-Iterations = 55
-Final Relative Residual Norm = 7.325820e-09
+Iterations = 56
+Final Relative Residual Norm = 8.508319e-09
 
 # Output file: gpu_boomer.out.2
-     Complexity:    grid = 1.387120
-                operator = 2.317188
-                memory = 2.741105
+     Complexity:    grid = 1.386764
+                operator = 2.315610
+                memory = 2.739421
 
-Iterations = 46
-Final Relative Residual Norm = 8.947971e-09
+Iterations = 47
+Final Relative Residual Norm = 7.443756e-09
 
 # Output file: gpu_boomer.out.3
      Complexity:    grid = 1.233970
-                operator = 1.239483
-                memory = 1.468476
+                operator = 1.239504
+                memory = 1.468498
 
-Iterations = 93
-Final Relative Residual Norm = 7.691537e-09
+Iterations = 94
+Final Relative Residual Norm = 9.463641e-09
 
 # Output file: gpu_boomer.out.4
-     Complexity:    grid = 1.363975
-                operator = 2.853325
-                memory = 3.479495
+     Complexity:    grid = 1.363922
+                operator = 2.853255
+                memory = 3.479417
 
 Iterations = 20
-Final Relative Residual Norm = 9.978545e-09
+Final Relative Residual Norm = 6.686114e-09
 
 # Output file: gpu_boomer.out.5
-     Complexity:    grid = 1.091923
-                operator = 1.219757
-                memory = 1.372872
+     Complexity:    grid = 1.091826
+                operator = 1.219666
+                memory = 1.372779
 
 Iterations = 18
-Final Relative Residual Norm = 8.584825e-09
+Final Relative Residual Norm = 6.945768e-09
 
 # Output file: gpu_boomer.out.6
-     Complexity:    grid = 1.233962
-                operator = 1.239507
-                memory = 1.468539
+     Complexity:    grid = 1.233952
+                operator = 1.239494
+                memory = 1.468523
 
-Iterations = 85
-Final Relative Residual Norm = 8.321047e-09
+Iterations = 88
+Final Relative Residual Norm = 8.805761e-09
 
 # Output file: gpu_boomer.out.7
-     Complexity:    grid = 1.223659
-                operator = 1.527136
-                memory = 1.986840
+     Complexity:    grid = 1.223661
+                operator = 1.527139
+                memory = 1.986845
 
 Iterations = 20
-Final Relative Residual Norm = 9.179707e-09
+Final Relative Residual Norm = 5.811424e-09
 
 # Output file: gpu_boomer.out.8
-     Complexity:    grid = 1.386678
-                operator = 2.319459
-                memory = 2.742954
+     Complexity:    grid = 1.386319
+                operator = 2.317869
+                memory = 2.741273
 
-Iterations = 53
-Final Relative Residual Norm = 9.994590e-09
+Iterations = 56
+Final Relative Residual Norm = 7.529893e-09
 
 # Output file: gpu_boomer.out.9
-     Complexity:    grid = 1.387120
-                operator = 2.317188
-                memory = 2.741105
+     Complexity:    grid = 1.386764
+                operator = 2.315610
+                memory = 2.739421
 
-Iterations = 46
-Final Relative Residual Norm = 8.947966e-09
+Iterations = 47
+Final Relative Residual Norm = 7.443752e-09
 
 # Output file: gpu_boomer.out.10
-     Complexity:    grid = 1.233964
-                operator = 1.239474
-                memory = 1.468461
+     Complexity:    grid = 1.233958
+                operator = 1.239476
+                memory = 1.468463
 
-Iterations = 91
-Final Relative Residual Norm = 9.949208e-09
+Iterations = 94
+Final Relative Residual Norm = 7.813333e-09
 
 # Output file: gpu_boomer.out.11
-     Complexity:    grid = 1.363975
-                operator = 2.853325
-                memory = 3.479495
+     Complexity:    grid = 1.363922
+                operator = 2.853255
+                memory = 3.479417
 
 Iterations = 20
-Final Relative Residual Norm = 9.978545e-09
+Final Relative Residual Norm = 6.686114e-09
 
 # Output file: gpu_boomer.out.12
-     Complexity:    grid = 1.091923
-                operator = 1.219757
-                memory = 1.372872
+     Complexity:    grid = 1.091826
+                operator = 1.219666
+                memory = 1.372779
 
 Iterations = 18
-Final Relative Residual Norm = 8.584825e-09
+Final Relative Residual Norm = 6.945768e-09
 
 # Output file: gpu_boomer.out.13
-     Complexity:    grid = 1.233960
-                operator = 1.239500
-                memory = 1.468531
+     Complexity:    grid = 1.233954
+                operator = 1.239496
+                memory = 1.468525
 
-Iterations = 86
-Final Relative Residual Norm = 9.124148e-09
+Iterations = 89
+Final Relative Residual Norm = 8.673390e-09
 
 # Output file: gpu_boomer.out.14
-     Complexity:    grid = 1.353583
-                operator = 2.780935
-                memory = 3.404952
+     Complexity:    grid = 1.353535
+                operator = 2.780820
+                memory = 3.404831
 
 Iterations = 21
-Final Relative Residual Norm = 3.537798e-09
+Final Relative Residual Norm = 3.960884e-09
 
 # Output file: gpu_boomer.out.15
-     Complexity:    grid = 1.363222
-                operator = 2.857388
-                memory = 3.482754
+     Complexity:    grid = 1.363161
+                operator = 2.857143
+                memory = 3.482500
 
 Iterations = 22
-Final Relative Residual Norm = 5.884113e-09
+Final Relative Residual Norm = 3.966029e-09
 
 # Output file: gpu_boomer.out.16
-     Complexity:    grid = 1.353612
-                operator = 2.783465
-                memory = 3.407485
-
-Iterations = 21
-Final Relative Residual Norm = 3.523696e-09
-
-# Output file: gpu_boomer.out.17
-     Complexity:    grid = 1.015746
-                operator = 1.046402
-                memory = 1.316738
-
-Iterations = 19
-Final Relative Residual Norm = 9.103286e-09
-
-# Output file: gpu_boomer.out.18
-     Complexity:    grid = 1.071022
-                operator = 1.449093
-                memory = 1.990325
+     Complexity:    grid = 1.353544
+                operator = 2.783059
+                memory = 3.407071
 
 Iterations = 20
-Final Relative Residual Norm = 4.979852e-09
+Final Relative Residual Norm = 6.929038e-09
+
+# Output file: gpu_boomer.out.17
+     Complexity:    grid = 1.015720
+                operator = 1.046367
+                memory = 1.316703
+
+Iterations = 19
+Final Relative Residual Norm = 9.102494e-09
+
+# Output file: gpu_boomer.out.18
+     Complexity:    grid = 1.070971
+                operator = 1.448978
+                memory = 1.990206
+
+Iterations = 20
+Final Relative Residual Norm = 4.900227e-09
 
 # Output file: gpu_boomer.out.19
-     Complexity:    grid = 1.079893
-                operator = 1.704726
-                memory = 1.933165
+     Complexity:    grid = 1.079817
+                operator = 1.704510
+                memory = 1.932945
 
-Iterations = 41
-Final Relative Residual Norm = 9.471310e-09
+Iterations = 42
+Final Relative Residual Norm = 6.128329e-09
 
 # Output file: gpu_boomer.out.20
-     Complexity:    grid = 1.082416
-                operator = 1.552538
-                memory = 2.056275
+     Complexity:    grid = 1.082244
+                operator = 1.552200
+                memory = 2.055928
 
 Iterations = 38
-Final Relative Residual Norm = 5.410777e-09
+Final Relative Residual Norm = 5.393928e-09
 
 # Output file: gpu_boomer.out.21
-     Complexity:    grid = 1.061742
-                operator = 1.424801
-                memory = 2.084273
+     Complexity:    grid = 1.061731
+                operator = 1.424640
+                memory = 2.083989
 
 Iterations = 26
-Final Relative Residual Norm = 7.116822e-09
+Final Relative Residual Norm = 9.655585e-09
 

--- a/src/test/TEST_cuda_ray/gpu_boomer.saved
+++ b/src/test/TEST_cuda_ray/gpu_boomer.saved
@@ -143,20 +143,20 @@ Iterations = 20
 Final Relative Residual Norm = 4.900227e-09
 
 # Output file: gpu_boomer.out.19
-     Complexity:    grid = 1.079817
-                operator = 1.704510
-                memory = 1.932945
+     Complexity:    grid = 1.080002
+                operator = 1.534482
+                memory = 1.702717
 
-Iterations = 42
-Final Relative Residual Norm = 6.128329e-09
+Iterations = 43
+Final Relative Residual Norm = 6.926584e-09
 
 # Output file: gpu_boomer.out.20
-     Complexity:    grid = 1.082244
-                operator = 1.552200
-                memory = 2.055928
+     Complexity:    grid = 1.082216
+                operator = 1.551730
+                memory = 2.055461
 
 Iterations = 38
-Final Relative Residual Norm = 5.393928e-09
+Final Relative Residual Norm = 6.219917e-09
 
 # Output file: gpu_boomer.out.21
      Complexity:    grid = 1.061731

--- a/src/test/TEST_cuda_ray/gpu_boomer.saved
+++ b/src/test/TEST_cuda_ray/gpu_boomer.saved
@@ -1,128 +1,168 @@
 # Output file: gpu_boomer.out.1
-     Complexity:    grid = 1.386318
-                operator = 2.317868
-                memory = 2.741269
+     Complexity:    grid = 1.386668
+                operator = 2.319415
+                memory = 2.742907
 
-Iterations = 56
-Final Relative Residual Norm = 8.508319e-09
+Iterations = 55
+Final Relative Residual Norm = 7.325820e-09
 
 # Output file: gpu_boomer.out.2
-     Complexity:    grid = 1.386764
-                operator = 2.315610
-                memory = 2.739421
+     Complexity:    grid = 1.387120
+                operator = 2.317188
+                memory = 2.741105
 
-Iterations = 47
-Final Relative Residual Norm = 7.443756e-09
+Iterations = 46
+Final Relative Residual Norm = 8.947971e-09
 
 # Output file: gpu_boomer.out.3
      Complexity:    grid = 1.233970
-                operator = 1.239504
-                memory = 1.468498
+                operator = 1.239483
+                memory = 1.468476
 
-Iterations = 94
-Final Relative Residual Norm = 9.463641e-09
+Iterations = 93
+Final Relative Residual Norm = 7.691537e-09
 
 # Output file: gpu_boomer.out.4
-     Complexity:    grid = 1.363922
-                operator = 2.853255
-                memory = 3.479417
+     Complexity:    grid = 1.363975
+                operator = 2.853325
+                memory = 3.479495
 
 Iterations = 20
-Final Relative Residual Norm = 6.686114e-09
+Final Relative Residual Norm = 9.978545e-09
 
 # Output file: gpu_boomer.out.5
-     Complexity:    grid = 1.091826
-                operator = 1.219666
-                memory = 1.372779
+     Complexity:    grid = 1.091923
+                operator = 1.219757
+                memory = 1.372872
 
 Iterations = 18
-Final Relative Residual Norm = 6.945768e-09
+Final Relative Residual Norm = 8.584825e-09
 
 # Output file: gpu_boomer.out.6
-     Complexity:    grid = 1.233952
-                operator = 1.239494
-                memory = 1.468523
+     Complexity:    grid = 1.233962
+                operator = 1.239507
+                memory = 1.468539
 
-Iterations = 88
-Final Relative Residual Norm = 8.805761e-09
+Iterations = 85
+Final Relative Residual Norm = 8.321047e-09
 
 # Output file: gpu_boomer.out.7
-     Complexity:    grid = 1.223661
-                operator = 1.527139
-                memory = 1.986845
+     Complexity:    grid = 1.223659
+                operator = 1.527136
+                memory = 1.986840
 
 Iterations = 20
-Final Relative Residual Norm = 5.811424e-09
+Final Relative Residual Norm = 9.179707e-09
 
 # Output file: gpu_boomer.out.8
-     Complexity:    grid = 1.386319
-                operator = 2.317869
-                memory = 2.741273
+     Complexity:    grid = 1.386678
+                operator = 2.319459
+                memory = 2.742954
 
-Iterations = 56
-Final Relative Residual Norm = 7.529893e-09
+Iterations = 53
+Final Relative Residual Norm = 9.994590e-09
 
 # Output file: gpu_boomer.out.9
-     Complexity:    grid = 1.386764
-                operator = 2.315610
-                memory = 2.739421
+     Complexity:    grid = 1.387120
+                operator = 2.317188
+                memory = 2.741105
 
-Iterations = 47
-Final Relative Residual Norm = 7.443752e-09
+Iterations = 46
+Final Relative Residual Norm = 8.947966e-09
 
 # Output file: gpu_boomer.out.10
-     Complexity:    grid = 1.233958
-                operator = 1.239476
-                memory = 1.468463
+     Complexity:    grid = 1.233964
+                operator = 1.239474
+                memory = 1.468461
 
-Iterations = 94
-Final Relative Residual Norm = 7.813333e-09
+Iterations = 91
+Final Relative Residual Norm = 9.949208e-09
 
 # Output file: gpu_boomer.out.11
-     Complexity:    grid = 1.363922
-                operator = 2.853255
-                memory = 3.479417
+     Complexity:    grid = 1.363975
+                operator = 2.853325
+                memory = 3.479495
 
 Iterations = 20
-Final Relative Residual Norm = 6.686114e-09
+Final Relative Residual Norm = 9.978545e-09
 
 # Output file: gpu_boomer.out.12
-     Complexity:    grid = 1.091826
-                operator = 1.219666
-                memory = 1.372779
+     Complexity:    grid = 1.091923
+                operator = 1.219757
+                memory = 1.372872
 
 Iterations = 18
-Final Relative Residual Norm = 6.945768e-09
+Final Relative Residual Norm = 8.584825e-09
 
 # Output file: gpu_boomer.out.13
-     Complexity:    grid = 1.233954
-                operator = 1.239496
-                memory = 1.468525
+     Complexity:    grid = 1.233960
+                operator = 1.239500
+                memory = 1.468531
 
-Iterations = 89
-Final Relative Residual Norm = 8.673390e-09
+Iterations = 86
+Final Relative Residual Norm = 9.124148e-09
 
 # Output file: gpu_boomer.out.14
-     Complexity:    grid = 1.353535
-                operator = 2.780820
-                memory = 3.404831
+     Complexity:    grid = 1.353583
+                operator = 2.780935
+                memory = 3.404952
 
 Iterations = 21
-Final Relative Residual Norm = 3.960884e-09
+Final Relative Residual Norm = 3.537798e-09
 
 # Output file: gpu_boomer.out.15
-     Complexity:    grid = 1.363161
-                operator = 2.857143
-                memory = 3.482500
+     Complexity:    grid = 1.363222
+                operator = 2.857388
+                memory = 3.482754
 
 Iterations = 22
-Final Relative Residual Norm = 3.966029e-09
+Final Relative Residual Norm = 5.884113e-09
 
 # Output file: gpu_boomer.out.16
-     Complexity:    grid = 1.353544
-                operator = 2.783059
-                memory = 3.407071
+     Complexity:    grid = 1.353612
+                operator = 2.783465
+                memory = 3.407485
+
+Iterations = 21
+Final Relative Residual Norm = 3.523696e-09
+
+# Output file: gpu_boomer.out.17
+     Complexity:    grid = 1.015746
+                operator = 1.046402
+                memory = 1.316738
+
+Iterations = 19
+Final Relative Residual Norm = 9.103286e-09
+
+# Output file: gpu_boomer.out.18
+     Complexity:    grid = 1.071022
+                operator = 1.449093
+                memory = 1.990325
 
 Iterations = 20
-Final Relative Residual Norm = 6.929038e-09
+Final Relative Residual Norm = 4.979852e-09
+
+# Output file: gpu_boomer.out.19
+     Complexity:    grid = 1.079893
+                operator = 1.704726
+                memory = 1.933165
+
+Iterations = 41
+Final Relative Residual Norm = 9.471310e-09
+
+# Output file: gpu_boomer.out.20
+     Complexity:    grid = 1.082416
+                operator = 1.552538
+                memory = 2.056275
+
+Iterations = 38
+Final Relative Residual Norm = 5.410777e-09
+
+# Output file: gpu_boomer.out.21
+     Complexity:    grid = 1.061742
+                operator = 1.424801
+                memory = 2.084273
+
+Iterations = 26
+Final Relative Residual Norm = 7.116822e-09
 

--- a/src/test/TEST_cuda_ray/gpu_boomer.sh
+++ b/src/test/TEST_cuda_ray/gpu_boomer.sh
@@ -29,6 +29,11 @@ FILES="\
  ${TNAME}.out.14\
  ${TNAME}.out.15\
  ${TNAME}.out.16\
+ ${TNAME}.out.17\
+ ${TNAME}.out.18\
+ ${TNAME}.out.19\
+ ${TNAME}.out.20\
+ ${TNAME}.out.21\
 "
 
 for i in $FILES

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -2786,14 +2786,18 @@ main( hypre_int argc,
       HYPRE_IJVectorSetObjectType(ij_x, HYPRE_PARCSR);
       HYPRE_IJVectorInitialize(ij_x);
 
-      values = hypre_CTAlloc(HYPRE_Real, local_num_cols, HYPRE_MEMORY_DEVICE);
+      HYPRE_Real *values_h = hypre_CTAlloc(HYPRE_Real, local_num_cols, HYPRE_MEMORY_HOST);
+      HYPRE_Real *values_d = hypre_CTAlloc(HYPRE_Real, local_num_cols, memory_location);
       for (i = 0; i < local_num_cols; i++)
       {
-         values[i] = 1.;
+         values_h[i] = 1.;
       }
-      HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values);
+      hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_cols, memory_location, HYPRE_MEMORY_HOST);
+
+      HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values_d);
       HYPRE_IJVectorAssemble(ij_x);
-      hypre_TFree(values, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(values_h, HYPRE_MEMORY_HOST);
+      hypre_TFree(values_d, memory_location);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
@@ -2832,14 +2836,18 @@ main( hypre_int argc,
       HYPRE_IJVectorSetObjectType(ij_x, HYPRE_PARCSR);
       HYPRE_IJVectorInitialize(ij_x);
 
-      values = hypre_CTAlloc(HYPRE_Real, local_num_cols, HYPRE_MEMORY_DEVICE);
+      HYPRE_Real *values_h = hypre_CTAlloc(HYPRE_Real, local_num_cols, HYPRE_MEMORY_HOST);
+      HYPRE_Real *values_d = hypre_CTAlloc(HYPRE_Real, local_num_cols, memory_location);
       for (i = 0; i < local_num_cols; i++)
       {
-         values[i] = 1.;
+         values_h[i] = 1.;
       }
-      HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values);
+      hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_cols, memory_location, HYPRE_MEMORY_HOST);
+
+      HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values_d);
       HYPRE_IJVectorAssemble(ij_x);
-      hypre_TFree(values, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(values_h, HYPRE_MEMORY_HOST);
+      hypre_TFree(values_d, memory_location);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
@@ -2903,14 +2911,18 @@ main( hypre_int argc,
       HYPRE_IJVectorSetObjectType(ij_b, HYPRE_PARCSR);
       HYPRE_IJVectorInitialize(ij_b);
 
-      values = hypre_CTAlloc(HYPRE_Real, local_num_rows, HYPRE_MEMORY_DEVICE);
+      HYPRE_Real *values_h = hypre_CTAlloc(HYPRE_Real, local_num_rows, HYPRE_MEMORY_HOST);
+      HYPRE_Real *values_d = hypre_CTAlloc(HYPRE_Real, local_num_rows, memory_location);
       for (i = 0; i < local_num_rows; i++)
       {
-         values[i] = 1.;
+         values_h[i] = 1.;
       }
-      HYPRE_IJVectorSetValues(ij_b, local_num_rows, NULL, values);
+      hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_rows, memory_location, HYPRE_MEMORY_HOST);
+
+      HYPRE_IJVectorSetValues(ij_b, local_num_rows, NULL, values_d);
       HYPRE_IJVectorAssemble(ij_b);
-      hypre_TFree(values, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(values_h, HYPRE_MEMORY_HOST);
+      hypre_TFree(values_d, memory_location);
 
       ierr = HYPRE_IJVectorGetObject( ij_b, &object );
       b = (HYPRE_ParVector) object;
@@ -2940,15 +2952,19 @@ main( hypre_int argc,
       HYPRE_IJVectorSetObjectType(ij_b, HYPRE_PARCSR);
       HYPRE_IJVectorInitialize(ij_b);
 
-      values = hypre_CTAlloc(HYPRE_Real, local_num_rows, HYPRE_MEMORY_DEVICE);
+      HYPRE_Real *values_h = hypre_CTAlloc(HYPRE_Real, local_num_rows, HYPRE_MEMORY_HOST);
+      HYPRE_Real *values_d = hypre_CTAlloc(HYPRE_Real, local_num_rows, memory_location);
       hypre_SeedRand(myid);
       for (i = 0; i < local_num_rows; i++)
       {
-         values[i] = hypre_Rand();
+         values_h[i] = hypre_Rand();
       }
-      HYPRE_IJVectorSetValues(ij_b, local_num_rows, NULL, values);
+      hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_rows, memory_location, HYPRE_MEMORY_HOST);
+
+      HYPRE_IJVectorSetValues(ij_b, local_num_rows, NULL, values_d);
       HYPRE_IJVectorAssemble(ij_b);
-      hypre_TFree(values, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(values_h, HYPRE_MEMORY_HOST);
+      hypre_TFree(values_d, memory_location);
 
       ierr = HYPRE_IJVectorGetObject( ij_b, &object );
       b = (HYPRE_ParVector) object;
@@ -2978,15 +2994,19 @@ main( hypre_int argc,
       HYPRE_IJVectorSetObjectType(ij_b, HYPRE_PARCSR);
       HYPRE_IJVectorInitialize(ij_b);
 
-      values = hypre_CTAlloc(HYPRE_Real, local_num_rows, HYPRE_MEMORY_DEVICE);
+      HYPRE_Real *values_h = hypre_CTAlloc(HYPRE_Real, local_num_rows, HYPRE_MEMORY_HOST);
+      HYPRE_Real *values_d = hypre_CTAlloc(HYPRE_Real, local_num_rows, memory_location);
       hypre_SeedRand(myid);
       for (i = 0; i < local_num_rows; i++)
       {
-         values[i] = hypre_Rand()/dt;
+         values_h[i] = hypre_Rand()/dt;
       }
-      HYPRE_IJVectorSetValues(ij_b, local_num_rows, NULL, values);
+      hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_rows, memory_location, HYPRE_MEMORY_HOST);
+
+      HYPRE_IJVectorSetValues(ij_b, local_num_rows, NULL, values_d);
       HYPRE_IJVectorAssemble(ij_b);
-      hypre_TFree(values, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(values_h, HYPRE_MEMORY_HOST);
+      hypre_TFree(values_d, memory_location);
 
       ierr = HYPRE_IJVectorGetObject( ij_b, &object );
       b = (HYPRE_ParVector) object;
@@ -2998,15 +3018,19 @@ main( hypre_int argc,
 
       /* For backward Euler the previous backward Euler iterate (assumed
          random in 0 - 1 here) is usually used as the initial guess */
-      values = hypre_CTAlloc(HYPRE_Real, local_num_cols, HYPRE_MEMORY_DEVICE);
+      values_h = hypre_CTAlloc(HYPRE_Real, local_num_cols, HYPRE_MEMORY_HOST);
+      values_d = hypre_CTAlloc(HYPRE_Real, local_num_cols, memory_location);
       hypre_SeedRand(myid);
       for (i = 0; i < local_num_cols; i++)
       {
-         values[i] = hypre_Rand();
+         values_h[i] = hypre_Rand();
       }
-      HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values);
+      hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_cols, memory_location, HYPRE_MEMORY_HOST);
+
+      HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values_d);
       HYPRE_IJVectorAssemble(ij_x);
-      hypre_TFree(values, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(values_h, HYPRE_MEMORY_HOST);
+      hypre_TFree(values_d, memory_location);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
@@ -3025,16 +3049,20 @@ main( hypre_int argc,
 
       /* For backward Euler the previous backward Euler iterate (assumed
          random in 0 - 1 here) is usually used as the initial guess */
-      values = hypre_CTAlloc(HYPRE_Real, local_num_cols, HYPRE_MEMORY_DEVICE);
+      HYPRE_Real *values_h = hypre_CTAlloc(HYPRE_Real, local_num_cols, HYPRE_MEMORY_HOST);
+      HYPRE_Real *values_d = hypre_CTAlloc(HYPRE_Real, local_num_cols, memory_location);
       hypre_SeedRand(myid+2747);
       hypre_SeedRand(myid);
       for (i = 0; i < local_num_cols; i++)
       {
-         values[i] = hypre_Rand();
+         values_h[i] = hypre_Rand();
       }
-      HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values);
+      hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_cols, memory_location, HYPRE_MEMORY_HOST);
+
+      HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values_d);
       HYPRE_IJVectorAssemble(ij_x);
-      hypre_TFree(values, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(values_h, HYPRE_MEMORY_HOST);
+      hypre_TFree(values_d, memory_location);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
@@ -3083,15 +3111,19 @@ main( hypre_int argc,
 
       /* For backward Euler the previous backward Euler iterate (assumed
          random in 0 - 1 here) is usually used as the initial guess */
-      values = hypre_CTAlloc(HYPRE_Real, local_num_cols, HYPRE_MEMORY_DEVICE);
+      HYPRE_Real *values_h = hypre_CTAlloc(HYPRE_Real, local_num_cols, HYPRE_MEMORY_HOST);
+      HYPRE_Real *values_d = hypre_CTAlloc(HYPRE_Real, local_num_cols, memory_location);
       hypre_SeedRand(myid);
       for (i = 0; i < local_num_cols; i++)
       {
-         values[i] = hypre_Rand();
+         values_h[i] = hypre_Rand();
       }
-      HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values);
+      hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_cols, memory_location, HYPRE_MEMORY_HOST);
+
+      HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values_d);
       HYPRE_IJVectorAssemble(ij_x);
-      hypre_TFree(values, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(values_h, HYPRE_MEMORY_HOST);
+      hypre_TFree(values_d, memory_location);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;

--- a/src/test/runtest.sh
+++ b/src/test/runtest.sh
@@ -107,6 +107,14 @@ function MpirunString
          shift
          RunString="srun -n$*"
          ;;
+      ray*)
+         shift
+         RunString="lrun -n$*"
+         ;;
+      lassen*)
+         shift
+         RunString="lrun -n$*"
+         ;;
       *)
          shift
          if [ $NumThreads -gt 0 ] ; then

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -670,6 +670,19 @@ struct less_than : public thrust::unary_function<T,bool>
    }
 };
 
+template<typename T>
+struct equal : public thrust::unary_function<T,bool>
+{
+   T val;
+
+   equal(T val_) { val = val_; }
+
+   __host__ __device__ bool operator()(const T &x)
+   {
+      return (x == val);
+   }
+};
+
 /* hypre_cuda_utils.c */
 dim3 hypre_GetDefaultCUDABlockDimension();
 

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -664,6 +664,19 @@ struct less_than : public thrust::unary_function<T,bool>
    }
 };
 
+template<typename T>
+struct equal : public thrust::unary_function<T,bool>
+{
+   T val;
+
+   equal(T val_) { val = val_; }
+
+   __host__ __device__ bool operator()(const T &x)
+   {
+      return (x == val);
+   }
+};
+
 /* hypre_cuda_utils.c */
 dim3 hypre_GetDefaultCUDABlockDimension();
 

--- a/src/utilities/hypre_general.c
+++ b/src/utilities/hypre_general.c
@@ -102,15 +102,16 @@ hypre_SetDevice(HYPRE_Int use_device, hypre_Handle *hypre_handle_)
 #if defined(HYPRE_USING_CUDA)
    HYPRE_CUDA_CALL( cudaSetDevice(device_id) );
 #else
+   HYPRE_CUDA_CALL( cudaSetDevice(device_id) );
    omp_set_default_device(device_id);
 #endif
 
    hypre_HandleCudaDevice(hypre_handle_) = device_id;
 
-   /*
+#ifdef HYPRE_DEBUG
    hypre_printf("Proc [global %d/%d, local %d/%d] can see %d GPUs and is running on %d\n",
                  myid, nproc, myNodeid, NodeSize, nDevices, device_id);
-   */
+#endif
 
    return hypre_error_flag;
 }

--- a/src/utilities/hypre_general.c
+++ b/src/utilities/hypre_general.c
@@ -108,7 +108,7 @@ hypre_SetDevice(HYPRE_Int use_device, hypre_Handle *hypre_handle_)
 
    hypre_HandleCudaDevice(hypre_handle_) = device_id;
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && defined(HYPRE_PRINT_ERRORS)
    hypre_printf("Proc [global %d/%d, local %d/%d] can see %d GPUs and is running on %d\n",
                  myid, nproc, myNodeid, NodeSize, nDevices, device_id);
 #endif

--- a/src/utilities/hypre_omp_device.c
+++ b/src/utilities/hypre_omp_device.c
@@ -52,8 +52,14 @@ HYPRE_OMPOffloadOn()
    hypre__global_offload = 1;
    hypre__offload_device_num = omp_get_default_device();
    hypre__offload_host_num   = omp_get_initial_device();
-   hypre_fprintf(stdout, "Hypre OMP 4.5 offloading has been turned on. Device %d\n",
-                 hypre__offload_device_num);
+
+   /*
+   HYPRE_Int myid, nproc;
+   hypre_MPI_Comm_rank(hypre_MPI_COMM_WORLD, &myid);
+   hypre_MPI_Comm_size(hypre_MPI_COMM_WORLD, &nproc);
+   hypre_fprintf(stdout, "Proc %d: Hypre OMP 4.5 offloading has been turned on. Device %d\n",
+                 myid, hypre__offload_device_num);
+   */
 
    return 0;
 }
@@ -61,7 +67,13 @@ HYPRE_OMPOffloadOn()
 HYPRE_Int
 HYPRE_OMPOffloadOff()
 {
-   fprintf(stdout, "Hypre OMP 4.5 offloading has been turned off\n");
+   /*
+   HYPRE_Int myid, nproc;
+   hypre_MPI_Comm_rank(hypre_MPI_COMM_WORLD, &myid);
+   hypre_MPI_Comm_size(hypre_MPI_COMM_WORLD, &nproc);
+   fprintf(stdout, "Proc %d: Hypre OMP 4.5 offloading has been turned off\n", myid);
+   */
+
    hypre__global_offload = 0;
    hypre__offload_device_num = omp_get_initial_device();
    hypre__offload_host_num   = omp_get_initial_device();


### PR DESCRIPTION
This PR contains the implementation of aggressive coarsening and 2-stage MM-extended-type interpolations on GPU. The main functions are 
1. Aggressive coarsening (hypre_BoomerAMGCreate2ndS)
2. Partial MM-ext Interpolation (hypre_BoomerAMGBuildModPartialExtInterpDevice)
3. Partial MM-ext+e Interpolation (hypre_BoomerAMGBuildModPartialExtPEInterpDevice)