### PR TITLE
Add HYPRE_WARP_BITSHIFT Macro

### DIFF
--- a/src/seq_mv/csr_spgemm_device.h
+++ b/src/seq_mv/csr_spgemm_device.h
@@ -32,7 +32,7 @@ hypre_int get_thread_id()
 static __device__ __forceinline__
 hypre_int get_warp_id()
 {
-   // return get_thread_id() >> 5;                          // in general cases
+   // return get_thread_id() >> HYPRE_WARP_BITSHIFT;        // in general cases
    return threadIdx.z;                                      // if blockDim.x * blockDim.y = WARP_SIZE
 }
 
@@ -88,4 +88,3 @@ HYPRE_Int csr_spmm_create_hash_table(HYPRE_Int m, HYPRE_Int *d_rc, HYPRE_Int *d_
 
 #endif /* HYPRE_USING_CUDA */
 #endif
-

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -79,7 +79,9 @@ extern "C++" {
 struct hypre_cub_CachingDeviceAllocator;
 typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator;
 
+// HYPRE_WARP_BITSHIFT is just log2 of HYPRE_WARP_SIZE
 #define HYPRE_WARP_SIZE       32
+#define HYPRE_WARP_BITSHIFT   5
 #define HYPRE_WARP_FULL_MASK  0xFFFFFFFF
 #define HYPRE_MAX_NUM_WARPS   (64 * 64 * 32)
 #define HYPRE_FLT_LARGE       1e30
@@ -281,7 +283,7 @@ template <hypre_int dim>
 static __device__ __forceinline__
 hypre_int hypre_cuda_get_num_warps()
 {
-   return hypre_cuda_get_num_threads<dim>() >> 5;
+   return hypre_cuda_get_num_threads<dim>() >> HYPRE_WARP_BITSHIFT;
 }
 
 /* return the warp id in block */
@@ -289,7 +291,7 @@ template <hypre_int dim>
 static __device__ __forceinline__
 hypre_int hypre_cuda_get_warp_id()
 {
-   return hypre_cuda_get_thread_id<dim>() >> 5;
+   return hypre_cuda_get_thread_id<dim>() >> HYPRE_WARP_BITSHIFT;
 }
 
 /* return the thread lane id in warp */
@@ -767,7 +769,6 @@ cusparseIndexType_t hypre_HYPREIntToCusparseIndexType();
 #endif // #if defined(HYPRE_USING_CUSPARSE)
 
 #endif /* #ifndef HYPRE_CUDA_UTILS_H */
-
 /******************************************************************************
  * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
@@ -912,7 +913,7 @@ T blockReduceSum(T val)
    //HYPRE_Int lane = threadIdx.x % warpSize;
    //HYPRE_Int wid  = threadIdx.x / warpSize;
    HYPRE_Int lane = threadIdx.x & (warpSize - 1);
-   HYPRE_Int wid  = threadIdx.x >> 5;
+   HYPRE_Int wid  = threadIdx.x >> HYPRE_WARP_BITSHIFT;
 
    val = warpReduceSum(val);       // Each warp performs partial reduction
 

--- a/src/utilities/hypre_cuda_reducer.h
+++ b/src/utilities/hypre_cuda_reducer.h
@@ -142,7 +142,7 @@ T blockReduceSum(T val)
    //HYPRE_Int lane = threadIdx.x % warpSize;
    //HYPRE_Int wid  = threadIdx.x / warpSize;
    HYPRE_Int lane = threadIdx.x & (warpSize - 1);
-   HYPRE_Int wid  = threadIdx.x >> 5;
+   HYPRE_Int wid  = threadIdx.x >> HYPRE_WARP_BITSHIFT;
 
    val = warpReduceSum(val);       // Each warp performs partial reduction
 
@@ -269,4 +269,3 @@ struct ReduceSum
 #endif /* #if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) */
 #endif /* #if defined(HYPRE_USING_CUDA) */
 #endif /* #ifndef HYPRE_CUDA_REDUCER_H */
-

--- a/src/utilities/hypre_cuda_utils.c
+++ b/src/utilities/hypre_cuda_utils.c
@@ -58,7 +58,7 @@ hypre_GetDefaultCUDAGridDimension( HYPRE_Int n,
    }
    else if (granularity[0] == 'w')
    {
-      HYPRE_Int num_warps_per_block = num_threads_per_block >> 5;
+      HYPRE_Int num_warps_per_block = num_threads_per_block >> HYPRE_WARP_BITSHIFT;
 
       hypre_assert(num_warps_per_block * HYPRE_WARP_SIZE == num_threads_per_block);
 
@@ -1076,4 +1076,3 @@ hypre_SyncCudaComputeStream(hypre_Handle *hypre_handle)
 }
 
 #endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
-

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -69,7 +69,9 @@
 struct hypre_cub_CachingDeviceAllocator;
 typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator;
 
+// HYPRE_WARP_BITSHIFT is just log2 of HYPRE_WARP_SIZE
 #define HYPRE_WARP_SIZE       32
+#define HYPRE_WARP_BITSHIFT   5
 #define HYPRE_WARP_FULL_MASK  0xFFFFFFFF
 #define HYPRE_MAX_NUM_WARPS   (64 * 64 * 32)
 #define HYPRE_FLT_LARGE       1e30

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -273,7 +273,7 @@ template <hypre_int dim>
 static __device__ __forceinline__
 hypre_int hypre_cuda_get_num_warps()
 {
-   return hypre_cuda_get_num_threads<dim>() >> 5;
+   return hypre_cuda_get_num_threads<dim>() >> HYPRE_WARP_BITSHIFT;
 }
 
 /* return the warp id in block */
@@ -281,7 +281,7 @@ template <hypre_int dim>
 static __device__ __forceinline__
 hypre_int hypre_cuda_get_warp_id()
 {
-   return hypre_cuda_get_thread_id<dim>() >> 5;
+   return hypre_cuda_get_thread_id<dim>() >> HYPRE_WARP_BITSHIFT;
 }
 
 /* return the thread lane id in warp */
@@ -759,4 +759,3 @@ cusparseIndexType_t hypre_HYPREIntToCusparseIndexType();
 #endif // #if defined(HYPRE_USING_CUSPARSE)
 
 #endif /* #ifndef HYPRE_CUDA_UTILS_H */
-


### PR DESCRIPTION
This PR adds the macro `HYPRE_WARP_BITSHIFT` in the same vein as `HYPRE_WARP_SIZE`. The goal is the remove the magic number "5" from `>> 5` in several places in the code. This is forward-looking to adding ROCm/HIP support for which the bitshift will be `>> 6`. I tested this using the AMG Solve benchmark on CUDA 10.2 and CUDA 11.0 on V100. I'm happy to update the name if others have a better one/one they prefer. Thank you.