### PR TITLE
More hip support

### DIFF
--- a/src/config/Makefile.config.in
+++ b/src/config/Makefile.config.in
@@ -87,10 +87,10 @@ AR     = @AR@
 RANLIB = @RANLIB@
 
 LDFLAGS = @LDFLAGS@
-LIBS    = @LIBS@ ${CALIPER_LIBS} ${HYPRE_CUDA_LIBS} ${HYPRE_RAJA_LIB_DIR} ${HYPRE_RAJA_LIB} ${HYPRE_KOKKOS_LIB_DIR} ${HYPRE_KOKKOS_LIB} ${HYPRE_UMPIRE_LIB_DIR} ${HYPRE_UMPIRE_LIB}
+LIBS    = @LIBS@ ${CALIPER_LIBS} ${HYPRE_CUDA_LIBS} ${HYPRE_HIP_LIBS} ${HYPRE_RAJA_LIB_DIR} ${HYPRE_RAJA_LIB} ${HYPRE_KOKKOS_LIB_DIR} ${HYPRE_KOKKOS_LIB} ${HYPRE_UMPIRE_LIB_DIR} ${HYPRE_UMPIRE_LIB}
 FLIBS   = @FLIBS@
 
-INCLUDES = ${CALIPER_INCLUDE} ${HYPRE_CUDA_INCLUDE} ${HYPRE_RAJA_INCLUDE} ${HYPRE_KOKKOS_INCLUDE} ${HYPRE_UMPIRE_INCLUDE} ${HYPRE_NAP_INCLUDE}
+INCLUDES = ${CALIPER_INCLUDE} ${HYPRE_CUDA_INCLUDE} ${HYPRE_HIP_INCLUDE} ${HYPRE_RAJA_INCLUDE} ${HYPRE_KOKKOS_INCLUDE} ${HYPRE_UMPIRE_INCLUDE} ${HYPRE_NAP_INCLUDE}
 
 ##################################################################
 ##  LAPACK Library Flags
@@ -122,6 +122,12 @@ HYPRE_NAP_INCLUDE = @HYPRE_NAP_INCLUDE@
 ##################################################################
 HYPRE_CUDA_INCLUDE = @HYPRE_CUDA_INCLUDE@
 HYPRE_CUDA_LIBS = @HYPRE_CUDA_LIBS@
+
+##################################################################
+##  HIP options
+##################################################################
+HYPRE_HIP_INCLUDE=@HYPRE_HIP_INCL@
+HYPRE_HIP_LIBS=@HYPRE_HIP_LIBS@
 
 ##################################################################
 ##  Caliper options

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -2216,7 +2216,12 @@ dnl                          LINK_F77="${F77} -brtl"
    FFLAGS="${FFLAGS} ${SHARED_COMPILE_FLAG}"
    CFLAGS="${CFLAGS} ${SHARED_COMPILE_FLAG}"
    CXXFLAGS="${CXXFLAGS} ${SHARED_COMPILE_FLAG}"
-   CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
+   if [test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes"]; then
+      CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
+   fi
+   if [test "x$hypre_using_hip" = "xyes"]; then
+      CUFLAGS="${CUFLAGS} ${SHARED_COMPILE_FLAG}"
+   fi
 dnl   BUILD_F77_SHARED="${F77} ${SHARED_BUILD_FLAG}"
    BUILD_FC_SHARED="${FC} ${SHARED_BUILD_FLAG}"
    if test "$hypre_using_fei" = "yes"

--- a/src/configure
+++ b/src/configure
@@ -9053,7 +9053,12 @@ then
    FFLAGS="${FFLAGS} ${SHARED_COMPILE_FLAG}"
    CFLAGS="${CFLAGS} ${SHARED_COMPILE_FLAG}"
    CXXFLAGS="${CXXFLAGS} ${SHARED_COMPILE_FLAG}"
-   CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
+   if test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes"; then
+      CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
+   fi
+   if test "x$hypre_using_hip" = "xyes"; then
+      CUFLAGS="${CUFLAGS} ${SHARED_COMPILE_FLAG}"
+   fi
    BUILD_FC_SHARED="${FC} ${SHARED_BUILD_FLAG}"
    if test "$hypre_using_fei" = "yes"
    then

--- a/src/parcsr_ls/par_coarsen_device.c
+++ b/src/parcsr_ls/par_coarsen_device.c
@@ -261,7 +261,9 @@ hypreCUDAKernel_PMISCoarseningInit(HYPRE_Int   nrows,
    if (CF_init == 1)
    {
       // TODO
+#if !defined(HYPRE_USING_HIP)
       assert(0);
+#endif
    }
    else
    {
@@ -389,7 +391,7 @@ hypreCUDAKernel_PMISCoarseningUpdateCF(HYPRE_Int   graph_diag_size,
    }
    else
    {
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
       assert(marker_row == 0);
 #endif
       /*-------------------------------------------------

--- a/src/parcsr_ls/par_coarsen_device.c
+++ b/src/parcsr_ls/par_coarsen_device.c
@@ -261,9 +261,7 @@ hypreCUDAKernel_PMISCoarseningInit(HYPRE_Int   nrows,
    if (CF_init == 1)
    {
       // TODO
-#if !defined(HYPRE_USING_HIP)
-      assert(0);
-#endif
+      hypre_device_assert(0);
    }
    else
    {
@@ -391,8 +389,8 @@ hypreCUDAKernel_PMISCoarseningUpdateCF(HYPRE_Int   graph_diag_size,
    }
    else
    {
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-      assert(marker_row == 0);
+#if defined(HYPRE_DEBUG)
+      hypre_device_assert(marker_row == 0);
 #endif
       /*-------------------------------------------------
        * Now treat the case where this node is not in the

--- a/src/parcsr_ls/par_coarsen_device.c
+++ b/src/parcsr_ls/par_coarsen_device.c
@@ -389,9 +389,8 @@ hypreCUDAKernel_PMISCoarseningUpdateCF(HYPRE_Int   graph_diag_size,
    }
    else
    {
-#if defined(HYPRE_DEBUG)
       hypre_device_assert(marker_row == 0);
-#endif
+
       /*-------------------------------------------------
        * Now treat the case where this node is not in the
        * independent set: loop over

--- a/src/parcsr_ls/par_ilu.c
+++ b/src/parcsr_ls/par_ilu.c
@@ -14,7 +14,6 @@
 #include "_hypre_parcsr_ls.h"
 #include "_hypre_utilities.hpp"
 #include "par_ilu.h"
-#include <assert.h>
 
 /* Create */
 void *

--- a/src/parcsr_ls/par_interp_device.c
+++ b/src/parcsr_ls/par_interp_device.c
@@ -661,9 +661,7 @@ hypre_BoomerAMGBuildDirInterp_getcoef( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
-#if !defined(HYPRE_USING_HIP)
-   assert(k == q_diag_P);
-#endif
+   hypre_device_assert(k == q_diag_P);
 
    /* offd part */
    HYPRE_Int p_offd_A, q_offd_A, p_offd_P, q_offd_P;
@@ -727,9 +725,7 @@ hypre_BoomerAMGBuildDirInterp_getcoef( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
-#if !defined(HYPRE_USING_HIP)
-   assert(k == q_offd_P);
-#endif
+   hypre_device_assert(k == q_offd_P);
 
    diagonal  = warp_allreduce_sum(diagonal);
    sum_N_pos = warp_allreduce_sum(sum_N_pos);
@@ -925,9 +921,7 @@ hypre_BoomerAMGBuildDirInterp_getcoef_v2( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
-#if !defined(HYPRE_USING_HIP)
-   assert(k == q_diag_P);
-#endif
+   hypre_device_assert(k == q_diag_P);
 
    /* offd part */
    HYPRE_Int p_offd_A, q_offd_A, p_offd_P, q_offd_P;
@@ -983,9 +977,7 @@ hypre_BoomerAMGBuildDirInterp_getcoef_v2( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
-#if !defined(HYPRE_USING_HIP)
-   assert(k == q_offd_P);
-#endif
+   hypre_device_assert(k == q_offd_P);
 
    diagonal  = warp_allreduce_sum(diagonal);
    sum_F     = warp_allreduce_sum(sum_F);

--- a/src/parcsr_ls/par_interp_device.c
+++ b/src/parcsr_ls/par_interp_device.c
@@ -661,7 +661,9 @@ hypre_BoomerAMGBuildDirInterp_getcoef( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
+#if !defined(HYPRE_USING_HIP)
    assert(k == q_diag_P);
+#endif
 
    /* offd part */
    HYPRE_Int p_offd_A, q_offd_A, p_offd_P, q_offd_P;
@@ -725,7 +727,9 @@ hypre_BoomerAMGBuildDirInterp_getcoef( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
+#if !defined(HYPRE_USING_HIP)
    assert(k == q_offd_P);
+#endif
 
    diagonal  = warp_allreduce_sum(diagonal);
    sum_N_pos = warp_allreduce_sum(sum_N_pos);
@@ -921,7 +925,9 @@ hypre_BoomerAMGBuildDirInterp_getcoef_v2( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
+#if !defined(HYPRE_USING_HIP)
    assert(k == q_diag_P);
+#endif
 
    /* offd part */
    HYPRE_Int p_offd_A, q_offd_A, p_offd_P, q_offd_P;
@@ -977,7 +983,9 @@ hypre_BoomerAMGBuildDirInterp_getcoef_v2( HYPRE_Int   nr_of_rows,
       k += sum;
    }
 
+#if !defined(HYPRE_USING_HIP)
    assert(k == q_offd_P);
+#endif
 
    diagonal  = warp_allreduce_sum(diagonal);
    sum_F     = warp_allreduce_sum(sum_F);

--- a/src/parcsr_ls/par_mgr.c
+++ b/src/parcsr_ls/par_mgr.c
@@ -2006,7 +2006,7 @@ hypre_MGRComputeNonGalerkinCoarseGrid(hypre_ParCSRMatrix    *A,
   for (i = 0; i < n_local_fine_grid; i++)
   {
     HYPRE_Int point_type = CF_marker[i];
-    assert(point_type == 1 || point_type == -1);
+    hypre_assert(point_type == 1 || point_type == -1);
     c_marker[i] = point_type;
     f_marker[i] = -point_type;
   }

--- a/src/parcsr_mv/par_csr_triplemat_device.c
+++ b/src/parcsr_mv/par_csr_triplemat_device.c
@@ -486,9 +486,7 @@ hypre_ParCSRTMatMatKTDevice( hypre_ParCSRMatrix  *A,
                     HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
    }
 
-#ifdef HYPRE_DEBUG
    hypre_assert(!hypre_CSRMatrixCheckDiagFirstDevice(hypre_ParCSRMatrixDiag(C)));
-#endif
 
    hypre_SyncCudaComputeStream(hypre_handle());
 
@@ -802,9 +800,7 @@ hypre_ParCSRMatrixRAPKTDevice( hypre_ParCSRMatrix *R,
                     HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
    }
 
-#ifdef HYPRE_DEBUG
    hypre_assert(!hypre_CSRMatrixCheckDiagFirstDevice(hypre_ParCSRMatrixDiag(C)));
-#endif
 
    hypre_SyncCudaComputeStream(hypre_handle());
 

--- a/src/seq_mv/csr_matrix_cuda_utils.c
+++ b/src/seq_mv/csr_matrix_cuda_utils.c
@@ -37,10 +37,10 @@ hypre_CSRMatrixToCusparseSpMat_core( HYPRE_Int      n,
    cusparseSpMatDescr_t matA;
 
    /*
-   assert( (hypre_CSRMatrixNumRows(A) - offset != 0) &&
-           (hypre_CSRMatrixNumCols(A) != 0) &&
-           (hypre_CSRMatrixNumNonzeros(A) != 0) &&
-           "Matrix has no nonzeros");
+   hypre_assert( (hypre_CSRMatrixNumRows(A) - offset != 0) &&
+                 (hypre_CSRMatrixNumCols(A) != 0) &&
+                 (hypre_CSRMatrixNumNonzeros(A) != 0) &&
+                 "Matrix has no nonzeros");
    */
 
    HYPRE_CUSPARSE_CALL( cusparseCreateCsr(&matA,

--- a/src/seq_mv/csr_spgemm_device_attempt.c
+++ b/src/seq_mv/csr_spgemm_device_attempt.c
@@ -192,10 +192,10 @@ csr_spmm_attempt(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
    __shared__ volatile char s_failed[NUM_WARPS_PER_BLOCK];
    volatile char *warp_s_failed = s_failed + warp_id;
 
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-   assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
-   assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
-   assert(NUM_WARPS_PER_BLOCK <= HYPRE_WARP_SIZE);
+#if defined(HYPRE_DEBUG)
+   hypre_device_assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
+   hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
+   hypre_device_assert(NUM_WARPS_PER_BLOCK <= HYPRE_WARP_SIZE);
 #endif
 
    for (HYPRE_Int i = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
@@ -250,10 +250,10 @@ csr_spmm_attempt(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
                                                           ghash_size, jg + istart_g, ag + istart_g,
                                                           failed, warp_s_failed);
 
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
+#if defined(HYPRE_DEBUG)
       if (attempt == 2)
       {
-         assert(failed == 0);
+         hypre_device_assert(failed == 0);
       }
 #endif
 
@@ -358,8 +358,8 @@ copy_from_hash_into_C(HYPRE_Int  M,   HYPRE_Int *js,  HYPRE_Complex *as,
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-   assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
+#if defined(HYPRE_DEBUG)
+   hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
    for (HYPRE_Int i = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
@@ -410,8 +410,8 @@ copy_from_hash_into_C(HYPRE_Int  M,   HYPRE_Int *js,  HYPRE_Complex *as,
          (lane_id, js + i * SHMEM_HASH_SIZE, as + i * SHMEM_HASH_SIZE, g2_size, jg2 + istart_g2,
          ag2 + istart_g2, jc + istart_c, ac + istart_c);
       }
-#if defined(HYPRE_DEBUG)  && !defined(HYPRE_USING_HIP)
-      assert(istart_c + j == iend_c);
+#if defined(HYPRE_DEBUG)
+      hypre_device_assert(istart_c + j == iend_c);
 #endif
    }
 }

--- a/src/seq_mv/csr_spgemm_device_attempt.c
+++ b/src/seq_mv/csr_spgemm_device_attempt.c
@@ -192,7 +192,7 @@ csr_spmm_attempt(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
    __shared__ volatile char s_failed[NUM_WARPS_PER_BLOCK];
    volatile char *warp_s_failed = s_failed + warp_id;
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
    assert(NUM_WARPS_PER_BLOCK <= HYPRE_WARP_SIZE);
@@ -250,7 +250,7 @@ csr_spmm_attempt(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
                                                           ghash_size, jg + istart_g, ag + istart_g,
                                                           failed, warp_s_failed);
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
       if (attempt == 2)
       {
          assert(failed == 0);
@@ -358,7 +358,7 @@ copy_from_hash_into_C(HYPRE_Int  M,   HYPRE_Int *js,  HYPRE_Complex *as,
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
@@ -410,7 +410,7 @@ copy_from_hash_into_C(HYPRE_Int  M,   HYPRE_Int *js,  HYPRE_Complex *as,
          (lane_id, js + i * SHMEM_HASH_SIZE, as + i * SHMEM_HASH_SIZE, g2_size, jg2 + istart_g2,
          ag2 + istart_g2, jc + istart_c, ac + istart_c);
       }
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG)  && !defined(HYPRE_USING_HIP)
       assert(istart_c + j == iend_c);
 #endif
    }

--- a/src/seq_mv/csr_spgemm_device_attempt.c
+++ b/src/seq_mv/csr_spgemm_device_attempt.c
@@ -192,11 +192,9 @@ csr_spmm_attempt(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
    __shared__ volatile char s_failed[NUM_WARPS_PER_BLOCK];
    volatile char *warp_s_failed = s_failed + warp_id;
 
-#if defined(HYPRE_DEBUG)
    hypre_device_assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
    hypre_device_assert(NUM_WARPS_PER_BLOCK <= HYPRE_WARP_SIZE);
-#endif
 
    for (HYPRE_Int i = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
             i < M;
@@ -358,9 +356,7 @@ copy_from_hash_into_C(HYPRE_Int  M,   HYPRE_Int *js,  HYPRE_Complex *as,
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#if defined(HYPRE_DEBUG)
    hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
-#endif
 
    for (HYPRE_Int i = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
             i < M;

--- a/src/seq_mv/csr_spgemm_device_confident.c
+++ b/src/seq_mv/csr_spgemm_device_confident.c
@@ -128,7 +128,7 @@ csr_spmm_compute_row_numer(HYPRE_Int  rowi,
                pos = hash_insert_numer<HashType, FAILED_SYMBL>
                      (g_HashSize, g_HashKeys, g_HashVals, k_idx, k_val, num_new_insert);
             }
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
             assert(pos != -1);
 #endif
          }
@@ -214,7 +214,7 @@ csr_spmm_numeric(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
    volatile HYPRE_Int  *warp_s_HashKeys = s_HashKeys + warp_id * SHMEM_HASH_SIZE;
    volatile HYPRE_Complex *warp_s_HashVals = s_HashVals + warp_id * SHMEM_HASH_SIZE;
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
@@ -289,7 +289,7 @@ csr_spmm_numeric(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
              (lane_id, warp_s_HashKeys, warp_s_HashVals, ghash_size, jg + istart_g,
               ag + istart_g, jc + istart_c, ac + istart_c);
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
       if (FAILED_SYMBL)
       {
          assert(istart_c + j <= iend_c);
@@ -315,7 +315,7 @@ copy_from_Cext_into_C(HYPRE_Int  M,
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
@@ -334,7 +334,7 @@ copy_from_Cext_into_C(HYPRE_Int  M,
       HYPRE_Int istart_c = __shfl_sync(HYPRE_WARP_FULL_MASK, kc, 0);
       HYPRE_Int iend_c   = __shfl_sync(HYPRE_WARP_FULL_MASK, kc, 1);
       HYPRE_Int istart_x = __shfl_sync(HYPRE_WARP_FULL_MASK, kx, 0);
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
       HYPRE_Int iend_x   = __shfl_sync(HYPRE_WARP_FULL_MASK, kx, 1);
       assert(iend_c - istart_c <= iend_x - istart_x);
 #endif

--- a/src/seq_mv/csr_spgemm_device_confident.c
+++ b/src/seq_mv/csr_spgemm_device_confident.c
@@ -128,9 +128,8 @@ csr_spmm_compute_row_numer(HYPRE_Int  rowi,
                pos = hash_insert_numer<HashType, FAILED_SYMBL>
                      (g_HashSize, g_HashKeys, g_HashVals, k_idx, k_val, num_new_insert);
             }
-#if defined(HYPRE_DEBUG)
+
             hypre_device_assert(pos != -1);
-#endif
          }
       }
    }
@@ -214,10 +213,8 @@ csr_spmm_numeric(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
    volatile HYPRE_Int  *warp_s_HashKeys = s_HashKeys + warp_id * SHMEM_HASH_SIZE;
    volatile HYPRE_Complex *warp_s_HashVals = s_HashVals + warp_id * SHMEM_HASH_SIZE;
 
-#if defined(HYPRE_DEBUG)
    hypre_device_assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
-#endif
 
    /* a warp working on the ith row */
    for (HYPRE_Int i = grid_warp_id; i < M; i += num_warps)
@@ -315,9 +312,7 @@ copy_from_Cext_into_C(HYPRE_Int  M,
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#if defined(HYPRE_DEBUG)
    hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
-#endif
 
    for (HYPRE_Int i = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
             i < M;

--- a/src/seq_mv/csr_spgemm_device_confident.c
+++ b/src/seq_mv/csr_spgemm_device_confident.c
@@ -128,8 +128,8 @@ csr_spmm_compute_row_numer(HYPRE_Int  rowi,
                pos = hash_insert_numer<HashType, FAILED_SYMBL>
                      (g_HashSize, g_HashKeys, g_HashVals, k_idx, k_val, num_new_insert);
             }
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-            assert(pos != -1);
+#if defined(HYPRE_DEBUG)
+            hypre_device_assert(pos != -1);
 #endif
          }
       }
@@ -214,9 +214,9 @@ csr_spmm_numeric(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
    volatile HYPRE_Int  *warp_s_HashKeys = s_HashKeys + warp_id * SHMEM_HASH_SIZE;
    volatile HYPRE_Complex *warp_s_HashVals = s_HashVals + warp_id * SHMEM_HASH_SIZE;
 
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-   assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
-   assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
+#if defined(HYPRE_DEBUG)
+   hypre_device_assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
+   hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
    /* a warp working on the ith row */
@@ -289,14 +289,14 @@ csr_spmm_numeric(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
              (lane_id, warp_s_HashKeys, warp_s_HashVals, ghash_size, jg + istart_g,
               ag + istart_g, jc + istart_c, ac + istart_c);
 
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
+#if defined(HYPRE_DEBUG)
       if (FAILED_SYMBL)
       {
-         assert(istart_c + j <= iend_c);
+         hypre_device_assert(istart_c + j <= iend_c);
       }
       else
       {
-         assert(istart_c + j == iend_c);
+         hypre_device_assert(istart_c + j == iend_c);
       }
 #endif
    }
@@ -315,8 +315,8 @@ copy_from_Cext_into_C(HYPRE_Int  M,
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-   assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
+#if defined(HYPRE_DEBUG)
+   hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
    for (HYPRE_Int i = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
@@ -334,9 +334,9 @@ copy_from_Cext_into_C(HYPRE_Int  M,
       HYPRE_Int istart_c = __shfl_sync(HYPRE_WARP_FULL_MASK, kc, 0);
       HYPRE_Int iend_c   = __shfl_sync(HYPRE_WARP_FULL_MASK, kc, 1);
       HYPRE_Int istart_x = __shfl_sync(HYPRE_WARP_FULL_MASK, kx, 0);
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
+#if defined(HYPRE_DEBUG)
       HYPRE_Int iend_x   = __shfl_sync(HYPRE_WARP_FULL_MASK, kx, 1);
-      assert(iend_c - istart_c <= iend_x - istart_x);
+      hypre_device_assert(iend_c - istart_c <= iend_x - istart_x);
 #endif
 
       HYPRE_Int p = istart_x - istart_c;

--- a/src/seq_mv/csr_spgemm_device_rowbound.c
+++ b/src/seq_mv/csr_spgemm_device_rowbound.c
@@ -151,7 +151,7 @@ void csr_spmm_symbolic(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
 
    char failed = 0;
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
    assert(NUM_WARPS_PER_BLOCK <= HYPRE_WARP_SIZE);
@@ -205,7 +205,7 @@ void csr_spmm_symbolic(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
                                                SHMEM_HASH_SIZE, warp_s_HashKeys,
                                                ghash_size, jg + istart_g, failed);
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
       if (ATTEMPT == 2)
       {
          assert(failed == 0);

--- a/src/seq_mv/csr_spgemm_device_rowbound.c
+++ b/src/seq_mv/csr_spgemm_device_rowbound.c
@@ -151,11 +151,9 @@ void csr_spmm_symbolic(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
 
    char failed = 0;
 
-#if defined(HYPRE_DEBUG)
    hypre_device_assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
    hypre_device_assert(NUM_WARPS_PER_BLOCK <= HYPRE_WARP_SIZE);
-#endif
 
    for (HYPRE_Int i = grid_warp_id; i < M; i += num_warps)
    {
@@ -343,9 +341,7 @@ hypreDevice_CSRSpGemmRownnz(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n,
    {
       gpu_csr_spmm_rownnz_attempt<2> (m, k, n, d_ia, d_ja, d_ib, d_jb, d_rc, d_rf);
 
-#ifdef HYPRE_DEBUG
       hypre_assert(hypreDevice_IntegerReduceSum(m, d_rf) == 0);
-#endif
    }
 
    hypre_TFree(d_rf, HYPRE_MEMORY_DEVICE);

--- a/src/seq_mv/csr_spgemm_device_rowbound.c
+++ b/src/seq_mv/csr_spgemm_device_rowbound.c
@@ -151,10 +151,10 @@ void csr_spmm_symbolic(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
 
    char failed = 0;
 
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-   assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
-   assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
-   assert(NUM_WARPS_PER_BLOCK <= HYPRE_WARP_SIZE);
+#if defined(HYPRE_DEBUG)
+   hypre_device_assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
+   hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
+   hypre_device_assert(NUM_WARPS_PER_BLOCK <= HYPRE_WARP_SIZE);
 #endif
 
    for (HYPRE_Int i = grid_warp_id; i < M; i += num_warps)
@@ -205,10 +205,10 @@ void csr_spmm_symbolic(HYPRE_Int  M, /* HYPRE_Int K, HYPRE_Int N, */
                                                SHMEM_HASH_SIZE, warp_s_HashKeys,
                                                ghash_size, jg + istart_g, failed);
 
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
+#if defined(HYPRE_DEBUG)
       if (ATTEMPT == 2)
       {
-         assert(failed == 0);
+         hypre_device_assert(failed == 0);
       }
 #endif
 

--- a/src/seq_mv/csr_spgemm_device_rowest.c
+++ b/src/seq_mv/csr_spgemm_device_rowest.c
@@ -65,9 +65,7 @@ void csr_spmm_rownnz_naive(HYPRE_Int M, /*HYPRE_Int K,*/ HYPRE_Int N, HYPRE_Int 
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#if defined(HYPRE_DEBUG)
    hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
-#endif
 
    for (HYPRE_Int i = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
             i < M;
@@ -112,9 +110,7 @@ void expdistfromuniform(HYPRE_Int n, float *x)
    const HYPRE_Int global_thread_id  = blockIdx.x * get_block_size() + get_thread_id();
    const HYPRE_Int total_num_threads = gridDim.x  * get_block_size();
 
-#if defined(HYPRE_DEBUG)
    hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
-#endif
 
    for (HYPRE_Int i = global_thread_id; i < n; i += total_num_threads)
    {
@@ -138,11 +134,9 @@ void cohen_rowest_kernel(HYPRE_Int nrow, HYPRE_Int *rowptr, HYPRE_Int *colidx, T
    volatile HYPRE_Int  *warp_s_col = s_col + warp_id * SHMEM_SIZE_PER_WARP;
 #endif
 
-#if defined(HYPRE_DEBUG)
    hypre_device_assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
    hypre_device_assert(sizeof(T) == sizeof(float));
-#endif
 
    for (HYPRE_Int i = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
             i < nrow;
@@ -205,9 +199,8 @@ void cohen_rowest_kernel(HYPRE_Int nrow, HYPRE_Int *rowptr, HYPRE_Int *colidx, T
                HYPRE_Int colk = __shfl_sync(HYPRE_WARP_FULL_MASK, col, k);
                if (colk == -1)
                {
-#if defined(HYPRE_DEBUG)
                   hypre_device_assert(j + HYPRE_WARP_SIZE >= iend);
-#endif
+
                   break;
                }
                if (r + lane_id < nsamples)

--- a/src/seq_mv/csr_spgemm_device_rowest.c
+++ b/src/seq_mv/csr_spgemm_device_rowest.c
@@ -65,7 +65,7 @@ void csr_spmm_rownnz_naive(HYPRE_Int M, /*HYPRE_Int K,*/ HYPRE_Int N, HYPRE_Int 
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
@@ -112,7 +112,7 @@ void expdistfromuniform(HYPRE_Int n, float *x)
    const HYPRE_Int global_thread_id  = blockIdx.x * get_block_size() + get_thread_id();
    const HYPRE_Int total_num_threads = gridDim.x  * get_block_size();
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
@@ -138,7 +138,7 @@ void cohen_rowest_kernel(HYPRE_Int nrow, HYPRE_Int *rowptr, HYPRE_Int *colidx, T
    volatile HYPRE_Int  *warp_s_col = s_col + warp_id * SHMEM_SIZE_PER_WARP;
 #endif
 
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
    assert(sizeof(T) == sizeof(float));
@@ -205,7 +205,7 @@ void cohen_rowest_kernel(HYPRE_Int nrow, HYPRE_Int *rowptr, HYPRE_Int *colidx, T
                HYPRE_Int colk = __shfl_sync(HYPRE_WARP_FULL_MASK, col, k);
                if (colk == -1)
                {
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
                   assert(j + HYPRE_WARP_SIZE >= iend);
 #endif
                   break;

--- a/src/seq_mv/csr_spgemm_device_rowest.c
+++ b/src/seq_mv/csr_spgemm_device_rowest.c
@@ -65,8 +65,8 @@ void csr_spmm_rownnz_naive(HYPRE_Int M, /*HYPRE_Int K,*/ HYPRE_Int N, HYPRE_Int 
    /* lane id inside the warp */
    volatile const HYPRE_Int lane_id = get_lane_id();
 
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-   assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
+#if defined(HYPRE_DEBUG)
+   hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
    for (HYPRE_Int i = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
@@ -112,8 +112,8 @@ void expdistfromuniform(HYPRE_Int n, float *x)
    const HYPRE_Int global_thread_id  = blockIdx.x * get_block_size() + get_thread_id();
    const HYPRE_Int total_num_threads = gridDim.x  * get_block_size();
 
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-   assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
+#if defined(HYPRE_DEBUG)
+   hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
    for (HYPRE_Int i = global_thread_id; i < n; i += total_num_threads)
@@ -138,10 +138,10 @@ void cohen_rowest_kernel(HYPRE_Int nrow, HYPRE_Int *rowptr, HYPRE_Int *colidx, T
    volatile HYPRE_Int  *warp_s_col = s_col + warp_id * SHMEM_SIZE_PER_WARP;
 #endif
 
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-   assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
-   assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
-   assert(sizeof(T) == sizeof(float));
+#if defined(HYPRE_DEBUG)
+   hypre_device_assert(blockDim.z              == NUM_WARPS_PER_BLOCK);
+   hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
+   hypre_device_assert(sizeof(T) == sizeof(float));
 #endif
 
    for (HYPRE_Int i = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
@@ -205,8 +205,8 @@ void cohen_rowest_kernel(HYPRE_Int nrow, HYPRE_Int *rowptr, HYPRE_Int *colidx, T
                HYPRE_Int colk = __shfl_sync(HYPRE_WARP_FULL_MASK, col, k);
                if (colk == -1)
                {
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-                  assert(j + HYPRE_WARP_SIZE >= iend);
+#if defined(HYPRE_DEBUG)
+                  hypre_device_assert(j + HYPRE_WARP_SIZE >= iend);
 #endif
                   break;
                }

--- a/src/seq_mv/csr_spgemm_device_util.c
+++ b/src/seq_mv/csr_spgemm_device_util.c
@@ -8,18 +8,19 @@
 #include "seq_mv.h"
 #include "csr_spgemm_device.h"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 /* assume d_i is of length (m+1) and contains the "sizes" in d_i[1], ..., d_i[m]
    the value of d_i[0] is not assumed
  */
 void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_i, HYPRE_Int **d_j, HYPRE_Complex **d_a, HYPRE_Int *nnz)
 {
-   cudaMemset(d_i, 0, sizeof(HYPRE_Int));
+   hypre_Memset(d_i, 0, sizeof(HYPRE_Int), HYPRE_MEMORY_DEVICE);
+
    /* make ghash pointers by prefix scan */
    HYPRE_THRUST_CALL(inclusive_scan, d_i, d_i + m + 1, d_i);
    /* total size */
-   cudaMemcpy(nnz, d_i + m, sizeof(HYPRE_Int), cudaMemcpyDeviceToHost);
+   hypre_Memcpy(nnz, d_i + m, sizeof(HYPRE_Int), HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
    if (d_j)
    {
       *d_j = hypre_TAlloc(HYPRE_Int, *nnz, HYPRE_MEMORY_DEVICE);
@@ -34,11 +35,14 @@ void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_i, HYPRE_Int **d_j, HYPRE_Com
 void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_c, HYPRE_Int **d_i, HYPRE_Int **d_j, HYPRE_Complex **d_a, HYPRE_Int *nnz)
 {
    *d_i = hypre_TAlloc(HYPRE_Int, m+1, HYPRE_MEMORY_DEVICE);
-   cudaMemset(*d_i, 0, sizeof(HYPRE_Int));
+   hypre_Memset(d_i, 0, sizeof(HYPRE_Int), HYPRE_MEMORY_DEVICE);
+
    /* make ghash pointers by prefix scan */
    HYPRE_THRUST_CALL(inclusive_scan, d_c, d_c + m, *d_i + 1);
+
    /* total size */
-   cudaMemcpy(nnz, (*d_i) + m, sizeof(HYPRE_Int), cudaMemcpyDeviceToHost);
+   hypre_Memcpy(nnz, (*d_i) + m, sizeof(HYPRE_Int), HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+
    if (d_j)
    {
       *d_j = hypre_TAlloc(HYPRE_Int, *nnz, HYPRE_MEMORY_DEVICE);
@@ -107,7 +111,7 @@ csr_spmm_create_hash_table(HYPRE_Int m, HYPRE_Int *d_rc, HYPRE_Int *d_rf, HYPRE_
    }
    else
    {
-      cudaMemset(*d_ghash_i, 0, (num_ghash + 1) * sizeof(HYPRE_Int));
+      hypre_Memset(*d_ghash_i, 0, (num_ghash + 1) * sizeof(HYPRE_Int), HYPRE_MEMORY_DEVICE);
       HYPRE_CUDA_LAUNCH( csr_spmm_get_ghash_size, gDim, bDim, m, num_ghash, d_rc, d_rf, (*d_ghash_i) + 1, SHMEM_HASH_SIZE );
    }
 
@@ -116,4 +120,4 @@ csr_spmm_create_hash_table(HYPRE_Int m, HYPRE_Int *d_rc, HYPRE_Int *d_rf, HYPRE_
    return hypre_error_flag;
 }
 
-#endif /* HYPRE_USING_CUDA */
+#endif /* defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP) */

--- a/src/seq_mv/csr_spgemm_device_util.c
+++ b/src/seq_mv/csr_spgemm_device_util.c
@@ -20,7 +20,7 @@ void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_i, HYPRE_Int **d_j, HYPRE_Com
    /* make ghash pointers by prefix scan */
    HYPRE_THRUST_CALL(inclusive_scan, d_i, d_i + m + 1, d_i);
    /* total size */
-   hypre_Memcpy(nnz, d_i + m, sizeof(HYPRE_Int), HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+   hypre_TMemcpy(nnz, d_i + m, HYPRE_Int, 1, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
    if (d_j)
    {
       *d_j = hypre_TAlloc(HYPRE_Int, *nnz, HYPRE_MEMORY_DEVICE);
@@ -41,7 +41,7 @@ void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_c, HYPRE_Int **d_i, HYPRE_Int
    HYPRE_THRUST_CALL(inclusive_scan, d_c, d_c + m, *d_i + 1);
 
    /* total size */
-   hypre_Memcpy(nnz, (*d_i) + m, sizeof(HYPRE_Int), HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+   hypre_TMemcpy(nnz, (*d_i) + m, HYPRE_Int, 1, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
 
    if (d_j)
    {

--- a/src/seq_mv/csr_spgemm_device_util.c
+++ b/src/seq_mv/csr_spgemm_device_util.c
@@ -56,8 +56,8 @@ void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_c, HYPRE_Int **d_i, HYPRE_Int
 __global__
 void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_Int *rg, HYPRE_Int SHMEM_HASH_SIZE)
 {
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-   assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
+#if defined(HYPRE_DEBUG)
+   hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
    const HYPRE_Int global_thread_id  = blockIdx.x * get_block_size() + get_thread_id();
@@ -73,8 +73,8 @@ void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_In
 __global__
 void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int num_ghash, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_Int *rg, HYPRE_Int SHMEM_HASH_SIZE)
 {
-#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
-   assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
+#if defined(HYPRE_DEBUG)
+   hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
    const HYPRE_Int global_thread_id  = blockIdx.x * get_block_size() + get_thread_id();

--- a/src/seq_mv/csr_spgemm_device_util.c
+++ b/src/seq_mv/csr_spgemm_device_util.c
@@ -35,7 +35,7 @@ void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_i, HYPRE_Int **d_j, HYPRE_Com
 void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_c, HYPRE_Int **d_i, HYPRE_Int **d_j, HYPRE_Complex **d_a, HYPRE_Int *nnz)
 {
    *d_i = hypre_TAlloc(HYPRE_Int, m+1, HYPRE_MEMORY_DEVICE);
-   hypre_Memset(d_i, 0, sizeof(HYPRE_Int), HYPRE_MEMORY_DEVICE);
+   hypre_Memset(*d_i, 0, sizeof(HYPRE_Int), HYPRE_MEMORY_DEVICE);
 
    /* make ghash pointers by prefix scan */
    HYPRE_THRUST_CALL(inclusive_scan, d_c, d_c + m, *d_i + 1);

--- a/src/seq_mv/csr_spgemm_device_util.c
+++ b/src/seq_mv/csr_spgemm_device_util.c
@@ -56,7 +56,7 @@ void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_c, HYPRE_Int **d_i, HYPRE_Int
 __global__
 void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_Int *rg, HYPRE_Int SHMEM_HASH_SIZE)
 {
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 
@@ -73,7 +73,7 @@ void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_In
 __global__
 void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int num_ghash, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_Int *rg, HYPRE_Int SHMEM_HASH_SIZE)
 {
-#ifdef HYPRE_DEBUG
+#if defined(HYPRE_DEBUG) && !defined(HYPRE_USING_HIP)
    assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
 #endif
 

--- a/src/seq_mv/csr_spgemm_device_util.c
+++ b/src/seq_mv/csr_spgemm_device_util.c
@@ -56,9 +56,7 @@ void csr_spmm_create_ija(HYPRE_Int m, HYPRE_Int *d_c, HYPRE_Int **d_i, HYPRE_Int
 __global__
 void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_Int *rg, HYPRE_Int SHMEM_HASH_SIZE)
 {
-#if defined(HYPRE_DEBUG)
    hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
-#endif
 
    const HYPRE_Int global_thread_id  = blockIdx.x * get_block_size() + get_thread_id();
    const HYPRE_Int total_num_threads = gridDim.x  * get_block_size();
@@ -73,9 +71,7 @@ void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_In
 __global__
 void csr_spmm_get_ghash_size(HYPRE_Int n, HYPRE_Int num_ghash, HYPRE_Int *rc, HYPRE_Int *rf, HYPRE_Int *rg, HYPRE_Int SHMEM_HASH_SIZE)
 {
-#if defined(HYPRE_DEBUG)
    hypre_device_assert(blockDim.x * blockDim.y == HYPRE_WARP_SIZE);
-#endif
 
    const HYPRE_Int global_thread_id  = blockIdx.x * get_block_size() + get_thread_id();
    const HYPRE_Int total_num_threads = gridDim.x  * get_block_size();

--- a/src/struct_mv/struct_vector.c
+++ b/src/struct_mv/struct_vector.c
@@ -66,7 +66,7 @@ hypre_StructVectorDestroy( hypre_StructVector *vector )
       {
          if (hypre_StructVectorDataAlloced(vector))
          {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
             hypre_StructGrid     *grid = hypre_StructVectorGrid(vector);
             if (hypre_StructGridDataLocation(grid) != HYPRE_MEMORY_HOST)
             {
@@ -195,7 +195,7 @@ hypre_StructVectorInitialize( hypre_StructVector *vector )
    HYPRE_Complex *data;
 
    hypre_StructVectorInitializeShell(vector);
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_StructGrid     *grid = hypre_StructVectorGrid(vector);
    if (hypre_StructGridDataLocation(grid) != HYPRE_MEMORY_HOST)
    {
@@ -617,7 +617,7 @@ hypre_StructVectorSetDataSize(hypre_StructVector *vector,
 			      HYPRE_Int          *data_size,
 			      HYPRE_Int          *data_host_size)
 {
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_StructGrid     *grid = hypre_StructVectorGrid(vector);
    if (hypre_StructGridDataLocation(grid) != HYPRE_MEMORY_HOST)
    {
@@ -1219,5 +1219,3 @@ hypre_StructVectorClone(
 
    return y;
 }
-
-

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -139,7 +139,7 @@ endif
 
 # C
 
-ij: ij.o
+ij: ij.${OBJ_SUFFIX}
 	@echo  "Building" $@ "... "
 	${LINK_CC} -o $@ $< ${LFLAGS}
 

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -28,9 +28,7 @@
 #include "HYPRE_krylov.h"
 
 #if defined(HYPRE_USING_GPU)
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <cuda_profiler_api.h>
+#include "_hypre_utilities.hpp"
 #endif
 
 #if defined(HYPRE_USING_UMPIRE)
@@ -3254,7 +3252,7 @@ main( hypre_int argc,
       }
 
 #if defined(HYPRE_USING_GPU)
-      cudaDeviceSynchronize();
+      hypre_SyncCudaDevice(hypre_handle());
 #endif
 
       hypre_EndTiming(time_index);
@@ -3586,7 +3584,7 @@ main( hypre_int argc,
 #endif
 
 #if defined(HYPRE_USING_GPU)
-      cudaDeviceSynchronize();
+      hypre_SyncCudaDevice(hypre_handle());
 #endif
 
       hypre_EndTiming(time_index);
@@ -3624,7 +3622,7 @@ main( hypre_int argc,
 #endif
 
 #if defined(HYPRE_USING_GPU)
-      cudaDeviceSynchronize();
+      hypre_SyncCudaDevice(hypre_handle());
 #endif
 
       hypre_EndTiming(time_index);
@@ -3685,7 +3683,7 @@ main( hypre_int argc,
 #endif
 
 #if defined(HYPRE_USING_GPU)
-      cudaDeviceSynchronize();
+      hypre_SyncCudaDevice(hypre_handle());
 #endif
 
       tt = hypre_MPI_Wtime() - tt;
@@ -3717,7 +3715,7 @@ main( hypre_int argc,
 #endif
 
 #if defined(HYPRE_USING_GPU)
-      cudaDeviceSynchronize();
+      hypre_SyncCudaDevice(hypre_handle());
 #endif
 
       tt = hypre_MPI_Wtime() - tt;
@@ -7539,8 +7537,10 @@ main( hypre_int argc,
    hypre_MPI_Finalize();
 
    /* when using cuda-memcheck --leak-check full, uncomment this */
-#if defined(HYPRE_USING_GPU)
+#if defined(HYPRE_USING_CUDA)
    cudaDeviceReset();
+#elif defined(HYPRE_USING_HIP)
+   hipDeviceReset();
 #endif
 
    return (0);

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -125,15 +125,19 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
 #define hypre_error_w_msg(IERR, msg)  hypre_error_handler(__FILE__, __LINE__, IERR, msg)
 #define hypre_error_in_arg(IARG)  hypre_error(HYPRE_ERROR_ARG | IARG<<3)
 
-#ifdef HYPRE_DEBUG
-#define hypre_assert(EX) do { if (!(EX)) { hypre_fprintf(stderr, "[%s, %d] hypre_assert failed: %s\n", __FILE__, __LINE__, #EX); hypre_error(1); assert(EX); } } while (0)
-#else
-#ifdef __cplusplus
-/*extern "C++" { template<class T> static inline void hypre_assert( const T& ) { } }*/
-#define hypre_assert(EX) do { static_cast<void> (EX); } while (0)
-#else
-#define hypre_assert(EX) do { (void) (EX); } while (0)
+#if defined(HYPRE_DEBUG)
+/* host assert */
+#define hypre_assert(EX) do { if (!(EX)) { hypre_fprintf(stderr, "[%s, %d] hypre_assert failed: %s\n", __FILE__, __LINE__, #EX); hypre_error(1); assert(0); } } while (0)
+/* device assert */
+#if defined(HYPRE_USING_CUDA)
+#define hypre_device_assert(EX) assert(EX)
+#elif defined(HYPRE_USING_HIP)
+/* FIXME: Currently, asserts in device kernels in HIP do not behave well */
+#define hypre_device_assert(EX)
 #endif
+#else /* #ifdef HYPRE_DEBUG */
+#define hypre_assert(EX)
+#define hypre_device_assert(EX)
 #endif
 
 #endif /* hypre_ERROR_HEADER */

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -136,7 +136,12 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
 #define hypre_device_assert(EX)
 #endif
 #else /* #ifdef HYPRE_DEBUG */
-#define hypre_assert(EX)
+/* this is to silence compiler's unused variable warnings */
+#ifdef __cplusplus
+#define hypre_assert(EX) do { if (0) { static_cast<void> (EX); } } while (0)
+#else
+#define hypre_assert(EX) do { if (0) { (void) (EX); } } while (0)
+#endif
 #define hypre_device_assert(EX)
 #endif
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -151,6 +151,15 @@ struct hypre_umpire_device_allocator
       assert(0); exit(1);                                                                    \
    } } while(0)
 
+
+// Currently, asserts in device kernels in HIP
+// do not behave well.
+#if defined(HYPRE_USING_CUDA)
+#define hypre_device_assert(EX) assert(EX)
+#elif defined(HYPRE_USING_HIP)
+#define hypre_device_assert(EX)
+#endif
+
 struct hypre_cub_CachingDeviceAllocator;
 typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator;
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -113,16 +113,16 @@ struct hypre_umpire_device_allocator
    if (cudaSuccess != err) {                                                                 \
       hypre_printf("CUDA ERROR (code = %d, %s) at %s:%d\n", err, cudaGetErrorString(err),    \
                    __FILE__, __LINE__);                                                      \
-      assert(0); exit(1);                                                                    \
+      hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
 #elif defined(HYPRE_USING_HIP)
 #define HYPRE_HIP_CALL(call) do {                                                           \
    hipError_t err = call;                                                                   \
    if (hipSuccess != err) {                                                                 \
-      hypre_printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),    \
+      hypre_printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),     \
                    __FILE__, __LINE__);                                                     \
-      assert(0); exit(1);                                                                   \
+      hypre_assert(0); exit(1);                                                             \
    } } while(0)
 
 #endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
@@ -132,7 +132,7 @@ struct hypre_umpire_device_allocator
    if (CUBLAS_STATUS_SUCCESS != err) {                                                       \
       hypre_printf("CUBLAS ERROR (code = %d, %d) at %s:%d\n",                                \
             err, err == CUBLAS_STATUS_EXECUTION_FAILED, __FILE__, __LINE__);                 \
-      assert(0); exit(1);                                                                    \
+      hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
 #define HYPRE_CUSPARSE_CALL(call) do {                                                       \
@@ -140,7 +140,7 @@ struct hypre_umpire_device_allocator
    if (CUSPARSE_STATUS_SUCCESS != err) {                                                     \
       hypre_printf("CUSPARSE ERROR (code = %d, %s) at %s:%d\n",                              \
             err, cusparseGetErrorString(err), __FILE__, __LINE__);                           \
-      assert(0); exit(1);                                                                    \
+      hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
 
@@ -148,17 +148,8 @@ struct hypre_umpire_device_allocator
    curandStatus_t err = call;                                                                \
    if (CURAND_STATUS_SUCCESS != err) {                                                       \
       hypre_printf("CURAND ERROR (code = %d) at %s:%d\n", err, __FILE__, __LINE__);          \
-      assert(0); exit(1);                                                                    \
+      hypre_assert(0); exit(1);                                                              \
    } } while(0)
-
-
-// Currently, asserts in device kernels in HIP
-// do not behave well.
-#if defined(HYPRE_USING_CUDA)
-#define hypre_device_assert(EX) assert(EX)
-#elif defined(HYPRE_USING_HIP)
-#define hypre_device_assert(EX)
-#endif
 
 struct hypre_cub_CachingDeviceAllocator;
 typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator;

--- a/src/utilities/hypre_cuda_utils.c
+++ b/src/utilities/hypre_cuda_utils.c
@@ -17,7 +17,7 @@ hypreCUDAKernel_CompileFlagSafetyCheck(HYPRE_Int cuda_arch_actual)
    if (cuda_arch_actual != __CUDA_ARCH__)
    {
       printf("ERROR: Compile arch flags %d does not match actual device arch = sm_%d\n", __CUDA_ARCH__, cuda_arch_actual);
-      assert(0);
+      hypre_device_assert(0);
    }
 #endif
 }

--- a/src/utilities/hypre_cuda_utils.c
+++ b/src/utilities/hypre_cuda_utils.c
@@ -8,7 +8,7 @@
 #include "_hypre_utilities.h"
 #include "_hypre_utilities.hpp"
 
-#if defined(HYPRE_USING_CUDA)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 __global__ void
 hypreCUDAKernel_CompileFlagSafetyCheck(HYPRE_Int cuda_arch_actual)
@@ -24,6 +24,9 @@ hypreCUDAKernel_CompileFlagSafetyCheck(HYPRE_Int cuda_arch_actual)
 
 void hypre_CudaCompileFlagCheck()
 {
+  // This is really only defined for CUDA and not for HIP
+#if defined(HYPRE_USING_CUDA)
+
    HYPRE_Int device = hypre_HandleCudaDevice(hypre_handle());
 
    struct cudaDeviceProp props;
@@ -34,6 +37,8 @@ void hypre_CudaCompileFlagCheck()
    HYPRE_CUDA_LAUNCH( hypreCUDAKernel_CompileFlagSafetyCheck, gDim, bDim, cuda_arch_actual );
 
    HYPRE_CUDA_CALL(cudaDeviceSynchronize());
+
+#endif // defined(HYPRE_USING_CUDA)
 }
 
 dim3
@@ -713,7 +718,7 @@ hypreDevice_ReduceByTupleKey(HYPRE_Int N, T1 *keys1_in,  T2 *keys2_in,  T3 *vals
 
 template HYPRE_Int hypreDevice_ReduceByTupleKey(HYPRE_Int N, HYPRE_Int *keys1_in, HYPRE_Int *keys2_in, HYPRE_Complex *vals_in, HYPRE_Int *keys1_out, HYPRE_Int *keys2_out, HYPRE_Complex *vals_out);
 
-#endif // #if defined(HYPRE_USING_CUDA)
+#endif // #if defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP)
 
 #if defined(HYPRE_USING_CUSPARSE)
 /*

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -86,6 +86,15 @@
       assert(0); exit(1);                                                                    \
    } } while(0)
 
+
+// Currently, asserts in device kernels in HIP
+// do not behave well.
+#if defined(HYPRE_USING_CUDA)
+#define hypre_device_assert(EX) assert(EX)
+#elif defined(HYPRE_USING_HIP)
+#define hypre_device_assert(EX)
+#endif
+
 struct hypre_cub_CachingDeviceAllocator;
 typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator;
 

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -48,16 +48,16 @@
    if (cudaSuccess != err) {                                                                 \
       hypre_printf("CUDA ERROR (code = %d, %s) at %s:%d\n", err, cudaGetErrorString(err),    \
                    __FILE__, __LINE__);                                                      \
-      assert(0); exit(1);                                                                    \
+      hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
 #elif defined(HYPRE_USING_HIP)
 #define HYPRE_HIP_CALL(call) do {                                                           \
    hipError_t err = call;                                                                   \
    if (hipSuccess != err) {                                                                 \
-      hypre_printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),    \
+      hypre_printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),     \
                    __FILE__, __LINE__);                                                     \
-      assert(0); exit(1);                                                                   \
+      hypre_assert(0); exit(1);                                                             \
    } } while(0)
 
 #endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
@@ -67,7 +67,7 @@
    if (CUBLAS_STATUS_SUCCESS != err) {                                                       \
       hypre_printf("CUBLAS ERROR (code = %d, %d) at %s:%d\n",                                \
             err, err == CUBLAS_STATUS_EXECUTION_FAILED, __FILE__, __LINE__);                 \
-      assert(0); exit(1);                                                                    \
+      hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
 #define HYPRE_CUSPARSE_CALL(call) do {                                                       \
@@ -75,7 +75,7 @@
    if (CUSPARSE_STATUS_SUCCESS != err) {                                                     \
       hypre_printf("CUSPARSE ERROR (code = %d, %s) at %s:%d\n",                              \
             err, cusparseGetErrorString(err), __FILE__, __LINE__);                           \
-      assert(0); exit(1);                                                                    \
+      hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
 
@@ -83,17 +83,8 @@
    curandStatus_t err = call;                                                                \
    if (CURAND_STATUS_SUCCESS != err) {                                                       \
       hypre_printf("CURAND ERROR (code = %d) at %s:%d\n", err, __FILE__, __LINE__);          \
-      assert(0); exit(1);                                                                    \
+      hypre_assert(0); exit(1);                                                              \
    } } while(0)
-
-
-// Currently, asserts in device kernels in HIP
-// do not behave well.
-#if defined(HYPRE_USING_CUDA)
-#define hypre_device_assert(EX) assert(EX)
-#elif defined(HYPRE_USING_HIP)
-#define hypre_device_assert(EX)
-#endif
 
 struct hypre_cub_CachingDeviceAllocator;
 typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator;

--- a/src/utilities/hypre_error.h
+++ b/src/utilities/hypre_error.h
@@ -27,15 +27,19 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
 #define hypre_error_w_msg(IERR, msg)  hypre_error_handler(__FILE__, __LINE__, IERR, msg)
 #define hypre_error_in_arg(IARG)  hypre_error(HYPRE_ERROR_ARG | IARG<<3)
 
-#ifdef HYPRE_DEBUG
-#define hypre_assert(EX) do { if (!(EX)) { hypre_fprintf(stderr, "[%s, %d] hypre_assert failed: %s\n", __FILE__, __LINE__, #EX); hypre_error(1); assert(EX); } } while (0)
-#else
-#ifdef __cplusplus
-/*extern "C++" { template<class T> static inline void hypre_assert( const T& ) { } }*/
-#define hypre_assert(EX) do { static_cast<void> (EX); } while (0)
-#else
-#define hypre_assert(EX) do { (void) (EX); } while (0)
+#if defined(HYPRE_DEBUG)
+/* host assert */
+#define hypre_assert(EX) do { if (!(EX)) { hypre_fprintf(stderr, "[%s, %d] hypre_assert failed: %s\n", __FILE__, __LINE__, #EX); hypre_error(1); assert(0); } } while (0)
+/* device assert */
+#if defined(HYPRE_USING_CUDA)
+#define hypre_device_assert(EX) assert(EX)
+#elif defined(HYPRE_USING_HIP)
+/* FIXME: Currently, asserts in device kernels in HIP do not behave well */
+#define hypre_device_assert(EX)
 #endif
+#else /* #ifdef HYPRE_DEBUG */
+#define hypre_assert(EX)
+#define hypre_device_assert(EX)
 #endif
 
 #endif /* hypre_ERROR_HEADER */

--- a/src/utilities/hypre_error.h
+++ b/src/utilities/hypre_error.h
@@ -38,7 +38,12 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
 #define hypre_device_assert(EX)
 #endif
 #else /* #ifdef HYPRE_DEBUG */
-#define hypre_assert(EX)
+/* this is to silence compiler's unused variable warnings */
+#ifdef __cplusplus
+#define hypre_assert(EX) do { if (0) { static_cast<void> (EX); } } while (0)
+#else
+#define hypre_assert(EX) do { if (0) { (void) (EX); } } while (0)
+#endif
 #define hypre_device_assert(EX)
 #endif
 

--- a/src/utilities/hypre_memory.c
+++ b/src/utilities/hypre_memory.c
@@ -1069,15 +1069,6 @@ hypre_MemoryTrackerInsert(const char           *action,
    /* -1 is the initial value */
    entry->_pair = (size_t) -1;
 
-   /*
-   HYPRE_Int myid;
-   hypre_MPI_Comm_rank(hypre_MPI_COMM_WORLD, &myid);
-   if (myid == 0 && tracker->actual_size == 3655)
-   {
-      assert(0);
-   }
-   */
-
    tracker->actual_size ++;
 }
 


### PR DESCRIPTION
By @pbauman #301 

There were a couple of places that I missed in the first HIP pass in #297. Also I missed adding some pieces of the build system in #288. This PR takes care of those. 

Perhaps the more important thing here is the guarding of asserts in device kernels. Unfortunately, at present, asserts in device kernels behave sub-optimally and may either cause the compiler to fail (an ICE) or may produce code that behaves incorrectly.

The library itself will still compile in static mode with `--with-hip=yes`. However, building in shared mode or trying to compile the `ij` test (for example) will fail as there are a couple of missing functions. Those will be taken care of the in the (very shortly) forthcoming rocSPARSE support PR. I wanted to keep these changes separate from that.