### PR TITLE
Add Basic HIP Support

### DIFF
--- a/src/IJ_mv/HYPRE_IJMatrix.c
+++ b/src/IJ_mv/HYPRE_IJMatrix.c
@@ -433,7 +433,7 @@ HYPRE_IJMatrixSetValues2( HYPRE_IJMatrix       matrix,
       return hypre_error_flag;
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_IJMatrixMemoryLocation(matrix) );
 
    if (exec == HYPRE_EXEC_DEVICE)
@@ -640,7 +640,7 @@ HYPRE_IJMatrixAddToValues2( HYPRE_IJMatrix       matrix,
       return hypre_error_flag;
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_IJMatrixMemoryLocation(matrix) );
 
    if (exec == HYPRE_EXEC_DEVICE)
@@ -708,7 +708,7 @@ HYPRE_IJMatrixAssemble( HYPRE_IJMatrix matrix )
 
    if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
    {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_IJMatrixMemoryLocation(matrix) );
 
       if (exec == HYPRE_EXEC_DEVICE)
@@ -1203,4 +1203,3 @@ HYPRE_IJMatrixSetOMPFlag( HYPRE_IJMatrix matrix,
 
    return hypre_error_flag;
 }
-

--- a/src/IJ_mv/HYPRE_IJVector.c
+++ b/src/IJ_mv/HYPRE_IJVector.c
@@ -252,7 +252,7 @@ HYPRE_IJVectorSetValues( HYPRE_IJVector        vector,
 
    if ( hypre_IJVectorObjectType(vec) == HYPRE_PARCSR )
    {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_IJVectorMemoryLocation(vector) );
 
       if (exec == HYPRE_EXEC_DEVICE)
@@ -307,7 +307,7 @@ HYPRE_IJVectorAddToValues( HYPRE_IJVector        vector,
 
    if ( hypre_IJVectorObjectType(vec) == HYPRE_PARCSR )
    {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_IJVectorMemoryLocation(vector) );
 
       if (exec == HYPRE_EXEC_DEVICE)
@@ -345,7 +345,7 @@ HYPRE_IJVectorAssemble( HYPRE_IJVector vector )
 
    if ( hypre_IJVectorObjectType(vec) == HYPRE_PARCSR )
    {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_IJVectorMemoryLocation(vector) );
 
       if (exec == HYPRE_EXEC_DEVICE)

--- a/src/IJ_mv/IJMatrix_parcsr.c
+++ b/src/IJ_mv/IJMatrix_parcsr.c
@@ -120,7 +120,7 @@ hypre_IJMatrixSetRowSizesParCSR(hypre_IJMatrix  *matrix,
    }
    hypre_AuxParCSRMatrixRowSpace(aux_matrix) = row_space;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_AuxParCSRMatrixUsrOnProcElmts(aux_matrix) = 0;
    for (i = 0; i < local_num_rows; i++)
    {
@@ -189,7 +189,7 @@ HYPRE_Int
 hypre_IJMatrixSetMaxOnProcElmtsParCSR(hypre_IJMatrix *matrix,
                                       HYPRE_Int       max_on_proc_elmts)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_AuxParCSRMatrix *aux_matrix;
    HYPRE_Int local_num_rows, local_num_cols, my_id;
    HYPRE_BigInt *row_partitioning = hypre_IJMatrixRowPartitioning(matrix);
@@ -239,7 +239,7 @@ hypre_IJMatrixSetMaxOffProcElmtsParCSR(hypre_IJMatrix *matrix,
    }
    hypre_AuxParCSRMatrixMaxOffProcElmts(aux_matrix) = max_off_proc_elmts;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_AuxParCSRMatrixUsrOffProcElmts(aux_matrix) = max_off_proc_elmts;
 #endif
 
@@ -1064,7 +1064,7 @@ hypre_IJMatrixSetConstantValuesParCSR( hypre_IJMatrix *matrix,
 {
    if (hypre_IJMatrixAssembleFlag(matrix))  /* matrix already assembled*/
    {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (hypre_GetExecPolicy1(hypre_IJMatrixMemoryLocation(matrix)) == HYPRE_EXEC_DEVICE)
       {
          hypre_IJMatrixSetConstantValuesParCSRDevice(matrix, value);
@@ -2235,7 +2235,7 @@ hypre_IJMatrixAssembleOffProcValsParCSR( hypre_IJMatrix       *matrix,
       hypre_TMemcpy(off_proc_data_recv_d, off_proc_data_recv, HYPRE_Complex, off_proc_nelm_recv_cur,
                     HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       hypre_IJMatrixSetAddValuesParCSRDevice(matrix, off_proc_nelm_recv_cur, NULL, off_proc_i_recv_d, NULL, off_proc_j_recv_d,
                                              off_proc_data_recv_d, "add");
 #endif
@@ -4072,4 +4072,3 @@ hypre_IJMatrixAddToValuesOMPParCSR( hypre_IJMatrix       *matrix,
 
    return hypre_error_flag;
 }
-

--- a/src/IJ_mv/IJMatrix_parcsr_device.c
+++ b/src/IJ_mv/IJMatrix_parcsr_device.c
@@ -14,7 +14,7 @@
 #include "_hypre_IJ_mv.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 __global__ void
 hypreCUDAKernel_IJMatrixValues_dev1(HYPRE_Int n, HYPRE_Int *rowind, HYPRE_Int *row_ptr, HYPRE_Int *row_len, HYPRE_Int *mark)
@@ -742,4 +742,3 @@ hypre_IJMatrixSetConstantValuesParCSRDevice( hypre_IJMatrix *matrix,
 }
 
 #endif
-

--- a/src/IJ_mv/IJVector_parcsr.c
+++ b/src/IJ_mv/IJVector_parcsr.c
@@ -138,7 +138,7 @@ hypre_IJVectorSetMaxOffProcElmtsPar(hypre_IJVector *vector,
    }
    hypre_AuxParVectorMaxOffProcElmts(aux_vector) = max_off_proc_elmts;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_AuxParVectorUsrOffProcElmts(aux_vector) = max_off_proc_elmts;
 #endif
 
@@ -1183,7 +1183,7 @@ hypre_IJVectorAssembleOffProcValsPar( hypre_IJVector       *vector,
       hypre_TMemcpy(off_proc_data_recv_d, off_proc_data_recv, HYPRE_Complex, off_proc_nelm_recv_cur,
                     HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       hypre_IJVectorSetAddValuesParDevice(vector, off_proc_nelm_recv_cur, off_proc_i_recv_d, off_proc_data_recv_d, "add");
 #endif
    }

--- a/src/IJ_mv/IJVector_parcsr_device.c
+++ b/src/IJ_mv/IJVector_parcsr_device.c
@@ -14,7 +14,7 @@
 #include "_hypre_IJ_mv.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 template<typename T1, typename T2>
 struct hypre_IJVectorAssembleFunctor : public thrust::binary_function< thrust::tuple<T1, T2>, thrust::tuple<T1, T2>, thrust::tuple<T1, T2> >
@@ -362,4 +362,3 @@ hypreCUDAKernel_IJVectorAssemblePar(HYPRE_Int n, HYPRE_Complex *x, HYPRE_BigInt 
 }
 
 #endif
-

--- a/src/IJ_mv/_hypre_IJ_mv.h
+++ b/src/IJ_mv/_hypre_IJ_mv.h
@@ -78,7 +78,7 @@ typedef struct
 
    HYPRE_MemoryLocation memory_location;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_Int            max_stack_elmts;
    HYPRE_Int            current_stack_elmts;
    HYPRE_BigInt        *stack_i;
@@ -120,7 +120,7 @@ typedef struct
 
 #define hypre_AuxParCSRMatrixMemoryLocation(matrix)       ((matrix) -> memory_location)
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #define hypre_AuxParCSRMatrixMaxStackElmts(matrix)        ((matrix) -> max_stack_elmts)
 #define hypre_AuxParCSRMatrixCurrentStackElmts(matrix)    ((matrix) -> current_stack_elmts)
 #define hypre_AuxParCSRMatrixStackI(matrix)               ((matrix) -> stack_i)
@@ -134,7 +134,6 @@ typedef struct
 #endif
 
 #endif /* #ifndef hypre_AUX_PARCSR_MATRIX_HEADER */
-
 /******************************************************************************
  * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
@@ -167,7 +166,7 @@ typedef struct
 
    HYPRE_MemoryLocation memory_location;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_Int            max_stack_elmts;      /* length of stash for SetValues and AddToValues*/
    HYPRE_Int            current_stack_elmts;  /* current no. of elements stored in stash */
    HYPRE_BigInt        *stack_i;              /* contains column indices */
@@ -190,7 +189,7 @@ typedef struct
 
 #define hypre_AuxParVectorMemoryLocation(vector)       ((vector) -> memory_location)
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #define hypre_AuxParVectorMaxStackElmts(vector)        ((vector) -> max_stack_elmts)
 #define hypre_AuxParVectorCurrentStackElmts(vector)    ((vector) -> current_stack_elmts)
 #define hypre_AuxParVectorStackI(vector)               ((vector) -> stack_i)
@@ -202,7 +201,6 @@ typedef struct
 #endif
 
 #endif /* #ifndef hypre_AUX_PAR_VECTOR_HEADER */
-
 /******************************************************************************
  * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.

--- a/src/IJ_mv/aux_par_vector.c
+++ b/src/IJ_mv/aux_par_vector.c
@@ -32,7 +32,7 @@ hypre_AuxParVectorCreate( hypre_AuxParVector **aux_vector)
    hypre_AuxParVectorOffProcI(vector) = NULL;
    hypre_AuxParVectorOffProcData(vector) = NULL;
    hypre_AuxParVectorMemoryLocation(vector) = HYPRE_MEMORY_HOST;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_AuxParVectorMaxStackElmts(vector) = 0;
    hypre_AuxParVectorCurrentStackElmts(vector) = 0;
    hypre_AuxParVectorStackI(vector) = NULL;
@@ -61,7 +61,7 @@ hypre_AuxParVectorDestroy( hypre_AuxParVector *vector )
       hypre_TFree(hypre_AuxParVectorOffProcI(vector),    HYPRE_MEMORY_HOST);
       hypre_TFree(hypre_AuxParVectorOffProcData(vector), HYPRE_MEMORY_HOST);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       hypre_TFree(hypre_AuxParVectorStackI(vector),    hypre_AuxParVectorMemoryLocation(vector));
       hypre_TFree(hypre_AuxParVectorStackData(vector), hypre_AuxParVectorMemoryLocation(vector));
       hypre_TFree(hypre_AuxParVectorStackSorA(vector), hypre_AuxParVectorMemoryLocation(vector));
@@ -96,4 +96,3 @@ hypre_AuxParVectorInitialize_v2( hypre_AuxParVector *vector, HYPRE_MemoryLocatio
 
    return 0;
 }
-

--- a/src/IJ_mv/aux_par_vector.h
+++ b/src/IJ_mv/aux_par_vector.h
@@ -30,7 +30,7 @@ typedef struct
 
    HYPRE_MemoryLocation memory_location;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_Int            max_stack_elmts;      /* length of stash for SetValues and AddToValues*/
    HYPRE_Int            current_stack_elmts;  /* current no. of elements stored in stash */
    HYPRE_BigInt        *stack_i;              /* contains column indices */
@@ -53,7 +53,7 @@ typedef struct
 
 #define hypre_AuxParVectorMemoryLocation(vector)       ((vector) -> memory_location)
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #define hypre_AuxParVectorMaxStackElmts(vector)        ((vector) -> max_stack_elmts)
 #define hypre_AuxParVectorCurrentStackElmts(vector)    ((vector) -> current_stack_elmts)
 #define hypre_AuxParVectorStackI(vector)               ((vector) -> stack_i)
@@ -65,4 +65,3 @@ typedef struct
 #endif
 
 #endif /* #ifndef hypre_AUX_PAR_VECTOR_HEADER */
-

--- a/src/IJ_mv/aux_parcsr_matrix.c
+++ b/src/IJ_mv/aux_parcsr_matrix.c
@@ -50,7 +50,7 @@ hypre_AuxParCSRMatrixCreate( hypre_AuxParCSRMatrix **aux_matrix,
    hypre_AuxParCSRMatrixOffProcJ(matrix) = NULL;
    hypre_AuxParCSRMatrixOffProcData(matrix) = NULL;
    hypre_AuxParCSRMatrixMemoryLocation(matrix) = HYPRE_MEMORY_HOST;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_AuxParCSRMatrixMaxStackElmts(matrix) = 0;
    hypre_AuxParCSRMatrixCurrentStackElmts(matrix) = 0;
    hypre_AuxParCSRMatrixStackI(matrix) = NULL;
@@ -112,7 +112,7 @@ hypre_AuxParCSRMatrixDestroy( hypre_AuxParCSRMatrix *matrix )
       hypre_TFree(hypre_AuxParCSRMatrixOffProcJ(matrix),    HYPRE_MEMORY_HOST);
       hypre_TFree(hypre_AuxParCSRMatrixOffProcData(matrix), HYPRE_MEMORY_HOST);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       hypre_TFree(hypre_AuxParCSRMatrixStackI(matrix),    hypre_AuxParCSRMatrixMemoryLocation(matrix));
       hypre_TFree(hypre_AuxParCSRMatrixStackJ(matrix),    hypre_AuxParCSRMatrixMemoryLocation(matrix));
       hypre_TFree(hypre_AuxParCSRMatrixStackData(matrix), hypre_AuxParCSRMatrixMemoryLocation(matrix));
@@ -216,4 +216,3 @@ hypre_AuxParCSRMatrixInitialize(hypre_AuxParCSRMatrix *matrix)
 
    return -2;
 }
-

--- a/src/IJ_mv/aux_parcsr_matrix.h
+++ b/src/IJ_mv/aux_parcsr_matrix.h
@@ -63,7 +63,7 @@ typedef struct
 
    HYPRE_MemoryLocation memory_location;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_Int            max_stack_elmts;
    HYPRE_Int            current_stack_elmts;
    HYPRE_BigInt        *stack_i;
@@ -105,7 +105,7 @@ typedef struct
 
 #define hypre_AuxParCSRMatrixMemoryLocation(matrix)       ((matrix) -> memory_location)
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #define hypre_AuxParCSRMatrixMaxStackElmts(matrix)        ((matrix) -> max_stack_elmts)
 #define hypre_AuxParCSRMatrixCurrentStackElmts(matrix)    ((matrix) -> current_stack_elmts)
 #define hypre_AuxParCSRMatrixStackI(matrix)               ((matrix) -> stack_i)
@@ -119,4 +119,3 @@ typedef struct
 #endif
 
 #endif /* #ifndef hypre_AUX_PARCSR_MATRIX_HEADER */
-

--- a/src/parcsr_ls/ams.c
+++ b/src/parcsr_ls/ams.c
@@ -305,7 +305,7 @@ HYPRE_Int hypre_ParCSRMatrixFixZeroRows(hypre_ParCSRMatrix *A)
  * cf_marker is not NULL.
  *--------------------------------------------------------------------------*/
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 struct l1_norm_op1 : public thrust::binary_function<HYPRE_Complex, HYPRE_Complex, HYPRE_Complex>
 {
    __host__ __device__
@@ -439,7 +439,7 @@ HYPRE_Int hypre_ParCSRComputeL1Norms(hypre_ParCSRMatrix  *A,
       }
 
       /* Truncate according to Remark 6.2 */
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (exec == HYPRE_EXEC_DEVICE)
       {
          HYPRE_THRUST_CALL( transform, l1_norm, l1_norm + num_rows, diag_tmp, l1_norm, l1_norm_op1() );
@@ -461,7 +461,7 @@ HYPRE_Int hypre_ParCSRComputeL1Norms(hypre_ParCSRMatrix  *A,
       /* Set the diag element */
       hypre_CSRMatrixExtractDiagonal(A_diag, l1_norm, 0);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if ( exec == HYPRE_EXEC_DEVICE)
       {
          thrust::identity<HYPRE_Complex> identity;
@@ -493,7 +493,7 @@ HYPRE_Int hypre_ParCSRComputeL1Norms(hypre_ParCSRMatrix  *A,
    /* Set the diag element */
    hypre_CSRMatrixExtractDiagonal(A_diag, diag_tmp, 0);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if (exec == HYPRE_EXEC_DEVICE)
    {
       HYPRE_THRUST_CALL( transform_if, l1_norm, l1_norm + num_rows, diag_tmp, l1_norm, thrust::negate<HYPRE_Real>(),
@@ -3377,4 +3377,3 @@ HYPRE_Int hypre_ParCSRComputeL1NormsThreads(hypre_ParCSRMatrix *A,
 
    return hypre_error_flag;
 }
-

--- a/src/parcsr_ls/par_2s_interp.c
+++ b/src/parcsr_ls/par_2s_interp.c
@@ -525,7 +525,7 @@ hypre_BoomerAMGBuildModPartialExtInterp( hypre_ParCSRMatrix  *A,
                                          HYPRE_Int           *col_offd_S_to_A,
                                          hypre_ParCSRMatrix **P_ptr )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("PartialExtInterp");
 #endif
 
@@ -538,7 +538,7 @@ hypre_BoomerAMGBuildModPartialExtInterp( hypre_ParCSRMatrix  *A,
       ierr = hypre_BoomerAMGBuildModPartialExtInterpHost(A, CF_marker, S, num_cpts_global, num_old_cpts_global,
                                                          debug_flag, trunc_factor, max_elmts, col_offd_S_to_A, P_ptr);
    }
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    else
    {
       ierr = hypre_BoomerAMGBuildModPartialExtInterpDevice(A, CF_marker, S, num_cpts_global, num_old_cpts_global,
@@ -546,7 +546,7 @@ hypre_BoomerAMGBuildModPartialExtInterp( hypre_ParCSRMatrix  *A,
    }
 #endif
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
@@ -1112,7 +1112,7 @@ hypre_BoomerAMGBuildModPartialExtPEInterp( hypre_ParCSRMatrix  *A,
                                            HYPRE_Int           *col_offd_S_to_A,
                                            hypre_ParCSRMatrix **P_ptr )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("PartialExtPEInterp");
 #endif
 
@@ -1125,7 +1125,7 @@ hypre_BoomerAMGBuildModPartialExtPEInterp( hypre_ParCSRMatrix  *A,
       ierr = hypre_BoomerAMGBuildModPartialExtPEInterpHost(A, CF_marker, S, num_cpts_global, num_old_cpts_global,
                                                            debug_flag, trunc_factor, max_elmts, col_offd_S_to_A, P_ptr);
    }
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    else
    {
       ierr = hypre_BoomerAMGBuildModPartialExtPEInterpDevice(A, CF_marker, S, num_cpts_global, num_old_cpts_global,
@@ -1133,10 +1133,9 @@ hypre_BoomerAMGBuildModPartialExtPEInterp( hypre_ParCSRMatrix  *A,
    }
 #endif
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
    return ierr;
 }
-

--- a/src/parcsr_ls/par_2s_interp_device.c
+++ b/src/parcsr_ls/par_2s_interp_device.c
@@ -8,7 +8,7 @@
 #include "_hypre_parcsr_ls.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 __global__ void hypreCUDAKernel_compute_weak_rowsums( HYPRE_Int nr_of_rows, bool has_offd, HYPRE_Int *CF_marker, HYPRE_Int *A_diag_i, HYPRE_Complex *A_diag_a, HYPRE_Int *S_diag_j, HYPRE_Int *A_offd_i, HYPRE_Complex *A_offd_a, HYPRE_Int *S_offd_j, HYPRE_Real *rs, HYPRE_Int flag );
 
@@ -787,4 +787,4 @@ void hypreCUDAKernel_MMPEInterpScaleAFF( HYPRE_Int      AFF_nrows,
    }
 }
 
-#endif /* #if defined(HYPRE_USING_CUDA) */
+#endif /* #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -764,7 +764,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
       needZ = hypre_max(needZ, 1);
    }
 
-#if !defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_CUDA) && !defined(HYPRE_USING_HIP)
    /* GPU impl. needs Z */
    if (num_threads > 1)
 #endif

--- a/src/parcsr_ls/par_amgdd_comp_grid.c
+++ b/src/parcsr_ls/par_amgdd_comp_grid.c
@@ -924,7 +924,7 @@ HYPRE_Int hypre_AMGDDCompGridFinalize( hypre_ParAMGDDData *amgdd_data )
    HYPRE_Int             num_nonowned_real_c_points;
    HYPRE_Int             real_cnt, ghost_cnt;
    HYPRE_Int             proc, outer_level, level, i, j;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_Int             c_cnt, f_cnt;
 #endif
 
@@ -1037,7 +1037,7 @@ HYPRE_Int hypre_AMGDDCompGridFinalize( hypre_ParAMGDDData *amgdd_data )
          hypre_AMGDDCompGridNumOwnedCPoints(compGrid[level])        = num_owned_c_points;
          hypre_AMGDDCompGridNumNonOwnedRealCPoints(compGrid[level]) = num_nonowned_real_c_points;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
          // Setup owned C and F masks. NOTE: only used in the cuda version of masked matvecs.
          hypre_AMGDDCompGridOwnedCMask(compGrid[level]) = hypre_CTAlloc(HYPRE_Int,
                                                                         num_owned_c_points,
@@ -1092,7 +1092,7 @@ HYPRE_Int hypre_AMGDDCompGridFinalize( hypre_ParAMGDDData *amgdd_data )
          {
             hypre_AMGDDCompGridNonOwnedFMask(compGrid[level])[i] = i;
          }
-#endif
+#endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       }
 
       // Reorder nonowned matrices

--- a/src/parcsr_ls/par_amgdd_fac_cycle.c
+++ b/src/parcsr_ls/par_amgdd_fac_cycle.c
@@ -215,7 +215,7 @@ hypre_BoomerAMGDD_FAC_Jacobi( void      *amgdd_vdata,
                               HYPRE_Int  level,
                               HYPRE_Int  cycle_param )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_ParAMGDDData      *amgdd_data      = (hypre_ParAMGDDData*) amgdd_vdata;
    hypre_AMGDDCompGrid     *compGrid        = hypre_ParAMGDDDataCompGrid(amgdd_data)[level];
    HYPRE_MemoryLocation     memory_location = hypre_AMGDDCompGridMemoryLocation(compGrid);
@@ -540,7 +540,7 @@ hypre_BoomerAMGDD_FAC_CFL1Jacobi( void      *amgdd_vdata,
                                   HYPRE_Int  level,
                                   HYPRE_Int  cycle_param )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_ParAMGDDData      *amgdd_data      = (hypre_ParAMGDDData*) amgdd_vdata;
    hypre_AMGDDCompGrid     *compGrid        = hypre_ParAMGDDDataCompGrid(amgdd_data)[level];
    HYPRE_MemoryLocation     memory_location = hypre_AMGDDCompGridMemoryLocation(compGrid);

--- a/src/parcsr_ls/par_amgdd_fac_cycle_device.c
+++ b/src/parcsr_ls/par_amgdd_fac_cycle_device.c
@@ -8,7 +8,7 @@
 #include "_hypre_parcsr_ls.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 HYPRE_Int
 hypre_BoomerAMGDD_FAC_JacobiDevice( void     *amgdd_vdata,
@@ -216,4 +216,4 @@ hypre_BoomerAMGDD_FAC_CFL1JacobiDevice( void      *amgdd_vdata,
    return hypre_error_flag;
 }
 
-#endif
+#endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)

--- a/src/parcsr_ls/par_cg_relax_wt.c
+++ b/src/parcsr_ls/par_cg_relax_wt.c
@@ -125,7 +125,7 @@ hypre_BoomerAMGCGRelaxWt( void       *amg_vdata,
    if (hypre_ParAMGDataL1Norms(amg_data) != NULL)
       l1_norms = hypre_ParAMGDataL1Norms(amg_data)[level];
 
-#if !defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_CUDA) && !defined(HYPRE_USING_HIP)
    if (num_threads > 1)
 #endif
    {

--- a/src/parcsr_ls/par_coarsen.c
+++ b/src/parcsr_ls/par_coarsen.c
@@ -2744,13 +2744,13 @@ hypre_BoomerAMGCoarsenPMIS( hypre_ParCSRMatrix    *S,
                             HYPRE_Int              debug_flag,
                             HYPRE_Int            **CF_marker_ptr)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("PMIS");
 #endif
 
    HYPRE_Int ierr = 0;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(A)) );
 
    if (exec == HYPRE_EXEC_DEVICE)
@@ -2763,7 +2763,7 @@ hypre_BoomerAMGCoarsenPMIS( hypre_ParCSRMatrix    *S,
       ierr = hypre_BoomerAMGCoarsenPMISHost( S, A, CF_init, debug_flag, CF_marker_ptr );
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
@@ -2791,4 +2791,3 @@ hypre_BoomerAMGCoarsenHMIS( hypre_ParCSRMatrix    *S,
 
    return (ierr);
 }
-

--- a/src/parcsr_ls/par_coarsen_device.c
+++ b/src/parcsr_ls/par_coarsen_device.c
@@ -14,7 +14,7 @@
 #define COMMON_C_PT  2
 #define Z_PT -2
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 HYPRE_Int hypre_PMISCoarseningInitDevice( hypre_ParCSRMatrix *S, hypre_ParCSRCommPkg *comm_pkg, HYPRE_Int CF_init, HYPRE_Real *measure_diag, HYPRE_Real *measure_offd, HYPRE_Real *real_send_buf, HYPRE_Int *graph_diag_size, HYPRE_Int *graph_diag, HYPRE_Int *CF_marker_diag);
 
@@ -526,7 +526,7 @@ hypre_PMISCoarseningUpdateCFDevice( hypre_ParCSRMatrix  *S,               /* in 
    return hypre_error_flag;
 }
 
-#endif // #if defined(HYPRE_USING_CUDA)
+#endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 
 

--- a/src/parcsr_ls/par_gauss_elim.c
+++ b/src/parcsr_ls/par_gauss_elim.c
@@ -365,7 +365,7 @@ HYPRE_Int hypre_GaussElimSolve (hypre_ParAMGData *amg_data, HYPRE_Int level, HYP
 #include "_hypre_utilities.h"
 #include "_hypre_blas.h"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #define BLOCK_SIZE 512
 
@@ -425,5 +425,5 @@ HYPRE_Int hypre_dgemv_device(HYPRE_Int m, HYPRE_Int n, HYPRE_Int lda, HYPRE_Real
    return hypre_error_flag;
 }
 
-#endif
+#endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #endif

--- a/src/parcsr_ls/par_indepset_device.c
+++ b/src/parcsr_ls/par_indepset_device.c
@@ -12,7 +12,7 @@
 #include "_hypre_parcsr_ls.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 __global__ void
 hypreCUDAKernel_IndepSetMain(HYPRE_Int   graph_diag_size,
                              HYPRE_Int  *graph_diag,
@@ -247,5 +247,4 @@ hypre_BoomerAMGIndepSetInitDevice( hypre_ParCSRMatrix *S,
    return hypre_error_flag;
 }
 
-#endif // #if defined(HYPRE_USING_CUDA)
-
+#endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)

--- a/src/parcsr_ls/par_indepset_device.c
+++ b/src/parcsr_ls/par_indepset_device.c
@@ -224,6 +224,7 @@ hypre_BoomerAMGIndepSetInitDevice( hypre_ParCSRMatrix *S,
    }
    else
    {
+#if defined(HYPRE_USING_CURAND)
       curandGenerator_t gen = hypre_HandleCurandGenerator(hypre_handle());
 
       HYPRE_CURAND_CALL( curandSetPseudoRandomGeneratorSeed(gen, 2747 + my_id) );
@@ -236,6 +237,7 @@ hypre_BoomerAMGIndepSetInitDevice( hypre_ParCSRMatrix *S,
       {
          HYPRE_CURAND_CALL( curandGenerateUniform(gen, (float *) urand, num_rows_diag) );
       }
+#endif
    }
 
    thrust::plus<HYPRE_Real> op;

--- a/src/parcsr_ls/par_interp.c
+++ b/src/parcsr_ls/par_interp.c
@@ -2666,13 +2666,13 @@ hypre_BoomerAMGBuildDirInterp( hypre_ParCSRMatrix   *A,
                                HYPRE_Int             interp_type,
                                hypre_ParCSRMatrix  **P_ptr)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("DirInterp");
 #endif
 
    HYPRE_Int ierr = 0;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(A) );
 
    if (exec == HYPRE_EXEC_DEVICE)
@@ -2688,7 +2688,7 @@ hypre_BoomerAMGBuildDirInterp( hypre_ParCSRMatrix   *A,
                                                debug_flag,trunc_factor,max_elmts,col_offd_S_to_A, P_ptr);
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
@@ -2709,7 +2709,7 @@ hypre_BoomerAMGInterpTruncation( hypre_ParCSRMatrix *P,
       return 0;
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(P) );
 
    if (exec == HYPRE_EXEC_DEVICE)
@@ -4387,4 +4387,3 @@ hypre_BoomerAMGBuildInterpOnePnt( hypre_ParCSRMatrix  *A,
 
    return hypre_error_flag;
 }
-

--- a/src/parcsr_ls/par_interp_device.c
+++ b/src/parcsr_ls/par_interp_device.c
@@ -8,7 +8,7 @@
 #include "_hypre_parcsr_ls.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 __global__ void hypre_BoomerAMGBuildDirInterp_getnnz( HYPRE_Int nr_of_rows, HYPRE_Int *S_diag_i, HYPRE_Int *S_diag_j, HYPRE_Int *S_offd_i, HYPRE_Int *S_offd_j, HYPRE_Int *CF_marker, HYPRE_Int *CF_marker_offd, HYPRE_Int num_functions, HYPRE_Int *dof_func, HYPRE_Int *dof_func_offd, HYPRE_Int *P_diag_i, HYPRE_Int *P_offd_i, HYPRE_Int *col_offd_S_to_A);
 
@@ -1009,5 +1009,4 @@ hypre_BoomerAMGBuildDirInterp_getcoef_v2( HYPRE_Int   nr_of_rows,
    }
 }
 
-#endif
-
+#endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)

--- a/src/parcsr_ls/par_interp_trunc_device.c
+++ b/src/parcsr_ls/par_interp_trunc_device.c
@@ -8,7 +8,7 @@
 #include "_hypre_parcsr_ls.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 __global__ void
 hypreCUDAKernel_InterpTruncation( HYPRE_Int   nrows,
@@ -216,4 +216,4 @@ hypre_BoomerAMGInterpTruncationDevice( hypre_ParCSRMatrix *P, HYPRE_Real trunc_f
    return ierr;
 }
 
-#endif /* #if defined(HYPRE_USING_CUDA) */
+#endif /* #if defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP) */

--- a/src/parcsr_ls/par_lr_interp.c
+++ b/src/parcsr_ls/par_lr_interp.c
@@ -5420,7 +5420,7 @@ hypre_BoomerAMGBuildExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                               HYPRE_Int *col_offd_S_to_A,
                               hypre_ParCSRMatrix  **P_ptr)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("ExtInterp");
 #endif
 
@@ -5433,7 +5433,7 @@ hypre_BoomerAMGBuildExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
       ierr = hypre_BoomerAMGBuildExtInterpHost(A,CF_marker,S,num_cpts_global,num_functions,dof_func,
                                                debug_flag,trunc_factor,max_elmts,col_offd_S_to_A,P_ptr);
    }
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    else
    {
       ierr = hypre_BoomerAMGBuildExtInterpDevice(A,CF_marker,S,num_cpts_global,num_functions,dof_func,
@@ -5441,7 +5441,7 @@ hypre_BoomerAMGBuildExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
    }
 #endif
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
@@ -5463,7 +5463,7 @@ hypre_BoomerAMGBuildExtPIInterp(hypre_ParCSRMatrix   *A,
                                 HYPRE_Int            *col_offd_S_to_A,
                                 hypre_ParCSRMatrix  **P_ptr)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("ExtPIInterp");
 #endif
 
@@ -5476,7 +5476,7 @@ hypre_BoomerAMGBuildExtPIInterp(hypre_ParCSRMatrix   *A,
       ierr = hypre_BoomerAMGBuildExtPIInterpHost(A, CF_marker, S, num_cpts_global, num_functions, dof_func,
                                                  debug_flag, trunc_factor, max_elmts, col_offd_S_to_A, P_ptr);
    }
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    else
    {
       ierr = hypre_BoomerAMGBuildExtPIInterpDevice(A, CF_marker, S, num_cpts_global, num_functions, dof_func,
@@ -5484,10 +5484,9 @@ hypre_BoomerAMGBuildExtPIInterp(hypre_ParCSRMatrix   *A,
    }
 #endif
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
    return ierr;
 }
-

--- a/src/parcsr_ls/par_lr_interp_device.c
+++ b/src/parcsr_ls/par_lr_interp_device.c
@@ -9,7 +9,7 @@
 #include "aux_interp.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #define MAX_C_CONNECTIONS 100
 #define HAVE_COMMON_C 1
@@ -1409,5 +1409,4 @@ void hypreCUDAKernel_compute_dlam_dtmp( HYPRE_Int      nr_of_rows,
    }
 }
 
-#endif
-
+#endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)

--- a/src/parcsr_ls/par_mod_lr_interp.c
+++ b/src/parcsr_ls/par_mod_lr_interp.c
@@ -432,7 +432,7 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix  *A,
                                  HYPRE_Int           *col_offd_S_to_A,
                                  hypre_ParCSRMatrix **P_ptr)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("ModExtInterp");
 #endif
 
@@ -445,7 +445,7 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix  *A,
       ierr = hypre_BoomerAMGBuildModExtInterpHost(A,CF_marker,S,num_cpts_global,
                                                   debug_flag,trunc_factor,max_elmts,col_offd_S_to_A,P_ptr);
    }
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    else
    {
       ierr = hypre_BoomerAMGBuildExtInterpDevice(A,CF_marker,S,num_cpts_global,1,NULL,
@@ -453,7 +453,7 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix  *A,
    }
 #endif
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
@@ -990,7 +990,7 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix  *A,
                                    HYPRE_Int           *col_offd_S_to_A,
                                    hypre_ParCSRMatrix **P_ptr)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("ExtPIInterp");
 #endif
 
@@ -1003,7 +1003,7 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix  *A,
       ierr = hypre_BoomerAMGBuildModExtPIInterpHost(A, CF_marker, S, num_cpts_global,
                                                     debug_flag, trunc_factor, max_elmts, col_offd_S_to_A, P_ptr);
    }
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    else
    {
       ierr = hypre_BoomerAMGBuildExtPIInterpDevice(A, CF_marker, S, num_cpts_global, 1, NULL,
@@ -1011,7 +1011,7 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix  *A,
    }
 #endif
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
@@ -1521,7 +1521,7 @@ hypre_BoomerAMGBuildModExtPEInterp(hypre_ParCSRMatrix  *A,
                                       HYPRE_Int           *col_offd_S_to_A,
                                       hypre_ParCSRMatrix **P_ptr)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("ExtPEInterp");
 #endif
 
@@ -1534,7 +1534,7 @@ hypre_BoomerAMGBuildModExtPEInterp(hypre_ParCSRMatrix  *A,
       ierr = hypre_BoomerAMGBuildModExtPEInterpHost(A, CF_marker, S, num_cpts_global,
                                                     debug_flag, trunc_factor, max_elmts, col_offd_S_to_A, P_ptr);
    }
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    else
    {
       ierr = hypre_BoomerAMGBuildExtPEInterpDevice(A,CF_marker,S,num_cpts_global,1,NULL,
@@ -1542,10 +1542,9 @@ hypre_BoomerAMGBuildModExtPEInterp(hypre_ParCSRMatrix  *A,
    }
 #endif
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
    return ierr;
 }
-

--- a/src/parcsr_ls/par_relax.c
+++ b/src/parcsr_ls/par_relax.c
@@ -302,7 +302,7 @@ hypre_BoomerAMGRelax18WeightedL1Jacobi( hypre_ParCSRMatrix *A,
                                         hypre_ParVector    *u,
                                         hypre_ParVector    *Vtemp )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_VectorMemoryLocation(x), hypre_VectorMemoryLocation(b) );
    //RL: TODO back to hypre_GetExecPolicy2 later
    HYPRE_ExecutionPolicy exec = HYPRE_EXEC_DEVICE;
@@ -862,7 +862,7 @@ hypre_BoomerAMGRelax3HybridGaussSeidel( hypre_ParCSRMatrix *A,
                                         hypre_ParVector    *Vtemp,
                                         hypre_ParVector    *Ztemp )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_VectorMemoryLocation(x), hypre_VectorMemoryLocation(b) );
    //RL: TODO back to hypre_GetExecPolicy2 later
    HYPRE_ExecutionPolicy exec = HYPRE_EXEC_DEVICE;
@@ -897,7 +897,7 @@ hypre_BoomerAMGRelax4HybridGaussSeidel( hypre_ParCSRMatrix *A,
                                         hypre_ParVector    *Vtemp,
                                         hypre_ParVector    *Ztemp )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_VectorMemoryLocation(x), hypre_VectorMemoryLocation(b) );
    //RL: TODO back to hypre_GetExecPolicy2 later
    HYPRE_ExecutionPolicy exec = HYPRE_EXEC_DEVICE;
@@ -1029,7 +1029,7 @@ hypre_BoomerAMGRelax6HybridSSOR( hypre_ParCSRMatrix *A,
                                  hypre_ParVector    *Vtemp,
                                  hypre_ParVector    *Ztemp )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_VectorMemoryLocation(x), hypre_VectorMemoryLocation(b) );
    //RL: TODO back to hypre_GetExecPolicy2 later
    HYPRE_ExecutionPolicy exec = HYPRE_EXEC_DEVICE;
@@ -1075,7 +1075,7 @@ hypre_BoomerAMGRelax7Jacobi( hypre_ParCSRMatrix *A,
    hypre_VectorMemoryLocation(&l1_norms_vec) = hypre_ParVectorMemoryLocation(f);
    hypre_ParVectorLocalVector(&l1_norms_parvec) = &l1_norms_vec;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_Int sync_stream;
    hypre_GetSyncCudaCompute(&sync_stream);
    hypre_SetSyncCudaCompute(0);
@@ -1096,7 +1096,7 @@ hypre_BoomerAMGRelax7Jacobi( hypre_ParCSRMatrix *A,
     *-----------------------------------------------------------------*/
    hypre_ParVectorElmdivpy(Vtemp, &l1_norms_parvec, u);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_SetSyncCudaCompute(sync_stream);
    hypre_SyncCudaComputeStream(hypre_handle());
 #endif
@@ -1508,7 +1508,7 @@ hypre_BoomerAMGRelax11TwoStageGaussSeidel( hypre_ParCSRMatrix *A,
                                            hypre_ParVector    *Vtemp,
                                            hypre_ParVector    *Ztemp )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_VectorMemoryLocation(x), hypre_VectorMemoryLocation(b) );
    //RL: TODO back to hypre_GetExecPolicy2 later
    HYPRE_ExecutionPolicy exec = HYPRE_EXEC_DEVICE;
@@ -1582,7 +1582,7 @@ hypre_BoomerAMGRelax12TwoStageGaussSeidel( hypre_ParCSRMatrix *A,
                                            hypre_ParVector    *Vtemp,
                                            hypre_ParVector    *Ztemp )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_VectorMemoryLocation(x), hypre_VectorMemoryLocation(b) );
    //RL: TODO back to hypre_GetExecPolicy2 later
    HYPRE_ExecutionPolicy exec = HYPRE_EXEC_DEVICE;
@@ -1599,4 +1599,3 @@ hypre_BoomerAMGRelax12TwoStageGaussSeidel( hypre_ParCSRMatrix *A,
 
    return hypre_error_flag;
 }
-

--- a/src/parcsr_ls/par_relax_device.c
+++ b/src/parcsr_ls/par_relax_device.c
@@ -9,7 +9,7 @@
 #include "_hypre_parcsr_ls.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 HYPRE_Int
 hypre_BoomerAMGRelaxHybridGaussSeidelDevice( hypre_ParCSRMatrix *A,
@@ -133,4 +133,4 @@ hypre_BoomerAMGRelaxTwoStageGaussSeidelDevice ( hypre_ParCSRMatrix *A,
    return 0;
 }
 
-#endif /* #if defined(HYPRE_USING_CUDA) */
+#endif /* #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */

--- a/src/parcsr_ls/par_strength.c
+++ b/src/parcsr_ls/par_strength.c
@@ -538,13 +538,13 @@ hypre_BoomerAMGCreateS(hypre_ParCSRMatrix    *A,
                        HYPRE_Int             *dof_func,
                        hypre_ParCSRMatrix   **S_ptr)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("CreateS");
 #endif
 
    HYPRE_Int ierr = 0;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(A)) );
 
    if (exec == HYPRE_EXEC_DEVICE)
@@ -557,7 +557,7 @@ hypre_BoomerAMGCreateS(hypre_ParCSRMatrix    *A,
       ierr = hypre_BoomerAMGCreateSHost(A,strength_threshold,max_row_sum,num_functions,dof_func,S_ptr);
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
@@ -2917,13 +2917,13 @@ hypre_BoomerAMGCreate2ndS( hypre_ParCSRMatrix  *S,
                            HYPRE_BigInt        *coarse_row_starts,
                            hypre_ParCSRMatrix **C_ptr)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("Create2ndS");
 #endif
 
    HYPRE_Int ierr = 0;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(S)) );
 
    if (exec == HYPRE_EXEC_DEVICE)
@@ -2936,7 +2936,7 @@ hypre_BoomerAMGCreate2ndS( hypre_ParCSRMatrix  *S,
       ierr = hypre_BoomerAMGCreate2ndSHost( S, CF_marker, num_paths, coarse_row_starts, C_ptr );
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 

--- a/src/parcsr_ls/par_strength2nd_device.c
+++ b/src/parcsr_ls/par_strength2nd_device.c
@@ -16,7 +16,7 @@
 #include "_hypre_parcsr_mv.h"
 #include "HYPRE_utilities.h"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 //-----------------------------------------------------------------------
 HYPRE_Int
@@ -144,5 +144,4 @@ hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix  *S,
    return 0;
 }
 
-#endif /* #if defined(HYPRE_USING_CUDA) */
-
+#endif /* #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */

--- a/src/parcsr_ls/par_strength_device.c
+++ b/src/parcsr_ls/par_strength_device.c
@@ -8,7 +8,7 @@
 #include "_hypre_parcsr_ls.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 __global__ void hypre_BoomerAMGCreateS_rowcount( HYPRE_Int nr_of_rows,
                                                  HYPRE_Real max_row_sum, HYPRE_Real strength_threshold,
@@ -369,5 +369,4 @@ hypre_BoomerAMGCreateSDevice(hypre_ParCSRMatrix    *A,
    }
 }
 
-#endif /* #if defined(HYPRE_USING_CUDA) */
-
+#endif /* #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */

--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -362,7 +362,7 @@ typedef struct hypre_ParCSRMatrix_struct
    HYPRE_Complex        *bdiaginv;
    hypre_ParCSRCommPkg  *bdiaginv_comm_pkg;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    /* these two arrays are reserveed for SoC matrices on GPUs to help build interpolation */
    HYPRE_Int            *soc_diag_j;
    HYPRE_Int            *soc_offd_j;
@@ -402,7 +402,7 @@ typedef struct hypre_ParCSRMatrix_struct
 #define hypre_ParCSRMatrixAssumedPartition(matrix)       ((matrix) -> assumed_partition)
 #define hypre_ParCSRMatrixOwnsAssumedPartition(matrix)   ((matrix) -> owns_assumed_partition)
 #define hypre_ParCSRMatrixProcOrdering(matrix)           ((matrix) -> proc_ordering)
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #define hypre_ParCSRMatrixSocDiagJ(matrix)               ((matrix) -> soc_diag_j)
 #define hypre_ParCSRMatrixSocOffdJ(matrix)               ((matrix) -> soc_offd_j)
 #endif
@@ -482,7 +482,6 @@ typedef struct
 #define hypre_ParCSRBooleanMatrix_Get_Getrowactive(matrix)  ((matrix)->getrowactive)
 
 #endif
-
 /******************************************************************************
  * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.

--- a/src/parcsr_mv/par_csr_fffc_device.c
+++ b/src/parcsr_mv/par_csr_fffc_device.c
@@ -9,7 +9,7 @@
 #include "_hypre_parcsr_mv.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 typedef thrust::tuple<HYPRE_Int, HYPRE_Int> Tuple;
 //typedef thrust::tuple<HYPRE_Int, HYPRE_Int, HYPRe_Int> Tuple3;
@@ -1406,5 +1406,4 @@ hypre_ParCSRMatrixGenerate1DCFDevice( hypre_ParCSRMatrix  *A,
    return hypre_error_flag;
 }
 
-#endif // #if defined(HYPRE_USING_CUDA)
-
+#endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)

--- a/src/parcsr_mv/par_csr_matop.c
+++ b/src/parcsr_mv/par_csr_matop.c
@@ -2002,7 +2002,7 @@ hypre_ParCSRMatrixTranspose( hypre_ParCSRMatrix  *A,
  * G_csr is the node to edge connectivity matrix
  * ----------------------------------------------------------------------------- */
 
-void 
+void
 hypre_ParCSRMatrixGenSpanningTree( hypre_ParCSRMatrix *G_csr,
                                    HYPRE_Int         **indices,
                                    HYPRE_Int           G_type )
@@ -3830,7 +3830,7 @@ hypre_ParCSRMatrix *hypre_ParTMatmul( hypre_ParCSRMatrix  *A,
      hypre_CSRMatrixDestroy(C_tmp_offd);
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if ( hypre_GetExecPolicy2(memory_location_A, memory_location_B) == HYPRE_EXEC_DEVICE )
    {
       hypre_CSRMatrixMoveDiagFirstDevice(hypre_ParCSRMatrixDiag(C));
@@ -5588,4 +5588,3 @@ hypre_ParCSRMatrixExtractSubmatrixFC( hypre_ParCSRMatrix  *A,
 
    return hypre_error_flag;
 }
-

--- a/src/parcsr_mv/par_csr_matop_device.c
+++ b/src/parcsr_mv/par_csr_matop_device.c
@@ -9,7 +9,7 @@
 #include "_hypre_parcsr_mv.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 HYPRE_Int
 hypre_ParcsrGetExternalRowsDeviceInit( hypre_ParCSRMatrix   *A,
@@ -1100,7 +1100,7 @@ hypre_ParCSRMatrixDropSmallEntriesDevice( hypre_ParCSRMatrix *A,
    return hypre_error_flag;
 }
 
-#endif // #if defined(HYPRE_USING_CUDA)
+#endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 /*--------------------------------------------------------------------------
  * HYPRE_ParCSRDiagScale
@@ -1120,10 +1120,10 @@ hypre_ParCSRDiagScale( HYPRE_ParCSRMatrix HA,
    HYPRE_Int *A_i = hypre_CSRMatrixI(hypre_ParCSRMatrixDiag(A));
    HYPRE_Int local_size = hypre_VectorSize(hypre_ParVectorLocalVector(x));
    HYPRE_Int ierr = 0;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypreDevice_DiagScaleVector(local_size, A_i, A_data, y_data, 0.0, x_data);
    //hypre_SyncCudaComputeStream(hypre_handle());
-#else /* #if defined(HYPRE_USING_CUDA) */
+#else /* #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */
    HYPRE_Int i;
 #if defined(HYPRE_USING_DEVICE_OPENMP)
 #pragma omp target teams distribute parallel for private(i) is_device_ptr(x_data,y_data,A_data,A_i)
@@ -1138,4 +1138,3 @@ hypre_ParCSRDiagScale( HYPRE_ParCSRMatrix HA,
 
    return ierr;
 }
-

--- a/src/parcsr_mv/par_csr_matrix.c
+++ b/src/parcsr_mv/par_csr_matrix.c
@@ -126,7 +126,7 @@ hypre_ParCSRMatrixCreate( MPI_Comm comm,
    matrix->bdiaginv_comm_pkg = NULL;
    matrix->bdiag_size = -1;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_ParCSRMatrixSocDiagJ(matrix) = NULL;
    hypre_ParCSRMatrixSocOffdJ(matrix) = NULL;
 #endif
@@ -212,7 +212,7 @@ hypre_ParCSRMatrixDestroy( hypre_ParCSRMatrix *matrix )
          hypre_MatvecCommPkgDestroy(matrix->bdiaginv_comm_pkg);
       }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       hypre_TFree(hypre_ParCSRMatrixSocDiagJ(matrix), HYPRE_MEMORY_DEVICE);
       hypre_TFree(hypre_ParCSRMatrixSocOffdJ(matrix), HYPRE_MEMORY_DEVICE);
 #endif
@@ -1158,7 +1158,7 @@ hypre_ParCSRMatrixGetRow( hypre_ParCSRMatrix  *mat,
                           HYPRE_BigInt       **col_ind,
                           HYPRE_Complex      **values )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(mat) );
 
    if (exec == HYPRE_EXEC_DEVICE)
@@ -2983,4 +2983,3 @@ hypre_ParCSRMatrixTruncate(hypre_ParCSRMatrix *A,
 
    return ierr;
 }
-

--- a/src/parcsr_mv/par_csr_matrix.h
+++ b/src/parcsr_mv/par_csr_matrix.h
@@ -85,7 +85,7 @@ typedef struct hypre_ParCSRMatrix_struct
    HYPRE_Complex        *bdiaginv;
    hypre_ParCSRCommPkg  *bdiaginv_comm_pkg;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    /* these two arrays are reserveed for SoC matrices on GPUs to help build interpolation */
    HYPRE_Int            *soc_diag_j;
    HYPRE_Int            *soc_offd_j;
@@ -125,7 +125,7 @@ typedef struct hypre_ParCSRMatrix_struct
 #define hypre_ParCSRMatrixAssumedPartition(matrix)       ((matrix) -> assumed_partition)
 #define hypre_ParCSRMatrixOwnsAssumedPartition(matrix)   ((matrix) -> owns_assumed_partition)
 #define hypre_ParCSRMatrixProcOrdering(matrix)           ((matrix) -> proc_ordering)
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #define hypre_ParCSRMatrixSocDiagJ(matrix)               ((matrix) -> soc_diag_j)
 #define hypre_ParCSRMatrixSocOffdJ(matrix)               ((matrix) -> soc_offd_j)
 #endif
@@ -205,4 +205,3 @@ typedef struct
 #define hypre_ParCSRBooleanMatrix_Get_Getrowactive(matrix)  ((matrix)->getrowactive)
 
 #endif
-

--- a/src/parcsr_mv/par_csr_matvec.c
+++ b/src/parcsr_mv/par_csr_matvec.c
@@ -223,7 +223,7 @@ hypre_ParCSRMatrixMatvecOutOfPlace( HYPRE_Complex       alpha,
       HYPRE_Complex *locl_data = x_local_data + jv * vecstride;
 
       /* if on device, no need to Sync: send_data is on device memory */
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       /* pack send data on device */
       HYPRE_THRUST_CALL( gather,
                          hypre_ParCSRCommPkgDeviceSendMapElmts(comm_pkg),
@@ -643,7 +643,7 @@ hypre_ParCSRMatrixMatvecT( HYPRE_Complex       alpha,
       HYPRE_Complex *recv_data = (HYPRE_Complex *) y_buf_data[jv];
       HYPRE_Complex *locl_data = y_local_data + jv * vecstride;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       /* unpack recv data on device */
       if (!hypre_ParCSRCommPkgWorkSpace(comm_pkg))
       {

--- a/src/parcsr_mv/par_csr_triplemat.c
+++ b/src/parcsr_mv/par_csr_triplemat.c
@@ -205,13 +205,13 @@ hypre_ParCSRMatrix*
 hypre_ParCSRMatMat( hypre_ParCSRMatrix  *A,
                     hypre_ParCSRMatrix  *B )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("Mat-Mat");
 #endif
 
    hypre_ParCSRMatrix *C = NULL;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_ParCSRMatrixMemoryLocation(A),
                                                        hypre_ParCSRMatrixMemoryLocation(B) );
 
@@ -225,7 +225,7 @@ hypre_ParCSRMatMat( hypre_ParCSRMatrix  *A,
       C = hypre_ParCSRMatMatHost(A,B);
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
@@ -464,13 +464,13 @@ hypre_ParCSRTMatMatKT( hypre_ParCSRMatrix  *A,
                        hypre_ParCSRMatrix  *B,
                        HYPRE_Int            keep_transpose)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("Mat-T-Mat");
 #endif
 
    hypre_ParCSRMatrix *C = NULL;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_ParCSRMatrixMemoryLocation(A),
                                                        hypre_ParCSRMatrixMemoryLocation(B) );
 
@@ -484,7 +484,7 @@ hypre_ParCSRTMatMatKT( hypre_ParCSRMatrix  *A,
       C = hypre_ParCSRTMatMatKTHost(A, B, keep_transpose);
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
@@ -926,13 +926,13 @@ hypre_ParCSRMatrixRAPKT( hypre_ParCSRMatrix  *R,
                          hypre_ParCSRMatrix  *P,
                          HYPRE_Int            keep_transpose)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("TripleMat-RAP");
 #endif
 
    hypre_ParCSRMatrix *C = NULL;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_ParCSRMatrixMemoryLocation(R),
                                                       hypre_ParCSRMatrixMemoryLocation(A) );
 
@@ -946,7 +946,7 @@ hypre_ParCSRMatrixRAPKT( hypre_ParCSRMatrix  *R,
       C = hypre_ParCSRMatrixRAPKTHost(R, A, P, keep_transpose);
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 
@@ -1001,4 +1001,3 @@ hypre_ParCSRMatrix *hypre_ParCSRMatrixRAP( hypre_ParCSRMatrix *R,
  *               even want to store a copy of it in this form
  *               temporarily?
  *--------------------------------------------------------------------------*/
-

--- a/src/parcsr_mv/par_csr_triplemat_device.c
+++ b/src/parcsr_mv/par_csr_triplemat_device.c
@@ -8,7 +8,7 @@
 #include "_hypre_parcsr_mv.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 /* option == 1, T = HYPRE_BigInt
  * option == 2, T = HYPRE_Int,
@@ -811,5 +811,4 @@ hypre_ParCSRMatrixRAPKTDevice( hypre_ParCSRMatrix *R,
    return C;
 }
 
-#endif // #if defined(HYPRE_USING_CUDA)
-
+#endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)

--- a/src/parcsr_mv/par_vector.c
+++ b/src/parcsr_mv/par_vector.c
@@ -1091,7 +1091,7 @@ hypre_ParVectorGetValues(hypre_ParVector *vector,
                          HYPRE_BigInt    *indices,
                          HYPRE_Complex   *values)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if (HYPRE_EXEC_DEVICE == hypre_GetExecPolicy1( hypre_ParVectorMemoryLocation(vector) ))
    {
       hypre_ParVectorGetValuesDevice(vector, num_values, indices, values);

--- a/src/parcsr_mv/par_vector_device.c
+++ b/src/parcsr_mv/par_vector_device.c
@@ -7,7 +7,7 @@
 #include "_hypre_parcsr_mv.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 HYPRE_Int
 hypre_ParVectorGetValuesDevice(hypre_ParVector *vector,
@@ -66,5 +66,4 @@ hypre_ParVectorGetValuesDevice(hypre_ParVector *vector,
    return hypre_error_flag;
 }
 
-#endif // #if defined(HYPRE_USING_CUDA)
-
+#endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)

--- a/src/seq_mv/csr_matop.c
+++ b/src/seq_mv/csr_matop.c
@@ -143,7 +143,7 @@ hypre_CSRMatrixAdd( hypre_CSRMatrix *A,
 {
    hypre_CSRMatrix *C = NULL;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_CSRMatrixMemoryLocation(A),
                                                        hypre_CSRMatrixMemoryLocation(B) );
 
@@ -478,7 +478,7 @@ hypre_CSRMatrixMultiply( hypre_CSRMatrix *A,
 {
    hypre_CSRMatrix *C = NULL;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_CSRMatrixMemoryLocation(A),
                                                        hypre_CSRMatrixMemoryLocation(B) );
 
@@ -785,7 +785,7 @@ hypre_CSRMatrixTranspose(hypre_CSRMatrix  *A,
 {
    HYPRE_Int ierr = 0;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_CSRMatrixMemoryLocation(A) );
 
    if (exec == HYPRE_EXEC_DEVICE)
@@ -1363,7 +1363,7 @@ hypre_CSRMatrixComputeRowSum( hypre_CSRMatrix *A,
 {
    hypre_assert( (CF_i && CF_j) || (!CF_i && !CF_j) );
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_CSRMatrixMemoryLocation(A) );
 
    if (exec == HYPRE_EXEC_DEVICE)
@@ -1419,7 +1419,7 @@ hypre_CSRMatrixExtractDiagonal( hypre_CSRMatrix *A,
                                 HYPRE_Complex   *d,
                                 HYPRE_Int        type)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_CSRMatrixMemoryLocation(A) );
 
    if (exec == HYPRE_EXEC_DEVICE)
@@ -1432,4 +1432,3 @@ hypre_CSRMatrixExtractDiagonal( hypre_CSRMatrix *A,
       hypre_CSRMatrixExtractDiagonalHost(A, d, type);
    }
 }
-

--- a/src/seq_mv/csr_matop_device.c
+++ b/src/seq_mv/csr_matop_device.c
@@ -51,7 +51,7 @@ hypre_CsrsvDataDestroy(hypre_CsrsvData* data)
 }
 #endif /* #if defined(HYPRE_USING_CUSPARSE) */
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 hypre_CSRMatrix*
 hypre_CSRMatrixAddDevice ( hypre_CSRMatrix *A,
@@ -1141,7 +1141,7 @@ hypre_CSRMatrixDropSmallEntriesDevice( hypre_CSRMatrix *A,
    return hypre_error_flag;
 }
 
-#endif /* HYPRE_USING_CUDA */
+#endif /* HYPRE_USING_CUDA || defined(HYPRE_USING_HIP) */
 
 #if defined(HYPRE_USING_GPU)
 
@@ -1295,7 +1295,7 @@ hypre_CSRMatrixTriLowerUpperSolveCusparse(char             uplo,
       hypre_TMemcpy(A_sj, A_j, HYPRE_Int, nnzA, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
       hypre_TMemcpy(A_sa, A_a, HYPRE_Complex, nnzA, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       hypre_CSRMatrixData(A) = A_sa;
       HYPRE_Int err = hypre_CSRMatrixCheckDiagFirstSetValueZeroDevice(A, INFINITY);  hypre_assert(err == 0);
       hypre_CSRMatrixData(A) = A_a;

--- a/src/seq_mv/csr_matvec_device.c
+++ b/src/seq_mv/csr_matvec_device.c
@@ -68,7 +68,7 @@ hypre_CSRMatrixMatvecDevice( HYPRE_Int        trans,
                              hypre_Vector    *y,
                              HYPRE_Int        offset )
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPushRange("CSRMatrixMatvec");
 #endif
 
@@ -114,7 +114,7 @@ hypre_CSRMatrixMatvecDevice( HYPRE_Int        trans,
 
    hypre_SyncCudaComputeStream(hypre_handle());
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_NvtxPopRange();
 #endif
 

--- a/src/seq_mv/csr_matvec_device.c
+++ b/src/seq_mv/csr_matvec_device.c
@@ -48,6 +48,8 @@ hypre_CSRMatrixMatvecDevice2( HYPRE_Int        trans,
 #endif
 #elif defined(HYPRE_USING_DEVICE_OPENMP)
    hypre_CSRMatrixMatvecOMPOffload(trans, alpha, A, x, beta, y, offset);
+#elif defined(HYPRE_USING_HIP)
+#warning SPMV NOT IMPLEMENTED FOR HIP YET
 #else // #ifdef HYPRE_USING_CUSPARSE
 #error HYPRE SPMV TODO
 #endif

--- a/src/seq_mv/csr_spadd_device.c
+++ b/src/seq_mv/csr_spadd_device.c
@@ -8,7 +8,7 @@
 #include "seq_mv.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 /* in Matlab notation: if num_b != NULL, C = A, and
  *                                       for each num_b[i], A(num_b[i], :) += B(i,:).
@@ -136,5 +136,4 @@ hypreDevice_CSRSpAdd(HYPRE_Int  ma,       HYPRE_Int   mb,        HYPRE_Int   n,
    return hypre_error_flag;
 }
 
-#endif
-
+#endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)

--- a/src/seq_mv/csr_spgemm_device.c
+++ b/src/seq_mv/csr_spgemm_device.c
@@ -8,7 +8,7 @@
 #include "seq_mv.h"
 #include "csr_spgemm_device.h"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 HYPRE_Int
 hypreDevice_CSRSpGemm(HYPRE_Int   m,        HYPRE_Int   k,        HYPRE_Int       n,
@@ -133,7 +133,7 @@ hypre_CSRMatrixDeviceSpGemmSetHashType( char value )
    return 0;
 }
 
-#endif /* HYPRE_USING_CUDA */
+#endif /* HYPRE_USING_CUDA  || defined(HYPRE_USING_HIP) */
 
 HYPRE_Int
 hypre_CSRMatrixDeviceSpGemmSetUseCusparse( HYPRE_Int use_cusparse )
@@ -143,4 +143,3 @@ hypre_CSRMatrixDeviceSpGemmSetUseCusparse( HYPRE_Int use_cusparse )
 #endif
    return 0;
 }
-

--- a/src/seq_mv/csr_spgemm_device.h
+++ b/src/seq_mv/csr_spgemm_device.h
@@ -10,7 +10,7 @@
 
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #define COHEN_USE_SHMEM 0
 
@@ -86,5 +86,5 @@ void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_c, HYPRE_Int **d_i, HYPRE_Int
 HYPRE_Int csr_spmm_create_hash_table(HYPRE_Int m, HYPRE_Int *d_rc, HYPRE_Int *d_rf, HYPRE_Int SHMEM_HASH_SIZE, HYPRE_Int num_ghash, HYPRE_Int **d_ghash_i, HYPRE_Int **d_ghash_j, HYPRE_Complex **d_ghash_a, HYPRE_Int *ghash_size);
 
 
-#endif /* HYPRE_USING_CUDA */
+#endif /* HYPRE_USING_CUDA || defined(HYPRE_USING_HIP) */
 #endif

--- a/src/seq_mv/csr_spgemm_device_attempt.c
+++ b/src/seq_mv/csr_spgemm_device_attempt.c
@@ -11,7 +11,7 @@
 #include "seq_mv.h"
 #include "csr_spgemm_device.h"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 template <char HashType, HYPRE_Int attempt>
 static __device__ __forceinline__
@@ -545,4 +545,4 @@ hypreDevice_CSRSpGemmWithRownnzEstimate(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n,
    return hypre_error_flag;
 }
 
-#endif /* HYPRE_USING_CUDA */
+#endif /* HYPRE_USING_CUDA  || defined(HYPRE_USING_HIP) */

--- a/src/seq_mv/csr_spgemm_device_confident.c
+++ b/src/seq_mv/csr_spgemm_device_confident.c
@@ -11,7 +11,7 @@
 #include "seq_mv.h"
 #include "csr_spgemm_device.h"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 /*- - - - - - - - - - - - - - - - - - - - - - - - - - *
                 Numerical Multiplication
@@ -499,5 +499,4 @@ hypreDevice_CSRSpGemmWithRownnzUpperbound(HYPRE_Int   m,        HYPRE_Int   k,  
    return hypre_error_flag;
 }
 
-#endif /* HYPRE_USING_CUDA */
-
+#endif /* HYPRE_USING_CUDA  || defined(HYPRE_USING_HIP) */

--- a/src/seq_mv/csr_spgemm_device_rowbound.c
+++ b/src/seq_mv/csr_spgemm_device_rowbound.c
@@ -8,7 +8,7 @@
 #include "seq_mv.h"
 #include "csr_spgemm_device.h"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 /*- - - - - - - - - - - - - - - - - - - - - - - - - -
  *- - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -353,5 +353,4 @@ hypreDevice_CSRSpGemmRownnz(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n,
    return hypre_error_flag;
 }
 
-#endif /* HYPRE_USING_CUDA */
-
+#endif /* HYPRE_USING_CUDA  || defined(HYPRE_USING_HIP) */

--- a/src/seq_mv/csr_spgemm_device_rowest.c
+++ b/src/seq_mv/csr_spgemm_device_rowest.c
@@ -12,7 +12,7 @@
 #include "seq_mv.h"
 #include "csr_spgemm_device.h"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 /*- - - - - - - - - - - - - - - - - - - - - - - - - - *
                        NAIVE
@@ -286,10 +286,13 @@ void csr_spmm_rownnz_cohen(HYPRE_Int M, HYPRE_Int K, HYPRE_Int N, HYPRE_Int *d_i
    //d_V1 = hypre_TAlloc(T, nsamples*N, HYPRE_MEMORY_DEVICE);
    //d_V2 = hypre_TAlloc(T, nsamples*K, HYPRE_MEMORY_DEVICE);
 
+#if defined(HYPRE_USING_CURAND)
    curandGenerator_t gen = hypre_HandleCurandGenerator(hypre_handle());
    //CURAND_CALL(curandSetGeneratorOrdering(gen, CURAND_ORDERING_PSEUDO_SEEDED));
    /* random V1: uniform --> exp */
    HYPRE_CURAND_CALL(curandGenerateUniform(gen, d_V1, nsamples * N));
+#endif
+
    //  CURAND_CALL(curandGenerateUniformDouble(gen, d_V1, nsamples * N));
    dim3 gDim( (nsamples * N + bDim.z * HYPRE_WARP_SIZE - 1) / (bDim.z * HYPRE_WARP_SIZE) );
 
@@ -388,5 +391,4 @@ hypreDevice_CSRSpGemmRownnzEstimate(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n,
    return hypre_error_flag;
 }
 
-#endif /* HYPRE_USING_CUDA */
-
+#endif /* HYPRE_USING_CUDA  || defined(HYPRE_USING_HIP) */

--- a/src/seq_mv/csr_spgemm_device_util.c
+++ b/src/seq_mv/csr_spgemm_device_util.c
@@ -117,4 +117,3 @@ csr_spmm_create_hash_table(HYPRE_Int m, HYPRE_Int *d_rc, HYPRE_Int *d_rf, HYPRE_
 }
 
 #endif /* HYPRE_USING_CUDA */
-

--- a/src/seq_mv/csr_spmv_device.c
+++ b/src/seq_mv/csr_spmv_device.c
@@ -14,7 +14,7 @@
 #include "seq_mv.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #define SPMV_BLOCKDIM 512
 #define VERSION 1
@@ -258,5 +258,4 @@ hypre_CSRMatrixSpMVDevice( HYPRE_Complex    alpha,
    return hypre_error_flag;
 }
 
-#endif /*#if defined(HYPRE_USING_CUDA) */
-
+#endif /*#if defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP) */

--- a/src/seq_mv/csr_sptrans_device.c
+++ b/src/seq_mv/csr_sptrans_device.c
@@ -96,7 +96,7 @@ hypreDevice_CSRSpTransCusparse(HYPRE_Int   m,        HYPRE_Int   n,        HYPRE
 #endif // #if defined(HYPRE_USING_CUSPARSE)
 
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 HYPRE_Int
 hypreDevice_CSRSpTrans(HYPRE_Int   m,        HYPRE_Int   n,        HYPRE_Int       nnzA,
@@ -180,5 +180,4 @@ hypreDevice_CSRSpTrans(HYPRE_Int   m,        HYPRE_Int   n,        HYPRE_Int    
    return hypre_error_flag;
 }
 
-#endif /* HYPRE_USING_CUDA */
-
+#endif /* HYPRE_USING_CUDA  || defined(HYPRE_USING_HIP) */

--- a/src/seq_mv/vector.c
+++ b/src/seq_mv/vector.c
@@ -281,7 +281,7 @@ hypre_SeqVectorSetConstantValues( hypre_Vector *v,
 
    //hypre_SeqVectorPrefetch(v, HYPRE_MEMORY_DEVICE);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if (size > 0)
    {
       HYPRE_THRUST_CALL( fill_n, vector_data, size, value );
@@ -297,7 +297,7 @@ hypre_SeqVectorSetConstantValues( hypre_Vector *v,
    {
       vector_data[i] = value;
    }
-#endif /* defined(HYPRE_USING_CUDA) */
+#endif /* defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP) */
 
 #if defined(HYPRE_USING_GPU)
    hypre_SyncCudaComputeStream(hypre_handle());
@@ -466,7 +466,7 @@ hypre_SeqVectorScale( HYPRE_Complex alpha,
 
    //hypre_SeqVectorPrefetch(y, HYPRE_MEMORY_DEVICE);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #if defined(HYPRE_USING_CUBLAS)
    HYPRE_CUBLAS_CALL( cublasDscal(hypre_HandleCublasHandle(hypre_handle()), size, &alpha, y_data, 1) );
 #else
@@ -484,7 +484,7 @@ hypre_SeqVectorScale( HYPRE_Complex alpha,
       y_data[i] *= alpha;
    }
 
-#endif /* defined(HYPRE_USING_CUDA) */
+#endif /* defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP) */
 
 #if defined(HYPRE_USING_GPU)
    hypre_SyncCudaComputeStream(hypre_handle());
@@ -519,7 +519,7 @@ hypre_SeqVectorAxpy( HYPRE_Complex alpha,
    //hypre_SeqVectorPrefetch(x, HYPRE_MEMORY_DEVICE);
    //hypre_SeqVectorPrefetch(y, HYPRE_MEMORY_DEVICE);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #if defined(HYPRE_USING_CUBLAS)
    HYPRE_CUBLAS_CALL( cublasDaxpy(hypre_HandleCublasHandle(hypre_handle()), size, &alpha, x_data, 1, y_data, 1) );
 #else
@@ -537,7 +537,7 @@ hypre_SeqVectorAxpy( HYPRE_Complex alpha,
       y_data[i] += alpha * x_data[i];
    }
 
-#endif /* defined(HYPRE_USING_CUDA) */
+#endif /* defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP) */
 
 #if defined(HYPRE_USING_GPU)
    hypre_SyncCudaComputeStream(hypre_handle());
@@ -565,7 +565,7 @@ hypre_SeqVectorElmdivpy( hypre_Vector *x,
    HYPRE_Complex *y_data = hypre_VectorData(y);
    HYPRE_Int      size   = hypre_VectorSize(b);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy2( hypre_VectorMemoryLocation(x), hypre_VectorMemoryLocation(b) );
    //RL: TODO back to hypre_GetExecPolicy2 later
    HYPRE_ExecutionPolicy exec = HYPRE_EXEC_DEVICE;
@@ -625,7 +625,7 @@ hypre_SeqVectorInnerProd( hypre_Vector *x,
    //hypre_SeqVectorPrefetch(x, HYPRE_MEMORY_DEVICE);
    //hypre_SeqVectorPrefetch(y, HYPRE_MEMORY_DEVICE);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #ifndef HYPRE_COMPLEX
 #if defined(HYPRE_USING_CUBLAS)
    HYPRE_CUBLAS_CALL( cublasDdot(hypre_HandleCublasHandle(hypre_handle()), size, x_data, 1, y_data, 1, &result) );
@@ -636,7 +636,7 @@ hypre_SeqVectorInnerProd( hypre_Vector *x,
    /* TODO */
 #error "Complex inner product"
 #endif
-#else /* #if defined(HYPRE_USING_CUDA) */
+#else /* #if defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP) */
    HYPRE_Int i;
 #if defined(HYPRE_USING_DEVICE_OPENMP)
 #pragma omp target teams  distribute  parallel for private(i) reduction(+:result) is_device_ptr(y_data,x_data) map(result)
@@ -647,7 +647,7 @@ hypre_SeqVectorInnerProd( hypre_Vector *x,
    {
      result += hypre_conj(y_data[i]) * x_data[i];
    }
-#endif /* defined(HYPRE_USING_CUDA) */
+#endif /* defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */
 
 #if defined(HYPRE_USING_GPU)
    hypre_SyncCudaComputeStream(hypre_handle());
@@ -731,7 +731,7 @@ hypre_SeqVectorMax( HYPRE_Complex alpha,
 
    thrust::maximum<HYPRE_Complex> mx;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_THRUST_CALL( transform,
                       thrust::make_transform_iterator(x_data,        alpha * _1),
                       thrust::make_transform_iterator(x_data + size, alpha * _1),
@@ -750,7 +750,7 @@ hypre_SeqVectorMax( HYPRE_Complex alpha,
       y_data[i] += hypre_max(alpha * x_data[i], beta * y_data[i]);
    }
 
-#endif /* defined(HYPRE_USING_CUDA) */
+#endif /* defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */
 
    hypre_SyncCudaComputeStream(hypre_handle());
 

--- a/src/sstruct_ls/hypre_MaxwellSolve.c
+++ b/src/sstruct_ls/hypre_MaxwellSolve.c
@@ -88,7 +88,7 @@ hypre_MaxwellSolve( void                * maxwell_vdata,
    /* added for the relaxation routines */
    hypre_ParVector *ze = NULL;
 
-#if !defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_CUDA) && !defined(HYPRE_USING_HIP)
    /* GPU impl. needs ze */
    if (hypre_NumThreads() > 1)
 #endif
@@ -785,4 +785,3 @@ hypre_MaxwellSolve( void                * maxwell_vdata,
 
    return ierr;
 }
-

--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -908,7 +908,7 @@ hypre_SStructUMatrixSetValues( hypre_SStructMatrix *matrix,
       }
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_BigInt  *d_row_coords = hypre_SStructMatrixTmpRowCoordsDevice(matrix);
    HYPRE_BigInt  *d_col_coords = hypre_SStructMatrixTmpColCoordsDevice(matrix);
    HYPRE_Complex *d_coeffs     = hypre_SStructMatrixTmpCoeffsDevice(matrix);

--- a/src/struct_ls/HYPRE_struct_int.c
+++ b/src/struct_ls/HYPRE_struct_int.c
@@ -47,7 +47,7 @@ hypre_StructVectorSetRandomValues( hypre_StructVector *vector,
       hypre_BoxGetSize(box, loop_size);
 
       /* TODO: generate on host and copy to device. FIX? */
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
       HYPRE_Int loop_n = 1, ii;
       for (ii = 0; ii < hypre_StructVectorNDim(vector); ii++)
       {
@@ -71,7 +71,7 @@ hypre_StructVectorSetRandomValues( hypre_StructVector *vector,
       hypre_BoxLoop1Begin(hypre_StructVectorNDim(vector), loop_size,
                           v_data_box, start, unit_stride, vi);
       {
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
          vp[vi] = rand_device[idx];
 #else
          vp[vi] = 2.0*hypre_Rand() - 1.0;
@@ -80,7 +80,7 @@ hypre_StructVectorSetRandomValues( hypre_StructVector *vector,
       hypre_BoxLoop1End(vi);
 #undef DEVICE_VAR
 
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
       hypre_TFree(rand_device, HYPRE_MEMORY_DEVICE);
       hypre_TFree(rand_host, HYPRE_MEMORY_HOST);
 #endif

--- a/src/struct_ls/HYPRE_struct_ls.h
+++ b/src/struct_ls/HYPRE_struct_ls.h
@@ -318,7 +318,7 @@ HYPRE_Int HYPRE_StructPFMGGetNumIterations(HYPRE_StructSolver  solver,
 HYPRE_Int HYPRE_StructPFMGGetFinalRelativeResidualNorm(HYPRE_StructSolver  solver,
                                                  HYPRE_Real         *norm);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 HYPRE_Int
 HYPRE_StructPFMGSetDeviceLevel( HYPRE_StructSolver  solver,
 				HYPRE_Int   device_level  );
@@ -441,7 +441,7 @@ HYPRE_Int HYPRE_StructSMGGetNumIterations(HYPRE_StructSolver  solver,
 HYPRE_Int HYPRE_StructSMGGetFinalRelativeResidualNorm(HYPRE_StructSolver  solver,
                                                 HYPRE_Real         *norm);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 HYPRE_Int
 HYPRE_StructSMGSetDeviceLevel( HYPRE_StructSolver  solver,
 			       HYPRE_Int   device_level  );

--- a/src/struct_ls/HYPRE_struct_ls.h
+++ b/src/struct_ls/HYPRE_struct_ls.h
@@ -208,7 +208,7 @@ HYPRE_Int HYPRE_StructPFMGSetMaxIter(HYPRE_StructSolver solver,
 /**
  * (Optional) Set maximum number of multigrid grid levels.
  **/
-HYPRE_Int HYPRE_StructPFMGSetMaxLevels(HYPRE_StructSolver solver, 
+HYPRE_Int HYPRE_StructPFMGSetMaxLevels(HYPRE_StructSolver solver,
                                  HYPRE_Int          max_levels);
 
 /**
@@ -322,7 +322,7 @@ HYPRE_Int HYPRE_StructPFMGGetFinalRelativeResidualNorm(HYPRE_StructSolver  solve
 HYPRE_Int
 HYPRE_StructPFMGSetDeviceLevel( HYPRE_StructSolver  solver,
 				HYPRE_Int   device_level  );
-#endif  
+#endif
 /**@}*/
 
 /*--------------------------------------------------------------------------
@@ -770,7 +770,7 @@ HYPRE_Int HYPRE_StructLGMRESSetTol(HYPRE_StructSolver solver,
 
 HYPRE_Int HYPRE_StructLGMRESSetAbsoluteTol(HYPRE_StructSolver solver,
                                      HYPRE_Real         tol);
-   
+
 HYPRE_Int HYPRE_StructLGMRESSetMaxIter(HYPRE_StructSolver solver,
                                  HYPRE_Int          max_iter);
 
@@ -1142,4 +1142,3 @@ HYPRE_StructSetupMatvec(HYPRE_MatvecFunctions *mv);
 #endif
 
 #endif
-

--- a/src/struct_ls/HYPRE_struct_pfmg.c
+++ b/src/struct_ls/HYPRE_struct_pfmg.c
@@ -21,7 +21,7 @@ HYPRE_StructPFMGCreate( MPI_Comm comm, HYPRE_StructSolver *solver )
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
 
-HYPRE_Int 
+HYPRE_Int
 HYPRE_StructPFMGDestroy( HYPRE_StructSolver solver )
 {
    return( hypre_PFMGDestroy( (void *) solver ) );
@@ -30,7 +30,7 @@ HYPRE_StructPFMGDestroy( HYPRE_StructSolver solver )
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
 
-HYPRE_Int 
+HYPRE_Int
 HYPRE_StructPFMGSetup( HYPRE_StructSolver solver,
                        HYPRE_StructMatrix A,
                        HYPRE_StructVector b,
@@ -45,7 +45,7 @@ HYPRE_StructPFMGSetup( HYPRE_StructSolver solver,
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
 
-HYPRE_Int 
+HYPRE_Int
 HYPRE_StructPFMGSolve( HYPRE_StructSolver solver,
                        HYPRE_StructMatrix A,
                        HYPRE_StructVector b,
@@ -127,7 +127,7 @@ HYPRE_StructPFMGGetRelChange( HYPRE_StructSolver solver,
 
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
- 
+
 HYPRE_Int
 HYPRE_StructPFMGSetZeroGuess( HYPRE_StructSolver solver )
 {
@@ -143,7 +143,7 @@ HYPRE_StructPFMGGetZeroGuess( HYPRE_StructSolver solver,
 
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
- 
+
 HYPRE_Int
 HYPRE_StructPFMGSetNonZeroGuess( HYPRE_StructSolver solver )
 {

--- a/src/struct_ls/HYPRE_struct_pfmg.c
+++ b/src/struct_ls/HYPRE_struct_pfmg.c
@@ -314,7 +314,7 @@ HYPRE_StructPFMGGetFinalRelativeResidualNorm( HYPRE_StructSolver  solver,
    return( hypre_PFMGGetFinalRelativeResidualNorm( (void *) solver, norm ) );
 }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 HYPRE_Int
 HYPRE_StructPFMGSetDeviceLevel( HYPRE_StructSolver  solver,
 				HYPRE_Int   device_level  )

--- a/src/struct_ls/HYPRE_struct_smg.c
+++ b/src/struct_ls/HYPRE_struct_smg.c
@@ -239,7 +239,7 @@ HYPRE_StructSMGGetFinalRelativeResidualNorm( HYPRE_StructSolver  solver,
    return( hypre_SMGGetFinalRelativeResidualNorm( (void *) solver, norm ) );
 }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 HYPRE_Int
 HYPRE_StructSMGSetDeviceLevel( HYPRE_StructSolver  solver,
 			       HYPRE_Int   device_level  )

--- a/src/struct_ls/HYPRE_struct_smg.c
+++ b/src/struct_ls/HYPRE_struct_smg.c
@@ -21,7 +21,7 @@ HYPRE_StructSMGCreate( MPI_Comm comm, HYPRE_StructSolver *solver )
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
 
-HYPRE_Int 
+HYPRE_Int
 HYPRE_StructSMGDestroy( HYPRE_StructSolver solver )
 {
    return( hypre_SMGDestroy( (void *) solver ) );
@@ -30,7 +30,7 @@ HYPRE_StructSMGDestroy( HYPRE_StructSolver solver )
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
 
-HYPRE_Int 
+HYPRE_Int
 HYPRE_StructSMGSetup( HYPRE_StructSolver solver,
                       HYPRE_StructMatrix A,
                       HYPRE_StructVector b,
@@ -45,7 +45,7 @@ HYPRE_StructSMGSetup( HYPRE_StructSolver solver,
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
 
-HYPRE_Int 
+HYPRE_Int
 HYPRE_StructSMGSolve( HYPRE_StructSolver solver,
                       HYPRE_StructMatrix A,
                       HYPRE_StructVector b,
@@ -127,7 +127,7 @@ HYPRE_StructSMGGetRelChange( HYPRE_StructSolver solver,
 
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
- 
+
 HYPRE_Int
 HYPRE_StructSMGSetZeroGuess( HYPRE_StructSolver solver )
 {
@@ -143,7 +143,7 @@ HYPRE_StructSMGGetZeroGuess( HYPRE_StructSolver solver,
 
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
- 
+
 HYPRE_Int
 HYPRE_StructSMGSetNonZeroGuess( HYPRE_StructSolver solver )
 {
@@ -151,7 +151,7 @@ HYPRE_StructSMGSetNonZeroGuess( HYPRE_StructSolver solver )
 }
 
 /*--------------------------------------------------------------------------
- * Note that we require at least 1 pre-relax sweep. 
+ * Note that we require at least 1 pre-relax sweep.
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int

--- a/src/struct_ls/cyclic_reduction.c
+++ b/src/struct_ls/cyclic_reduction.c
@@ -501,7 +501,7 @@ hypre_CyclicReductionSetup( void               *cyc_red_vdata,
    HYPRE_Int               flop_divisor;
 
    HYPRE_Int               x_num_ghost[] = {0, 0, 0, 0, 0, 0};
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_MemoryLocation    data_location = HYPRE_MEMORY_DEVICE;
 #endif
 
@@ -523,7 +523,7 @@ hypre_CyclicReductionSetup( void               *cyc_red_vdata,
    grid_l    = hypre_TAlloc(hypre_StructGrid *,  num_levels, HYPRE_MEMORY_HOST);
    hypre_StructGridRef(grid, &grid_l[0]);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    data_location = hypre_StructGridDataLocation(grid);
 #endif
    for (l = 0; ; l++)
@@ -549,7 +549,7 @@ hypre_CyclicReductionSetup( void               *cyc_red_vdata,
 
       /* coarsen the grid */
       hypre_StructCoarsen(grid_l[l], cindex, stride, 1, &grid_l[l+1]);
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       hypre_StructGridDataLocation(grid_l[l+1]) = data_location;
 #endif
    }
@@ -632,7 +632,7 @@ hypre_CyclicReductionSetup( void               *cyc_red_vdata,
       data += hypre_StructMatrixDataSize(A_l[l+1]);
       data_const += hypre_StructMatrixDataConstSize(A_l[l+1]);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (data_location != HYPRE_MEMORY_HOST)
       {
          hypre_StructVectorInitializeData(x_l[l+1], data);

--- a/src/struct_ls/pfmg.c
+++ b/src/struct_ls/pfmg.c
@@ -42,7 +42,7 @@ hypre_PFMGCreate( MPI_Comm  comm )
 
    /* initialize */
    (pfmg_data -> num_levels)  = -1;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    (pfmg_data -> devicelevel) = 200;
 #endif
    return (void *) pfmg_data;
@@ -550,7 +550,7 @@ hypre_PFMGGetFinalRelativeResidualNorm( void   *pfmg_vdata,
    return hypre_error_flag;
 }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 HYPRE_Int
 hypre_PFMGSetDeviceLevel( void *pfmg_vdata,
 			  HYPRE_Int   device_level  )

--- a/src/struct_ls/pfmg.h
+++ b/src/struct_ls/pfmg.h
@@ -74,7 +74,7 @@ typedef struct
    HYPRE_Int             logging;
    HYPRE_Real           *norms;
    HYPRE_Real           *rel_norms;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
   HYPRE_Int             devicelevel;
 #endif
 

--- a/src/struct_ls/pfmg_setup.c
+++ b/src/struct_ls/pfmg_setup.c
@@ -129,7 +129,7 @@ hypre_PFMGSetup( void               *pfmg_vdata,
    HYPRE_Int             b_num_ghost[]  = {0, 0, 0, 0, 0, 0};
    HYPRE_Int             x_num_ghost[]  = {1, 1, 1, 1, 1, 1};
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_Int             num_level_GPU = 0;
    HYPRE_MemoryLocation  data_location = HYPRE_MEMORY_DEVICE;
    HYPRE_Int             max_box_size  = 0;
@@ -197,7 +197,7 @@ hypre_PFMGSetup( void               *pfmg_vdata,
    relax_weights = hypre_CTAlloc(HYPRE_Real, max_levels, HYPRE_MEMORY_HOST);
    hypre_SetIndex3(coarsen, 1, 1, 1); /* forces relaxation on finest grid */
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    data_location = hypre_StructGridDataLocation(grid);
    if (data_location != HYPRE_MEMORY_HOST)
    {
@@ -329,7 +329,7 @@ hypre_PFMGSetup( void               *pfmg_vdata,
 
       /* build the coarse grid */
       hypre_StructCoarsen(grid_l[l], cindex, stride, 1, &grid_l[l+1]);
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       hypre_StructGridDataLocation(P_grid_l[l+1]) = data_location;
       if (device_level == -1 && num_level_GPU > 0)
       {
@@ -449,7 +449,7 @@ hypre_PFMGSetup( void               *pfmg_vdata,
       tx_l[l+1] = hypre_StructVectorCreate(comm, grid_l[l+1]);
       hypre_StructVectorSetNumGhost(tx_l[l+1], x_num_ghost);
       hypre_StructVectorInitializeShell(tx_l[l+1]);
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (l+1 == num_level_GPU)
       {
          hypre_StructVectorSetDataSize(tx_l[l+1], &data_size, &data_size_const);
@@ -459,14 +459,14 @@ hypre_PFMGSetup( void               *pfmg_vdata,
 
    data = hypre_CTAlloc(HYPRE_Real, data_size, HYPRE_MEMORY_DEVICE);
    data_const = hypre_CTAlloc(HYPRE_Real, data_size_const, HYPRE_MEMORY_HOST);
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //hypre_printf("num_level_GPU = %d,device_level = %d / %d\n",num_level_GPU,device_level,num_levels);
 #endif
 
    (pfmg_data -> data) = data;
    (pfmg_data -> data_const) = data_const;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    data_location = hypre_StructGridDataLocation(grid_l[0]);
    if (data_location != HYPRE_MEMORY_HOST)
    {
@@ -502,7 +502,7 @@ hypre_PFMGSetup( void               *pfmg_vdata,
       }
 #endif
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (l+1 == num_level_GPU)
       {
          data_location = HYPRE_MEMORY_HOST;
@@ -513,7 +513,7 @@ hypre_PFMGSetup( void               *pfmg_vdata,
       data += hypre_StructMatrixDataSize(A_l[l+1]);
       data_const += hypre_StructMatrixDataConstSize(A_l[l+1]);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (data_location != HYPRE_MEMORY_HOST)
       {
          hypre_StructVectorInitializeData(b_l[l+1], data);
@@ -580,7 +580,7 @@ hypre_PFMGSetup( void               *pfmg_vdata,
 
    for (l = 0; l < (num_levels - 1); l++)
    {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (l == num_level_GPU)
       {
          hypre_SetDeviceOff();
@@ -618,7 +618,7 @@ hypre_PFMGSetup( void               *pfmg_vdata,
                               cindex, findex, stride);
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if (l == num_level_GPU)
    {
       hypre_SetDeviceOff();
@@ -640,7 +640,7 @@ hypre_PFMGSetup( void               *pfmg_vdata,
       active_l[l] = 0;
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if (hypre_StructGridDataLocation(grid) != HYPRE_MEMORY_HOST)
    {
       hypre_SetDeviceOn();
@@ -999,7 +999,7 @@ hypre_PFMGComputeDxyz_SS5( HYPRE_Int           bi,
    hypre_Index            stride;
    hypre_Index            index;
    HYPRE_Real            *a_cc, *a_cw, *a_ce, *a_cs, *a_cn;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_Int              data_location = hypre_StructGridDataLocation(
    //                                       hypre_StructMatrixGrid(A) );
 #endif
@@ -1083,7 +1083,7 @@ hypre_PFMGComputeDxyz_SS5( HYPRE_Int           bi,
 
 #if defined(HYPRE_USING_RAJA)
    ReduceSum<hypre_raja_reduce_policy, HYPRE_Real> cxb(cxyz[0]),cyb(cxyz[1]),sqcxb(sqcxyz[0]),sqcyb(sqcxyz[1]);
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_double4 d4(cxyz[0], cxyz[1], sqcxyz[0], sqcxyz[1]);
    ReduceSum<HYPRE_double4> sum4(d4);
 #else
@@ -1167,7 +1167,7 @@ hypre_PFMGComputeDxyz_SS9( HYPRE_Int bi,
    hypre_Index            index;
    HYPRE_Real            *a_cc, *a_cw, *a_ce, *a_cs, *a_cn;
    HYPRE_Real            *a_csw, *a_cse, *a_cne, *a_cnw;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_Int              data_location = hypre_StructGridDataLocation(
    //                                       hypre_StructMatrixGrid(A) );
 #endif
@@ -1272,7 +1272,7 @@ hypre_PFMGComputeDxyz_SS9( HYPRE_Int bi,
 
 #if defined(HYPRE_USING_RAJA)
    ReduceSum<hypre_raja_reduce_policy, HYPRE_Real> cxb(cxyz[0]),cyb(cxyz[1]),sqcxb(sqcxyz[0]),sqcyb(sqcxyz[1]);
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_double4 d4(cxyz[0], cxyz[1], sqcxyz[0], sqcxyz[1]);
    ReduceSum<HYPRE_double4> sum4(d4);
 #else
@@ -1355,7 +1355,7 @@ hypre_PFMGComputeDxyz_SS7( HYPRE_Int           bi,
    hypre_Index            stride;
    hypre_Index            index;
    HYPRE_Real            *a_cc, *a_cw, *a_ce, *a_cs, *a_cn, *a_ac, *a_bc;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_Int              data_location = hypre_StructGridDataLocation(
    //                                       hypre_StructMatrixGrid(A) );
 #endif
@@ -1467,7 +1467,7 @@ hypre_PFMGComputeDxyz_SS7( HYPRE_Int           bi,
 
 #if defined(HYPRE_USING_RAJA)
    ReduceSum<hypre_raja_reduce_policy, HYPRE_Real> cxb(cxyz[0]),cyb(cxyz[1]),czb(cxyz[2]),sqcxb(sqcxyz[0]),sqcyb(sqcxyz[1]), sqczb(sqcxyz[2]);
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_double6 d6(cxyz[0], cxyz[1], cxyz[2], sqcxyz[0], sqcxyz[1], sqcxyz[2]);
    ReduceSum<HYPRE_double6> sum6(d6);
 #else
@@ -1557,7 +1557,7 @@ hypre_PFMGComputeDxyz_SS19( HYPRE_Int           bi,
    HYPRE_Real            *a_cc, *a_cw, *a_ce, *a_cs, *a_cn, *a_ac, *a_bc;
    HYPRE_Real            *a_csw, *a_cse, *a_cne, *a_cnw;
    HYPRE_Real            *a_aw, *a_ae, *a_as, *a_an, *a_bw, *a_be, *a_bs, *a_bn;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_Int              data_location = hypre_StructGridDataLocation(
    //                                       hypre_StructMatrixGrid(A) );
 #endif
@@ -1722,7 +1722,7 @@ hypre_PFMGComputeDxyz_SS19( HYPRE_Int           bi,
 
 #if defined(HYPRE_USING_RAJA)
    ReduceSum<hypre_raja_reduce_policy, HYPRE_Real> cxb(cxyz[0]),cyb(cxyz[1]),czb(cxyz[2]),sqcxb(sqcxyz[0]),sqcyb(sqcxyz[1]), sqczb(sqcxyz[2]);
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_double6 d6(cxyz[0], cxyz[1], cxyz[2], sqcxyz[0], sqcxyz[1], sqcxyz[2]);
    ReduceSum<HYPRE_double6> sum6(d6);
 #else
@@ -1816,7 +1816,7 @@ hypre_PFMGComputeDxyz_SS27( HYPRE_Int           bi,
    HYPRE_Real            *a_aw, *a_ae, *a_as, *a_an, *a_bw, *a_be, *a_bs, *a_bn;
    HYPRE_Real            *a_asw, *a_ase, *a_ane, *a_anw,*a_bsw, *a_bse, *a_bne, *a_bnw;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_Int              data_location = hypre_StructGridDataLocation(
    //                                       hypre_StructMatrixGrid(A) );
 #endif
@@ -2030,7 +2030,7 @@ hypre_PFMGComputeDxyz_SS27( HYPRE_Int           bi,
 
 #if defined(HYPRE_USING_RAJA)
    ReduceSum<hypre_raja_reduce_policy, HYPRE_Real> cxb(cxyz[0]),cyb(cxyz[1]),czb(cxyz[2]),sqcxb(sqcxyz[0]),sqcyb(sqcxyz[1]), sqczb(sqcxyz[2]);
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_double6 d6(cxyz[0], cxyz[1], cxyz[2], sqcxyz[0], sqcxyz[1], sqcxyz[2]);
    ReduceSum<HYPRE_double6> sum6(d6);
 #else
@@ -2132,7 +2132,7 @@ hypre_ZeroDiagonal( hypre_StructMatrix *A )
    HYPRE_Int              zero_diag = 0;
 
    HYPRE_Int              constant_coefficient;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //HYPRE_Int              data_location = hypre_StructGridDataLocation(hypre_StructMatrixGrid(A));
 #endif
 
@@ -2166,7 +2166,7 @@ hypre_ZeroDiagonal( hypre_StructMatrix *A )
          HYPRE_Real diag_product_local = diag_product;
 #elif defined(HYPRE_USING_RAJA)
          ReduceSum<hypre_raja_reduce_policy, HYPRE_Real> diag_product_local(diag_product);
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
          ReduceSum<HYPRE_Real> diag_product_local(diag_product);
 #else
          HYPRE_Real diag_product_local = diag_product;

--- a/src/struct_ls/pfmg_setup.c
+++ b/src/struct_ls/pfmg_setup.c
@@ -1114,7 +1114,7 @@ hypre_PFMGComputeDxyz_SS5( HYPRE_Int           bi,
       tcx = -diag * (a_cw[Ai] + a_ce[Ai]);
       tcy = -diag * (a_cn[Ai] + a_cs[Ai]);
 
-#if !defined(HYPRE_USING_RAJA) && defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_RAJA) && (defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP))
       HYPRE_double4 tmp(tcx, tcy, tcx*tcx, tcy*tcy);
       sum4 += tmp;
 #else
@@ -1129,7 +1129,7 @@ hypre_PFMGComputeDxyz_SS5( HYPRE_Int           bi,
 
 #endif /* kokkos */
 
-#if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && (defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP))
    HYPRE_double4 tmp = (HYPRE_double4) sum4;
    cxyz[0]   = tmp.x;
    cxyz[1]   = tmp.y;
@@ -1304,7 +1304,7 @@ hypre_PFMGComputeDxyz_SS9( HYPRE_Int bi,
        tcx = -diag * (a_cw[Ai] + a_ce[Ai] + a_csw[Ai] + a_cse[Ai] + a_cnw[Ai] + a_cne[Ai]);
        tcy = -diag * (a_cs[Ai] + a_cn[Ai] + a_csw[Ai] + a_cse[Ai] + a_cnw[Ai] + a_cne[Ai]);
 
-#if !defined(HYPRE_USING_RAJA) && defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_RAJA) && (defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP))
        HYPRE_double4 tmp(tcx, tcy, tcx*tcx, tcy*tcy);
        sum4 += tmp;
 #else
@@ -1319,7 +1319,7 @@ hypre_PFMGComputeDxyz_SS9( HYPRE_Int bi,
 
 #endif /* kokkos */
 
-#if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && (defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP))
    HYPRE_double4 tmp = (HYPRE_double4) sum4;
    cxyz[0]   = tmp.x;
    cxyz[1]   = tmp.y;
@@ -1501,7 +1501,7 @@ hypre_PFMGComputeDxyz_SS7( HYPRE_Int           bi,
       tcx = -diag * (a_cw[Ai] + a_ce[Ai]);
       tcy = -diag * (a_cs[Ai] + a_cn[Ai]);
       tcz = -diag * (a_ac[Ai] + a_bc[Ai]);
-#if !defined(HYPRE_USING_RAJA) && defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_RAJA) && (defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP))
       HYPRE_double6 tmp(tcx, tcy, tcz, tcx*tcx, tcy*tcy, tcz*tcz);
       sum6 += tmp;
 #else
@@ -1518,7 +1518,7 @@ hypre_PFMGComputeDxyz_SS7( HYPRE_Int           bi,
 
 #endif /* kokkos */
 
-#if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && (defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP))
    HYPRE_double6 tmp = (HYPRE_double6) sum6;
    cxyz[0]   = tmp.x;
    cxyz[1]   = tmp.y;
@@ -1757,7 +1757,7 @@ hypre_PFMGComputeDxyz_SS19( HYPRE_Int           bi,
       tcy = -diag * (a_cs[Ai] + a_cn[Ai] + a_an[Ai] + a_as[Ai] + a_bn[Ai] + a_bs[Ai] + a_csw[Ai] + a_cse[Ai] + a_cnw[Ai] + a_cne[Ai]);
       tcz = -diag * (a_ac[Ai] + a_bc[Ai] + a_aw[Ai] + a_ae[Ai] + a_an[Ai] + a_as[Ai] +  a_bw[Ai]  + a_be[Ai] +  a_bn[Ai] +  a_bs[Ai]);
 
-#if !defined(HYPRE_USING_RAJA) && defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_RAJA) && (defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP))
       HYPRE_double6 tmp(tcx, tcy, tcz, tcx*tcx, tcy*tcy, tcz*tcz);
       sum6 += tmp;
 #else
@@ -1774,7 +1774,7 @@ hypre_PFMGComputeDxyz_SS19( HYPRE_Int           bi,
 
 #endif /* kokkos */
 
-#if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && (defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP))
    HYPRE_double6 tmp = (HYPRE_double6) sum6;
    cxyz[0]   = tmp.x;
    cxyz[1]   = tmp.y;
@@ -2069,7 +2069,7 @@ hypre_PFMGComputeDxyz_SS27( HYPRE_Int           bi,
 
       tcz -= diag * (a_ac[Ai]  +  a_bc[Ai] +  a_aw[Ai] +  a_ae[Ai] +  a_an[Ai] +  a_as[Ai] +  a_bw[Ai] +  a_be[Ai] + a_bn[Ai] + a_bs[Ai]);
       tcz -= diag * (a_asw[Ai] + a_ase[Ai] + a_anw[Ai] + a_ane[Ai] + a_bsw[Ai] + a_bse[Ai] + a_bnw[Ai] + a_bne[Ai]);
-#if !defined(HYPRE_USING_RAJA) && defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_RAJA) && (defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP))
       HYPRE_double6 tmp(tcx, tcy, tcz, tcx*tcx, tcy*tcy, tcz*tcz);
       sum6 += tmp;
 #else
@@ -2086,7 +2086,7 @@ hypre_PFMGComputeDxyz_SS27( HYPRE_Int           bi,
 
 #endif /* kokkos */
 
-#if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && defined(HYPRE_USING_CUDA)
+#if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && (defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP))
    HYPRE_double6 tmp = (HYPRE_double6) sum6;
    cxyz[0]   = tmp.x;
    cxyz[1]   = tmp.y;

--- a/src/struct_ls/pfmg_setup_interp.c
+++ b/src/struct_ls/pfmg_setup_interp.c
@@ -608,12 +608,12 @@ hypre_PFMGSetupInterpOp_CC1
    {
       warning_cnt++;
       Pp0[Pi] = 0.0;
-      Pp1[Pi] = 0.0;  
+      Pp1[Pi] = 0.0;
    }
    else
    {
       Pp0[Pi] /= center;
-      Pp1[Pi] /= center;  
+      Pp1[Pi] /= center;
    }
 
    /*----------------------------------------------
@@ -845,7 +845,7 @@ hypre_PFMGSetupInterpOp_CC0_SS5
 
    /*-----------------------------------------------------------------
     * Extract pointers for 5-point fine grid operator:
-    * 
+    *
     * a_cc is pointer for center coefficient
     * a_cw is pointer for west coefficient
     * a_ce is pointer for east coefficient
@@ -866,7 +866,7 @@ hypre_PFMGSetupInterpOp_CC0_SS5
    a_cs = hypre_StructMatrixExtractPointerByIndex(A, i, index);
 
    hypre_SetIndex3(index,0,1,0);
-   a_cn = hypre_StructMatrixExtractPointerByIndex(A, i, index);   
+   a_cn = hypre_StructMatrixExtractPointerByIndex(A, i, index);
 
 #define DEVICE_VAR is_device_ptr(a_cc,a_cs,a_cn,a_cw,a_ce,Pp0,Pp1,p0,p1)
    hypre_BoxLoop2Begin(hypre_StructMatrixNDim(A), loop_size,
@@ -893,7 +893,7 @@ hypre_PFMGSetupInterpOp_CC0_SS5
       {
          //warning_cnt++;
          Pp0[Pi] = 0.0;
-         Pp1[Pi] = 0.0;  
+         Pp1[Pi] = 0.0;
       }
       else
       {
@@ -970,7 +970,7 @@ hypre_PFMGSetupInterpOp_CC0_SS9
    p1 = hypre_StructMatrixExtractPointerByIndex(A, i, P_stencil_shape[1]);
    /*-----------------------------------------------------------------
     * Extract pointers for 5-point grid operator:
-    * 
+    *
     * a_cc is pointer for center coefficient
     * a_cw is pointer for west coefficient
     * a_ce is pointer for east coefficient
@@ -1012,7 +1012,7 @@ hypre_PFMGSetupInterpOp_CC0_SS9
    a_cnw = hypre_StructMatrixExtractPointerByIndex(A, i, index);
 
    hypre_SetIndex3(index, 1, 1, 0);
-   a_cne = hypre_StructMatrixExtractPointerByIndex(A, i, index);   
+   a_cne = hypre_StructMatrixExtractPointerByIndex(A, i, index);
 
 #define DEVICE_VAR is_device_ptr(a_cc,a_cs,a_cn,a_cw,a_csw,a_cnw,a_ce,a_cse,a_cne,Pp0,Pp1,p0,p1)
    hypre_BoxLoop2Begin(hypre_StructMatrixNDim(A), loop_size,
@@ -1039,7 +1039,7 @@ hypre_PFMGSetupInterpOp_CC0_SS9
       {
          //warning_cnt++;
          Pp0[Pi] = 0.0;
-         Pp1[Pi] = 0.0;  
+         Pp1[Pi] = 0.0;
       }
       else
       {
@@ -1107,7 +1107,7 @@ hypre_PFMGSetupInterpOp_CC0_SS7
 
    /*-----------------------------------------------------------------
     * Extract pointers for 7-point grid operator:
-    * 
+    *
     * a_cc is pointer for center coefficient
     * a_cw is pointer for west coefficient in same plane
     * a_ce is pointer for east coefficient in same plane
@@ -1167,7 +1167,7 @@ hypre_PFMGSetupInterpOp_CC0_SS7
       if (!center)
       {
          Pp0[Pi] = 0.0;
-         Pp1[Pi] = 0.0;  
+         Pp1[Pi] = 0.0;
       }
       else
       {
@@ -1237,7 +1237,7 @@ hypre_PFMGSetupInterpOp_CC0_SS15
 
    /*-----------------------------------------------------------------
     * Extract pointers for 7-point grid operator:
-    * 
+    *
     * a_cc is pointer for center coefficient
     * a_cw is pointer for west coefficient in same plane
     * a_ce is pointer for east coefficient in same plane
@@ -1357,12 +1357,12 @@ hypre_PFMGSetupInterpOp_CC0_SS15
                break;
             case 1:
                center =  a_cc[Ai] +  a_cw[Ai] +  a_ce[Ai] +  a_ac[Ai] +  a_aw[Ai] + a_ae[Ai] +
-                         a_bc[Ai] +  a_bw[Ai] +  a_be[Ai];  
+                         a_bc[Ai] +  a_bw[Ai] +  a_be[Ai];
                left   = -a_cs[Ai] - a_csw[Ai] - a_cse[Ai]; /* front */
                right  = -a_cn[Ai] - a_cnw[Ai] - a_cne[Ai]; /* back */
                break;
             case 2:
-               center =   a_cc[Ai] +  a_cw[Ai] +   a_ce[Ai] +  a_cs[Ai] + a_cn[Ai] + 
+               center =   a_cc[Ai] +  a_cw[Ai] +   a_ce[Ai] +  a_cs[Ai] + a_cn[Ai] +
                          a_csw[Ai] + a_cse[Ai] +  a_cnw[Ai] - a_cne[Ai];
                left   =  -a_bc[Ai] -  a_bw[Ai] -   a_be[Ai]; /* below */
                right  =  -a_ac[Ai] -  a_aw[Ai] -   a_ae[Ai]; /* above */
@@ -1372,7 +1372,7 @@ hypre_PFMGSetupInterpOp_CC0_SS15
          if (!center)
          {
             Pp0[Pi] = 0.0;
-            Pp1[Pi] = 0.0;  
+            Pp1[Pi] = 0.0;
          }
          else
          {
@@ -1393,7 +1393,7 @@ hypre_PFMGSetupInterpOp_CC0_SS15
          {
             Pp0[Pi] = 0.0;
          }
-         if (p1[Ai] == 0.0) 
+         if (p1[Ai] == 0.0)
          {
             Pp1[Pi] = 0.0;
          }
@@ -1417,12 +1417,12 @@ hypre_PFMGSetupInterpOp_CC0_SS15
                right  = -a_ce[Ai] - a_cse[Ai] - a_cne[Ai];
                break;
             case 1:
-               center =  a_cc[Ai] + a_cw[Ai] + a_ce[Ai] +  a_ac[Ai] +  a_bc[Ai];  
+               center =  a_cc[Ai] + a_cw[Ai] + a_ce[Ai] +  a_ac[Ai] +  a_bc[Ai];
                left   = -a_cs[Ai] - a_as[Ai] - a_bs[Ai] - a_csw[Ai] - a_cse[Ai]; /* front */
                right  = -a_cn[Ai] - a_an[Ai] - a_bn[Ai] - a_cnw[Ai] - a_cne[Ai]; /* back */
                break;
             case 2:
-               center =  a_cc[Ai] + a_cw[Ai] + a_ce[Ai] + a_cs[Ai] + a_cn[Ai] + 
+               center =  a_cc[Ai] + a_cw[Ai] + a_ce[Ai] + a_cs[Ai] + a_cn[Ai] +
                          a_csw[Ai] + a_cse[Ai] + a_cnw[Ai] + a_cne[Ai];
                left   = -a_bc[Ai] - a_bs[Ai] - a_bn[Ai]; /* below */
                right  = -a_ac[Ai] - a_as[Ai] - a_an[Ai]; /* above */
@@ -1432,7 +1432,7 @@ hypre_PFMGSetupInterpOp_CC0_SS15
          if (!center)
          {
             Pp0[Pi] = 0.0;
-            Pp1[Pi] = 0.0;  
+            Pp1[Pi] = 0.0;
          }
          else
          {
@@ -1453,7 +1453,7 @@ hypre_PFMGSetupInterpOp_CC0_SS15
          {
             Pp0[Pi] = 0.0;
          }
-         if (p1[Ai] == 0.0) 
+         if (p1[Ai] == 0.0)
          {
             Pp1[Pi] = 0.0;
          }
@@ -1492,7 +1492,7 @@ hypre_PFMGSetupInterpOp_CC0_SS15
          if (!center)
          {
             Pp0[Pi] = 0.0;
-            Pp1[Pi] = 0.0;  
+            Pp1[Pi] = 0.0;
          }
          else
          {
@@ -1513,7 +1513,7 @@ hypre_PFMGSetupInterpOp_CC0_SS15
          {
             Pp0[Pi] = 0.0;
          }
-         if (p1[Ai] == 0.0) 
+         if (p1[Ai] == 0.0)
          {
             Pp1[Pi] = 0.0;
          }
@@ -1561,7 +1561,7 @@ hypre_PFMGSetupInterpOp_CC0_SS19
 
    /*-----------------------------------------------------------------
     * Extract pointers for 7-point grid operator:
-    * 
+    *
     * a_cc is pointer for center coefficient
     * a_cw is pointer for west coefficient in same plane
     * a_ce is pointer for east coefficient in same plane
@@ -1674,7 +1674,7 @@ hypre_PFMGSetupInterpOp_CC0_SS19
       if (!center)
       {
          Pp0[Pi] = 0.0;
-         Pp1[Pi] = 0.0;  
+         Pp1[Pi] = 0.0;
       }
       else
       {
@@ -1746,7 +1746,7 @@ hypre_PFMGSetupInterpOp_CC0_SS27
 
    /*-----------------------------------------------------------------
     * Extract pointers for 7-point grid operator:
-    * 
+    *
     * a_cc is pointer for center coefficient
     * a_cw is pointer for west coefficient in same plane
     * a_ce is pointer for east coefficient in same plane
@@ -1934,4 +1934,3 @@ hypre_PFMGSetupInterpOp_CC0_SS27
 }
 
 #endif
-

--- a/src/struct_ls/pfmg_setup_interp.c
+++ b/src/struct_ls/pfmg_setup_interp.c
@@ -295,7 +295,7 @@ hypre_PFMGSetupInterpOp_CC0
    HYPRE_Int              stencil_size = hypre_StructStencilSize(stencil);
    HYPRE_Int              warning_cnt= 0;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_Int              data_location = hypre_StructGridDataLocation(hypre_StructMatrixGrid(A));
 #endif
 
@@ -334,7 +334,7 @@ hypre_PFMGSetupInterpOp_CC0
 
       for (si = 0; si < stencil_size; si++)
       {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
          if (data_location != HYPRE_MEMORY_HOST)
          {
             Ap     = matrixA_data + data_indices_boxi_d[si];
@@ -449,7 +449,7 @@ hypre_PFMGSetupInterpOp_CC0
    HYPRE_Int              dim, si, loop_length = 1, Astenc;
    HYPRE_Real            *Ap, *center, *Ap0, *Ap1;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //What TODO? HYPRE_Int data_location = hypre_StructGridDataLocation(hypre_StructMatrixGrid(A));
 #endif
 

--- a/src/struct_ls/pfmg_setup_rap.c
+++ b/src/struct_ls/pfmg_setup_rap.c
@@ -119,7 +119,7 @@ hypre_PFMGSetupRAPOp( hypre_StructMatrix *R,
 
    hypre_StructMatrix    *Ac_tmp;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_MemoryLocation data_location_A = hypre_StructGridDataLocation(hypre_StructMatrixGrid(A));
    HYPRE_MemoryLocation data_location_Ac = hypre_StructGridDataLocation(hypre_StructMatrixGrid(Ac));
    HYPRE_Int constant_coefficient = hypre_StructMatrixConstantCoefficient(Ac);
@@ -197,7 +197,7 @@ hypre_PFMGSetupRAPOp( hypre_StructMatrix *R,
 
    hypre_StructMatrixAssemble(Ac_tmp);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if ( data_location_A != data_location_Ac )
    {
      if (constant_coefficient == 0)

--- a/src/struct_ls/pfmg_setup_rap.c
+++ b/src/struct_ls/pfmg_setup_rap.c
@@ -227,4 +227,3 @@ hypre_PFMGSetupRAPOp( hypre_StructMatrix *R,
 
    return hypre_error_flag;
 }
-

--- a/src/struct_ls/pfmg_solve.c
+++ b/src/struct_ls/pfmg_solve.c
@@ -201,7 +201,7 @@ hypre_PFMGSolve( void               *pfmg_vdata,
          {
             HYPRE_ANNOTATE_MGLEVEL_BEGIN(l);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
             if (hypre_StructGridDataLocation(hypre_StructVectorGrid(r_l[l])) == HYPRE_MEMORY_HOST)
             {
                hypre_SetDeviceOff();
@@ -273,7 +273,7 @@ hypre_PFMGSolve( void               *pfmg_vdata,
 
          for (l = (num_levels - 2); l >= 1; l--)
          {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
             if (hypre_StructGridDataLocation(hypre_StructVectorGrid(e_l[l])) == HYPRE_MEMORY_DEVICE)
             {
                hypre_SetDeviceOn();
@@ -305,7 +305,7 @@ hypre_PFMGSolve( void               *pfmg_vdata,
                hypre_PFMGRelax(relax_data_l[l], A_l[l], b_l[l], x_l[l]);
             }
          }
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
          if (hypre_StructGridDataLocation(hypre_StructVectorGrid(e_l[0])) == HYPRE_MEMORY_DEVICE)
          {
             hypre_SetDeviceOn();

--- a/src/struct_ls/red_black_gs.h
+++ b/src/struct_ls/red_black_gs.h
@@ -352,4 +352,3 @@ typedef struct
    }\
 }
 #endif
-

--- a/src/struct_ls/red_black_gs.h
+++ b/src/struct_ls/red_black_gs.h
@@ -152,7 +152,7 @@ typedef struct
    hypre_fence();                                                   \
 }
 
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #define hypre_RedBlackLoopInit()
 #define hypre_RedBlackLoopBegin(ni,nj,nk,redblack,      \

--- a/src/struct_ls/semi_interp.c
+++ b/src/struct_ls/semi_interp.c
@@ -171,7 +171,7 @@ hypre_SemiInterp( void               *interp_vdata,
    cgrid_boxes = hypre_StructGridBoxes(cgrid);
    cgrid_ids = hypre_StructGridIDs(cgrid);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_MemoryLocation data_location_f = hypre_StructGridDataLocation(fgrid);
    HYPRE_MemoryLocation data_location_c = hypre_StructGridDataLocation(cgrid);
 
@@ -322,7 +322,7 @@ hypre_SemiInterp( void               *interp_vdata,
          }
       }
    }
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if (data_location_f != data_location_c)
    {
       hypre_StructVectorDestroy(xc_tmp);

--- a/src/struct_ls/semi_interp.c
+++ b/src/struct_ls/semi_interp.c
@@ -357,4 +357,3 @@ hypre_SemiInterpDestroy( void *interp_vdata )
 
    return hypre_error_flag;
 }
-

--- a/src/struct_ls/semi_restrict.c
+++ b/src/struct_ls/semi_restrict.c
@@ -328,4 +328,3 @@ hypre_SemiRestrictDestroy( void *restrict_vdata )
 
    return hypre_error_flag;
 }
-

--- a/src/struct_ls/semi_restrict.c
+++ b/src/struct_ls/semi_restrict.c
@@ -166,7 +166,7 @@ hypre_SemiRestrict( void               *restrict_vdata,
    cgrid_boxes = hypre_StructGridBoxes(cgrid);
    cgrid_ids = hypre_StructGridIDs(cgrid);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_MemoryLocation data_location_f = hypre_StructGridDataLocation(fgrid);
    HYPRE_MemoryLocation data_location_c = hypre_StructGridDataLocation(cgrid);
 
@@ -292,7 +292,7 @@ hypre_SemiRestrict( void               *restrict_vdata,
          }
       }
    }
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if (data_location_f != data_location_c)
    {
       hypre_TMemcpy(hypre_StructVectorData(rc),hypre_StructVectorData(rc_tmp),HYPRE_Complex,hypre_StructVectorDataSize(rc_tmp),HYPRE_MEMORY_HOST,HYPRE_MEMORY_DEVICE);

--- a/src/struct_ls/smg.c
+++ b/src/struct_ls/smg.c
@@ -39,7 +39,7 @@ hypre_SMGCreate( MPI_Comm  comm )
 
    /* initialize */
    (smg_data -> num_levels) = -1;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    (smg_data -> devicelevel) = 200;
 #endif
    return (void *) smg_data;
@@ -516,7 +516,7 @@ hypre_StructSMGSetMaxLevel( void   *smg_vdata,
    return hypre_error_flag;
 }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 HYPRE_Int
 hypre_StructSMGSetDeviceLevel( void   *smg_vdata,
                                HYPRE_Int   device_level  )

--- a/src/struct_ls/smg.h
+++ b/src/struct_ls/smg.h
@@ -72,7 +72,7 @@ typedef struct
    HYPRE_Int             logging;
    HYPRE_Real           *norms;
    HYPRE_Real           *rel_norms;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_Int             devicelevel;
 #endif
 } hypre_SMGData;

--- a/src/struct_ls/smg.h
+++ b/src/struct_ls/smg.h
@@ -21,16 +21,16 @@
 typedef struct
 {
    MPI_Comm              comm;
-                      
+
    HYPRE_Int             memory_use;
    HYPRE_Real            tol;
    HYPRE_Int             max_iter;
    HYPRE_Int             rel_change;
    HYPRE_Int             zero_guess;
    HYPRE_Int             max_levels;  /* max_level <= 0 means no limit */
-                      
+
    HYPRE_Int             num_levels;
-                      
+
    HYPRE_Int             num_pre_relax;  /* number of pre relaxation sweeps */
    HYPRE_Int             num_post_relax; /* number of post relaxation sweeps */
 
@@ -42,7 +42,7 @@ typedef struct
 
    hypre_StructGrid    **grid_l;
    hypre_StructGrid    **PT_grid_l;
-                    
+
    HYPRE_Real           *data;
    HYPRE_Real           *data_const;
    hypre_StructMatrix  **A_l;

--- a/src/struct_ls/smg_setup.c
+++ b/src/struct_ls/smg_setup.c
@@ -83,7 +83,7 @@ hypre_SMGSetup( void               *smg_vdata,
    char                  filename[255];
 #endif
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_Int             num_level_GPU = 0;
    HYPRE_MemoryLocation  data_location;
    HYPRE_Int             max_box_size  = 0;
@@ -118,7 +118,7 @@ hypre_SMGSetup( void               *smg_vdata,
    PT_grid_l[0] = NULL;
    hypre_StructGridRef(grid, &grid_l[0]);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    data_location = hypre_StructGridDataLocation(grid);
    if (data_location != HYPRE_MEMORY_HOST)
    {
@@ -160,7 +160,7 @@ hypre_SMGSetup( void               *smg_vdata,
 
       /* build the coarse grid */
       hypre_StructCoarsen(grid_l[l], cindex, stride, 1, &grid_l[l+1]);
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       hypre_StructGridDataLocation(PT_grid_l[l+1]) = data_location;
       if (device_level == -1 && num_level_GPU > 0)
       {
@@ -272,7 +272,7 @@ hypre_SMGSetup( void               *smg_vdata,
       tx_l[l+1] = hypre_StructVectorCreate(comm, grid_l[l+1]);
       hypre_StructVectorSetNumGhost(tx_l[l+1], hypre_StructVectorNumGhost(x));
       hypre_StructVectorInitializeShell(tx_l[l+1]);
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (l+1 == num_level_GPU)
       {
          hypre_StructVectorSetDataSize(tb_l[l+1], &data_size, &data_size_const);
@@ -287,7 +287,7 @@ hypre_SMGSetup( void               *smg_vdata,
    (smg_data -> data) = data;
    (smg_data -> data_const) = data_const;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //if (hypre_StructGridNDim(grid) == hypre_StructStencilNDim(hypre_StructMatrixStencil(A)))
    //   printf("num_level_GPU = %d,device_level = %d / %d\n",num_level_GPU,device_level,num_levels);
    data_location = hypre_StructGridDataLocation(grid_l[0]);
@@ -336,7 +336,7 @@ hypre_SMGSetup( void               *smg_vdata,
       }
 #endif
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (l+1 == num_level_GPU)
       {
          data_location = HYPRE_MEMORY_HOST;
@@ -347,7 +347,7 @@ hypre_SMGSetup( void               *smg_vdata,
       data += hypre_StructMatrixDataSize(A_l[l+1]);
       data_const += hypre_StructMatrixDataConstSize(A_l[l+1]);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (data_location != HYPRE_MEMORY_HOST)
       {
          hypre_StructVectorInitializeData(b_l[l+1], data);
@@ -453,7 +453,7 @@ hypre_SMGSetup( void               *smg_vdata,
 
    for (l = 0; l < (num_levels - 1); l++)
    {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (l == num_level_GPU)
       {
          hypre_SetDeviceOff();
@@ -520,7 +520,7 @@ hypre_SMGSetup( void               *smg_vdata,
                           cindex, stride);
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if (l == num_level_GPU)
    {
       hypre_SetDeviceOff();
@@ -585,7 +585,7 @@ hypre_SMGSetup( void               *smg_vdata,
       hypre_StructMatrixPrint(filename, A_l[l], 0);
    }
 #endif
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if (hypre_StructGridDataLocation(grid) != HYPRE_MEMORY_HOST)
    {
       hypre_SetDeviceOn();

--- a/src/struct_ls/smg_setup_rap.c
+++ b/src/struct_ls/smg_setup_rap.c
@@ -85,7 +85,7 @@ hypre_SMGSetupRAPOp( hypre_StructMatrix *R,
 
    hypre_StructStencil   *stencil;
    hypre_StructMatrix    *Ac_tmp;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_MemoryLocation data_location_A = hypre_StructGridDataLocation(hypre_StructMatrixGrid(A));
    HYPRE_MemoryLocation data_location_Ac = hypre_StructGridDataLocation(hypre_StructMatrixGrid(Ac));
    if (data_location_A != data_location_Ac)
@@ -189,7 +189,7 @@ hypre_SMGSetupRAPOp( hypre_StructMatrix *R,
 
    hypre_StructMatrixAssemble(Ac_tmp);
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    if (data_location_A != data_location_Ac)
    {
 

--- a/src/struct_ls/smg_setup_rap.c
+++ b/src/struct_ls/smg_setup_rap.c
@@ -203,4 +203,3 @@ hypre_SMGSetupRAPOp( hypre_StructMatrix *R,
 #endif
    return hypre_error_flag;
 }
-

--- a/src/struct_mv/HYPRE_struct_grid.c
+++ b/src/struct_mv/HYPRE_struct_grid.c
@@ -105,7 +105,7 @@ HYPRE_StructGridSetNumGhost( HYPRE_StructGrid grid, HYPRE_Int *num_ghost )
    return ( hypre_StructGridSetNumGhost(grid, num_ghost) );
 }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 HYPRE_Int
 HYPRE_StructGridSetDataLocation( HYPRE_StructGrid grid, HYPRE_MemoryLocation data_location )
 {

--- a/src/struct_mv/HYPRE_struct_mv.h
+++ b/src/struct_mv/HYPRE_struct_mv.h
@@ -552,7 +552,7 @@ HYPRE_Int HYPRE_CommPkgDestroy(HYPRE_CommPkg comm_pkg);
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 HYPRE_Int
 HYPRE_StructGridSetDataLocation( HYPRE_StructGrid grid, HYPRE_MemoryLocation data_location );
 #endif

--- a/src/struct_mv/_hypre_struct_mv.h
+++ b/src/struct_mv/_hypre_struct_mv.h
@@ -35,7 +35,7 @@ extern "C" {
 #define HYPRE_MAXDIM 3
 #endif
 
-#if defined(HYPRE_USING_RAJA) || defined(HYPRE_USING_KOKKOS) || defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_RAJA) || defined(HYPRE_USING_KOKKOS) || defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP) || defined(HYPRE_USING_HIP)
 #define hypre_BoxLoopSetOneBlock()
 #else
 #define hypre_BoxLoopSetOneBlock zypre_BoxLoopSetOneBlock
@@ -1009,7 +1009,7 @@ typedef struct hypre_StructGrid_struct
    HYPRE_Int            num_ghost[2*HYPRE_MAXDIM]; /* ghost layer size */
 
    hypre_BoxManager    *boxman;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_MemoryLocation data_location;
 #endif
 } hypre_StructGrid;
@@ -1039,7 +1039,7 @@ typedef struct hypre_StructGrid_struct
 #define hypre_StructGridNumBoxes(grid)      (hypre_BoxArraySize(hypre_StructGridBoxes(grid)))
 
 #define hypre_StructGridIDPeriod(grid)      hypre_BoxNeighborsIDPeriod(hypre_StructGridNeighbors(grid))
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #define hypre_StructGridDataLocation(grid)  ((grid) -> data_location)
 #endif
 /*--------------------------------------------------------------------------
@@ -1048,7 +1048,7 @@ typedef struct hypre_StructGrid_struct
 
 #define hypre_ForStructGridBoxI(i, grid)    hypre_ForBoxI(i, hypre_StructGridBoxes(grid))
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #define HYPRE_MIN_GPU_SIZE                  (131072)
 #define hypre_SetDeviceOn()                 hypre_HandleStructExecPolicy(hypre_handle()) = HYPRE_EXEC_DEVICE
 #define hypre_SetDeviceOff()                hypre_HandleStructExecPolicy(hypre_handle()) = HYPRE_EXEC_HOST
@@ -1821,7 +1821,7 @@ HYPRE_Int hypre_ComputeBoxnums ( hypre_BoxArray *boxes , HYPRE_Int *procs , HYPR
 HYPRE_Int hypre_StructGridPrint ( FILE *file , hypre_StructGrid *grid );
 HYPRE_Int hypre_StructGridRead ( MPI_Comm comm , FILE *file , hypre_StructGrid **grid_ptr );
 HYPRE_Int hypre_StructGridSetNumGhost ( hypre_StructGrid *grid , HYPRE_Int *num_ghost );
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 HYPRE_Int hypre_StructGridGetMaxBoxSize(hypre_StructGrid *grid);
 HYPRE_Int hypre_StructGridSetDataLocation( HYPRE_StructGrid grid, HYPRE_MemoryLocation data_location );
 #endif
@@ -2484,7 +2484,7 @@ hypre__J = hypre__thread;  i1 = i2 = 0; \
 #endif
 
 
-#elif !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && !defined(HYPRE_USING_CUDA)
+#elif !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && !defined(HYPRE_USING_CUDA) && !defined(HYPRE_USING_HIP)
 /******************************************************************************
  * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.

--- a/src/struct_mv/_hypre_struct_mv.hpp
+++ b/src/struct_mv/_hypre_struct_mv.hpp
@@ -721,7 +721,7 @@ struct ColumnSums
 #define hypre_BasicBoxLoop2Begin hypre_newBasicBoxLoop2Begin
 #endif
 
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 /******************************************************************************
  * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.

--- a/src/struct_mv/box.h
+++ b/src/struct_mv/box.h
@@ -18,7 +18,7 @@
 #define HYPRE_MAXDIM 3
 #endif
 
-#if defined(HYPRE_USING_RAJA) || defined(HYPRE_USING_KOKKOS) || defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_RAJA) || defined(HYPRE_USING_KOKKOS) || defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP) || defined(HYPRE_USING_HIP)
 #define hypre_BoxLoopSetOneBlock()
 #else
 #define hypre_BoxLoopSetOneBlock zypre_BoxLoopSetOneBlock

--- a/src/struct_mv/headers
+++ b/src/struct_mv/headers
@@ -61,7 +61,7 @@ cat boxloop_omp_device.h          >> $INTERNAL_HEADER
 
 cat >> $INTERNAL_HEADER <<@
 
-#elif !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && !defined(HYPRE_USING_CUDA)
+#elif !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) && !defined(HYPRE_USING_CUDA) && !defined(HYPRE_USING_HIP)
 @
 
 cat boxloop_host.h                >> $INTERNAL_HEADER
@@ -130,7 +130,7 @@ cat boxloop_kokkos.h              >> $INTERNAL_HEADER
 
 cat >> $INTERNAL_HEADER <<@
 
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 @
 
 cat boxloop_cuda.h                >> $INTERNAL_HEADER

--- a/src/struct_mv/protos.h
+++ b/src/struct_mv/protos.h
@@ -217,7 +217,7 @@ HYPRE_Int hypre_ComputeBoxnums ( hypre_BoxArray *boxes , HYPRE_Int *procs , HYPR
 HYPRE_Int hypre_StructGridPrint ( FILE *file , hypre_StructGrid *grid );
 HYPRE_Int hypre_StructGridRead ( MPI_Comm comm , FILE *file , hypre_StructGrid **grid_ptr );
 HYPRE_Int hypre_StructGridSetNumGhost ( hypre_StructGrid *grid , HYPRE_Int *num_ghost );
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 HYPRE_Int hypre_StructGridGetMaxBoxSize(hypre_StructGrid *grid);
 HYPRE_Int hypre_StructGridSetDataLocation( HYPRE_StructGrid grid, HYPRE_MemoryLocation data_location );
 #endif

--- a/src/struct_mv/struct_communication.c
+++ b/src/struct_mv/struct_communication.c
@@ -846,7 +846,7 @@ hypre_InitializeCommunication( hypre_CommPkg     *comm_pkg,
 #if defined(HYPRE_USING_GPU)
 #if defined(HYPRE_USING_RAJA) || defined(HYPRE_USING_KOKKOS)
    alloc_dev_buffer = 1;
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    alloc_dev_buffer = (hypre_HandleStructExecPolicy(hypre_handle()) == HYPRE_EXEC_DEVICE);
 #elif defined(HYPRE_USING_DEVICE_OPENMP)
    alloc_dev_buffer = hypre__global_offload;
@@ -1218,7 +1218,7 @@ hypre_FinalizeCommunication( hypre_CommHandle *comm_handle )
 #if defined(HYPRE_USING_GPU)
 #if defined(HYPRE_USING_RAJA) || defined(HYPRE_USING_KOKKOS)
    alloc_dev_buffer = 1;
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    alloc_dev_buffer = (hypre_HandleStructExecPolicy(hypre_handle()) == HYPRE_EXEC_DEVICE);
 #elif defined(HYPRE_USING_DEVICE_OPENMP)
    alloc_dev_buffer = hypre__global_offload;

--- a/src/struct_mv/struct_grid.c
+++ b/src/struct_mv/struct_grid.c
@@ -60,7 +60,7 @@ hypre_StructGridCreate( MPI_Comm           comm,
       hypre_StructGridNumGhost(grid)[i] = 1;
    }
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_StructGridDataLocation(grid) = HYPRE_MEMORY_DEVICE;
 #endif
    *grid_ptr = grid;
@@ -856,7 +856,7 @@ hypre_StructGridSetNumGhost( hypre_StructGrid *grid, HYPRE_Int  *num_ghost )
 }
 
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 HYPRE_Int
 hypre_StructGridGetMaxBoxSize(hypre_StructGrid *grid)
 {

--- a/src/struct_mv/struct_grid.h
+++ b/src/struct_mv/struct_grid.h
@@ -46,7 +46,7 @@ typedef struct hypre_StructGrid_struct
    HYPRE_Int            num_ghost[2*HYPRE_MAXDIM]; /* ghost layer size */
 
    hypre_BoxManager    *boxman;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_MemoryLocation data_location;
 #endif
 } hypre_StructGrid;
@@ -76,7 +76,7 @@ typedef struct hypre_StructGrid_struct
 #define hypre_StructGridNumBoxes(grid)      (hypre_BoxArraySize(hypre_StructGridBoxes(grid)))
 
 #define hypre_StructGridIDPeriod(grid)      hypre_BoxNeighborsIDPeriod(hypre_StructGridNeighbors(grid))
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #define hypre_StructGridDataLocation(grid)  ((grid) -> data_location)
 #endif
 /*--------------------------------------------------------------------------
@@ -85,7 +85,7 @@ typedef struct hypre_StructGrid_struct
 
 #define hypre_ForStructGridBoxI(i, grid)    hypre_ForBoxI(i, hypre_StructGridBoxes(grid))
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #define HYPRE_MIN_GPU_SIZE                  (131072)
 #define hypre_SetDeviceOn()                 hypre_HandleStructExecPolicy(hypre_handle()) = HYPRE_EXEC_DEVICE
 #define hypre_SetDeviceOff()                hypre_HandleStructExecPolicy(hypre_handle()) = HYPRE_EXEC_HOST

--- a/src/struct_mv/struct_innerprod.c
+++ b/src/struct_mv/struct_innerprod.c
@@ -40,7 +40,7 @@ hypre_StructInnerProd( hypre_StructVector *x,
    HYPRE_Int        ndim = hypre_StructVectorNDim(x);
    HYPRE_Int        i;
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    //const HYPRE_Int  data_location = hypre_StructGridDataLocation(hypre_StructVectorGrid(y));
 #endif
 
@@ -66,7 +66,7 @@ hypre_StructInnerProd( hypre_StructVector *x,
       HYPRE_Real box_sum = 0.0;
 #elif defined(HYPRE_USING_RAJA)
       ReduceSum<hypre_raja_reduce_policy, HYPRE_Real> box_sum(0.0);
-#elif defined(HYPRE_USING_CUDA)
+#elif defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       ReduceSum<HYPRE_Real> box_sum(0.0);
 #else
       HYPRE_Real box_sum = 0.0;

--- a/src/struct_mv/struct_matrix.c
+++ b/src/struct_mv/struct_matrix.c
@@ -341,7 +341,7 @@ hypre_StructMatrixInitializeShell( hypre_StructMatrix *matrix )
       {
          hypre_assert( constant_coefficient == 2 );
          data_const_size += stencil_size;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
          if (hypre_StructGridDataLocation(grid) == HYPRE_MEMORY_HOST)
          {
             /* in this case, "data" is put on host using the space of
@@ -403,7 +403,7 @@ hypre_StructMatrixInitializeShell( hypre_StructMatrix *matrix )
        * if data location has not been set outside, set up the data location
        * based on the total number of
        *-----------------------------------------------------------------------*/
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (hypre_StructGridDataLocation(grid) == HYPRE_MEMORY_HOST)
       {
          data_const_size = data_size + data_const_size;
@@ -451,7 +451,7 @@ hypre_StructMatrixInitializeData( hypre_StructMatrix *matrix,
    hypre_Index          *stencil_shape;
    HYPRE_Complex       **stencil_data;
    HYPRE_Int stencil_size, i;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_StructGrid     *grid = hypre_StructMatrixGrid(matrix);
 #endif
    hypre_StructMatrixData(matrix) = data;
@@ -469,7 +469,7 @@ hypre_StructMatrixInitializeData( hypre_StructMatrix *matrix,
    {
       for (i = 0; i < stencil_size; i++)
       {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
          if (hypre_StructGridDataLocation(grid) != HYPRE_MEMORY_HOST)
          {
             stencil_data[i] = hypre_StructMatrixData(matrix);
@@ -497,7 +497,7 @@ hypre_StructMatrixInitializeData( hypre_StructMatrix *matrix,
          /* diagonal, variable coefficient */
          if (hypre_IndexEqual(stencil_shape[i], 0, ndim))
          {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
             if (hypre_StructGridDataLocation(grid) != HYPRE_MEMORY_HOST)
             {
                stencil_data[i] = hypre_StructMatrixData(matrix);
@@ -1227,7 +1227,7 @@ hypre_StructMatrixAssemble( hypre_StructMatrix *matrix )
    HYPRE_Int             *num_ghost = hypre_StructMatrixNumGhost(matrix);
 
    HYPRE_Int              comm_num_values, mat_num_values, constant_coefficient;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    HYPRE_Int              stencil_size;
    hypre_StructStencil   *stencil;
 #endif
@@ -1363,7 +1363,7 @@ hypre_StructMatrixAssemble( hypre_StructMatrix *matrix )
    if ( constant_coefficient==0 )
    {
       comm_num_values = mat_num_values;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (hypre_StructGridDataLocation(grid) == HYPRE_MEMORY_HOST)
       {
          matrix_data_comm = hypre_StructMatrixDataConst(matrix);
@@ -1377,7 +1377,7 @@ hypre_StructMatrixAssemble( hypre_StructMatrix *matrix )
    else /* constant_coefficient==2 */
    {
       comm_num_values = 1;
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (hypre_StructGridDataLocation(grid) == HYPRE_MEMORY_HOST)
       {
          stencil = hypre_StructMatrixStencil(matrix);
@@ -1786,7 +1786,7 @@ hypre_StructMatrixMigrate( hypre_StructMatrix *from_matrix,
       stencil_size = hypre_StructStencilSize(stencil);
       hypre_assert(stencil_size ==
                    hypre_StructStencilSize( hypre_StructMatrixStencil(to_matrix) ) );
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       if (hypre_StructGridDataLocation(hypre_StructMatrixGrid(from_matrix)) == HYPRE_MEMORY_HOST)
       {
          stencil = hypre_StructMatrixStencil(from_matrix);
@@ -2029,4 +2029,3 @@ hypre_StructMatrixClearBoundary( hypre_StructMatrix *matrix)
 
    return hypre_error_flag;
 }
-

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -157,11 +157,23 @@ typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator
 
 struct hypre_CudaData
 {
+#if defined(HYPRE_USING_CURAND)
    curandGenerator_t                 curand_generator;
+#endif
+
+#if defined(HYPRE_USING_CUBLAS)
    cublasHandle_t                    cublas_handle;
+#endif
+
+#if defined(HYPRE_USING_CUSPARSE)
    cusparseHandle_t                  cusparse_handle;
    cusparseMatDescr_t                cusparse_mat_descr;
+#endif
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
    cudaStream_t                      cuda_streams[HYPRE_MAX_NUM_STREAMS];
+#endif
+
 #ifdef HYPRE_USING_CUB_ALLOCATOR
    hypre_uint                        cub_bin_growth;
    hypre_uint                        cub_min_bin;
@@ -217,18 +229,31 @@ struct hypre_CudaData
 hypre_CudaData* hypre_CudaDataCreate();
 void hypre_CudaDataDestroy(hypre_CudaData* data);
 
+#if defined(HYPRE_USING_CURAND)
 curandGenerator_t  hypre_CudaDataCurandGenerator(hypre_CudaData *data);
+#endif
+
+#if defined(HYPRE_USING_CUBLAS)
 cublasHandle_t     hypre_CudaDataCublasHandle(hypre_CudaData *data);
+#endif
+
+#if defined(HYPRE_USING_CUSPARSE)
 cusparseHandle_t   hypre_CudaDataCusparseHandle(hypre_CudaData *data);
 cusparseMatDescr_t hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
+#endif
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 cudaStream_t       hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
 cudaStream_t       hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
+#endif
 
 // Data structure and accessor routines for Cuda Sparse Triangular Matrices
 struct hypre_CsrsvData
 {
+#if defined(HYPRE_USING_CUSPARSE)
    csrsv2Info_t info_L;
    csrsv2Info_t info_U;
+#endif
    hypre_int    BufferSize;
    char        *Buffer;
 };

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -18,7 +18,7 @@ extern "C++" {
 #ifndef HYPRE_UMPIRE_ALLOCATOR_H
 #define HYPRE_UMPIRE_ALLOCATOR_H
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #if defined(HYPRE_USING_UMPIRE_DEVICE)
 
 /*
@@ -60,10 +60,9 @@ struct hypre_umpire_device_allocator
 };
 
 #endif /* #ifdef HYPRE_USING_UMPIRE_DEVICE */
-#endif /* #if defined(HYPRE_USING_CUDA) */
+#endif /* #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */
 
 #endif
-
 /******************************************************************************
  * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -887,6 +887,7 @@ HYPRE_Int hypreDevice_BigToSmallCopy(HYPRE_Int *tgt, const HYPRE_BigInt *src, HY
 
 void hypre_CudaCompileFlagCheck();
 
+#if defined(HYPRE_USING_CUDA)
 cudaError_t hypre_CachingMallocDevice(void **ptr, size_t nbytes);
 
 cudaError_t hypre_CachingMallocManaged(void **ptr, size_t nbytes);
@@ -894,6 +895,8 @@ cudaError_t hypre_CachingMallocManaged(void **ptr, size_t nbytes);
 cudaError_t hypre_CachingFreeDevice(void *ptr);
 
 cudaError_t hypre_CachingFreeManaged(void *ptr);
+#endif
+
 
 void hypre_CudaDataCubCachingAllocatorDestroy(hypre_CudaData *data);
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -187,6 +187,8 @@ struct hypre_CudaData
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
    cudaStream_t                      cuda_streams[HYPRE_MAX_NUM_STREAMS];
+#elif defined(HYPRE_USING_HIP)
+   hipStream_t                       cuda_streams[HYPRE_MAX_NUM_STREAMS];
 #endif
 
 #ifdef HYPRE_USING_CUB_ALLOCATOR
@@ -260,6 +262,9 @@ cusparseMatDescr_t hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 cudaStream_t       hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
 cudaStream_t       hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
+#elif defined(HYPRE_USING_HIP)
+hipStream_t        hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
+hipStream_t        hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
 #endif
 
 // Data structure and accessor routines for Cuda Sparse Triangular Matrices

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -156,8 +156,14 @@ struct hypre_cub_CachingDeviceAllocator;
 typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator;
 
 // HYPRE_WARP_BITSHIFT is just log2 of HYPRE_WARP_SIZE
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 #define HYPRE_WARP_SIZE       32
 #define HYPRE_WARP_BITSHIFT   5
+#elif defined(HYPRE_USING_HIP)
+#define HYPRE_WARP_SIZE       64
+#define HYPRE_WARP_BITSHIFT   6
+#endif
+
 #define HYPRE_WARP_FULL_MASK  0xFFFFFFFF
 #define HYPRE_MAX_NUM_WARPS   (64 * 64 * 32)
 #define HYPRE_FLT_LARGE       1e30

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -942,7 +942,7 @@ cusparseIndexType_t hypre_HYPREIntToCusparseIndexType();
 #ifndef HYPRE_CUDA_REDUCER_H
 #define HYPRE_CUDA_REDUCER_H
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS)
 
 template<typename T> void OneBlockReduce(T *d_arr, HYPRE_Int N, T *h_out);
@@ -1022,7 +1022,7 @@ struct HYPRE_double6
 __inline__ __host__ __device__
 HYPRE_Real warpReduceSum(HYPRE_Real val)
 {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   for (HYPRE_Int offset = warpSize/2; offset > 0; offset /= 2)
   {
     val += __shfl_down_sync(HYPRE_WARP_FULL_MASK, val, offset);
@@ -1033,7 +1033,7 @@ HYPRE_Real warpReduceSum(HYPRE_Real val)
 
 __inline__ __host__ __device__
 HYPRE_double4 warpReduceSum(HYPRE_double4 val) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   for (HYPRE_Int offset = warpSize / 2; offset > 0; offset /= 2)
   {
     val.x += __shfl_down_sync(HYPRE_WARP_FULL_MASK, val.x, offset);
@@ -1047,7 +1047,7 @@ HYPRE_double4 warpReduceSum(HYPRE_double4 val) {
 
 __inline__ __host__ __device__
 HYPRE_double6 warpReduceSum(HYPRE_double6 val) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   for (HYPRE_Int offset = warpSize / 2; offset > 0; offset /= 2)
   {
     val.x += __shfl_down_sync(HYPRE_WARP_FULL_MASK, val.x, offset);
@@ -1066,7 +1066,7 @@ template <typename T>
 __inline__ __host__ __device__
 T blockReduceSum(T val)
 {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
    //static __shared__ T shared[HYPRE_WARP_SIZE]; // Shared mem for HYPRE_WARP_SIZE partial sums
 
    __shared__ T shared[HYPRE_WARP_SIZE];        // Shared mem for HYPRE_WARP_SIZE partial sums
@@ -1161,7 +1161,7 @@ struct ReduceSum
    __host__ __device__
    void BlockReduce() const
    {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
       __thread_sum = blockReduceSum(__thread_sum);
       if (threadIdx.x == 0)
       {
@@ -1199,7 +1199,7 @@ struct ReduceSum
 };
 
 #endif /* #if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) */
-#endif /* #if defined(HYPRE_USING_CUDA) */
+#endif /* #if defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP) */
 #endif /* #ifndef HYPRE_CUDA_REDUCER_H */
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -308,6 +308,7 @@ struct hypre_CsrsvData
 #include <thrust/inner_product.h>
 #include <thrust/logical.h>
 #include <thrust/replace.h>
+#include <thrust/sequence.h>
 
 using namespace thrust::placeholders;
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -74,8 +74,9 @@ struct hypre_umpire_device_allocator
 #ifndef HYPRE_CUDA_UTILS_H
 #define HYPRE_CUDA_UTILS_H
 
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
 
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <cuda_profiler_api.h>
@@ -100,6 +101,14 @@ struct hypre_umpire_device_allocator
 
 #define CUSPARSE_NEWAPI_VERSION 11000
 
+#elif defined(HYPRE_USING_HIP)
+
+#include <hip/hip_runtime.h>
+
+#endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 #define HYPRE_CUDA_CALL(call) do {                                                           \
    cudaError_t err = call;                                                                   \
    if (cudaSuccess != err) {                                                                 \
@@ -107,6 +116,8 @@ struct hypre_umpire_device_allocator
                    __FILE__, __LINE__);                                                      \
       assert(0); exit(1);                                                                    \
    } } while(0)
+
+#endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 
 #define HYPRE_CUBLAS_CALL(call) do {                                                         \
    cublasStatus_t err = call;                                                                \
@@ -227,7 +238,7 @@ struct hypre_CsrsvData
 #define hypre_CsrsvDataBufferSize(data) ((data) -> BufferSize)
 #define hypre_CsrsvDataBuffer(data)     ((data) -> Buffer)
 
-#endif //#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#endif //#if defined(HYPRE_USING_GPU)
 
 #if defined(HYPRE_USING_CUDA)
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -590,6 +590,18 @@ void __syncwarp()
 
 #endif // #if defined(HYPRE_USING_HIP) || (CUDA_VERSION < 9000)
 
+
+// __any was technically deprecated in CUDA 7 so we don't bother
+// with this overload for CUDA, just for HIP.
+#if defined(HYPRE_USING_HIP)
+static __device__ __forceinline__
+int __any_sync(unsigned mask, int predicate)
+{
+  return __any(predicate);
+}
+#endif
+
+
 template <typename T>
 static __device__ __forceinline__
 T read_only_load( const T *ptr )

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -533,7 +533,8 @@ hypre_double atomicAdd(hypre_double* address, hypre_double val)
 }
 #endif
 
-#if CUDA_VERSION < 9000
+// There are no *_sync functions in HIP
+#if defined(HYPRE_USING_HIP) || (CUDA_VERSION < 9000)
 
 template <typename T>
 static __device__ __forceinline__
@@ -568,7 +569,7 @@ void __syncwarp()
 {
 }
 
-#endif
+#endif // #if defined(HYPRE_USING_HIP) || (CUDA_VERSION < 9000)
 
 template <typename T>
 static __device__ __forceinline__

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -285,7 +285,7 @@ struct hypre_CsrsvData
 
 #endif //#if defined(HYPRE_USING_GPU)
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #include <thrust/execution_policy.h>
 #if defined(HYPRE_USING_CUDA)
@@ -920,7 +920,7 @@ cudaError_t hypre_CachingFreeManaged(void *ptr);
 
 void hypre_CudaDataCubCachingAllocatorDestroy(hypre_CudaData *data);
 
-#endif // #if defined(HYPRE_USING_CUDA)
+#endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #if defined(HYPRE_USING_CUSPARSE)
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -117,6 +117,15 @@ struct hypre_umpire_device_allocator
       assert(0); exit(1);                                                                    \
    } } while(0)
 
+#elif defined(HYPRE_USING_HIP)
+#define HYPRE_HIP_CALL(call) do {                                                           \
+   hipError_t err = call;                                                                   \
+   if (hipSuccess != err) {                                                                 \
+      hypre_printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),    \
+                   __FILE__, __LINE__);                                                     \
+      assert(0); exit(1);                                                                   \
+   } } while(0)
+
 #endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 
 #define HYPRE_CUBLAS_CALL(call) do {                                                         \

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -288,7 +288,11 @@ struct hypre_CsrsvData
 #if defined(HYPRE_USING_CUDA)
 
 #include <thrust/execution_policy.h>
+#if defined(HYPRE_USING_CUDA)
 #include <thrust/system/cuda/execution_policy.h>
+#elif defined(HYPRE_USING_HIP)
+#include <thrust/system/hip/execution_policy.h>
+#endif
 #include <thrust/count.h>
 #include <thrust/device_ptr.h>
 #include <thrust/unique.h>
@@ -374,12 +378,27 @@ using namespace thrust::placeholders;
 /* RL: TODO Want macro HYPRE_THRUST_CALL to return value but I don't know how to do it right
  * The following one works OK for now */
 #ifdef HYPRE_USING_UMPIRE_DEVICE
+
+#if defined(HYPRE_USING_CUDA)
 #define HYPRE_THRUST_CALL(func_name, ...)                                                                            \
    thrust::func_name(thrust::cuda::par(hypre_HandleUmpireDeviceAllocator(hypre_handle())).on(hypre_HandleCudaComputeStream(hypre_handle())), __VA_ARGS__);
+#elif defined(HYPRE_USING_HIP)
+#define HYPRE_THRUST_CALL(func_name, ...)                                                                            \
+   thrust::func_name(thrust::hip::par(hypre_HandleUmpireDeviceAllocator(hypre_handle())).on(hypre_HandleCudaComputeStream(hypre_handle())), __VA_ARGS__);
+#endif // HYPRE_USING_CUDA
+
 #else
+
+#if defined(HYPRE_USING_CUDA)
 #define HYPRE_THRUST_CALL(func_name, ...)                                                                            \
    thrust::func_name(thrust::cuda::par.on(hypre_HandleCudaComputeStream(hypre_handle())), __VA_ARGS__);
-#endif
+#elif defined(HYPRE_USING_HIP)
+#define HYPRE_THRUST_CALL(func_name, ...)                                                                            \
+   thrust::func_name(thrust::hip::par.on(hypre_HandleCudaComputeStream(hypre_handle())), __VA_ARGS__);
+#endif // HYPRE_USING_CUDA
+
+#endif // HYPRE_USING_UMPIRE_DEVICE
+
 
 /* return the number of threads in block */
 template <hypre_int dim>

--- a/src/utilities/hypre_cuda_reducer.h
+++ b/src/utilities/hypre_cuda_reducer.h
@@ -10,7 +10,7 @@
 #ifndef HYPRE_CUDA_REDUCER_H
 #define HYPRE_CUDA_REDUCER_H
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS)
 
 template<typename T> void OneBlockReduce(T *d_arr, HYPRE_Int N, T *h_out);
@@ -90,7 +90,7 @@ struct HYPRE_double6
 __inline__ __host__ __device__
 HYPRE_Real warpReduceSum(HYPRE_Real val)
 {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   for (HYPRE_Int offset = warpSize/2; offset > 0; offset /= 2)
   {
     val += __shfl_down_sync(HYPRE_WARP_FULL_MASK, val, offset);
@@ -101,7 +101,7 @@ HYPRE_Real warpReduceSum(HYPRE_Real val)
 
 __inline__ __host__ __device__
 HYPRE_double4 warpReduceSum(HYPRE_double4 val) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   for (HYPRE_Int offset = warpSize / 2; offset > 0; offset /= 2)
   {
     val.x += __shfl_down_sync(HYPRE_WARP_FULL_MASK, val.x, offset);
@@ -115,7 +115,7 @@ HYPRE_double4 warpReduceSum(HYPRE_double4 val) {
 
 __inline__ __host__ __device__
 HYPRE_double6 warpReduceSum(HYPRE_double6 val) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   for (HYPRE_Int offset = warpSize / 2; offset > 0; offset /= 2)
   {
     val.x += __shfl_down_sync(HYPRE_WARP_FULL_MASK, val.x, offset);
@@ -134,7 +134,7 @@ template <typename T>
 __inline__ __host__ __device__
 T blockReduceSum(T val)
 {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
    //static __shared__ T shared[HYPRE_WARP_SIZE]; // Shared mem for HYPRE_WARP_SIZE partial sums
 
    __shared__ T shared[HYPRE_WARP_SIZE];        // Shared mem for HYPRE_WARP_SIZE partial sums
@@ -229,7 +229,7 @@ struct ReduceSum
    __host__ __device__
    void BlockReduce() const
    {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
       __thread_sum = blockReduceSum(__thread_sum);
       if (threadIdx.x == 0)
       {
@@ -267,5 +267,5 @@ struct ReduceSum
 };
 
 #endif /* #if !defined(HYPRE_USING_RAJA) && !defined(HYPRE_USING_KOKKOS) */
-#endif /* #if defined(HYPRE_USING_CUDA) */
+#endif /* #if defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP) */
 #endif /* #ifndef HYPRE_CUDA_REDUCER_H */

--- a/src/utilities/hypre_cuda_utils.c
+++ b/src/utilities/hypre_cuda_utils.c
@@ -775,12 +775,21 @@ hypre_HYPREIntToCusparseIndexType()
 }
 #endif // #if defined(HYPRE_USING_CUSPARSE)
 
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
 
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 cudaStream_t
+#elif defined(HYPRE_USING_HIP)
+hipStream_t
+#endif
 hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i)
 {
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
    cudaStream_t stream = 0;
+#elif defined(HYPRE_USING_HIP)
+   hipStream_t stream = 0;
+#endif
+
 #if defined(HYPRE_USING_CUDA_STREAMS)
    if (i >= HYPRE_MAX_NUM_STREAMS)
    {
@@ -1076,4 +1085,4 @@ hypre_SyncCudaComputeStream(hypre_Handle *hypre_handle)
    return hypre_error_flag;
 }
 
-#endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#endif // #if defined(HYPRE_USING_GPU)

--- a/src/utilities/hypre_cuda_utils.c
+++ b/src/utilities/hypre_cuda_utils.c
@@ -806,8 +806,12 @@ hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i)
       return data->cuda_streams[i];
    }
 
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
    //HYPRE_CUDA_CALL(cudaStreamCreateWithFlags(&stream,cudaStreamNonBlocking));
    HYPRE_CUDA_CALL(cudaStreamCreateWithFlags(&stream, cudaStreamDefault));
+#elif defined(HYPRE_USING_HIP)
+   HYPRE_HIP_CALL(hipStreamCreateWithFlags(&stream, hipStreamDefault));
+#endif
 
    data->cuda_streams[i] = stream;
 #endif
@@ -815,7 +819,11 @@ hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i)
    return stream;
 }
 
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 cudaStream_t
+#elif defined(HYPRE_USING_HIP)
+hipStream_t
+#endif
 hypre_CudaDataCudaComputeStream(hypre_CudaData *data)
 {
    return hypre_CudaDataCudaStream(data,
@@ -976,7 +984,11 @@ hypre_CudaDataDestroy(hypre_CudaData *data)
    {
       if (data->cuda_streams[i])
       {
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
          HYPRE_CUDA_CALL( cudaStreamDestroy(data->cuda_streams[i]) );
+#elif defined(HYPRE_USING_HIP)
+         HYPRE_HIP_CALL( hipStreamDestroy(data->cuda_streams[i]) );
+#endif
       }
    }
 
@@ -992,6 +1004,8 @@ hypre_SyncCudaDevice(hypre_Handle *hypre_handle)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
    HYPRE_CUDA_CALL( cudaDeviceSynchronize() );
+#elif defined(HYPRE_USING_HIP)
+   HYPRE_HIP_CALL( hipDeviceSynchronize() );
 #endif
    return hypre_error_flag;
 }
@@ -1034,10 +1048,14 @@ hypre_SyncCudaComputeStream_core(HYPRE_Int     action,
          *cuda_compute_stream_sync_ptr = cuda_compute_stream_sync;
          break;
       case 4:
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
          if (cuda_compute_stream_sync)
          {
-            HYPRE_CUDA_CALL( cudaStreamSynchronize(hypre_HandleCudaComputeStream(hypre_handle)) ) ;
+#if defined(HYPRE_USING_CUDA)
+            HYPRE_CUDA_CALL( cudaStreamSynchronize(hypre_HandleCudaComputeStream(hypre_handle)) );
+#elif defined(HYPRE_USING_HIP)
+            HYPRE_HIP_CALL( hipStreamSynchronize(hypre_HandleCudaComputeStream(hypre_handle)) );
+#endif
          }
 #elif defined(HYPRE_USING_DEVICE_OPENMP)
          HYPRE_CUDA_CALL( cudaDeviceSynchronize() );

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -222,7 +222,11 @@ struct hypre_CsrsvData
 #if defined(HYPRE_USING_CUDA)
 
 #include <thrust/execution_policy.h>
+#if defined(HYPRE_USING_CUDA)
 #include <thrust/system/cuda/execution_policy.h>
+#elif defined(HYPRE_USING_HIP)
+#include <thrust/system/hip/execution_policy.h>
+#endif
 #include <thrust/count.h>
 #include <thrust/device_ptr.h>
 #include <thrust/unique.h>
@@ -308,12 +312,27 @@ using namespace thrust::placeholders;
 /* RL: TODO Want macro HYPRE_THRUST_CALL to return value but I don't know how to do it right
  * The following one works OK for now */
 #ifdef HYPRE_USING_UMPIRE_DEVICE
+
+#if defined(HYPRE_USING_CUDA)
 #define HYPRE_THRUST_CALL(func_name, ...)                                                                            \
    thrust::func_name(thrust::cuda::par(hypre_HandleUmpireDeviceAllocator(hypre_handle())).on(hypre_HandleCudaComputeStream(hypre_handle())), __VA_ARGS__);
+#elif defined(HYPRE_USING_HIP)
+#define HYPRE_THRUST_CALL(func_name, ...)                                                                            \
+   thrust::func_name(thrust::hip::par(hypre_HandleUmpireDeviceAllocator(hypre_handle())).on(hypre_HandleCudaComputeStream(hypre_handle())), __VA_ARGS__);
+#endif // HYPRE_USING_CUDA
+
 #else
+
+#if defined(HYPRE_USING_CUDA)
 #define HYPRE_THRUST_CALL(func_name, ...)                                                                            \
    thrust::func_name(thrust::cuda::par.on(hypre_HandleCudaComputeStream(hypre_handle())), __VA_ARGS__);
-#endif
+#elif defined(HYPRE_USING_HIP)
+#define HYPRE_THRUST_CALL(func_name, ...)                                                                            \
+   thrust::func_name(thrust::hip::par.on(hypre_HandleCudaComputeStream(hypre_handle())), __VA_ARGS__);
+#endif // HYPRE_USING_CUDA
+
+#endif // HYPRE_USING_UMPIRE_DEVICE
+
 
 /* return the number of threads in block */
 template <hypre_int dim>

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -821,6 +821,7 @@ HYPRE_Int hypreDevice_BigToSmallCopy(HYPRE_Int *tgt, const HYPRE_BigInt *src, HY
 
 void hypre_CudaCompileFlagCheck();
 
+#if defined(HYPRE_USING_CUDA)
 cudaError_t hypre_CachingMallocDevice(void **ptr, size_t nbytes);
 
 cudaError_t hypre_CachingMallocManaged(void **ptr, size_t nbytes);
@@ -828,6 +829,8 @@ cudaError_t hypre_CachingMallocManaged(void **ptr, size_t nbytes);
 cudaError_t hypre_CachingFreeDevice(void *ptr);
 
 cudaError_t hypre_CachingFreeManaged(void *ptr);
+#endif
+
 
 void hypre_CudaDataCubCachingAllocatorDestroy(hypre_CudaData *data);
 

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -51,6 +51,15 @@
       assert(0); exit(1);                                                                    \
    } } while(0)
 
+#elif defined(HYPRE_USING_HIP)
+#define HYPRE_HIP_CALL(call) do {                                                           \
+   hipError_t err = call;                                                                   \
+   if (hipSuccess != err) {                                                                 \
+      hypre_printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),    \
+                   __FILE__, __LINE__);                                                     \
+      assert(0); exit(1);                                                                   \
+   } } while(0)
+
 #endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 
 #define HYPRE_CUBLAS_CALL(call) do {                                                         \

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -525,6 +525,18 @@ void __syncwarp()
 
 #endif // #if defined(HYPRE_USING_HIP) || (CUDA_VERSION < 9000)
 
+
+// __any was technically deprecated in CUDA 7 so we don't bother
+// with this overload for CUDA, just for HIP.
+#if defined(HYPRE_USING_HIP)
+static __device__ __forceinline__
+int __any_sync(unsigned mask, int predicate)
+{
+  return __any(predicate);
+}
+#endif
+
+
 template <typename T>
 static __device__ __forceinline__
 T read_only_load( const T *ptr )

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -243,6 +243,7 @@ struct hypre_CsrsvData
 #include <thrust/inner_product.h>
 #include <thrust/logical.h>
 #include <thrust/replace.h>
+#include <thrust/sequence.h>
 
 using namespace thrust::placeholders;
 

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -8,8 +8,9 @@
 #ifndef HYPRE_CUDA_UTILS_H
 #define HYPRE_CUDA_UTILS_H
 
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
 
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <cuda_profiler_api.h>
@@ -34,6 +35,14 @@
 
 #define CUSPARSE_NEWAPI_VERSION 11000
 
+#elif defined(HYPRE_USING_HIP)
+
+#include <hip/hip_runtime.h>
+
+#endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 #define HYPRE_CUDA_CALL(call) do {                                                           \
    cudaError_t err = call;                                                                   \
    if (cudaSuccess != err) {                                                                 \
@@ -41,6 +50,8 @@
                    __FILE__, __LINE__);                                                      \
       assert(0); exit(1);                                                                    \
    } } while(0)
+
+#endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 
 #define HYPRE_CUBLAS_CALL(call) do {                                                         \
    cublasStatus_t err = call;                                                                \
@@ -161,7 +172,7 @@ struct hypre_CsrsvData
 #define hypre_CsrsvDataBufferSize(data) ((data) -> BufferSize)
 #define hypre_CsrsvDataBuffer(data)     ((data) -> Buffer)
 
-#endif //#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#endif //#if defined(HYPRE_USING_GPU)
 
 #if defined(HYPRE_USING_CUDA)
 

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -90,8 +90,14 @@ struct hypre_cub_CachingDeviceAllocator;
 typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator;
 
 // HYPRE_WARP_BITSHIFT is just log2 of HYPRE_WARP_SIZE
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 #define HYPRE_WARP_SIZE       32
 #define HYPRE_WARP_BITSHIFT   5
+#elif defined(HYPRE_USING_HIP)
+#define HYPRE_WARP_SIZE       64
+#define HYPRE_WARP_BITSHIFT   6
+#endif
+
 #define HYPRE_WARP_FULL_MASK  0xFFFFFFFF
 #define HYPRE_MAX_NUM_WARPS   (64 * 64 * 32)
 #define HYPRE_FLT_LARGE       1e30

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -467,7 +467,8 @@ hypre_double atomicAdd(hypre_double* address, hypre_double val)
 }
 #endif
 
-#if CUDA_VERSION < 9000
+// There are no *_sync functions in HIP
+#if defined(HYPRE_USING_HIP) || (CUDA_VERSION < 9000)
 
 template <typename T>
 static __device__ __forceinline__
@@ -502,7 +503,7 @@ void __syncwarp()
 {
 }
 
-#endif
+#endif // #if defined(HYPRE_USING_HIP) || (CUDA_VERSION < 9000)
 
 template <typename T>
 static __device__ __forceinline__

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -121,6 +121,8 @@ struct hypre_CudaData
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
    cudaStream_t                      cuda_streams[HYPRE_MAX_NUM_STREAMS];
+#elif defined(HYPRE_USING_HIP)
+   hipStream_t                       cuda_streams[HYPRE_MAX_NUM_STREAMS];
 #endif
 
 #ifdef HYPRE_USING_CUB_ALLOCATOR
@@ -194,6 +196,9 @@ cusparseMatDescr_t hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 cudaStream_t       hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
 cudaStream_t       hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
+#elif defined(HYPRE_USING_HIP)
+hipStream_t        hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
+hipStream_t        hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
 #endif
 
 // Data structure and accessor routines for Cuda Sparse Triangular Matrices

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -248,8 +248,9 @@ using namespace thrust::placeholders;
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  */
 
-#ifdef HYPRE_DEBUG                                                                                                   \
+#if defined(HYPRE_DEBUG)
 
+#if defined(HYPRE_USING_CUDA)
 #define HYPRE_CUDA_LAUNCH(kernel_name, gridsize, blocksize, ...)                                                     \
 {                                                                                                                    \
    if ( gridsize.x  == 0 || gridsize.y  == 0 || gridsize.z  == 0 ||                                                  \
@@ -266,8 +267,26 @@ using namespace thrust::placeholders;
    hypre_SyncCudaComputeStream(hypre_handle());                                                                      \
    HYPRE_CUDA_CALL( cudaGetLastError() );                                                                            \
 }
+#elif defined(HYPRE_USING_HIP)
+#define HYPRE_CUDA_LAUNCH(kernel_name, gridsize, blocksize, ...)                                                     \
+{                                                                                                                    \
+   if ( gridsize.x  == 0 || gridsize.y  == 0 || gridsize.z  == 0 ||                                                  \
+        blocksize.x == 0 || blocksize.y == 0 || blocksize.z == 0 )                                                   \
+   {                                                                                                                 \
+      /* hypre_printf("Warning %s %d: Zero CUDA grid/block (%d %d %d) (%d %d %d)\n",                                 \
+                 __FILE__, __LINE__,                                                                                 \
+                 gridsize.x, gridsize.y, gridsize.z, blocksize.x, blocksize.y, blocksize.z); */                      \
+   }                                                                                                                 \
+   else                                                                                                              \
+   {                                                                                                                 \
+      (kernel_name) <<< (gridsize), (blocksize), 0, hypre_HandleCudaComputeStream(hypre_handle()) >>> (__VA_ARGS__); \
+   }                                                                                                                 \
+   hypre_SyncCudaComputeStream(hypre_handle());                                                                      \
+   HYPRE_HIP_CALL( hipGetLastError() );                                                                            \
+}
+#endif //HYPRE_USING_CUDA
 
-#else
+#else // #if defined(HYPRE_DEBUG)
 
 #define HYPRE_CUDA_LAUNCH(kernel_name, gridsize, blocksize, ...)                                                     \
 {                                                                                                                    \
@@ -284,7 +303,7 @@ using namespace thrust::placeholders;
    }                                                                                                                 \
 }
 
-#endif
+#endif // defined(HYPRE_DEBUG)
 
 /* RL: TODO Want macro HYPRE_THRUST_CALL to return value but I don't know how to do it right
  * The following one works OK for now */

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -219,7 +219,7 @@ struct hypre_CsrsvData
 
 #endif //#if defined(HYPRE_USING_GPU)
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #include <thrust/execution_policy.h>
 #if defined(HYPRE_USING_CUDA)
@@ -854,7 +854,7 @@ cudaError_t hypre_CachingFreeManaged(void *ptr);
 
 void hypre_CudaDataCubCachingAllocatorDestroy(hypre_CudaData *data);
 
-#endif // #if defined(HYPRE_USING_CUDA)
+#endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #if defined(HYPRE_USING_CUSPARSE)
 

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -91,11 +91,23 @@ typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator
 
 struct hypre_CudaData
 {
+#if defined(HYPRE_USING_CURAND)
    curandGenerator_t                 curand_generator;
+#endif
+
+#if defined(HYPRE_USING_CUBLAS)
    cublasHandle_t                    cublas_handle;
+#endif
+
+#if defined(HYPRE_USING_CUSPARSE)
    cusparseHandle_t                  cusparse_handle;
    cusparseMatDescr_t                cusparse_mat_descr;
+#endif
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
    cudaStream_t                      cuda_streams[HYPRE_MAX_NUM_STREAMS];
+#endif
+
 #ifdef HYPRE_USING_CUB_ALLOCATOR
    hypre_uint                        cub_bin_growth;
    hypre_uint                        cub_min_bin;
@@ -151,18 +163,31 @@ struct hypre_CudaData
 hypre_CudaData* hypre_CudaDataCreate();
 void hypre_CudaDataDestroy(hypre_CudaData* data);
 
+#if defined(HYPRE_USING_CURAND)
 curandGenerator_t  hypre_CudaDataCurandGenerator(hypre_CudaData *data);
+#endif
+
+#if defined(HYPRE_USING_CUBLAS)
 cublasHandle_t     hypre_CudaDataCublasHandle(hypre_CudaData *data);
+#endif
+
+#if defined(HYPRE_USING_CUSPARSE)
 cusparseHandle_t   hypre_CudaDataCusparseHandle(hypre_CudaData *data);
 cusparseMatDescr_t hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
+#endif
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 cudaStream_t       hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
 cudaStream_t       hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
+#endif
 
 // Data structure and accessor routines for Cuda Sparse Triangular Matrices
 struct hypre_CsrsvData
 {
+#if defined(HYPRE_USING_CUSPARSE)
    csrsv2Info_t info_L;
    csrsv2Info_t info_U;
+#endif
    hypre_int    BufferSize;
    char        *Buffer;
 };

--- a/src/utilities/hypre_general.c
+++ b/src/utilities/hypre_general.c
@@ -102,6 +102,8 @@ hypre_SetDevice(HYPRE_Int use_device, hypre_Handle *hypre_handle_)
    HYPRE_Int nDevices;
 #if defined(HYPRE_USING_CUDA)
    HYPRE_CUDA_CALL( cudaGetDeviceCount(&nDevices) );
+#elif defined(HYPRE_USING_HIP)
+   HYPRE_HIP_CALL( hipGetDeviceCount(&nDevices) );
 #else
    nDevices = omp_get_num_devices();
 #endif
@@ -117,6 +119,8 @@ hypre_SetDevice(HYPRE_Int use_device, hypre_Handle *hypre_handle_)
 
 #if defined(HYPRE_USING_CUDA)
    HYPRE_CUDA_CALL( cudaSetDevice(device_id) );
+#elif defined(HYPRE_USING_HIP)
+   HYPRE_HIP_CALL( hipSetDevice(device_id) );
 #else
    HYPRE_CUDA_CALL( cudaSetDevice(device_id) );
    omp_set_default_device(device_id);
@@ -156,7 +160,12 @@ HYPRE_Init()
    }
 
 #if defined(HYPRE_USING_GPU)
+
+#if defined(HYPRE_USING_CUDA)
    HYPRE_CUDA_CALL( cudaGetLastError() );
+#elif defined(HYPRE_USING_HIP)
+   HYPRE_HIP_CALL( hipGetLastError() );
+#endif
 
    /* Notice: the cudaStream created is specific to the device
     * that was in effect when you created the stream.
@@ -168,7 +177,7 @@ HYPRE_Init()
    /* If not here, will be done at the first use */
    hypre_HandleCudaComputeStream(_hypre_handle);
    //hypre_HandleCudaPrefetchStream(_hypre_handle);
-#endif
+#endif // HYPRE_USING_GPU
 
 #if defined(HYPRE_USING_CUBLAS)
    hypre_HandleCublasHandle(_hypre_handle);
@@ -250,6 +259,8 @@ HYPRE_Finalize()
 #endif
 */
    HYPRE_CUDA_CALL( cudaGetLastError() );
+#elif defined(HYPRE_USING_HIP)
+   HYPRE_HIP_CALL( hipGetLastError() );
 #endif
 
 #ifdef HYPRE_USING_MEMORY_TRACKER

--- a/src/utilities/hypre_general.c
+++ b/src/utilities/hypre_general.c
@@ -281,6 +281,14 @@ HYPRE_PrintDeviceInfo()
   HYPRE_CUDA_CALL( cudaGetDevice(&dev) );
   HYPRE_CUDA_CALL( cudaGetDeviceProperties(&deviceProp, dev) );
   hypre_printf("Running on \"%s\", major %d, minor %d, total memory %.2f GB\n", deviceProp.name, deviceProp.major, deviceProp.minor, deviceProp.totalGlobalMem/1e9);
+
+#elif defined(HYPRE_USING_HIP)
+  hypre_int dev;
+  hipDeviceProp_t deviceProp;
+
+  HYPRE_HIP_CALL( hipGetDevice(&dev) );
+  HYPRE_HIP_CALL( hipGetDeviceProperties(&deviceProp, dev) );
+  hypre_printf("Running on \"%s\", major %d, minor %d, total memory %.2f GB\n", deviceProp.name, deviceProp.major, deviceProp.minor, deviceProp.totalGlobalMem/1e9);
 #endif
 
    return hypre_error_flag;

--- a/src/utilities/hypre_general.c
+++ b/src/utilities/hypre_general.c
@@ -54,7 +54,7 @@ hypre_HandleCreate()
 
    hypre_HandleMemoryLocation(hypre_handle_) = HYPRE_MEMORY_DEVICE;
 
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
    hypre_HandleDefaultExecPolicy(hypre_handle_) = HYPRE_EXEC_HOST;
    hypre_HandleStructExecPolicy(hypre_handle_) = HYPRE_EXEC_DEVICE;
    hypre_HandleCudaData(hypre_handle_) = hypre_CudaDataCreate();
@@ -71,7 +71,7 @@ hypre_HandleDestroy(hypre_Handle *hypre_handle_)
       return hypre_error_flag;
    }
 
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
    hypre_CudaDataDestroy(hypre_HandleCudaData(hypre_handle_));
 #endif
 
@@ -80,7 +80,7 @@ hypre_HandleDestroy(hypre_Handle *hypre_handle_)
    return hypre_error_flag;
 }
 
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
 /* use_device == -1 to let Hypre decide on which device to use */
 HYPRE_Int
 hypre_SetDevice(HYPRE_Int use_device, hypre_Handle *hypre_handle_)
@@ -132,7 +132,7 @@ hypre_SetDevice(HYPRE_Int use_device, hypre_Handle *hypre_handle_)
    return hypre_error_flag;
 }
 
-#endif //#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#endif //#if defined(HYPRE_USING_GPU)
 
 /******************************************************************************
  *

--- a/src/utilities/hypre_memory.c
+++ b/src/utilities/hypre_memory.c
@@ -117,6 +117,21 @@ hypre_UnifiedMemPrefetch(void *ptr, size_t size, hypre_MemoryLocation location)
       HYPRE_CUDA_CALL( cudaMemPrefetchAsync(ptr, size, cudaCpuDeviceId,
                        hypre_HandleCudaComputeStream(hypre_handle())) );
    }
+#elif defined(HYPRE_USING_HIP)
+   // Not currently implemented for HIP, but leaving place holder
+   /*
+    *if (location == hypre_MEMORY_DEVICE)
+    *{
+    *  HYPRE_HIP_CALL( hipMemPrefetchAsync(ptr, size, hypre_HandleCudaDevice(hypre_handle()),
+    *                   hypre_HandleCudaComputeStream(hypre_handle())) );
+    *}
+    *else if (location == hypre_MEMORY_HOST)
+    *{
+    *   HYPRE_CUDA_CALL( hipMemPrefetchAsync(ptr, size, cudaCpuDeviceId,
+    *                    hypre_HandleCudaComputeStream(hypre_handle())) );
+    *}
+    */
+#endif
 #endif
 }
 

--- a/src/utilities/hypre_memory.c
+++ b/src/utilities/hypre_memory.c
@@ -865,6 +865,38 @@ hypre_GetPointerLocation(const void *ptr, hypre_MemoryLocation *memory_location)
 #endif // CUDART_VERSION >= 10000
 #endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 
+#if defined(HYPRE_USING_HIP)
+
+   struct hipPointerAttribute_t attr;
+   *memory_location = hypre_MEMORY_UNDEFINED;
+
+   hipError_t err = hipPointerGetAttributes(&attr, ptr);
+   if (err != hipSuccess)
+   {
+      ierr = 1;
+
+      /* clear the error */
+      hipGetLastError();
+
+      if (err == hipErrorInvalidValue)
+      {
+         *memory_location = hypre_MEMORY_HOST;
+      }
+   }
+   else if (attr.isManaged)
+   {
+      *memory_location = hypre_MEMORY_UNIFIED;
+   }
+   else if (attr.memoryType == hipMemoryTypeDevice)
+   {
+      *memory_location = hypre_MEMORY_DEVICE;
+   }
+   else if (attr.memoryType == hipMemoryTypeHost)
+   {
+      *memory_location = hypre_MEMORY_HOST_PINNED;
+   }
+#endif // defined(HYPRE_USING_HIP)
+
 #else /* #if defined(HYPRE_USING_GPU) */
    *memory_location = hypre_MEMORY_HOST;
 #endif

--- a/src/utilities/hypre_memory.c
+++ b/src/utilities/hypre_memory.c
@@ -93,7 +93,7 @@ hypre_UnifiedMemset(void *ptr, HYPRE_Int value, size_t num)
 static inline void
 hypre_UnifiedMemPrefetch(void *ptr, size_t size, hypre_MemoryLocation location)
 {
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
 #ifdef HYPRE_DEBUG
    hypre_MemoryLocation tmp;
    hypre_GetPointerLocation(ptr, &tmp);
@@ -102,6 +102,7 @@ hypre_UnifiedMemPrefetch(void *ptr, size_t size, hypre_MemoryLocation location)
    assert(hypre_MEMORY_UNIFIED == tmp);
 #endif
 
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
    if (location == hypre_MEMORY_DEVICE)
    {
       HYPRE_CUDA_CALL( cudaMemPrefetchAsync(ptr, size, hypre_HandleCudaDevice(hypre_handle()),
@@ -157,14 +158,14 @@ hypre_DeviceMalloc(size_t size, HYPRE_Int zeroinit)
    ptr = (void *) (&sp[1]);
    HYPRE_OMPOffload(hypre__offload_device_num, ptr, size, "enter", "alloc");
 #elif defined(HYPRE_USING_CUDA)
+
 #if defined(HYPRE_USING_CUB_ALLOCATOR)
    HYPRE_CUDA_CALL( hypre_CachingMallocDevice(&ptr, size) );
 #elif defined(HYPRE_USING_UMPIRE_DEVICE)
    hypre_umpire_device_pooled_allocate(&ptr, size);
 #else
    HYPRE_CUDA_CALL( cudaMalloc(&ptr, size) );
-#endif
-   /* HYPRE_CUDA_CALL( cudaDeviceSynchronize() ); */
+#endif // HYPRE_USING_CUB_ALLOCATOR
 #endif
 
    if (ptr && zeroinit)
@@ -180,12 +181,12 @@ hypre_UnifiedMalloc(size_t size, HYPRE_Int zeroinit)
 {
    void *ptr = NULL;
 
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
 #if defined(HYPRE_USING_CUB_ALLOCATOR)
    HYPRE_CUDA_CALL( hypre_CachingMallocManaged(&ptr, size) );
 #elif defined(HYPRE_USING_UMPIRE_UM)
    hypre_umpire_um_pooled_allocate(&ptr, size);
-#else
+#elif defined(HYPRE_USING_CUDA)
    HYPRE_CUDA_CALL( cudaMallocManaged(&ptr, size, cudaMemAttachGlobal) );
 #endif
    //HYPRE_CUDA_CALL( cudaMemAdvise(ptr, size, cudaMemAdviseSetPreferredLocation,
@@ -212,10 +213,10 @@ hypre_HostPinnedMalloc(size_t size, HYPRE_Int zeroinit)
 {
    void *ptr = NULL;
 
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
 #if defined(HYPRE_USING_UMPIRE_PINNED)
    hypre_umpire_pinned_pooled_allocate(&ptr, size);
-#else
+#elif defined(HYPRE_USING_CUDA)
    HYPRE_CUDA_CALL( cudaMallocHost(&ptr, size) );
 #endif
 
@@ -305,12 +306,12 @@ hypre_DeviceFree(void *ptr)
 static inline void
 hypre_UnifiedFree(void *ptr)
 {
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
 #ifdef HYPRE_USING_CUB_ALLOCATOR
    HYPRE_CUDA_CALL( hypre_CachingFreeManaged(ptr) );
 #elif defined(HYPRE_USING_UMPIRE_UM)
    hypre_umpire_um_pooled_free(ptr);
-#else
+#elif defined(HYPRE_USING_CUDA)
    HYPRE_CUDA_CALL( cudaFree(ptr) );
 #endif
 #endif
@@ -319,10 +320,10 @@ hypre_UnifiedFree(void *ptr)
 static inline void
 hypre_HostPinnedFree(void *ptr)
 {
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
 #if defined(HYPRE_USING_UMPIRE_PINNED)
    hypre_umpire_pinned_pooled_free(ptr);
-#else
+#elif defined(HYPRE_USING_CUDA)
    HYPRE_CUDA_CALL( cudaFreeHost(ptr) );
 #endif
 #endif
@@ -503,7 +504,7 @@ hypre_GetExecPolicy1_core(hypre_MemoryLocation location)
          exec = HYPRE_EXEC_DEVICE;
          break;
       case hypre_MEMORY_UNIFIED :
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
          exec = hypre_HandleDefaultExecPolicy(hypre_handle());
 #endif
          break;
@@ -550,7 +551,7 @@ hypre_GetExecPolicy2_core(hypre_MemoryLocation location1,
 
    if (location1 == hypre_MEMORY_UNIFIED && location2 == hypre_MEMORY_UNIFIED)
    {
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_GPU)
       exec = hypre_HandleDefaultExecPolicy(hypre_handle());
 #endif
    }
@@ -757,9 +758,11 @@ hypre_GetPointerLocation(const void *ptr, hypre_MemoryLocation *memory_location)
 {
    HYPRE_Int ierr = 0;
 
+#if defined(HYPRE_USING_GPU)
+   *memory_location = hypre_MEMORY_UNDEFINED;
+
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
    struct cudaPointerAttributes attr;
-   *memory_location = hypre_MEMORY_UNDEFINED;
 
 #if (CUDART_VERSION >= 10000)
 #if (CUDART_VERSION >= 11000)
@@ -815,9 +818,10 @@ hypre_GetPointerLocation(const void *ptr, hypre_MemoryLocation *memory_location)
    {
       *memory_location = hypre_MEMORY_HOST_PINNED;
    }
-#endif
+#endif // CUDART_VERSION >= 10000
+#endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 
-#else /* #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP) */
+#else /* #if defined(HYPRE_USING_GPU) */
    *memory_location = hypre_MEMORY_HOST;
 #endif
 
@@ -1389,4 +1393,3 @@ hypre_umpire_pinned_pooled_free(void *ptr)
    return hypre_error_flag;
 }
 #endif
-

--- a/src/utilities/hypre_umpire_allocator.h
+++ b/src/utilities/hypre_umpire_allocator.h
@@ -8,7 +8,7 @@
 #ifndef HYPRE_UMPIRE_ALLOCATOR_H
 #define HYPRE_UMPIRE_ALLOCATOR_H
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #if defined(HYPRE_USING_UMPIRE_DEVICE)
 
 /*
@@ -50,7 +50,6 @@ struct hypre_umpire_device_allocator
 };
 
 #endif /* #ifdef HYPRE_USING_UMPIRE_DEVICE */
-#endif /* #if defined(HYPRE_USING_CUDA) */
+#endif /* #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */
 
 #endif
-


### PR DESCRIPTION
This PR is the next step in HIP support, arguably the primary step. 

This adds the HIP path for many of the APIs in HYPRE. It does *not* add support for libraries other than Thrust (since it's header-only). The strategy was to mimic what was done for CUDA, namely use `HYPRE_USING_HIP` judiciously and then add supporting HIP APIs adjacent to the CUDA counterparts. 

I've tried to keep each of the commits small in order to facilitate ease of reading of each individual commit. Of course, this leads to many commits in the PR. Towards the end of this PR, starting roughly at 0b54652aa, is just turning on the compiler passes to HIP, i.e. adding `|| defined(HYPRE_USING_HIP)` alongside the `#if defined(HYPRE_USING_CUDA)` and similar. Everything before that commit hash is adding actual calls to the HIP APIs, so those probably warrant more careful examination.

This compiles with ROCm4.0/AMD GPUs using `./configure --with-hip=yes --without-MPI --enable-rocrand=no --enable-rocsparse=no --enable-rocblas=no`. I've not made a compiling pass with MPI yet nor has this PR been tested on AMD GPUs (I don't know what tests I could run that didn't require SpMV), but I wanted to get this going for review and possibly merge. I also checked that I didn't break compilation with CUDA 10.2 on V100. I built the `ij` test and ran it on V100, using `./ij -n 96 96 96 -pmis -keepT 1 -rlx 18 -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 1 -interptype 6 -solver 1 -agg_nl 0` without unified memory enable and `./ij -n 96 96 96 -pmis -keepT 1 -rlx 18 -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 1 -interptype 6 -solver 1 -agg_nl 1` with unified memory enabled, but nothing more than that.

My plan is to next add rocSPARSE support (rocSPARSE is the AMD sparse matrix library, analogous to cuSPARSE) and then test with MPI and then test using the AMG benchmark. rocRAND and rocBLAS support will be easy after that. rocTX support (analog with nvtx) also needs to be added, but will require some discussion.

Note that this will almost certainly conflict #296.