### PR TITLE
cmake: Optionally accept path to BLAS/LAPACK libraries.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,8 @@ option(HYPRE_USING_HOST_MEMORY       "Use host memory" ON)
 
 option(TPL_DSUPERLU_LIBRARIES        "List of absolute paths to SuperLU_Dist link libraries [].")
 option(TPL_DSUPERLU_INCLUDE_DIRS     "List of absolute paths to SuperLU_Dist include directories [].")
+option(TPL_BLAS_LIBRARIES            "Optional list of absolute paths to BLAS libraries, otherwise use FindBLAS to locate [].")
+option(TPL_LAPACK_LIBRARIES          "Optional list of absolute paths to LAPACK libraries, otherwise use FindLAPACK to locate [].")
 
 # Set config name values
 if (HYPRE_ENABLE_SHARED)
@@ -176,9 +178,15 @@ set(HYPRE_HEADERS ${HYPRE_HEADERS} ${HYPRE_MAIN_HEADERS})
 if (HYPRE_USING_HYPRE_BLAS)
   add_subdirectory(blas)
 else()
-  # Find system blas
-  find_package(BLAS REQUIRED)
-  target_link_libraries(HYPRE PUBLIC "${BLAS_LIBRARIES}")
+  # Use TPL_BLAS_LIBRARIES if set.
+  if (TPL_BLAS_LIBRARIES)
+    message("-- Using TPL_BLAS_LIBRARIES='${TPL_BLAS_LIBRARIES}'")
+    target_link_libraries(HYPRE PUBLIC "${TPL_BLAS_LIBRARIES}")
+  else()
+    # Find system blas
+    find_package(BLAS REQUIRED)
+    target_link_libraries(HYPRE PUBLIC "${BLAS_LIBRARIES}")
+  endif()
   target_compile_definitions(HYPRE PUBLIC "USE_VENDOR_BLAS")
 endif()
 
@@ -186,9 +194,15 @@ endif()
 if (HYPRE_USING_HYPRE_LAPACK)
   add_subdirectory(lapack)
 else()
-  # Find system lapack
-  find_package(LAPACK REQUIRED)
-  target_link_libraries(HYPRE PUBLIC "${LAPACK_LIBRARIES}")
+  # Use TPL_LAPACK_LIBRARIES if set.
+  if (TPL_LAPACK_LIBRARIES)
+    message("-- Using TPL_LAPACK_LIBRARIES='${TPL_BLAS_LIBRARIES}'")
+    target_link_libraries(HYPRE PUBLIC "${TPL_LAPACK_LIBRARIES}")
+  else()
+    # Find system lapack
+    find_package(LAPACK REQUIRED)
+    target_link_libraries(HYPRE PUBLIC "${LAPACK_LIBRARIES}")
+  endif()
 endif()
 
 # Find DSUPERLU, if requested


### PR DESCRIPTION
This change allows the BLAS/LAPACK libraries to be specified within cmake configuration. Otherwise, if external BLAS/LAPACK is used it will use cmake's find_package to locate libraries. This makes the cmake more xsdk compliant as well.  