### PR TITLE
MS-Windows OMP pragma

### DIFF
--- a/src/struct_ls/red_black_gs.h
+++ b/src/struct_ls/red_black_gs.h
@@ -298,7 +298,7 @@ typedef struct
 
 #ifdef HYPRE_USING_OPENMP
 #define HYPRE_BOX_REDUCTION
-#ifdef WIN32
+#if defined(WIN32) && defined(_MSC_VER)
 #define Pragma(x) __pragma(HYPRE_XSTR(x))
 #else
 #define Pragma(x) _Pragma(HYPRE_XSTR(x))

--- a/src/struct_mv/_hypre_struct_mv.h
+++ b/src/struct_mv/_hypre_struct_mv.h
@@ -2493,7 +2493,7 @@ hypre__J = hypre__thread;  i1 = i2 = 0; \
 
 #ifdef HYPRE_USING_OPENMP
 #define HYPRE_BOX_REDUCTION
-#ifdef WIN32
+#if defined(WIN32) && defined(_MSC_VER)
 #define Pragma(x) __pragma(HYPRE_XSTR(x))
 #else
 #define Pragma(x) _Pragma(HYPRE_XSTR(x))

--- a/src/struct_mv/boxloop_host.h
+++ b/src/struct_mv/boxloop_host.h
@@ -20,7 +20,7 @@
 
 #ifdef HYPRE_USING_OPENMP
 #define HYPRE_BOX_REDUCTION
-#ifdef WIN32
+#if defined(WIN32) && defined(_MSC_VER)
 #define Pragma(x) __pragma(HYPRE_XSTR(x))
 #else
 #define Pragma(x) _Pragma(HYPRE_XSTR(x))


### PR DESCRIPTION
This PR fixes OpenMP pragma in Windows but not using MSVC. (see #175 #219) by changing `#ifdef WIN32` to `#if defined(WIN32) && defined(_MSC_VER)` as suggested by @gkarpa and @rockydut

@rfalgout 
There exist more `WIN32` usage, see below, which seem to be fine.
```
(base) ruipeng@Chebyshev:~/workspace/hypre-git/master/src$ grep -R WIN32 .
./utilities/hypre_cub_allocator.h:    #if defined(_WIN32) || defined(_WIN64)
./utilities/hypre_cub_allocator.h:        #define WIN32_LEAN_AND_MEAN
./utilities/hypre_cub_allocator.h:        #undef WIN32_LEAN_AND_MEAN
./utilities/_hypre_utilities.hpp:    #if defined(_WIN32) || defined(_WIN64)
./utilities/_hypre_utilities.hpp:        #define WIN32_LEAN_AND_MEAN
./utilities/_hypre_utilities.hpp:        #undef WIN32_LEAN_AND_MEAN
./utilities/timer.c:#ifndef WIN32
./utilities/timer.c:#ifdef WIN32
./struct_ls/red_black_gs.h:#if defined(WIN32) && defined(_MSC_VER)
./distributed_ls/Euclid/sig_dh.c:#ifdef WIN32
./distributed_ls/Euclid/_hypre_Euclid.h:#ifndef WIN32
./distributed_ls/Euclid/sig_dh.h:#ifdef WIN32
./distributed_ls/Euclid/Timer_dh.h:#ifndef WIN32
./distributed_ls/Euclid/SubdomainGraph_dh.c:#ifndef WIN32
./distributed_ls/ParaSails/ParaSails.c:#ifdef WIN32
./FEI_mv/fei-hypre/HYPRE_LSI_blkprec.cxx:#ifdef WIN32
./FEI_mv/fei-hypre/HYPRE_LinSysCore.cxx:#ifdef WIN32
./FEI_mv/fei-hypre/HYPRE_LSI_mli.cxx:#ifdef WIN32
./FEI_mv/fei-hypre/HYPRE_LSC_aux.cxx:#ifdef WIN32
./FEI_mv/fei-hypre/HYPRE_LSI_UZAWA.cxx:#ifdef WIN32
./FEI_mv/femli/mli_fedata.cxx:#ifdef WIN32
./FEI_mv/femli/mli_method.cxx:#ifdef WIN32
./FEI_mv/femli/mli_solver_chebyshev.cxx:#ifdef WIN32
./FEI_mv/femli/mli_method_amgsa.cxx:#ifdef WIN32
./FEI_mv/femli/mli_method_amgrs.cxx:#ifdef WIN32
./FEI_mv/femli/mli_method_amgcr.cxx:#ifdef WIN32
./struct_mv/_hypre_struct_mv.h:#if defined(WIN32) && defined(_MSC_VER)
./struct_mv/boxloop_host.h:#if defined(WIN32) && defined(_MSC_VER)
```

I am not sure if we need to have `#ifdef _WIN64` in the changes as well. See, https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019
```
_WIN32 Defined as 1 when the compilation target is 32-bit ARM, 64-bit ARM, x86, or x64. Otherwise, undefined.
_WIN64 Defined as 1 when the compilation target is 64-bit ARM or x64. Otherwise, undefined.
```
It seems that `_WIN32` is defined in all the platforms where `_WIN64` is defined. So maybe it is fine.

@rfalgout Do we have Windows machines to test it? Thanks!