### PR TITLE
bug fix cycle_param

### DIFF
--- a/src/parcsr_ls/par_cycle.c
+++ b/src/parcsr_ls/par_cycle.c
@@ -459,7 +459,7 @@ hypre_BoomerAMGCycle( void              *amg_vdata,
                      /* need to do CF - so can't use the AMS one */
                      HYPRE_Int i;
                      HYPRE_Int loc_relax_points[2];
-                     if (cycle_type < 2)
+                     if (cycle_param < 2)
                      {
                         loc_relax_points[0] = 1;
                         loc_relax_points[1] = -1;

--- a/src/test/TEST_ij/smoother.saved
+++ b/src/test/TEST_ij/smoother.saved
@@ -47,8 +47,8 @@ BoomerAMG Iterations = 11
 Final Relative Residual Norm = 7.457693e-09
 
 # Output file: smoother.out.9
-BoomerAMG Iterations = 14
-Final Relative Residual Norm = 4.118037e-09
+BoomerAMG Iterations = 17
+Final Relative Residual Norm = 4.979125e-09
 
 # Output file: smoother.out.10
 BoomerAMG Iterations = 23


### PR DESCRIPTION
This PR fixes the improper use of `relax_type` in relax-18 with CF relax, see #235 