### PR TITLE
Euclid fix

### DIFF
--- a/src/distributed_ls/Euclid/Hash_dh.c
+++ b/src/distributed_ls/Euclid/Hash_dh.c
@@ -104,7 +104,8 @@ HashData * Hash_dhLookup(Hash_dh h, HYPRE_Int key)
   for (i=0; i<size; ++i) {
     HYPRE_Int tmp, idx;
     HASH_2(key, size, &tmp)
-    idx = (start + i*tmp) % size;
+    /* idx = (start + i*tmp) % size; */
+    idx = (start + hypre_multmod(i, tmp, size)) % size;
     if (data[idx].mark != curMark) {
       break;  /* key wasn't found */
     } else {
@@ -145,7 +146,8 @@ void Hash_dhInsert(Hash_dh h, HYPRE_Int key, HashData *dataIN)
     HYPRE_Int tmp, idx;
     HASH_2(key, size, &tmp)
 
-    idx = (start + i*tmp) % size;
+    /* idx = (start + i*tmp) % size; */
+    idx = (start + hypre_multmod(i, tmp, size)) % size;
     if (data[idx].mark < curMark) {
       data[idx].key = key;
       data[idx].mark = curMark;

--- a/src/distributed_ls/Euclid/Hash_i_dh.c
+++ b/src/distributed_ls/Euclid/Hash_i_dh.c
@@ -63,8 +63,8 @@ void Hash_i_dhCreate(Hash_i_dh *h, HYPRE_Int sizeIN)
   struct _hash_i_dh* tmp;
 
   size = DEFAULT_TABLE_SIZE;
-  if (sizeIN == -1) { 
-    sizeIN = size = DEFAULT_TABLE_SIZE; 
+  if (sizeIN == -1) {
+    sizeIN = size = DEFAULT_TABLE_SIZE;
   }
   tmp = (struct _hash_i_dh*)MALLOC_DH( sizeof(struct _hash_i_dh)); CHECK_V_ERROR;
   *h = tmp;
@@ -135,7 +135,8 @@ HYPRE_Int Hash_i_dhLookup(Hash_i_dh h, HYPRE_Int key)
 */
 
   for (i=0; i<size; ++i) {
-    idx = (start + i*inc) % size;
+    /* idx = (start + i*inc) % size; */
+    idx = (start + hypre_multmod(i, inc, size)) % size;
 
 /* hypre_printf("   idx= %i\n", idx); */
 
@@ -146,7 +147,7 @@ HYPRE_Int Hash_i_dhLookup(Hash_i_dh h, HYPRE_Int key)
         retval = data[idx].data;
         break;
       }
-    } 
+    }
   }
   END_FUNC_VAL(retval)
 }
@@ -184,7 +185,8 @@ void Hash_i_dhInsert(Hash_i_dh h, HYPRE_Int key, HYPRE_Int dataIN)
 /*hypre_printf("Hash_i_dhInsert::  tableSize= %i  start= %i  inc= %i\n", size, start, inc);
 */
   for (i=0; i<size; ++i) {
-    idx = (start + i*inc) % size;
+    /* idx = (start + i*inc) % size; */
+    idx = (start + hypre_multmod(i, inc, size)) % size;
 
 /* hypre_printf("   idx= %i\n", idx);
 */
@@ -216,11 +218,11 @@ void Hash_i_dhInsert(Hash_i_dh h, HYPRE_Int key, HYPRE_Int dataIN)
 void rehash_private(Hash_i_dh h)
 {
   START_FUNC_DH
-  HYPRE_Int i, 
-      old_size = h->size, 
+  HYPRE_Int i,
+      old_size = h->size,
       new_size = old_size*2,
       oldCurMark = h->curMark;
-  Hash_i_Record *oldData = h->data, 
+  Hash_i_Record *oldData = h->data,
                  *newData;
 
   hypre_sprintf(msgBuf_dh, "rehashing; old_size= %i, new_size= %i", old_size, new_size);
@@ -239,7 +241,7 @@ void rehash_private(Hash_i_dh h)
   h->count = 0;
   h->curMark = 0;
 
-  for (i=h->count; i<new_size; ++i) { 
+  for (i=h->count; i<new_size; ++i) {
     newData[i].key = -1;
     newData[i].mark = -1;
   }
@@ -253,7 +255,7 @@ void rehash_private(Hash_i_dh h)
       Hash_i_dhInsert(h, oldData[i].key, oldData[i].data); CHECK_V_ERROR;
     }
   }
-   
+
   FREE_DH(oldData); CHECK_V_ERROR;
   END_FUNC_DH
 }

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SRCS
   hypre_prefix_sum.c
   hypre_printf.c
   hypre_qsort.c
+  hypre_utilities.c
   mpistubs.c
   qsplit.c
   random.c

--- a/src/utilities/Makefile
+++ b/src/utilities/Makefile
@@ -48,6 +48,7 @@ FILES =\
  hypre_prefix_sum.c\
  hypre_printf.c\
  hypre_qsort.c\
+ hypre_utilities.c\
  mpistubs.c\
  qsplit.c\
  random.c\

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1524,6 +1524,10 @@ void hypre_NvtxPushRangeColor(const char *name, HYPRE_Int cid);
 void hypre_NvtxPushRange(const char *name);
 void hypre_NvtxPopRange();
 
+/* hypre_utilities.c */
+HYPRE_Int hypre_multmod(HYPRE_Int a, HYPRE_Int b, HYPRE_Int mod);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/utilities/hypre_utilities.c
+++ b/src/utilities/hypre_utilities.c
@@ -1,0 +1,28 @@
+/******************************************************************************
+ * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+
+#include "_hypre_utilities.h"
+
+HYPRE_Int hypre_multmod(HYPRE_Int a, HYPRE_Int b, HYPRE_Int mod)
+{
+    HYPRE_Int res = 0; // Initialize result
+    a %= mod;
+    while (b)
+    {
+        // If b is odd, add a with result
+        if (b & 1)
+        {
+            res = (res + a) % mod;
+        }
+        // Here we assume that doing 2*a
+        // doesn't cause overflow
+        a = (2 * a) % mod;
+        b >>= 1;  // b = b / 2
+    }
+    return res;
+}
+

--- a/src/utilities/protos.h
+++ b/src/utilities/protos.h
@@ -253,3 +253,7 @@ HYPRE_Int hypreDevice_BigIntFilln(HYPRE_BigInt *d_x, size_t n, HYPRE_BigInt v);
 void hypre_NvtxPushRangeColor(const char *name, HYPRE_Int cid);
 void hypre_NvtxPushRange(const char *name);
 void hypre_NvtxPopRange();
+
+/* hypre_utilities.c */
+HYPRE_Int hypre_multmod(HYPRE_Int a, HYPRE_Int b, HYPRE_Int mod);
+


### PR DESCRIPTION
This PR tries to fix issue #210, which is an integer overflow problem when computing hash values in the form of
```
idx = (start + i*inc) % size;
```
where `i*inc` can be too big to be held by `HYPRE_Int`.