### PR TITLE
Hip build

### DIFF
--- a/src/config/HYPRE_config.h.in
+++ b/src/config/HYPRE_config.h.in
@@ -181,6 +181,9 @@
 /* Define to 1 if executing on GPU device */
 #undef HYPRE_USING_GPU
 
+/* HIP being used */
+#undef HYPRE_USING_HIP
+
 /* Define to 1 if using host memory only */
 #undef HYPRE_USING_HOST_MEMORY
 
@@ -210,6 +213,15 @@
 
 /* Define to 1 if executing on host/device with RAJA */
 #undef HYPRE_USING_RAJA
+
+/* rocBLAS being used */
+#undef HYPRE_USING_ROCBLAS
+
+/* rocRAND being used */
+#undef HYPRE_USING_ROCRAND
+
+/* rocSPARSE being used */
+#undef HYPRE_USING_ROCSPARSE
 
 /* Define to 1 if using UMPIRE */
 #undef HYPRE_USING_UMPIRE

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -1810,20 +1810,33 @@ then
 fi
 
 
-if [test "$hypre_using_cuda" = "yes" || test "$hypre_using_device_openmp" = "yes" || test "$hypre_using_um" = "yes"]
+if [ test "x$hypre_using_um" = "xyes"]
 then
-   AC_CHECK_HEADERS(["${CUDA_HOME}/include/cuda.h"], [hypre_found_cuda=yes; HYPRE_CUDA_PATH=${CUDA_HOME}])
+  if [test "$hypre_using_cuda" = "yes" || test "$hypre_using_device_openmp" = "yes"]
+  then
+     AC_CHECK_HEADERS(["${CUDA_HOME}/include/cuda.h"], [hypre_found_cuda=yes; HYPRE_CUDA_PATH=${CUDA_HOME}])
 
-   if test "x$hypre_found_cuda" != "xyes"
-   then
-      AC_CHECK_HEADERS(["${CUDA_PATH}/include/cuda.h"], [hypre_found_cuda=yes; HYPRE_CUDA_PATH=${CUDA_PATH}])
-   fi
+     if test "x$hypre_found_cuda" != "xyes"
+     then
+        AC_CHECK_HEADERS(["${CUDA_PATH}/include/cuda.h"], [hypre_found_cuda=yes; HYPRE_CUDA_PATH=${CUDA_PATH}])
+     fi
 
-   if test "x$hypre_found_cuda" != "xyes"
-   then
-      AC_MSG_ERROR([unable to find cuda.h ... Ensure that CUDA_HOME or CUDA_PATH is set])
-   fi
-fi
+     if test "x$hypre_found_cuda" != "xyes"
+     then
+        AC_MSG_ERROR([unable to find cuda.h ... Ensure that CUDA_HOME or CUDA_PATH is set])
+     fi
+  dnl if not using cuda, make sure we're using hip
+  dnl if not error. if we are, HIP will be checked below.
+  else
+    if [test "x$hypre_using_hip" != "xyes"]
+    then
+       AC_MSG_ERROR([Asked for unified memory, but not using CUDA, HIP, or device OpenMP!])
+    fi
+  fi
+fi dnl hypre_using_um
+
+
+
 
 dnl *********************************************************************
 dnl * Set raja options
@@ -2003,6 +2016,14 @@ then
       AC_MSG_NOTICE([Use --enable-unified-memory to compile with unified memory.])
       AC_MSG_NOTICE([***********************************************************])
    fi
+   if test "$hypre_user_chose_hip" = "yes"
+   then
+      AC_MSG_NOTICE([***********************************************************])
+      AC_MSG_NOTICE([Configuring with --with-hip=yes without unified memory.])
+      AC_MSG_NOTICE([It only works for struct interface.])
+      AC_MSG_NOTICE([Use --enable-unified-memory to compile with unified memory.])
+      AC_MSG_NOTICE([***********************************************************])
+   fi
    if test "$hypre_using_device_openmp" = "yes"
    then
       AC_MSG_NOTICE([***********************************************************])
@@ -2138,7 +2159,7 @@ if test "x$hypre_using_um" = "xyes"
 then
    AC_DEFINE([HYPRE_USING_UNIFIED_MEMORY],1,[Define to 1 if using unified memory])
 else
-   if [test "x$hypre_user_chose_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes"]
+   if [test "x$hypre_user_chose_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes" || test "x$hypre_user_chose_hip" = "xyes"]
    then
       AC_DEFINE([HYPRE_USING_DEVICE_MEMORY],1,[Define to 1 if using device memory without UM])
    else

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -2023,6 +2023,76 @@ then
 fi
 
 dnl *********************************************************************
+dnl * Set HIP options
+dnl *********************************************************************
+AS_IF([test x"$hypre_user_chose_hip" == x"yes"],
+      [
+        AC_DEFINE(HYPRE_USING_GPU, 1, [Define to 1 if executing on GPU device])
+        AC_DEFINE(HYPRE_USING_HIP, 1, [HIP being used])
+
+        dnl hipcc is just a perl script that wraps things like detection
+        dnl of the AMD GPU and the actual invocation of the clang compiler
+        dnl from ROCm that supports HIP and all the command line foo needed
+        dnl by the compiler. You can force hipcc to emit what it actually does
+        dnl by setting HIPCC_VERBOSE=7 in your environment.
+        AC_CHECK_PROGS(HIPCC, hipcc)
+
+        dnl (Ab)Using CUCC when compiling HIP
+        dnl At this time, we need the linker to be hipcc in order to link
+        dnl in device code.
+        CUCC=${HIPCC}
+        LINK_CC=${HIPCC}
+        LINK_CXX=${HIPCC}
+
+        dnl At least -O2, but the user can override with CFLAGS/CXXFLAGS on the configure line.
+        dnl The "-x hip" is necessary to override the detection of .c files which clang
+        dnl interprets as C and therefore invokes the C compiler rather than the HIP part
+        dnl of clang.
+        HIPCXXFLAGS="-O2 -x hip -Wall"
+
+        AS_IF([test x"$hypre_using_debug" == x"yes"],
+              [HIPCXXFLAGS="-g -ggdb ${HIPCXXFLAGS}"])
+
+        dnl (Ab)Use CUFLAGS to capture HIP compilation flags
+        dnl Put CXXFLAGS at the end so the user can override the optimization level.
+        CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS} ${CXXFLAGS}"
+
+        dnl rocThrust depends on rocPrim so we need both for Thrust on AMD GPUs.
+        dnl These are header-only so no linking needed.
+        HYPRE_HIP_INCL="-I${HYPRE_ROCM_PREFIX}/rocthrust/include"
+        HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocprim/include"
+
+        dnl HIP library
+        HYPRE_HIP_LIBS="-L${HYPRE_ROCM_PREFIX}/lib -lamdhip64"
+
+        dnl rocSPARSE, for things like dcsrmv on AMD GPUs
+        AS_IF([test x"$hypre_using_rocsparse" == x"yes"],
+              [AC_DEFINE(HYPRE_USING_ROCSPARSE, 1, [rocSPARSE being used])
+	       HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocsparse"
+               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocsparse/include"
+               ])
+
+        dnl Note rocSPARSE requires rocBLAS, so this is only controlling
+        dnl whether HYPRE explicitly uses rocBLAS in other places or not.
+        dnl So we don't need to add any extra libs or anything.
+        AS_IF([test x"$hypre_using_rocblas" == x"yes"],
+              [AC_DEFINE(HYPRE_USING_ROCBLAS, 1, [rocBLAS being used])
+              HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocblas/include"
+              ])
+
+        dnl rocRAND: random number generation on AMD GPUs
+        AS_IF([test x"$hypre_using_rocrand" == x"yes"],
+              [AC_DEFINE(HYPRE_USING_ROCRAND, 1, [rocRAND being used])
+               HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocrand"
+               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocrand/include"
+               ])
+
+      ]) dnl AS_IF([test x"$hypre_user_chose_hip" == x"yes"]
+
+
+
+
+dnl *********************************************************************
 dnl * Set unified memory options
 dnl *********************************************************************
 if test "$hypre_using_um" != "yes"
@@ -2329,6 +2399,12 @@ dnl *********************************************************************
 AC_SUBST(CUFLAGS)
 AC_SUBST(HYPRE_CUDA_INCLUDE)
 AC_SUBST(HYPRE_CUDA_LIBS)
+
+dnl *********************************************************************
+dnl * HIP stuff
+dnl *********************************************************************
+AC_SUBST(HYPRE_HIP_INCL)
+AC_SUBST(HYPRE_HIP_LIBS)
 
 dnl *********************************************************************
 dnl * Caliper instrumentation

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -440,6 +440,42 @@ AS_HELP_STRING([--enable-curand],
 [hypre_using_curand=yes]
 )
 
+
+
+AC_ARG_ENABLE(rocsparse,
+AS_HELP_STRING([--enable-rocsparse],
+               [Use rocSPARSE (default is YES).]),
+[case "${enableval}" in
+    yes) hypre_using_rocsparse=yes ;;
+    no)  hypre_using_rocsparse=no ;;
+    *)   hypre_using_rocsparse=yes ;;
+ esac],
+[hypre_using_rocsparse=yes]
+)
+
+AC_ARG_ENABLE(rocblas,
+AS_HELP_STRING([--enable-rocblas],
+               [Use rocBLAS (default is NO).]),
+[case "${enableval}" in
+    yes) hypre_using_rocblas=yes ;;
+    no)  hypre_using_rocblas=no ;;
+    *)   hypre_using_rocblas=no ;;
+ esac],
+[hypre_using_rocblas=no]
+)
+
+AC_ARG_ENABLE(rocrand,
+AS_HELP_STRING([--enable-rocrand],
+               [Use rocRAND (default is YES).]),
+[case "${enableval}" in
+    yes) hypre_using_rocrand=yes ;;
+    no)  hypre_using_rocrand=no ;;
+    *)   hypre_using_rocrand=yes ;;
+ esac],
+[hypre_using_rocrand=yes]
+)
+
+
 AC_ARG_ENABLE(gpu-aware-mpi,
 AS_HELP_STRING([--enable-gpu-aware-mpi],
                [Use GPU memory aware MPI]),
@@ -1060,6 +1096,21 @@ AS_HELP_STRING([--with-cuda],
  esac],
 [hypre_using_cuda=no]
 )
+
+
+dnl ***** HIP
+AC_ARG_WITH(hip,
+AS_HELP_STRING([--with-hip],
+               [Use HIP for AMD GPUs. (default is NO).]),
+[case "$withval" in
+    yes) hypre_user_chose_hip=yes
+         hypre_using_hip=yes ;;
+    no)  hypre_using_hip=no ;;
+    *)   hypre_using_hip=no ;;
+ esac],
+[hypre_using_hip=no]
+)
+
 
 dnl ***** RAJA
 

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -165,6 +165,20 @@ hypre_found_cuda=no
 hypre_using_node_aware_mpi=no
 hypre_using_memory_tracker=no
 
+
+dnl *********************************************************************
+dnl * Initialize hypre-HIP variables
+dnl *********************************************************************
+hypre_user_chose_hip=no
+hypre_using_hip=no
+hypre_using_rocsparse=no
+hypre_using_rocblas=no
+hypre_using_rocrand=no
+
+hypre_found_hip=no
+
+
+
 dnl *********************************************************************
 dnl * Initialize flag-check variables
 dnl *********************************************************************

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -1835,6 +1835,26 @@ then
   fi
 fi dnl hypre_using_um
 
+dnl *********************************************************************
+dnl * Check for HIP header
+dnl *********************************************************************
+
+dnl If the user has requested to use HIP, we first check the environment
+dnl for ROCM_PATH to point at the ROCm installation. If that is not found,
+dnl then we default to `/opt/rocm`.
+dnl
+dnl TODO: Add an ARG_WITH for rocm so the user can control the ROCm path
+dnl       through the configure line
+AS_IF([ test x"$hypre_using_hip" == x"yes" ],
+      [ AS_IF([ test -n "$ROCM_PATH"],
+              [ HYPRE_ROCM_PREFIX=$ROCM_PATH ],
+              [ HYPRE_ROCM_PREFIX=/opt/rocm ])
+
+        AC_SUBST(HYPRE_ROCM_PREFIX)
+        AC_CHECK_HEADERS( ["${HYPRE_ROCM_PREFIX}/include/hip/hip_common.h"],
+                          [hypre_found_hip=yes],
+                          [AC_MSG_ERROR([unable to find ${HYPRE_ROCM_PREFIX}/include/hip/hip_common.h ... Ensure ROCm is installed and set ROCM_PATH environment variable to ROCm installation path.])] )],
+      [])
 
 
 

--- a/src/configure
+++ b/src/configure
@@ -633,6 +633,8 @@ SUPERLU_LIBS
 SUPERLU_INCLUDE
 CALIPER_LIBS
 CALIPER_INCLUDE
+HYPRE_HIP_LIBS
+HYPRE_HIP_INCL
 HYPRE_CUDA_LIBS
 HYPRE_CUDA_INCLUDE
 CUFLAGS
@@ -684,6 +686,8 @@ LINK_FC
 FFLAGS
 HOSTNAME
 HYPRE_ARCH
+HIPCC
+HYPRE_ROCM_PREFIX
 EGREP
 GREP
 CPP
@@ -738,6 +742,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -778,6 +783,9 @@ enable_cusparse
 enable_cub
 enable_cublas
 enable_curand
+enable_rocsparse
+enable_rocblas
+enable_rocrand
 enable_gpu_aware_mpi
 with_LD
 with_LDFLAGS
@@ -818,6 +826,7 @@ with_fei_inc_dir
 with_mli
 with_MPI
 with_cuda
+with_hip
 with_raja
 with_raja_include
 with_raja_lib
@@ -895,6 +904,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1147,6 +1157,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1284,7 +1303,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1437,6 +1456,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1494,6 +1514,9 @@ Optional Features:
   --enable-cub            Use CUB Allocator (default is NO).
   --enable-cublas         Use cuBLAS (default is NO).
   --enable-curand         Use cuRAND (default is YES).
+  --enable-rocsparse      Use rocSPARSE (default is YES).
+  --enable-rocblas        Use rocBLAS (default is NO).
+  --enable-rocrand        Use rocRAND (default is YES).
   --enable-gpu-aware-mpi  Use GPU memory aware MPI
 
 Optional Packages:
@@ -1612,6 +1635,7 @@ Optional Packages:
                           may affect which compiler is chosen.
   --with-cuda             Use CUDA. Require cuda-8.0 or higher (default is
                           NO).
+  --with-hip              Use HIP for AMD GPUs. (default is NO).
   --with-raja             Use RAJA. Require RAJA package to be compiled
                           properly (default is NO).
   --with-raja-include=DIR User specifies that RAJA/*.h is in DIR. The options
@@ -2700,6 +2724,17 @@ hypre_found_cuda=no
 hypre_using_node_aware_mpi=no
 hypre_using_memory_tracker=no
 
+
+hypre_user_chose_hip=no
+hypre_using_hip=no
+hypre_using_rocsparse=no
+hypre_using_rocblas=no
+hypre_using_rocrand=no
+
+hypre_found_hip=no
+
+
+
 hypre_blas_lib_old_style=no
 hypre_blas_lib_dir_old_style=no
 hypre_lapack_lib_old_style=no
@@ -3071,6 +3106,48 @@ else
   hypre_using_curand=yes
 
 fi
+
+
+
+
+# Check whether --enable-rocsparse was given.
+if test "${enable_rocsparse+set}" = set; then :
+  enableval=$enable_rocsparse; case "${enableval}" in
+    yes) hypre_using_rocsparse=yes ;;
+    no)  hypre_using_rocsparse=no ;;
+    *)   hypre_using_rocsparse=yes ;;
+ esac
+else
+  hypre_using_rocsparse=yes
+
+fi
+
+
+# Check whether --enable-rocblas was given.
+if test "${enable_rocblas+set}" = set; then :
+  enableval=$enable_rocblas; case "${enableval}" in
+    yes) hypre_using_rocblas=yes ;;
+    no)  hypre_using_rocblas=no ;;
+    *)   hypre_using_rocblas=no ;;
+ esac
+else
+  hypre_using_rocblas=no
+
+fi
+
+
+# Check whether --enable-rocrand was given.
+if test "${enable_rocrand+set}" = set; then :
+  enableval=$enable_rocrand; case "${enableval}" in
+    yes) hypre_using_rocrand=yes ;;
+    no)  hypre_using_rocrand=no ;;
+    *)   hypre_using_rocrand=yes ;;
+ esac
+else
+  hypre_using_rocrand=yes
+
+fi
+
 
 
 # Check whether --enable-gpu-aware-mpi was given.
@@ -3822,6 +3899,23 @@ else
   hypre_using_cuda=no
 
 fi
+
+
+
+
+# Check whether --with-hip was given.
+if test "${with_hip+set}" = set; then :
+  withval=$with_hip; case "$withval" in
+    yes) hypre_user_chose_hip=yes
+         hypre_using_hip=yes ;;
+    no)  hypre_using_hip=no ;;
+    *)   hypre_using_hip=no ;;
+ esac
+else
+  hypre_using_hip=no
+
+fi
+
 
 
 
@@ -8310,9 +8404,11 @@ $as_echo "$as_me: WARNING: *****************************************************
 fi
 
 
-if test "$hypre_using_cuda" = "yes" || test "$hypre_using_device_openmp" = "yes" || test "$hypre_using_um" = "yes"
+if  test "x$hypre_using_um" = "xyes"
 then
-   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ANSI C header files" >&5
+  if test "$hypre_using_cuda" = "yes" || test "$hypre_using_device_openmp" = "yes"
+  then
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ANSI C header files" >&5
 $as_echo_n "checking for ANSI C header files... " >&6; }
 if ${ac_cv_header_stdc+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8463,9 +8559,9 @@ fi
 done
 
 
-   if test "x$hypre_found_cuda" != "xyes"
-   then
-      for ac_header in "${CUDA_PATH}/include/cuda.h"
+     if test "x$hypre_found_cuda" != "xyes"
+     then
+        for ac_header in "${CUDA_PATH}/include/cuda.h"
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -8478,13 +8574,46 @@ fi
 
 done
 
-   fi
+     fi
 
-   if test "x$hypre_found_cuda" != "xyes"
-   then
-      as_fn_error $? "unable to find cuda.h ... Ensure that CUDA_HOME or CUDA_PATH is set" "$LINENO" 5
-   fi
+     if test "x$hypre_found_cuda" != "xyes"
+     then
+        as_fn_error $? "unable to find cuda.h ... Ensure that CUDA_HOME or CUDA_PATH is set" "$LINENO" 5
+     fi
+      else
+    if test "x$hypre_using_hip" != "xyes"
+    then
+       as_fn_error $? "Asked for unified memory, but not using CUDA, HIP, or device OpenMP!" "$LINENO" 5
+    fi
+  fi
 fi
+
+if  test x"$hypre_using_hip" == x"yes" ; then :
+   if  test -n "$ROCM_PATH"; then :
+   HYPRE_ROCM_PREFIX=$ROCM_PATH
+else
+   HYPRE_ROCM_PREFIX=/opt/rocm
+fi
+
+
+        for ac_header in "${HYPRE_ROCM_PREFIX}/include/hip/hip_common.h"
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
+ hypre_found_hip=yes
+else
+  as_fn_error $? "unable to find ${HYPRE_ROCM_PREFIX}/include/hip/hip_common.h ... Ensure ROCm is installed and set ROCM_PATH environment variable to ROCm installation path." "$LINENO" 5
+fi
+
+done
+
+fi
+
+
 
 if test "x$hypre_user_chose_raja" = "xyes"
 then
@@ -8704,6 +8833,106 @@ done
    fi
 fi
 
+if test x"$hypre_user_chose_hip" == x"yes"; then :
+
+
+$as_echo "#define HYPRE_USING_GPU 1" >>confdefs.h
+
+
+$as_echo "#define HYPRE_USING_HIP 1" >>confdefs.h
+
+
+                                                for ac_prog in hipcc
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_HIPCC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$HIPCC"; then
+  ac_cv_prog_HIPCC="$HIPCC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_HIPCC="$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+HIPCC=$ac_cv_prog_HIPCC
+if test -n "$HIPCC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $HIPCC" >&5
+$as_echo "$HIPCC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$HIPCC" && break
+done
+
+
+                                CUCC=${HIPCC}
+        LINK_CC=${HIPCC}
+        LINK_CXX=${HIPCC}
+
+                                        HIPCXXFLAGS="-O2 -x hip -Wall"
+
+        if test x"$hypre_using_debug" == x"yes"; then :
+  HIPCXXFLAGS="-g -ggdb ${HIPCXXFLAGS}"
+fi
+
+                        CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS} ${CXXFLAGS}"
+
+                        HYPRE_HIP_INCL="-I${HYPRE_ROCM_PREFIX}/rocthrust/include"
+        HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocprim/include"
+
+                HYPRE_HIP_LIBS="-L${HYPRE_ROCM_PREFIX}/lib -lamdhip64"
+
+                if test x"$hypre_using_rocsparse" == x"yes"; then :
+
+$as_echo "#define HYPRE_USING_ROCSPARSE 1" >>confdefs.h
+
+	       HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocsparse"
+               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocsparse/include"
+
+fi
+
+                                if test x"$hypre_using_rocblas" == x"yes"; then :
+
+$as_echo "#define HYPRE_USING_ROCBLAS 1" >>confdefs.h
+
+              HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocblas/include"
+
+fi
+
+                if test x"$hypre_using_rocrand" == x"yes"; then :
+
+$as_echo "#define HYPRE_USING_ROCRAND 1" >>confdefs.h
+
+               HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocrand"
+               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocrand/include"
+
+fi
+
+
+fi
+
+
+
 if test "$hypre_using_um" != "yes"
 then
       if test "$hypre_user_chose_cuda" = "yes"
@@ -8712,6 +8941,19 @@ then
 $as_echo "$as_me: ***********************************************************" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Configuring with --with-cuda=yes without unified memory." >&5
 $as_echo "$as_me: Configuring with --with-cuda=yes without unified memory." >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for struct interface." >&5
+$as_echo "$as_me: It only works for struct interface." >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: Use --enable-unified-memory to compile with unified memory." >&5
+$as_echo "$as_me: Use --enable-unified-memory to compile with unified memory." >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************" >&5
+$as_echo "$as_me: ***********************************************************" >&6;}
+   fi
+   if test "$hypre_user_chose_hip" = "yes"
+   then
+      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************" >&5
+$as_echo "$as_me: ***********************************************************" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: Configuring with --with-hip=yes without unified memory." >&5
+$as_echo "$as_me: Configuring with --with-hip=yes without unified memory." >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for struct interface." >&5
 $as_echo "$as_me: It only works for struct interface." >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Use --enable-unified-memory to compile with unified memory." >&5
@@ -8855,7 +9097,7 @@ then
 $as_echo "#define HYPRE_USING_UNIFIED_MEMORY 1" >>confdefs.h
 
 else
-   if test "x$hypre_user_chose_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes"
+   if test "x$hypre_user_chose_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes" || test "x$hypre_user_chose_hip" = "xyes"
    then
 
 $as_echo "#define HYPRE_USING_DEVICE_MEMORY 1" >>confdefs.h
@@ -8990,6 +9232,9 @@ $as_echo "#define HYPRE_LINUX 1" >>confdefs.h
          fi
          ;;
    esac
+
+
+
 
 
 


### PR DESCRIPTION
This PR is copied from #288 by @pbauman.

First of several PRs for HIP support.
This adds options to the build system for enabling ROCm and HIP support. No actual HIP support in the code is included in the PR, this is just the build system options. I've tried to retain the same defaults as the cuda support. The key option is --with-hip=yes to turn on HIP support. The environment variable ROCM_PATH controls where the build system looks for ROCm, defaulting to /opt/rocm.