### PR TITLE
Remove 'memory.h' includes since it is not ISO standard

### DIFF
--- a/src/distributed_ls/ParaSails/Matrix.c
+++ b/src/distributed_ls/ParaSails/Matrix.c
@@ -19,7 +19,7 @@
  *****************************************************************************/
 
 #include <stdlib.h>
-#include <memory.h>
+//#include <memory.h>
 #include "Common.h"
 #include "Matrix.h"
 #include "Numbering.h"

--- a/src/distributed_ls/ParaSails/Numbering.c
+++ b/src/distributed_ls/ParaSails/Numbering.c
@@ -22,7 +22,7 @@
  *****************************************************************************/
 
 #include <stdlib.h>
-#include <memory.h>
+//#include <memory.h>
 #include "Common.h"
 #include "Numbering.h"
 #include "OrderStat.h"


### PR DESCRIPTION
The 'memory.h' header file is not standard ISO C, but it is standard C++.  Apparently, some C compilers may accidentally find a C++ version of this file and cause compile problems.  See issue #274 .  Removing it from hypre seems to compile just fine for me.
