### PR TITLE
Fixing compile issues --with-caliper

### DIFF
--- a/src/sstruct_ls/sys_pfmg_solve.c
+++ b/src/sstruct_ls/sys_pfmg_solve.c
@@ -155,21 +155,21 @@ hypre_SysPFMGSolve( void                 *sys_pfmg_vdata,
          {
             norms[i] = sqrt(r_dot_r);
             if (b_dot_b > 0)
+            {
                rel_norms[i] = sqrt(r_dot_r/b_dot_b);
+            }
             else
+            {
                rel_norms[i] = 0.0;
+            }
          }
 
          /* always do at least 1 V-cycle */
          if ((r_dot_r/b_dot_b < eps) && (i > 0))
          {
-            if (rel_change)
+            if ( ((rel_change) && (e_dot_e/x_dot_x) < eps) || (!rel_change) )
             {
-               if ((e_dot_e/x_dot_x) < eps)
-                  break;
-            }
-            else
-            {
+               HYPRE_ANNOTATE_MGLEVEL_END(0);
                break;
             }
          }

--- a/src/struct_ls/pfmg_solve.c
+++ b/src/struct_ls/pfmg_solve.c
@@ -163,21 +163,21 @@ hypre_PFMGSolve( void               *pfmg_vdata,
          {
             norms[i] = sqrt(r_dot_r);
             if (b_dot_b > 0)
+            {
                rel_norms[i] = sqrt(r_dot_r/b_dot_b);
+            }
             else
+            {
                rel_norms[i] = 0.0;
+            }
          }
 
          /* always do at least 1 V-cycle */
          if ((r_dot_r/b_dot_b < eps) && (i > 0))
          {
-            if (rel_change)
+            if ( ((rel_change) && (e_dot_e/x_dot_x) < eps) || (!rel_change) )
             {
-               if ((e_dot_e/x_dot_x) < eps)
-                  break;
-            }
-            else
-            {
+               HYPRE_ANNOTATE_MGLEVEL_END(0);
                break;
             }
          }

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1153,9 +1153,17 @@ HYPRE_Int hypre_DataExchangeList(HYPRE_Int num_contacts, HYPRE_Int *contact_proc
 
 #ifdef HYPRE_USING_CALIPER
 
+#ifdef __cplusplus
+extern "C++" {
+#endif
+
 #include <caliper/cali.h>
 
-char hypre__levelname[16];
+#ifdef __cplusplus
+}
+#endif
+
+static char hypre__levelname[16];
 
 #define HYPRE_ANNOTATE_FUNC_BEGIN          CALI_MARK_FUNCTION_BEGIN
 #define HYPRE_ANNOTATE_FUNC_END            CALI_MARK_FUNCTION_END

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -4,6 +4,10 @@
 #ifndef hypre_UTILITIES_HPP
 #define hypre_UTILITIES_HPP
 
+#ifdef __cplusplus
+extern "C++" {
+#endif
+
 /******************************************************************************
  * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
@@ -13,10 +17,6 @@
 
 #ifndef HYPRE_CUDA_UTILS_H
 #define HYPRE_CUDA_UTILS_H
-
-#ifdef __cplusplus
-extern "C++" {
-#endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 
@@ -738,10 +738,6 @@ cudaStream_t hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
 
 #endif // #if defined(HYPRE_USING_CUDA)
 
-#ifdef __cplusplus
-}
-#endif
-
 #endif /* #ifndef HYPRE_CUDA_UTILS_H */
 
 /******************************************************************************
@@ -758,10 +754,6 @@ cudaStream_t hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
 
 #if defined(HYPRE_USING_CUDA)
 #if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS)
-
-#ifdef __cplusplus
-extern "C++" {
-#endif
 
 template<typename T> void OneBlockReduce(T *d_arr, HYPRE_Int N, T *h_out);
 
@@ -1016,10 +1008,6 @@ struct ReduceSum
    }
 };
 
-#ifdef __cplusplus
-}
-#endif
-
 #endif /* #if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) */
 #endif /* #if defined(HYPRE_USING_CUDA) */
 #endif /* #ifndef HYPRE_CUDA_REDUCER_H */
@@ -1061,10 +1049,6 @@ struct ReduceSum
 #define HYPRE_CUB_ALLOCATOR_HEADER
 
 #if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUB_ALLOCATOR)
-
-#ifdef __cplusplus
-extern "C++" {
-#endif
 
 #include <set>
 #include <map>
@@ -1853,14 +1837,13 @@ struct hypre_cub_CachingDeviceAllocator
     }
 };
 
+#endif // #if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUB_ALLOCATOR)
+#endif // #ifndef HYPRE_CUB_ALLOCATOR_HEADER
+
+
 #ifdef __cplusplus
 }
 #endif
-
-#endif // #if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUB_ALLOCATOR)
-
-#endif // #ifndef HYPRE_CUB_ALLOCATOR_HEADER
-
 
 #endif
 

--- a/src/utilities/caliper_instrumentation.h
+++ b/src/utilities/caliper_instrumentation.h
@@ -18,9 +18,17 @@
 
 #ifdef HYPRE_USING_CALIPER
 
+#ifdef __cplusplus
+extern "C++" {
+#endif
+
 #include <caliper/cali.h>
 
-char hypre__levelname[16];
+#ifdef __cplusplus
+}
+#endif
+
+static char hypre__levelname[16];
 
 #define HYPRE_ANNOTATE_FUNC_BEGIN          CALI_MARK_FUNCTION_BEGIN
 #define HYPRE_ANNOTATE_FUNC_END            CALI_MARK_FUNCTION_END

--- a/src/utilities/headers
+++ b/src/utilities/headers
@@ -76,6 +76,10 @@ cat > $INTERNAL_HEADER <<@
 #ifndef hypre_UTILITIES_HPP
 #define hypre_UTILITIES_HPP
 
+#ifdef __cplusplus
+extern "C++" {
+#endif
+
 @
 
 #===========================================================================
@@ -91,6 +95,10 @@ cat hypre_cub_allocator.h        >> $INTERNAL_HEADER
 #===========================================================================
 
 cat >> $INTERNAL_HEADER <<@
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/src/utilities/hypre_cub_allocator.h
+++ b/src/utilities/hypre_cub_allocator.h
@@ -36,10 +36,6 @@
 
 #if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUB_ALLOCATOR)
 
-#ifdef __cplusplus
-extern "C++" {
-#endif
-
 #include <set>
 #include <map>
 
@@ -827,11 +823,6 @@ struct hypre_cub_CachingDeviceAllocator
     }
 };
 
-#ifdef __cplusplus
-}
-#endif
-
 #endif // #if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUB_ALLOCATOR)
-
 #endif // #ifndef HYPRE_CUB_ALLOCATOR_HEADER
 

--- a/src/utilities/hypre_cuda_reducer.h
+++ b/src/utilities/hypre_cuda_reducer.h
@@ -13,10 +13,6 @@
 #if defined(HYPRE_USING_CUDA)
 #if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS)
 
-#ifdef __cplusplus
-extern "C++" {
-#endif
-
 template<typename T> void OneBlockReduce(T *d_arr, HYPRE_Int N, T *h_out);
 
 struct HYPRE_double4
@@ -269,10 +265,6 @@ struct ReduceSum
    {
    }
 };
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* #if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) */
 #endif /* #if defined(HYPRE_USING_CUDA) */

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -8,10 +8,6 @@
 #ifndef HYPRE_CUDA_UTILS_H
 #define HYPRE_CUDA_UTILS_H
 
-#ifdef __cplusplus
-extern "C++" {
-#endif
-
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 
 #include <cuda.h>
@@ -731,10 +727,6 @@ void hypre_CudaDataCubCachingAllocatorDestroy(hypre_CudaData *data);
 cudaStream_t hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
 
 #endif // #if defined(HYPRE_USING_CUDA)
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* #ifndef HYPRE_CUDA_UTILS_H */
 


### PR DESCRIPTION
This PR fixes the compile issues with Caliper. The configure line is 
```
./configure --with-cuda --enable-unified-memory --enable-debug --with-caliper --with-caliper-include=/g/g92/li50/workspace/Caliper/install/include --with-caliper-lib=/g/g92/li50/workspace/Caliper/install/lib64/libcaliper.so
```