### PR TITLE
Improve portability for update-release script (for LINUX, UNIX and macOS).

### DIFF
--- a/src/docs/update-release.sh
+++ b/src/docs/update-release.sh
@@ -10,12 +10,16 @@ refconf="ref-manual/conf.doxygen"
 
 version=`../utilities/version -number`
 reldate=`../utilities/version -date`
-usrdate=`date --date=$reldate +'%B %d, %Y'`
+if type -p gdate > /dev/null; then
+    usrdate=`gdate --date=$reldate +'%B %d, %Y'`;
+else
+    usrdate=`date --date=$reldate +'%B %d, %Y'`
+fi
 
 # User manual
-sed -e 's/version = .*/version = \x27'$version'\x27/' $usrconf |
-sed -e 's/release = .*/release = \x27'$version'\x27/' |
-sed -e 's#today = .*#today = \x27'"$usrdate"'\x27#' > $usrconf.tmp
+sed -e "s/version = .*/version = '$version'/" $usrconf |
+sed -e "s/release = .*/release = '$version'/" |
+sed -e "s#today = .*#today = '$usrdate'#" > $usrconf.tmp
 mv $usrconf.tmp $usrconf
 
 # Reference manual

--- a/src/docs/update-release.sh
+++ b/src/docs/update-release.sh
@@ -23,5 +23,5 @@ sed -e "s#today = .*#today = '$usrdate'#" > $usrconf.tmp
 mv $usrconf.tmp $usrconf
 
 # Reference manual
-sed -e 's/PROJECT_NUMBER .*=.*/PROJECT_NUMBER = '$version'/' $refconf > $refconf.tmp
+sed -e "s/PROJECT_NUMBER .*=.*/PROJECT_NUMBER = '$version'/" $refconf > $refconf.tmp
 mv $refconf.tmp $refconf


### PR DESCRIPTION
This PR addresses portability issues in the update-release script, particularly for macOS. 
1. The use of the 'date' command has been modified to use GNUs 'date' command (if installed). 
2. In addition, single quotes for sed commands have been replaced by double quotes to allow the use of single quotes around internal variables. This appears to be more portable than the use of '\x27'. Note that this means shell meta-characters need to be escaped if they need to be treated as string literals.