### PR TITLE
Modification to fix error code warning for ILU-NSH coarse level solver

### DIFF
--- a/src/parcsr_ls/par_ilu.c
+++ b/src/parcsr_ls/par_ilu.c
@@ -124,7 +124,7 @@ hypre_ILUCreate()
 
    /* -> SCHUR-NSH */
    hypre_ParILUDataSchurNSHSolveMaxIter(ilu_data) = 5;
-   hypre_ParILUDataSchurNSHSolveTol(ilu_data) = 1e-02;
+   hypre_ParILUDataSchurNSHSolveTol(ilu_data) = 0.0;
    hypre_ParILUDataSchurNSHDroptol(ilu_data) = NULL;/* this is not the default option, set it only when switched to */
 
    hypre_ParILUDataSchurNSHMaxNumIter(ilu_data) = 2;


### PR DESCRIPTION
This PR fixes error code warnings for the NSH Schur solver for hypre-ILU. This addresses an issue brought up in #249 