### PR TITLE
Set default convergence tolerance to 1.0e-6

### DIFF
--- a/src/parcsr_ls/HYPRE_parcsr_ls.h
+++ b/src/parcsr_ls/HYPRE_parcsr_ls.h
@@ -187,7 +187,7 @@ HYPRE_Int HYPRE_BoomerAMGSetConvergeType(HYPRE_Solver solver,
 /**
  * (Optional) Set the convergence tolerance, if BoomerAMG is used
  * as a solver. If it is used as a preconditioner, it should be set to 0.
- * The default is 1.e-7.
+ * The default is 1.e-6.
  **/
 HYPRE_Int HYPRE_BoomerAMGSetTol(HYPRE_Solver solver,
                                 HYPRE_Real   tol);
@@ -2893,7 +2893,7 @@ HYPRE_Int HYPRE_ParCSRHybridSolve(HYPRE_Solver       solver,
                                   HYPRE_ParVector    b,
                                   HYPRE_ParVector    x);
 /**
- *  Set the convergence tolerance for the Krylov solver. The default is 1.e-7.
+ *  Set the convergence tolerance for the Krylov solver. The default is 1.e-6.
  **/
 HYPRE_Int HYPRE_ParCSRHybridSetTol(HYPRE_Solver solver,
                                    HYPRE_Real   tol);
@@ -3873,7 +3873,7 @@ HYPRE_MGRSetMaxIter( HYPRE_Solver solver,
 
 /**
  * (Optional) Set the convergence tolerance for the MGR solver.
- * Use tol = 0.0 if MGR is used as a preconditioner. The default is 1.e-7.
+ * Use tol = 0.0 if MGR is used as a preconditioner. The default is 1.e-6.
  **/
 HYPRE_Int
 HYPRE_MGRSetTol( HYPRE_Solver solver,
@@ -3988,7 +3988,7 @@ HYPRE_ILUSetMaxIter( HYPRE_Solver solver, HYPRE_Int max_iter );
 
 /**
  * (Optional) Set the convergence tolerance for the ILU smoother.
- * Use tol = 0.0 if ILU is used as a preconditioner. The default is 1.e-7.
+ * Use tol = 0.0 if ILU is used as a preconditioner. The default is 1.e-6.
  **/
 HYPRE_Int
 HYPRE_ILUSetTol( HYPRE_Solver solver, HYPRE_Real tol );

--- a/src/parcsr_ls/par_amg.c
+++ b/src/parcsr_ls/par_amg.c
@@ -200,7 +200,7 @@ hypre_BoomerAMGCreate()
    fcycle = 0;
    cycle_type = 1;
    converge_type = 0;
-   tol = 1.0e-7;
+   tol = 1.0e-6;
 
    num_sweeps = 1;
    relax_down = 13;

--- a/src/parcsr_ls/par_ilu.c
+++ b/src/parcsr_ls/par_ilu.c
@@ -59,7 +59,7 @@ hypre_ILUCreate()
    (ilu_data -> num_iterations)        = 0;
 
    (ilu_data -> max_iter)              = 20;
-   (ilu_data -> tol)                   = 1.0e-7;
+   (ilu_data -> tol)                   = 1.0e-6;
 
    (ilu_data -> logging)               = 0;
    (ilu_data -> print_level)           = 0;

--- a/src/parcsr_ls/par_mgr.c
+++ b/src/parcsr_ls/par_mgr.c
@@ -77,7 +77,7 @@ hypre_MGRCreate()
   (mgr_data -> use_default_fsolver) = -1; // set to -1 to avoid printing when not used
   (mgr_data -> omega) = 1.;
   (mgr_data -> max_iter) = 20;
-  (mgr_data -> tol) = 1.0e-7;
+  (mgr_data -> tol) = 1.0e-6;
   (mgr_data -> relax_type) = 0;
   (mgr_data -> relax_order) = 1; // not fully utilized. Only used to compute L1-norms.
   (mgr_data -> interp_type) = NULL;


### PR DESCRIPTION
This sets the default convergence tolerance to 1.0e-6 uniformly in hypre.  Note that the 'test' drivers change this default in many cases, which is good because it invokes the SetTol() routines.  This addresses Issue #70 and pull request #156.