### PR TITLE
More HIP Support

### DIFF
--- a/src/config/Makefile.config.in
+++ b/src/config/Makefile.config.in
@@ -87,10 +87,10 @@ AR     = @AR@
 RANLIB = @RANLIB@
 
 LDFLAGS = @LDFLAGS@
-LIBS    = @LIBS@ ${CALIPER_LIBS} ${HYPRE_CUDA_LIBS} ${HYPRE_RAJA_LIB_DIR} ${HYPRE_RAJA_LIB} ${HYPRE_KOKKOS_LIB_DIR} ${HYPRE_KOKKOS_LIB} ${HYPRE_UMPIRE_LIB_DIR} ${HYPRE_UMPIRE_LIB}
+LIBS    = @LIBS@ ${CALIPER_LIBS} ${HYPRE_CUDA_LIBS} ${HYPRE_HIP_LIBS} ${HYPRE_RAJA_LIB_DIR} ${HYPRE_RAJA_LIB} ${HYPRE_KOKKOS_LIB_DIR} ${HYPRE_KOKKOS_LIB} ${HYPRE_UMPIRE_LIB_DIR} ${HYPRE_UMPIRE_LIB}
 FLIBS   = @FLIBS@
 
-INCLUDES = ${CALIPER_INCLUDE} ${HYPRE_CUDA_INCLUDE} ${HYPRE_RAJA_INCLUDE} ${HYPRE_KOKKOS_INCLUDE} ${HYPRE_UMPIRE_INCLUDE} ${HYPRE_NAP_INCLUDE}
+INCLUDES = ${CALIPER_INCLUDE} ${HYPRE_CUDA_INCLUDE} ${HYPRE_HIP_INCLUDE} ${HYPRE_RAJA_INCLUDE} ${HYPRE_KOKKOS_INCLUDE} ${HYPRE_UMPIRE_INCLUDE} ${HYPRE_NAP_INCLUDE}
 
 ##################################################################
 ##  LAPACK Library Flags
@@ -122,6 +122,12 @@ HYPRE_NAP_INCLUDE = @HYPRE_NAP_INCLUDE@
 ##################################################################
 HYPRE_CUDA_INCLUDE = @HYPRE_CUDA_INCLUDE@
 HYPRE_CUDA_LIBS = @HYPRE_CUDA_LIBS@
+
+##################################################################
+##  HIP options
+##################################################################
+HYPRE_HIP_INCLUDE=@HYPRE_HIP_INCL@
+HYPRE_HIP_LIBS=@HYPRE_HIP_LIBS@
 
 ##################################################################
 ##  Caliper options

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -2216,7 +2216,12 @@ dnl                          LINK_F77="${F77} -brtl"
    FFLAGS="${FFLAGS} ${SHARED_COMPILE_FLAG}"
    CFLAGS="${CFLAGS} ${SHARED_COMPILE_FLAG}"
    CXXFLAGS="${CXXFLAGS} ${SHARED_COMPILE_FLAG}"
-   CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
+   if [test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes"]; then
+      CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
+   fi
+   if [test "x$hypre_using_hip" = "xyes"]; then
+      CUFLAGS="${CUFLAGS} ${SHARED_COMPILE_FLAG}"
+   fi
 dnl   BUILD_F77_SHARED="${F77} ${SHARED_BUILD_FLAG}"
    BUILD_FC_SHARED="${FC} ${SHARED_BUILD_FLAG}"
    if test "$hypre_using_fei" = "yes"

--- a/src/configure
+++ b/src/configure
@@ -9053,7 +9053,12 @@ then
    FFLAGS="${FFLAGS} ${SHARED_COMPILE_FLAG}"
    CFLAGS="${CFLAGS} ${SHARED_COMPILE_FLAG}"
    CXXFLAGS="${CXXFLAGS} ${SHARED_COMPILE_FLAG}"
-   CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
+   if test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes"; then
+      CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
+   fi
+   if test "x$hypre_using_hip" = "xyes"; then
+      CUFLAGS="${CUFLAGS} ${SHARED_COMPILE_FLAG}"
+   fi
    BUILD_FC_SHARED="${FC} ${SHARED_BUILD_FLAG}"
    if test "$hypre_using_fei" = "yes"
    then

--- a/src/parcsr_ls/par_coarsen_device.c
+++ b/src/parcsr_ls/par_coarsen_device.c
@@ -261,7 +261,9 @@ hypreCUDAKernel_PMISCoarseningInit(HYPRE_Int   nrows,
    if (CF_init == 1)
    {
       // TODO
+#if !defined(HYPRE_USING_HIP)
       assert(0);
+#endif
    }
    else
    {
@@ -389,7 +391,7 @@ hypreCUDAKernel_PMISCoarseningUpdateCF(HYPRE_Int   graph_diag_size,
    }
    else
    {
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
       assert(marker_row == 0);
 #endif
       /*-------------------------------------------------

--- a/src/parcsr_ls/par_interp_device.c
+++ b/src/parcsr_ls/par_interp_device.c
@@ -661,7 +661,9 @@ hypre_BoomerAMGBuildDirInterp_getcoef( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
+#if !defined(HYPRE_USING_HIP)
    assert(k == q_diag_P);
+#endif
 
    /* offd part */
    HYPRE_Int p_offd_A, q_offd_A, p_offd_P, q_offd_P;
@@ -725,7 +727,9 @@ hypre_BoomerAMGBuildDirInterp_getcoef( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
+#if !defined(HYPRE_USING_HIP)
    assert(k == q_offd_P);
+#endif
 
    diagonal  = warp_allreduce_sum(diagonal);
    sum_N_pos = warp_allreduce_sum(sum_N_pos);
@@ -921,7 +925,9 @@ hypre_BoomerAMGBuildDirInterp_getcoef_v2( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
+#if !defined(HYPRE_USING_HIP)
    assert(k == q_diag_P);
+#endif
 
    /* offd part */
    HYPRE_Int p_offd_A, q_offd_A, p_offd_P, q_offd_P;
@@ -977,7 +983,9 @@ hypre_BoomerAMGBuildDirInterp_getcoef_v2( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
+#if !defined(HYPRE_USING_HIP)
    assert(k == q_offd_P);
+#endif
 
    diagonal  = warp_allreduce_sum(diagonal);
    sum_F     = warp_allreduce_sum(sum_F);

--- a/src/seq_mv/csr_spgemm_device_attempt.c
+++ b/src/seq_mv/csr_spgemm_device_attempt.c
@@ -192,7 +192,7 @@ csr_spmm_attempt(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
    __shared__ volatile char s_failed[NUM_WARPS_PER_BLOCK];
    volatile char *warp_s_failed = s_failed + warp_id;
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
    assert(NUM_WARPS_PER_BLOCK <= HYPRE_WARP_SIZE);
@@ -250,7 +250,7 @@ csr_spmm_attempt(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
                                                           ghash_size, jg + istart_g, ag + istart_g,
                                                           failed, warp_s_failed);
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
       if (attempt == 2)
       {
          assert(failed == 0);
@@ -358,7 +358,7 @@ copy_from_hash_into_C(HYPRE_Int  M,   HYPRE_Int *js,  HYPRE_Complex *as,
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
@@ -410,7 +410,7 @@ copy_from_hash_into_C(HYPRE_Int  M,   HYPRE_Int *js,  HYPRE_Complex *as,
          (lane_id, js + i * SHMEM_HASH_SIZE, as + i * SHMEM_HASH_SIZE, g2_size, jg2 + istart_g2,
          ag2 + istart_g2, jc + istart_c, ac + istart_c);
       }
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG)  && !defined(HYPRE_USING_HIP)
       assert(istart_c + j == iend_c);
 #endif
    }

--- a/src/seq_mv/csr_spgemm_device_confident.c
+++ b/src/seq_mv/csr_spgemm_device_confident.c
@@ -128,7 +128,7 @@ csr_spmm_compute_row_numer(HYPRE_Int  rowi,
                pos = hash_insert_numer<HashType, FAILED_SYMBL>
                      (g_HashSize, g_HashKeys, g_HashVals, k_idx, k_val, num_new_insert);
             }
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
             assert(pos != -1);
 #endif
          }
@@ -214,7 +214,7 @@ csr_spmm_numeric(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
    volatile HYPRE_Int  *warp_s_HashKeys = s_HashKeys + warp_id * SHMEM_HASH_SIZE;
    volatile HYPRE_Complex *warp_s_HashVals = s_HashVals + warp_id * SHMEM_HASH_SIZE;
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
@@ -289,7 +289,7 @@ csr_spmm_numeric(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
              (lane_id, warp_s_HashKeys, warp_s_HashVals, ghash_size, jg + istart_g,
               ag + istart_g, jc + istart_c, ac + istart_c);
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
       if (FAILED_SYMBL)
       {
          assert(istart_c + j <= iend_c);
@@ -315,7 +315,7 @@ copy_from_Cext_into_C(HYPRE_Int  M,
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
@@ -334,7 +334,7 @@ copy_from_Cext_into_C(HYPRE_Int  M,
       HYPRE_Int istart_c = __shfl_sync(HYPRE_WARP_FULL_MASK, kc, 0);
       HYPRE_Int iend_c   = __shfl_sync(HYPRE_WARP_FULL_MASK, kc, 1);
       HYPRE_Int istart_x = __shfl_sync(HYPRE_WARP_FULL_MASK, kx, 0);
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
       HYPRE_Int iend_x   = __shfl_sync(HYPRE_WARP_FULL_MASK, kx, 1);
       assert(iend_c - istart_c <= iend_x - istart_x);
 #endif

--- a/src/seq_mv/csr_spgemm_device_rowbound.c
+++ b/src/seq_mv/csr_spgemm_device_rowbound.c
@@ -151,7 +151,7 @@ void csr_spmm_symbolic(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
 
    char failed = 0;
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
    assert(NUM_WARPS_PER_BLOCK <= HYPRE_WARP_SIZE);
@@ -205,7 +205,7 @@ void csr_spmm_symbolic(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
                                                SHMEM_HASH_SIZE, warp_s_HashKeys,
                                                ghash_size, jg + istart_g, failed);
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
       if (ATTEMPT == 2)
       {
          assert(failed == 0);

--- a/src/seq_mv/csr_spgemm_device_rowest.c
+++ b/src/seq_mv/csr_spgemm_device_rowest.c
@@ -65,7 +65,7 @@ void csr_spmm_rownnz_naive(HYPRE_Int M, /*HYPRE_Int K,*/ HYPRE_Int N, HYPRE_Int 
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
@@ -112,7 +112,7 @@ void expdistfromuniform(HYPRE_Int n, float *x)
    const HYPRE_Int global_thread_id  = blockIdx.x * get_block_size() + get_thread_id();
    const HYPRE_Int total_num_threads = gridDim.x  * get_block_size();
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
@@ -138,7 +138,7 @@ void cohen_rowest_kernel(HYPRE_Int nrow, HYPRE_Int *rowptr, HYPRE_Int *colidx, T
    volatile HYPRE_Int  *warp_s_col = s_col + warp_id * SHMEM_SIZE_PER_WARP;
 #endif
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
    assert(sizeof(T) == sizeof(float));
@@ -205,7 +205,7 @@ void cohen_rowest_kernel(HYPRE_Int nrow, HYPRE_Int *rowptr, HYPRE_Int *colidx, T
                HYPRE_Int colk = __shfl_sync(HYPRE_WARP_FULL_MASK, col, k);
                if (colk == -1)
                {
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
                   assert(j + HYPRE_WARP_SIZE >= iend);
 #endif
                   break;

--- a/src/seq_mv/csr_spgemm_device_util.c
+++ b/src/seq_mv/csr_spgemm_device_util.c
@@ -8,18 +8,19 @@
 #include "seq_mv.h"
 #include "csr_spgemm_device.h"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 /* assume d_i is of length (m+1) and contains the "sizes" in d_i[1], ..., d_i[m]
    the value of d_i[0] is not assumed
  */
 void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_i, HYPRE_Int **d_j, HYPRE_Complex **d_a, HYPRE_Int *nnz)
 {
-   cudaMemset(d_i, 0, sizeof(HYPRE_Int));
+   hypre_Memset(d_i, 0, sizeof(HYPRE_Int), HYPRE_MEMORY_DEVICE);
+
    /* make ghash pointers by prefix scan */
    HYPRE_THRUST_CALL(inclusive_scan, d_i, d_i + m + 1, d_i);
    /* total size */
-   cudaMemcpy(nnz, d_i + m, sizeof(HYPRE_Int), cudaMemcpyDeviceToHost);
+   hypre_Memcpy(nnz, d_i + m, sizeof(HYPRE_Int), HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
    if (d_j)
    {
       *d_j = hypre_TAlloc(HYPRE_Int, *nnz, HYPRE_MEMORY_DEVICE);
@@ -34,11 +35,14 @@ void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_i, HYPRE_Int **d_j, HYPRE_Com
 void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_c, HYPRE_Int **d_i, HYPRE_Int **d_j, HYPRE_Complex **d_a, HYPRE_Int *nnz)
 {
    *d_i = hypre_TAlloc(HYPRE_Int, m+1, HYPRE_MEMORY_DEVICE);
-   cudaMemset(*d_i, 0, sizeof(HYPRE_Int));
+   hypre_Memset(d_i, 0, sizeof(HYPRE_Int), HYPRE_MEMORY_DEVICE);
+
    /* make ghash pointers by prefix scan */
    HYPRE_THRUST_CALL(inclusive_scan, d_c, d_c + m, *d_i + 1);
+
    /* total size */
-   cudaMemcpy(nnz, (*d_i) + m, sizeof(HYPRE_Int), cudaMemcpyDeviceToHost);
+   hypre_Memcpy(nnz, (*d_i) + m, sizeof(HYPRE_Int), HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+
    if (d_j)
    {
       *d_j = hypre_TAlloc(HYPRE_Int, *nnz, HYPRE_MEMORY_DEVICE);
@@ -107,7 +111,7 @@ csr_spmm_create_hash_table(HYPRE_Int m, HYPRE_Int *d_rc, HYPRE_Int *d_rf, HYPRE_
    }
    else
    {
-      cudaMemset(*d_ghash_i, 0, (num_ghash + 1) * sizeof(HYPRE_Int));
+      hypre_Memset(*d_ghash_i, 0, (num_ghash + 1) * sizeof(HYPRE_Int), HYPRE_MEMORY_DEVICE);
       HYPRE_CUDA_LAUNCH( csr_spmm_get_ghash_size, gDim, bDim, m, num_ghash, d_rc, d_rf, (*d_ghash_i) + 1, SHMEM_HASH_SIZE );
    }
 
@@ -116,4 +120,4 @@ csr_spmm_create_hash_table(HYPRE_Int m, HYPRE_Int *d_rc, HYPRE_Int *d_rf, HYPRE_
    return hypre_error_flag;
 }
 
-#endif /* HYPRE_USING_CUDA */
+#endif /* defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP) */

--- a/src/seq_mv/csr_spgemm_device_util.c
+++ b/src/seq_mv/csr_spgemm_device_util.c
@@ -56,7 +56,7 @@ void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_c, HYPRE_Int **d_i, HYPRE_Int
 __global__
 void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_Int *rg, HYPRE_Int SHMEM_HASH_SIZE)
 {
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
@@ -73,7 +73,7 @@ void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_In
 __global__
 void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int num_ghash, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_Int *rg, HYPRE_Int SHMEM_HASH_SIZE)
 {
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 

--- a/src/struct_mv/struct_vector.c
+++ b/src/struct_mv/struct_vector.c
@@ -66,7 +66,7 @@ hypre_StructVectorDestroy( hypre_StructVector *vector )
       {
          if (hypre_StructVectorDataAlloced(vector))
          {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
             hypre_StructGrid     *grid = hypre_StructVectorGrid(vector);
             if (hypre_StructGridDataLocation(grid) != HYPRE_MEMORY_HOST)
             {
@@ -195,7 +195,7 @@ hypre_StructVectorInitialize( hypre_StructVector *vector )
    HYPRE_Complex *data;
 
    hypre_StructVectorInitializeShell(vector);
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_StructGrid     *grid = hypre_StructVectorGrid(vector);
    if (hypre_StructGridDataLocation(grid) != HYPRE_MEMORY_HOST)
    {
@@ -617,7 +617,7 @@ hypre_StructVectorSetDataSize(hypre_StructVector *vector,
 			      HYPRE_Int          *data_size,
 			      HYPRE_Int          *data_host_size)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_StructGrid     *grid = hypre_StructVectorGrid(vector);
    if (hypre_StructGridDataLocation(grid) != HYPRE_MEMORY_HOST)
    {
@@ -1219,5 +1219,3 @@ hypre_StructVectorClone(
 
    return y;
 }
-
-

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -139,7 +139,7 @@ endif
 
 # C
 
-ij: ij.o
+ij: ij.${OBJ_SUFFIX}
 	@echo  "Building" $@ "... "
 	${LINK_CC} -o $@ $< ${LFLAGS}
 

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -28,9 +28,7 @@
 #include "HYPRE_krylov.h"
 
 #if defined(HYPRE_USING_GPU)
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <cuda_profiler_api.h>
+#include "_hypre_utilities.hpp"
 #endif
 
 #if defined(HYPRE_USING_UMPIRE)
@@ -3254,7 +3252,7 @@ main( hypre_int argc,
       }
 
 #if defined(HYPRE_USING_GPU)
-      cudaDeviceSynchronize();
+      hypre_SyncCudaDevice(hypre_handle());
 #endif
 
       hypre_EndTiming(time_index);
@@ -3586,7 +3584,7 @@ main( hypre_int argc,
 #endif
 
 #if defined(HYPRE_USING_GPU)
-      cudaDeviceSynchronize();
+      hypre_SyncCudaDevice(hypre_handle());
 #endif
 
       hypre_EndTiming(time_index);
@@ -3624,7 +3622,7 @@ main( hypre_int argc,
 #endif
 
 #if defined(HYPRE_USING_GPU)
-      cudaDeviceSynchronize();
+      hypre_SyncCudaDevice(hypre_handle());
 #endif
 
       hypre_EndTiming(time_index);
@@ -3685,7 +3683,7 @@ main( hypre_int argc,
 #endif
 
 #if defined(HYPRE_USING_GPU)
-      cudaDeviceSynchronize();
+      hypre_SyncCudaDevice(hypre_handle());
 #endif
 
       tt = hypre_MPI_Wtime() - tt;
@@ -3717,7 +3715,7 @@ main( hypre_int argc,
 #endif
 
 #if defined(HYPRE_USING_GPU)
-      cudaDeviceSynchronize();
+      hypre_SyncCudaDevice(hypre_handle());
 #endif
 
       tt = hypre_MPI_Wtime() - tt;
@@ -7539,8 +7537,10 @@ main( hypre_int argc,
    hypre_MPI_Finalize();
 
    /* when using cuda-memcheck --leak-check full, uncomment this */
-#if defined(HYPRE_USING_GPU)
+#if defined(HYPRE_USING_CUDA)
    cudaDeviceReset();
+#elif defined(HYPRE_USING_HIP)
+   hipDeviceReset();
 #endif
 
    return (0);

--- a/src/utilities/hypre_cuda_utils.c
+++ b/src/utilities/hypre_cuda_utils.c
@@ -8,7 +8,7 @@
 #include "_hypre_utilities.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 __global__ void
 hypreCUDAKernel_CompileFlagSafetyCheck(HYPRE_Int cuda_arch_actual)
@@ -24,6 +24,9 @@ hypreCUDAKernel_CompileFlagSafetyCheck(HYPRE_Int cuda_arch_actual)
 
 void hypre_CudaCompileFlagCheck()
 {
+  // This is really only defined for CUDA and not for HIP
+#if defined(HYPRE_USING_CUDA)
+
    HYPRE_Int device = hypre_HandleCudaDevice(hypre_handle());
 
    struct cudaDeviceProp props;
@@ -34,6 +37,8 @@ void hypre_CudaCompileFlagCheck()
    HYPRE_CUDA_LAUNCH( hypreCUDAKernel_CompileFlagSafetyCheck, gDim, bDim, cuda_arch_actual );
 
    HYPRE_CUDA_CALL(cudaDeviceSynchronize());
+
+#endif // defined(HYPRE_USING_CUDA)
 }
 
 dim3
@@ -713,7 +718,7 @@ hypreDevice_ReduceByTupleKey(HYPRE_Int N, T1 *keys1_in,  T2 *keys2_in,  T3 *vals
 
 template HYPRE_Int hypreDevice_ReduceByTupleKey(HYPRE_Int N, HYPRE_Int *keys1_in, HYPRE_Int *keys2_in, HYPRE_Complex *vals_in, HYPRE_Int *keys1_out, HYPRE_Int *keys2_out, HYPRE_Complex *vals_out);
 
-#endif // #if defined(HYPRE_USING_CUDA)
+#endif // #if defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP)
 
 #if defined(HYPRE_USING_CUSPARSE)
 /*


### PR DESCRIPTION
There were a couple of places that I missed in the first HIP pass in #297. Also I missed adding some pieces of the build system in #288. This PR takes care of those. 

Perhaps the more important thing here is the guarding of asserts in device kernels. Unfortunately, at present, asserts in device kernels behave sub-optimally and may either cause the compiler to fail (an ICE) or may produce code that behaves incorrectly.

The library itself will still compile in static mode with `--with-hip=yes`. However, building in shared mode or trying to compile the `ij` test (for example) will fail as there are a couple of missing functions. Those will be taken care of the in the (very shortly) forthcoming rocSPARSE support PR. I wanted to keep these changes separate from that.