### PR TITLE
fixed wrong pointer checking; error handler in debug mode

### DIFF
--- a/src/seq_mv/csr_spgemm_device_rowest.c
+++ b/src/seq_mv/csr_spgemm_device_rowest.c
@@ -375,8 +375,9 @@ hypreDevice_CSRSpGemmRownnzEstimate(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n,
    }
    else
    {
-      printf("Unknown row nnz estimation method %d! \n", row_est_mtd);
-      exit(-1);
+      char msg[256];
+      hypre_sprintf(msg, "Unknown row nnz estimation method %d! \n", row_est_mtd);
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, msg);
    }
 
 #ifdef HYPRE_PROFILE

--- a/src/utilities/hypre_error.c
+++ b/src/utilities/hypre_error.c
@@ -15,7 +15,7 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
 {
    hypre_error_flag |= ierr;
 
-#if defined(HYPRE_PRINT_ERRORS) || defined(HYPRE_DEBUG)
+#ifdef HYPRE_PRINT_ERRORS
    if (msg)
    {
       hypre_fprintf(
@@ -28,10 +28,6 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
          stderr, "hypre error in file \"%s\", line %d, error code = %d\n",
          filename, line, ierr);
    }
-#endif
-
-#ifdef HYPRE_DEBUG
-   exit(-1);
 #endif
 }
 

--- a/src/utilities/hypre_error.c
+++ b/src/utilities/hypre_error.c
@@ -15,7 +15,7 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
 {
    hypre_error_flag |= ierr;
 
-#ifdef HYPRE_PRINT_ERRORS
+#if defined(HYPRE_PRINT_ERRORS) || defined(HYPRE_DEBUG)
    if (msg)
    {
       hypre_fprintf(
@@ -28,6 +28,10 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
          stderr, "hypre error in file \"%s\", line %d, error code = %d\n",
          filename, line, ierr);
    }
+#endif
+
+#ifdef HYPRE_DEBUG
+   exit(-1);
 #endif
 }
 


### PR DESCRIPTION
This PR fixed a pointer comparison error in GPU matvec `y=Ax`, (if both pointers of `x` and `y` are `NULL`, should not throw errors). 

~~Found this by changing hypre's error handler behavior, printing out error messages in debug mode, so it may be useful in the future.~~