### PR TITLE
Roc sparse

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -2042,14 +2042,17 @@ AS_IF([test x"$hypre_user_chose_hip" == x"yes"],
         LINK_CC=${HIPCC}
         LINK_CXX=${HIPCC}
 
-        dnl At least -O2, but the user can override with CFLAGS/CXXFLAGS on the configure line.
         dnl The "-x hip" is necessary to override the detection of .c files which clang
         dnl interprets as C and therefore invokes the C compiler rather than the HIP part
         dnl of clang.
-        HIPCXXFLAGS="-O2 -x hip -Wall"
+        HIPCXXFLAGS="-x hip"
 
+        dnl If not in debug mode, at least -O2, but the user can override with
+        dnl CFLAGS/CXXFLAGS on the configure line. If in debug mode, -O0 -Wall
+        dnl plus flags for debugging symbols
         AS_IF([test x"$hypre_using_debug" == x"yes"],
-              [HIPCXXFLAGS="-g -ggdb ${HIPCXXFLAGS}"])
+              [HIPCXXFLAGS="-O0 -Wall -g -ggdb ${HIPCXXFLAGS}"],
+              [HIPCXXFLAGS="-O2 ${HIPCXXFLAGS}"],)
 
         dnl (Ab)Use CUFLAGS to capture HIP compilation flags
         dnl Put CXXFLAGS at the end so the user can override the optimization level.

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -2044,19 +2044,20 @@ AS_IF([test x"$hypre_user_chose_hip" == x"yes"],
 
         dnl The "-x hip" is necessary to override the detection of .c files which clang
         dnl interprets as C and therefore invokes the C compiler rather than the HIP part
-        dnl of clang.
-        HIPCXXFLAGS="-x hip"
+        dnl of clang. Put HIPCXXFLAGS at the end so the user can override from
+        dnl from the configure line.
+        HIPCXXFLAGS="-x hip ${HIPCXXFLAGS}"
 
         dnl If not in debug mode, at least -O2, but the user can override with
-        dnl CFLAGS/CXXFLAGS on the configure line. If in debug mode, -O0 -Wall
+        dnl with HIPCXXFLAGS on the configure line. If in debug mode, -O0 -Wall
         dnl plus flags for debugging symbols
         AS_IF([test x"$hypre_using_debug" == x"yes"],
               [HIPCXXFLAGS="-O0 -Wall -g -ggdb ${HIPCXXFLAGS}"],
               [HIPCXXFLAGS="-O2 ${HIPCXXFLAGS}"],)
 
         dnl (Ab)Use CUFLAGS to capture HIP compilation flags
-        dnl Put CXXFLAGS at the end so the user can override the optimization level.
-        CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS} ${CXXFLAGS}"
+        dnl Put HIPCXXFLAGS at the end so the user can override the optimization level.
+        CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS}"
 
         dnl rocThrust depends on rocPrim so we need both for Thrust on AMD GPUs.
         dnl These are header-only so no linking needed.

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -2070,7 +2070,7 @@ AS_IF([test x"$hypre_user_chose_hip" == x"yes"],
         dnl rocSPARSE, for things like dcsrmv on AMD GPUs
         AS_IF([test x"$hypre_using_rocsparse" == x"yes"],
               [AC_DEFINE(HYPRE_USING_ROCSPARSE, 1, [rocSPARSE being used])
-	       HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocsparse"
+               HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocsparse"
                HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocsparse/include"
                ])
 

--- a/src/configure
+++ b/src/configure
@@ -8876,10 +8876,12 @@ done
         LINK_CC=${HIPCC}
         LINK_CXX=${HIPCC}
 
-                                        HIPCXXFLAGS="-O2 -x hip -Wall"
+                                HIPCXXFLAGS="-x hip"
 
-        if test x"$hypre_using_debug" == x"yes"; then :
-  HIPCXXFLAGS="-g -ggdb ${HIPCXXFLAGS}"
+                                if test x"$hypre_using_debug" == x"yes"; then :
+  HIPCXXFLAGS="-O0 -Wall -g -ggdb ${HIPCXXFLAGS}"
+elif HIPCXXFLAGS="-O2 ${HIPCXXFLAGS}"; then :
+
 fi
 
                         CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS} ${CXXFLAGS}"

--- a/src/configure
+++ b/src/configure
@@ -8876,7 +8876,7 @@ done
         LINK_CC=${HIPCC}
         LINK_CXX=${HIPCC}
 
-                                HIPCXXFLAGS="-x hip"
+                                        HIPCXXFLAGS="-x hip ${HIPCXXFLAGS}"
 
                                 if test x"$hypre_using_debug" == x"yes"; then :
   HIPCXXFLAGS="-O0 -Wall -g -ggdb ${HIPCXXFLAGS}"
@@ -8884,7 +8884,7 @@ elif HIPCXXFLAGS="-O2 ${HIPCXXFLAGS}"; then :
 
 fi
 
-                        CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS} ${CXXFLAGS}"
+                        CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS}"
 
                         HYPRE_HIP_INCL="-I${HYPRE_ROCM_PREFIX}/rocthrust/include"
         HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocprim/include"

--- a/src/seq_mv/Makefile
+++ b/src/seq_mv/Makefile
@@ -45,6 +45,7 @@ CUFILES =\
  csr_spgemm_device_attempt.c\
  csr_spgemm_device_confident.c\
  csr_spgemm_device_cusparse.c\
+ csr_spgemm_device_rocsparse.c \
  csr_spgemm_device_rowbound.c\
  csr_spgemm_device_rowest.c\
  csr_spgemm_device_util.c\

--- a/src/seq_mv/csr_matop_device.c
+++ b/src/seq_mv/csr_matop_device.c
@@ -1423,6 +1423,17 @@ hypre_CSRMatrixTriLowerUpperSolveCusparse(char             uplo,
 
 
 #if defined(HYPRE_USING_ROCSPARSE)
+// FIXME: We need a stub for this function until we can implement a rocsparse version
+HYPRE_Int
+hypre_CSRMatrixTriLowerUpperSolveCusparse(char             /*uplo*/,
+                                          hypre_CSRMatrix */*A*/,
+                                          hypre_Vector    */*f*/,
+                                          hypre_Vector    */*u*/ )
+{
+  hypre_error_w_msg(HYPRE_ERROR_GENERIC, "hypre_CSRMatrixTriLowerUpperSolveCusparse not implemented for rocSPARSE!\n");
+}
+
+
 /* @brief This functions sorts values and column indices in each row in ascending order OUT-OF-PLACE
  * @param[in] n Number of rows
  * @param[in] m Number of columns

--- a/src/seq_mv/csr_matop_device.c
+++ b/src/seq_mv/csr_matop_device.c
@@ -1195,6 +1195,19 @@ hypre_CSRMatrixTransposeDevice(hypre_CSRMatrix  *A,
 
 #endif
 
+HYPRE_Int
+hypre_CSRMatrixSortRow(hypre_CSRMatrix *A)
+{
+#if defined(HYPRE_USING_CUSPARSE)
+   hypre_SortCSRCusparse(hypre_CSRMatrixNumRows(A), hypre_CSRMatrixNumCols(A), hypre_CSRMatrixNumNonzeros(A),
+                         hypre_CSRMatrixI(A), hypre_CSRMatrixJ(A), hypre_CSRMatrixData(A));
+#else
+   hypre_error_w_msg(HYPRE_ERROR_GENERIC,"hypre_CSRMatrixSortRow only implemented for cuSPARSE!\n");
+#endif
+
+   return hypre_error_flag;
+}
+
 #if defined(HYPRE_USING_CUSPARSE)
 /* @brief This functions sorts values and column indices in each row in ascending order INPLACE
  * @param[in] n Number of rows
@@ -1251,15 +1264,6 @@ hypre_SortCSRCusparse( HYPRE_Int      n,
 
    hypre_TFree(pBuffer, HYPRE_MEMORY_DEVICE);
    HYPRE_CUSPARSE_CALL(cusparseDestroyCsru2csrInfo(sortInfoA));
-}
-
-HYPRE_Int
-hypre_CSRMatrixSortRow(hypre_CSRMatrix *A)
-{
-   hypre_SortCSRCusparse(hypre_CSRMatrixNumRows(A), hypre_CSRMatrixNumCols(A), hypre_CSRMatrixNumNonzeros(A),
-                         hypre_CSRMatrixI(A), hypre_CSRMatrixJ(A), hypre_CSRMatrixData(A));
-
-   return hypre_error_flag;
 }
 
 HYPRE_Int

--- a/src/seq_mv/csr_matop_device.c
+++ b/src/seq_mv/csr_matop_device.c
@@ -1173,6 +1173,8 @@ hypre_CSRMatrixTransposeDevice(hypre_CSRMatrix  *A,
    {
 #if defined(HYPRE_USING_CUSPARSE)
      hypreDevice_CSRSpTransCusparse(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
+#elif defined(HYPRE_USING_ROCSPARSE)
+     hypreDevice_CSRSpTransRocsparse(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
 #else
      hypreDevice_CSRSpTrans(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
 #endif

--- a/src/seq_mv/csr_matop_device.c
+++ b/src/seq_mv/csr_matop_device.c
@@ -1161,11 +1161,22 @@ hypre_CSRMatrixTransposeDevice(hypre_CSRMatrix  *A,
    HYPRE_Int        *C_j;
    hypre_CSRMatrix  *C;
 
+
+   /* trivial case */
+   if (nnz_A == 0)
+   {
+      C_i =    hypre_CTAlloc(HYPRE_Int,     ncols_A + 1, HYPRE_MEMORY_DEVICE);
+      C_j =    hypre_CTAlloc(HYPRE_Int,     0,           HYPRE_MEMORY_DEVICE);
+      C_data = hypre_CTAlloc(HYPRE_Complex, 0,           HYPRE_MEMORY_DEVICE);
+   }
+   else
+   {
 #if defined(HYPRE_USING_CUSPARSE)
-   hypreDevice_CSRSpTransCusparse(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
+     hypreDevice_CSRSpTransCusparse(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
 #else
-   hypreDevice_CSRSpTrans(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
+     hypreDevice_CSRSpTrans(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
 #endif
+   }
 
    C = hypre_CSRMatrixCreate(ncols_A, nrows_A, nnz_A);
    hypre_CSRMatrixI(C) = C_i;

--- a/src/seq_mv/csr_matop_device.c
+++ b/src/seq_mv/csr_matop_device.c
@@ -77,7 +77,7 @@ hypre_CSRMatrixAddDevice ( hypre_CSRMatrix *A,
 
    if (nrows_A != nrows_B || ncols_A != ncols_B)
    {
-      hypre_error_w_msg(HYPRE_ERROR_GENERIC,"Warning! incompatible matrix dimensions!\n");
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC,"Warning! Incompatible matrix dimensions!\n");
 
       return NULL;
    }
@@ -1172,11 +1172,11 @@ hypre_CSRMatrixTransposeDevice(hypre_CSRMatrix  *A,
    else
    {
 #if defined(HYPRE_USING_CUSPARSE)
-     hypreDevice_CSRSpTransCusparse(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
+      hypreDevice_CSRSpTransCusparse(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
 #elif defined(HYPRE_USING_ROCSPARSE)
-     hypreDevice_CSRSpTransRocsparse(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
+      hypreDevice_CSRSpTransRocsparse(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
 #else
-     hypreDevice_CSRSpTrans(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
+      hypreDevice_CSRSpTrans(nrows_A, ncols_A, nnz_A, A_i, A_j, A_data, &C_i, &C_j, &C_data, data);
 #endif
    }
 
@@ -1221,12 +1221,12 @@ hypre_CSRMatrixSortRow(hypre_CSRMatrix *A)
  * @param[in,out] *d_a_sorted On Start: Unsorted values. On Return: Sorted values corresponding with column indices
  */
 void
-hypre_SortCSRCusparse( HYPRE_Int      n,
-                       HYPRE_Int      m,
-                       HYPRE_Int      nnzA,
-                 const HYPRE_Int     *d_ia,
-                       HYPRE_Int     *d_ja_sorted,
-                       HYPRE_Complex *d_a_sorted )
+hypre_SortCSRCusparse(       HYPRE_Int      n,
+                             HYPRE_Int      m,
+                             HYPRE_Int      nnzA,
+                       const HYPRE_Int     *d_ia,
+                             HYPRE_Int     *d_ja_sorted,
+                             HYPRE_Complex *d_a_sorted )
 {
    cusparseHandle_t cusparsehandle = hypre_HandleCusparseHandle(hypre_handle());
    cusparseMatDescr_t descrA = hypre_HandleCusparseMatDescr(hypre_handle());
@@ -1317,7 +1317,8 @@ hypre_CSRMatrixTriLowerUpperSolveCusparse(char             uplo,
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       hypre_CSRMatrixData(A) = A_sa;
-      HYPRE_Int err = hypre_CSRMatrixCheckDiagFirstSetValueZeroDevice(A, INFINITY);  hypre_assert(err == 0);
+      HYPRE_Int err = hypre_CSRMatrixCheckDiagFirstSetValueZeroDevice(A, INFINITY);
+      hypre_assert(err == 0);
       hypre_CSRMatrixData(A) = A_a;
 #endif
 
@@ -1425,12 +1426,12 @@ hypre_CSRMatrixTriLowerUpperSolveCusparse(char             uplo,
 #if defined(HYPRE_USING_ROCSPARSE)
 // FIXME: We need a stub for this function until we can implement a rocsparse version
 HYPRE_Int
-hypre_CSRMatrixTriLowerUpperSolveCusparse(char             /*uplo*/,
-                                          hypre_CSRMatrix */*A*/,
-                                          hypre_Vector    */*f*/,
-                                          hypre_Vector    */*u*/ )
+hypre_CSRMatrixTriLowerUpperSolveCusparse(char              /*uplo*/,
+                                          hypre_CSRMatrix * /*A*/,
+                                          hypre_Vector    * /*f*/,
+                                          hypre_Vector    * /*u*/ )
 {
-  hypre_error_w_msg(HYPRE_ERROR_GENERIC, "hypre_CSRMatrixTriLowerUpperSolveCusparse not implemented for rocSPARSE!\n");
+   hypre_error_w_msg(HYPRE_ERROR_GENERIC, "hypre_CSRMatrixTriLowerUpperSolveCusparse not implemented for rocSPARSE!\n");
 }
 
 
@@ -1443,12 +1444,12 @@ hypre_CSRMatrixTriLowerUpperSolveCusparse(char             /*uplo*/,
  * @param[in,out] *d_a_sorted On Start: Unsorted values. On Return: Sorted values corresponding with column indices
  */
 void
-hypre_SortCSRRocsparse( HYPRE_Int      n,
-                        HYPRE_Int      m,
-                        HYPRE_Int      nnzA,
-                  const HYPRE_Int     *d_ia,
-                        HYPRE_Int     *d_ja_sorted,
-                        HYPRE_Complex *d_a_sorted )
+hypre_SortCSRRocsparse(       HYPRE_Int      n,
+                              HYPRE_Int      m,
+                              HYPRE_Int      nnzA,
+                        const HYPRE_Int     *d_ia,
+                              HYPRE_Int     *d_ja_sorted,
+                              HYPRE_Complex *d_a_sorted )
 {
    rocsparse_handle handle = hypre_HandleCusparseHandle(hypre_handle());
 
@@ -1468,7 +1469,7 @@ hypre_SortCSRRocsparse( HYPRE_Int      n,
    //        a temporary copy of the data for gthr, sort that, and then copy the sorted values
    //        back to the array being returned. Where there is an in-place version available,
    //        we should use it.
-   HYPRE_Complex * d_a_tmp;
+   HYPRE_Complex *d_a_tmp;
    d_a_tmp  = hypre_TAlloc(HYPRE_Complex, nnzA, HYPRE_MEMORY_DEVICE);
 
    HYPRE_ROCSPARSE_CALL( rocsparse_csrsort_buffer_size(handle, n, m, nnzA, d_ia, d_ja_sorted, &pBufferSizeInBytes) );
@@ -1481,11 +1482,11 @@ hypre_SortCSRRocsparse( HYPRE_Int      n,
 
    if (isDoublePrecision)
    {
-     HYPRE_ROCSPARSE_CALL( rocsparse_dgthr(handle, nnzA, d_a_sorted, d_a_tmp, P, rocsparse_index_base_zero) );
+      HYPRE_ROCSPARSE_CALL( rocsparse_dgthr(handle, nnzA, d_a_sorted, d_a_tmp, P, rocsparse_index_base_zero) );
    }
    else if (isSinglePrecision)
    {
-     HYPRE_ROCSPARSE_CALL( rocsparse_sgthr(handle, nnzA, (float *) d_a_sorted, (float *) d_a_tmp, P, rocsparse_index_base_zero) );
+      HYPRE_ROCSPARSE_CALL( rocsparse_sgthr(handle, nnzA, (float *) d_a_sorted, (float *) d_a_tmp, P, rocsparse_index_base_zero) );
    }
 
    hypre_TFree(pBuffer, HYPRE_MEMORY_DEVICE);
@@ -1496,3 +1497,4 @@ hypre_SortCSRRocsparse( HYPRE_Int      n,
    hypre_TFree(d_a_tmp, HYPRE_MEMORY_DEVICE);
 }
 #endif // #if defined(HYPRE_USING_ROCSPARSE)
+

--- a/src/seq_mv/csr_matvec_device.c
+++ b/src/seq_mv/csr_matvec_device.c
@@ -304,6 +304,20 @@ hypre_CSRMatrixMatvecCusparseOldAPI( HYPRE_Int        trans,
 #endif // #if defined(HYPRE_USING_CUSPARSE)
 
 #if defined(HYPRE_USING_ROCSPARSE)
+// We need a stub for this function since it's called elsewhere
+HYPRE_Int
+hypre_CSRMatrixMatvecMaskedDevice( HYPRE_Complex    /*alpha*/,
+                                   hypre_CSRMatrix */*A*/,
+                                   hypre_Vector    */*x*/,
+                                   HYPRE_Complex    /*beta*/,
+                                   hypre_Vector    */*b*/,
+                                   hypre_Vector    */*y*/,
+                                   HYPRE_Int       */*mask*/,
+                                   HYPRE_Int        /*size_of_mask*/ )
+{
+  hypre_error_w_msg(HYPRE_ERROR_GENERIC, "hypre_CSRMatrixMatvecMaskedDevice not implemented for rocSPARSE!\n");
+}
+
 HYPRE_Int
 hypre_CSRMatrixMatvecRocsparse( HYPRE_Int        trans,
                                 HYPRE_Complex    alpha,

--- a/src/seq_mv/csr_matvec_device.c
+++ b/src/seq_mv/csr_matvec_device.c
@@ -306,16 +306,16 @@ hypre_CSRMatrixMatvecCusparseOldAPI( HYPRE_Int        trans,
 #if defined(HYPRE_USING_ROCSPARSE)
 // We need a stub for this function since it's called elsewhere
 HYPRE_Int
-hypre_CSRMatrixMatvecMaskedDevice( HYPRE_Complex    /*alpha*/,
-                                   hypre_CSRMatrix */*A*/,
-                                   hypre_Vector    */*x*/,
-                                   HYPRE_Complex    /*beta*/,
-                                   hypre_Vector    */*b*/,
-                                   hypre_Vector    */*y*/,
-                                   HYPRE_Int       */*mask*/,
-                                   HYPRE_Int        /*size_of_mask*/ )
+hypre_CSRMatrixMatvecMaskedDevice( HYPRE_Complex     /*alpha*/,
+                                   hypre_CSRMatrix * /*A*/,
+                                   hypre_Vector    * /*x*/,
+                                   HYPRE_Complex     /*beta*/,
+                                   hypre_Vector    * /*b*/,
+                                   hypre_Vector    * /*y*/,
+                                   HYPRE_Int       * /*mask*/,
+                                   HYPRE_Int         /*size_of_mask*/ )
 {
-  hypre_error_w_msg(HYPRE_ERROR_GENERIC, "hypre_CSRMatrixMatvecMaskedDevice not implemented for rocSPARSE!\n");
+   hypre_error_w_msg(HYPRE_ERROR_GENERIC, "hypre_CSRMatrixMatvecMaskedDevice not implemented for rocSPARSE!\n");
 }
 
 HYPRE_Int
@@ -327,11 +327,11 @@ hypre_CSRMatrixMatvecRocsparse( HYPRE_Int        trans,
                                 hypre_Vector    *y,
                                 HYPRE_Int        offset )
 {
-  rocsparse_handle handle = hypre_HandleCusparseHandle(hypre_handle());
-  rocsparse_mat_descr descr = hypre_HandleCusparseMatDescr(hypre_handle());
-  rocsparse_mat_info info = hypre_HandleRocsparseMatInfo(hypre_handle());
+   rocsparse_handle handle = hypre_HandleCusparseHandle(hypre_handle());
+   rocsparse_mat_descr descr = hypre_HandleCusparseMatDescr(hypre_handle());
+   rocsparse_mat_info info = hypre_HandleRocsparseMatInfo(hypre_handle());
 
-  hypre_CSRMatrix *B;
+   hypre_CSRMatrix *B;
 
    if (trans)
    {
@@ -358,12 +358,13 @@ hypre_CSRMatrixMatvecRocsparse( HYPRE_Int        trans,
                                           hypre_VectorData(y) + offset) );
 
    if (trans)
-     {
-       hypre_CSRMatrixDestroy(B);
-     }
+   {
+      hypre_CSRMatrixDestroy(B);
+   }
 
    return hypre_error_flag;
 }
 #endif // #if defined(HYPRE_USING_ROCSPARSE)
 
 #endif // #if defined(HYPRE_USING_GPU)
+

--- a/src/seq_mv/csr_spgemm_device.c
+++ b/src/seq_mv/csr_spgemm_device.c
@@ -33,11 +33,18 @@ hypreDevice_CSRSpGemm(HYPRE_Int   m,        HYPRE_Int   k,        HYPRE_Int     
    hypre_profile_times[HYPRE_TIMER_ID_SPMM] -= hypre_MPI_Wtime();
 #endif
 
-   /* use CUSPARSE */
+   /* use CUSPARSE or rocSPARSE*/
    if (hypre_HandleSpgemmUseCusparse(hypre_handle()))
    {
+#if defined(HYPRE_USING_CUSPARSE)
       hypreDevice_CSRSpGemmCusparse(m, k, n, nnza, d_ia, d_ja, d_a, nnzb, d_ib, d_jb, d_b,
                                     nnzC, d_ic_out, d_jc_out, d_c_out);
+#elif defined(HYPRE_USING_ROCSPARSE)
+      hypreDevice_CSRSpGemmRocsparse(m, k, n, nnza, d_ia, d_ja, d_a, nnzb, d_ib, d_jb, d_b,
+                                     nnzC, d_ic_out, d_jc_out, d_c_out);
+#else
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC,"Attempting to use device sparse matrix library for SpGEMM without having compiled support for it!\n");
+#endif
    }
    else
    {

--- a/src/seq_mv/csr_spgemm_device_rocsparse.c
+++ b/src/seq_mv/csr_spgemm_device_rocsparse.c
@@ -1,0 +1,179 @@
+/******************************************************************************
+ * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+
+#include "seq_mv.h"
+#include "_hypre_utilities.hpp"
+
+#if defined(HYPRE_USING_HIP) && defined(HYPRE_USING_ROCSPARSE)
+
+HYPRE_Int
+hypreDevice_CSRSpGemmRocsparse(HYPRE_Int       m,
+                               HYPRE_Int       k,
+                               HYPRE_Int       n,
+                               HYPRE_Int       nnzA,
+                               HYPRE_Int      *d_ia,
+                               HYPRE_Int      *d_ja,
+                               HYPRE_Complex  *d_a,
+                               HYPRE_Int       nnzB,
+                               HYPRE_Int      *d_ib,
+                               HYPRE_Int      *d_jb,
+                               HYPRE_Complex  *d_b,
+                               HYPRE_Int      *nnzC_out,
+                               HYPRE_Int     **d_ic_out,
+                               HYPRE_Int     **d_jc_out,
+                               HYPRE_Complex **d_c_out)
+{
+  HYPRE_Int  *d_ic, *d_jc, baseC, nnzC;
+  HYPRE_Int  *d_ja_sorted, *d_jb_sorted;
+  HYPRE_Complex *d_c, *d_a_sorted, *d_b_sorted;
+
+  d_a_sorted  = hypre_TAlloc(HYPRE_Complex, nnzA, HYPRE_MEMORY_DEVICE);
+  d_b_sorted  = hypre_TAlloc(HYPRE_Complex, nnzB, HYPRE_MEMORY_DEVICE);
+  d_ja_sorted = hypre_TAlloc(HYPRE_Int,     nnzA, HYPRE_MEMORY_DEVICE);
+  d_jb_sorted = hypre_TAlloc(HYPRE_Int,     nnzB, HYPRE_MEMORY_DEVICE);
+
+  rocsparse_handle handle = hypre_HandleCusparseHandle(hypre_handle());
+
+  // FIXME: This is an abuse. Really, each matrix should have its own
+  //        rocsparse_mat_descr and rocsparse_mat_info and these should
+  //        not be global variables.
+  rocsparse_mat_descr descrA = hypre_HandleCusparseMatDescr(hypre_handle());
+  rocsparse_mat_descr descrB = hypre_HandleCusparseMatDescr(hypre_handle());
+  rocsparse_mat_descr descrC = hypre_HandleCusparseMatDescr(hypre_handle());
+  rocsparse_mat_info infoC = hypre_HandleRocsparseMatInfo(hypre_handle());
+
+  rocsparse_operation transA = rocsparse_operation_none;
+  rocsparse_operation transB = rocsparse_operation_none;
+
+  HYPRE_Int isDoublePrecision = sizeof(HYPRE_Complex) == sizeof(hypre_double);
+  HYPRE_Int isSinglePrecision = sizeof(HYPRE_Complex) == sizeof(hypre_double) / 2;
+
+  hypre_assert(isDoublePrecision || isSinglePrecision);
+
+  /* Copy the unsorted over as the initial "sorted" */
+  hypre_TMemcpy(d_ja_sorted, d_ja, HYPRE_Int,     nnzA, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+  hypre_TMemcpy(d_a_sorted,  d_a,  HYPRE_Complex, nnzA, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+  hypre_TMemcpy(d_jb_sorted, d_jb, HYPRE_Int,     nnzB, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+  hypre_TMemcpy(d_b_sorted,  d_b,  HYPRE_Complex, nnzB, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+
+  /* Sort each of the CSR matrices */
+  hypre_SortCSRRocsparse(m, k, nnzA, d_ia, d_ja_sorted, d_a_sorted);
+  hypre_SortCSRRocsparse(k, n, nnzB, d_ib, d_jb_sorted, d_b_sorted);
+
+  // nnzTotalDevHostPtr points to host memory
+  HYPRE_Int *nnzTotalDevHostPtr = &nnzC;
+  HYPRE_ROCSPARSE_CALL( rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host) );
+
+  d_ic = hypre_TAlloc(HYPRE_Int, m+1, HYPRE_MEMORY_DEVICE);
+
+  // For rocsparse, we need an extra buffer for computing the
+  // csrgemmnnz and the csrgemm
+  //
+  // Once the buffer is allocated, we can use the same allocated
+  // buffer for both the csrgemm_nnz and csrgemm
+  //
+  // Note that rocsparse csrgemms do: C = \alpha*A*B +\beta*D
+  // So we hardcode \alpha=1, D to nothing, and pass NULL for beta
+  // to indicate \beta = 0 to match the cusparse behavior.
+  HYPRE_Complex alpha = 1.0;
+
+  size_t rs_buffer_size =0;
+  void * rs_buffer;
+  if (isDoublePrecision)
+    {
+      HYPRE_ROCSPARSE_CALL( rocsparse_dcsrgemm_buffer_size(handle,
+                                                           transA, transB,
+                                                           m, n, k,
+                                                           &alpha, // \alpha = 1
+                                                           descrA, nnzA, d_ia, d_ja_sorted,
+                                                           descrB, nnzB, d_ib, d_jb_sorted,
+                                                           NULL, // \beta = 0
+                                                           NULL,   0,    NULL, NULL, // D is nothing
+                                                           infoC, &rs_buffer_size)
+                            );
+    }
+  else if (isSinglePrecision)
+    {
+      HYPRE_ROCSPARSE_CALL( rocsparse_scsrgemm_buffer_size(handle, transA, transB,
+                                                           m, n, k,
+                                                           (float *) &alpha, // \alpha = 1
+                                                           descrA, nnzA, d_ia, d_ja_sorted,
+                                                           descrB, nnzB, d_ib, d_jb_sorted,
+                                                           NULL, // \beta = 0
+                                                           NULL,   0,    NULL, NULL,
+                                                           infoC, &rs_buffer_size) );
+    }
+
+  HYPRE_HIP_CALL(hipMalloc(&rs_buffer, rs_buffer_size));
+
+  // Note that rocsparse csrgemms do: C = \alpha*A*B +\beta*D
+  // So we hardcode \alpha=1, D to nothing, and \beta = 0
+  // to match the cusparse behavior
+  HYPRE_ROCSPARSE_CALL( rocsparse_csrgemm_nnz(handle, transA, transB,
+                                              m, n, k,
+                                              descrA, nnzA, d_ia, d_ja_sorted,
+                                              descrB, nnzB, d_ib, d_jb_sorted,
+                                              NULL,   0,    NULL, NULL, // D is nothing
+                                              descrC,       d_ic, nnzTotalDevHostPtr,
+                                              infoC, rs_buffer) );
+
+  if (NULL != nnzTotalDevHostPtr)
+   {
+      nnzC = *nnzTotalDevHostPtr;
+   }
+   else
+   {
+      hypre_TMemcpy(&nnzC,  d_ic + m, HYPRE_Int, 1, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(&baseC, d_ic,     HYPRE_Int, 1, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+      nnzC -= baseC;
+   }
+
+   d_jc = hypre_TAlloc(HYPRE_Int,     nnzC, HYPRE_MEMORY_DEVICE);
+   d_c  = hypre_TAlloc(HYPRE_Complex, nnzC, HYPRE_MEMORY_DEVICE);
+
+  if (isDoublePrecision)
+  {
+    HYPRE_ROCSPARSE_CALL( rocsparse_dcsrgemm(handle, transA, transB,
+                                             m, n, k,
+                                             &alpha, // alpha = 1
+                                             descrA, nnzA, d_a_sorted, d_ia, d_ja_sorted,
+                                             descrB, nnzB, d_b_sorted, d_ib, d_jb_sorted,
+                                             NULL, // beta = 0
+                                             NULL,   0,    NULL,       NULL, NULL, // D is nothing
+                                             descrC,       d_c, d_ic, d_jc,
+                                             infoC, rs_buffer) );
+  }
+  else if (isSinglePrecision)
+  {
+    HYPRE_ROCSPARSE_CALL( rocsparse_scsrgemm(handle, transA, transB,
+                                             m, n, k,
+                                             (float *) &alpha, // alpha = 1
+                                             descrA, nnzA, (float *) d_a_sorted, d_ia, d_ja_sorted,
+                                             descrB, nnzB, (float *) d_b_sorted, d_ib, d_jb_sorted,
+                                             NULL, // beta = 0
+                                             NULL,   0,    NULL,       NULL, NULL, // D is nothing
+                                             descrC,       (float *) d_c, d_ic, d_jc,
+                                             infoC, rs_buffer) );
+  }
+
+  // Free up the memory needed by rocsparse
+  HYPRE_HIP_CALL(hipFree(rs_buffer));
+
+  *d_ic_out = d_ic;
+  *d_jc_out = d_jc;
+  *d_c_out  = d_c;
+  *nnzC_out = nnzC;
+
+  hypre_TFree(d_a_sorted,  HYPRE_MEMORY_DEVICE);
+  hypre_TFree(d_b_sorted,  HYPRE_MEMORY_DEVICE);
+  hypre_TFree(d_ja_sorted, HYPRE_MEMORY_DEVICE);
+  hypre_TFree(d_jb_sorted, HYPRE_MEMORY_DEVICE);
+
+  return hypre_error_flag;
+}
+
+#endif // defined(HYPRE_USING_HIP) && defined(HYPRE_USING_ROCSPARSE)

--- a/src/seq_mv/csr_spgemm_device_rocsparse.c
+++ b/src/seq_mv/csr_spgemm_device_rocsparse.c
@@ -108,7 +108,7 @@ hypreDevice_CSRSpGemmRocsparse(HYPRE_Int       m,
                                                            infoC, &rs_buffer_size) );
    }
 
-   HYPRE_HIP_CALL(hipMalloc(&rs_buffer, rs_buffer_size));
+   rs_buffer = hypre_TAlloc(char, rs_buffer_size, HYPRE_MEMORY_DEVICE);
 
    // Note that rocsparse csrgemms do: C = \alpha*A*B +\beta*D
    // So we hardcode \alpha=1, D to nothing, and \beta = 0
@@ -161,7 +161,7 @@ hypreDevice_CSRSpGemmRocsparse(HYPRE_Int       m,
    }
 
    // Free up the memory needed by rocsparse
-   HYPRE_HIP_CALL(hipFree(rs_buffer));
+   hypre_TFree(rs_buffer, HYPRE_MEMORY_DEVICE);
 
    *d_ic_out = d_ic;
    *d_jc_out = d_jc;
@@ -177,4 +177,3 @@ hypreDevice_CSRSpGemmRocsparse(HYPRE_Int       m,
 }
 
 #endif // defined(HYPRE_USING_HIP) && defined(HYPRE_USING_ROCSPARSE)
-

--- a/src/seq_mv/csr_spgemm_device_rocsparse.c
+++ b/src/seq_mv/csr_spgemm_device_rocsparse.c
@@ -27,64 +27,65 @@ hypreDevice_CSRSpGemmRocsparse(HYPRE_Int       m,
                                HYPRE_Int     **d_jc_out,
                                HYPRE_Complex **d_c_out)
 {
-  HYPRE_Int  *d_ic, *d_jc, baseC, nnzC;
-  HYPRE_Int  *d_ja_sorted, *d_jb_sorted;
-  HYPRE_Complex *d_c, *d_a_sorted, *d_b_sorted;
+   HYPRE_Int  *d_ic, *d_jc, baseC, nnzC;
+   HYPRE_Int  *d_ja_sorted, *d_jb_sorted;
+   HYPRE_Complex *d_c, *d_a_sorted, *d_b_sorted;
 
-  d_a_sorted  = hypre_TAlloc(HYPRE_Complex, nnzA, HYPRE_MEMORY_DEVICE);
-  d_b_sorted  = hypre_TAlloc(HYPRE_Complex, nnzB, HYPRE_MEMORY_DEVICE);
-  d_ja_sorted = hypre_TAlloc(HYPRE_Int,     nnzA, HYPRE_MEMORY_DEVICE);
-  d_jb_sorted = hypre_TAlloc(HYPRE_Int,     nnzB, HYPRE_MEMORY_DEVICE);
+   d_a_sorted  = hypre_TAlloc(HYPRE_Complex, nnzA, HYPRE_MEMORY_DEVICE);
+   d_b_sorted  = hypre_TAlloc(HYPRE_Complex, nnzB, HYPRE_MEMORY_DEVICE);
+   d_ja_sorted = hypre_TAlloc(HYPRE_Int,     nnzA, HYPRE_MEMORY_DEVICE);
+   d_jb_sorted = hypre_TAlloc(HYPRE_Int,     nnzB, HYPRE_MEMORY_DEVICE);
 
-  rocsparse_handle handle = hypre_HandleCusparseHandle(hypre_handle());
+   rocsparse_handle handle = hypre_HandleCusparseHandle(hypre_handle());
 
-  // FIXME: This is an abuse. Really, each matrix should have its own
-  //        rocsparse_mat_descr and rocsparse_mat_info and these should
-  //        not be global variables.
-  rocsparse_mat_descr descrA = hypre_HandleCusparseMatDescr(hypre_handle());
-  rocsparse_mat_descr descrB = hypre_HandleCusparseMatDescr(hypre_handle());
-  rocsparse_mat_descr descrC = hypre_HandleCusparseMatDescr(hypre_handle());
-  rocsparse_mat_info infoC = hypre_HandleRocsparseMatInfo(hypre_handle());
+   // FIXME: This is an abuse. Really, each matrix should have its own
+   //        rocsparse_mat_descr and rocsparse_mat_info and these should
+   //        not be global variables.
+   rocsparse_mat_descr descrA = hypre_HandleCusparseMatDescr(hypre_handle());
+   rocsparse_mat_descr descrB = hypre_HandleCusparseMatDescr(hypre_handle());
+   rocsparse_mat_descr descrC = hypre_HandleCusparseMatDescr(hypre_handle());
+   rocsparse_mat_info infoC = hypre_HandleRocsparseMatInfo(hypre_handle());
 
-  rocsparse_operation transA = rocsparse_operation_none;
-  rocsparse_operation transB = rocsparse_operation_none;
+   rocsparse_operation transA = rocsparse_operation_none;
+   rocsparse_operation transB = rocsparse_operation_none;
 
-  HYPRE_Int isDoublePrecision = sizeof(HYPRE_Complex) == sizeof(hypre_double);
-  HYPRE_Int isSinglePrecision = sizeof(HYPRE_Complex) == sizeof(hypre_double) / 2;
+   HYPRE_Int isDoublePrecision = sizeof(HYPRE_Complex) == sizeof(hypre_double);
+   HYPRE_Int isSinglePrecision = sizeof(HYPRE_Complex) == sizeof(hypre_double) / 2;
 
-  hypre_assert(isDoublePrecision || isSinglePrecision);
+   hypre_assert(isDoublePrecision || isSinglePrecision);
 
-  /* Copy the unsorted over as the initial "sorted" */
-  hypre_TMemcpy(d_ja_sorted, d_ja, HYPRE_Int,     nnzA, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
-  hypre_TMemcpy(d_a_sorted,  d_a,  HYPRE_Complex, nnzA, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
-  hypre_TMemcpy(d_jb_sorted, d_jb, HYPRE_Int,     nnzB, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
-  hypre_TMemcpy(d_b_sorted,  d_b,  HYPRE_Complex, nnzB, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+   /* Copy the unsorted over as the initial "sorted" */
+   hypre_TMemcpy(d_ja_sorted, d_ja, HYPRE_Int,     nnzA, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+   hypre_TMemcpy(d_a_sorted,  d_a,  HYPRE_Complex, nnzA, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+   hypre_TMemcpy(d_jb_sorted, d_jb, HYPRE_Int,     nnzB, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+   hypre_TMemcpy(d_b_sorted,  d_b,  HYPRE_Complex, nnzB, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
 
-  /* Sort each of the CSR matrices */
-  hypre_SortCSRRocsparse(m, k, nnzA, d_ia, d_ja_sorted, d_a_sorted);
-  hypre_SortCSRRocsparse(k, n, nnzB, d_ib, d_jb_sorted, d_b_sorted);
+   /* Sort each of the CSR matrices */
+   hypre_SortCSRRocsparse(m, k, nnzA, d_ia, d_ja_sorted, d_a_sorted);
+   hypre_SortCSRRocsparse(k, n, nnzB, d_ib, d_jb_sorted, d_b_sorted);
 
-  // nnzTotalDevHostPtr points to host memory
-  HYPRE_Int *nnzTotalDevHostPtr = &nnzC;
-  HYPRE_ROCSPARSE_CALL( rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host) );
+   // nnzTotalDevHostPtr points to host memory
+   HYPRE_Int *nnzTotalDevHostPtr = &nnzC;
+   HYPRE_ROCSPARSE_CALL( rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host) );
 
-  d_ic = hypre_TAlloc(HYPRE_Int, m+1, HYPRE_MEMORY_DEVICE);
+   d_ic = hypre_TAlloc(HYPRE_Int, m+1, HYPRE_MEMORY_DEVICE);
 
-  // For rocsparse, we need an extra buffer for computing the
-  // csrgemmnnz and the csrgemm
-  //
-  // Once the buffer is allocated, we can use the same allocated
-  // buffer for both the csrgemm_nnz and csrgemm
-  //
-  // Note that rocsparse csrgemms do: C = \alpha*A*B +\beta*D
-  // So we hardcode \alpha=1, D to nothing, and pass NULL for beta
-  // to indicate \beta = 0 to match the cusparse behavior.
-  HYPRE_Complex alpha = 1.0;
+   // For rocsparse, we need an extra buffer for computing the
+   // csrgemmnnz and the csrgemm
+   //
+   // Once the buffer is allocated, we can use the same allocated
+   // buffer for both the csrgemm_nnz and csrgemm
+   //
+   // Note that rocsparse csrgemms do: C = \alpha*A*B +\beta*D
+   // So we hardcode \alpha=1, D to nothing, and pass NULL for beta
+   // to indicate \beta = 0 to match the cusparse behavior.
+   HYPRE_Complex alpha = 1.0;
 
-  size_t rs_buffer_size =0;
-  void * rs_buffer;
-  if (isDoublePrecision)
-    {
+   size_t rs_buffer_size = 0;
+   void *rs_buffer;
+
+   if (isDoublePrecision)
+   {
       HYPRE_ROCSPARSE_CALL( rocsparse_dcsrgemm_buffer_size(handle,
                                                            transA, transB,
                                                            m, n, k,
@@ -93,11 +94,10 @@ hypreDevice_CSRSpGemmRocsparse(HYPRE_Int       m,
                                                            descrB, nnzB, d_ib, d_jb_sorted,
                                                            NULL, // \beta = 0
                                                            NULL,   0,    NULL, NULL, // D is nothing
-                                                           infoC, &rs_buffer_size)
-                            );
-    }
-  else if (isSinglePrecision)
-    {
+                                                           infoC, &rs_buffer_size) );
+   }
+   else if (isSinglePrecision)
+   {
       HYPRE_ROCSPARSE_CALL( rocsparse_scsrgemm_buffer_size(handle, transA, transB,
                                                            m, n, k,
                                                            (float *) &alpha, // \alpha = 1
@@ -106,22 +106,22 @@ hypreDevice_CSRSpGemmRocsparse(HYPRE_Int       m,
                                                            NULL, // \beta = 0
                                                            NULL,   0,    NULL, NULL,
                                                            infoC, &rs_buffer_size) );
-    }
+   }
 
-  HYPRE_HIP_CALL(hipMalloc(&rs_buffer, rs_buffer_size));
+   HYPRE_HIP_CALL(hipMalloc(&rs_buffer, rs_buffer_size));
 
-  // Note that rocsparse csrgemms do: C = \alpha*A*B +\beta*D
-  // So we hardcode \alpha=1, D to nothing, and \beta = 0
-  // to match the cusparse behavior
-  HYPRE_ROCSPARSE_CALL( rocsparse_csrgemm_nnz(handle, transA, transB,
-                                              m, n, k,
-                                              descrA, nnzA, d_ia, d_ja_sorted,
-                                              descrB, nnzB, d_ib, d_jb_sorted,
-                                              NULL,   0,    NULL, NULL, // D is nothing
-                                              descrC,       d_ic, nnzTotalDevHostPtr,
-                                              infoC, rs_buffer) );
+   // Note that rocsparse csrgemms do: C = \alpha*A*B +\beta*D
+   // So we hardcode \alpha=1, D to nothing, and \beta = 0
+   // to match the cusparse behavior
+   HYPRE_ROCSPARSE_CALL( rocsparse_csrgemm_nnz(handle, transA, transB,
+                                               m, n, k,
+                                               descrA, nnzA, d_ia, d_ja_sorted,
+                                               descrB, nnzB, d_ib, d_jb_sorted,
+                                               NULL,   0,    NULL, NULL, // D is nothing
+                                               descrC,       d_ic, nnzTotalDevHostPtr,
+                                               infoC, rs_buffer) );
 
-  if (NULL != nnzTotalDevHostPtr)
+   if (NULL != nnzTotalDevHostPtr)
    {
       nnzC = *nnzTotalDevHostPtr;
    }
@@ -135,45 +135,46 @@ hypreDevice_CSRSpGemmRocsparse(HYPRE_Int       m,
    d_jc = hypre_TAlloc(HYPRE_Int,     nnzC, HYPRE_MEMORY_DEVICE);
    d_c  = hypre_TAlloc(HYPRE_Complex, nnzC, HYPRE_MEMORY_DEVICE);
 
-  if (isDoublePrecision)
-  {
-    HYPRE_ROCSPARSE_CALL( rocsparse_dcsrgemm(handle, transA, transB,
-                                             m, n, k,
-                                             &alpha, // alpha = 1
-                                             descrA, nnzA, d_a_sorted, d_ia, d_ja_sorted,
-                                             descrB, nnzB, d_b_sorted, d_ib, d_jb_sorted,
-                                             NULL, // beta = 0
-                                             NULL,   0,    NULL,       NULL, NULL, // D is nothing
-                                             descrC,       d_c, d_ic, d_jc,
-                                             infoC, rs_buffer) );
-  }
-  else if (isSinglePrecision)
-  {
-    HYPRE_ROCSPARSE_CALL( rocsparse_scsrgemm(handle, transA, transB,
-                                             m, n, k,
-                                             (float *) &alpha, // alpha = 1
-                                             descrA, nnzA, (float *) d_a_sorted, d_ia, d_ja_sorted,
-                                             descrB, nnzB, (float *) d_b_sorted, d_ib, d_jb_sorted,
-                                             NULL, // beta = 0
-                                             NULL,   0,    NULL,       NULL, NULL, // D is nothing
-                                             descrC,       (float *) d_c, d_ic, d_jc,
-                                             infoC, rs_buffer) );
-  }
+   if (isDoublePrecision)
+   {
+      HYPRE_ROCSPARSE_CALL( rocsparse_dcsrgemm(handle, transA, transB,
+                                               m, n, k,
+                                               &alpha, // alpha = 1
+                                               descrA, nnzA, d_a_sorted, d_ia, d_ja_sorted,
+                                               descrB, nnzB, d_b_sorted, d_ib, d_jb_sorted,
+                                               NULL, // beta = 0
+                                               NULL,   0,    NULL,       NULL, NULL, // D is nothing
+                                               descrC,       d_c, d_ic, d_jc,
+                                               infoC, rs_buffer) );
+   }
+   else if (isSinglePrecision)
+   {
+      HYPRE_ROCSPARSE_CALL( rocsparse_scsrgemm(handle, transA, transB,
+                                               m, n, k,
+                                               (float *) &alpha, // alpha = 1
+                                               descrA, nnzA, (float *) d_a_sorted, d_ia, d_ja_sorted,
+                                               descrB, nnzB, (float *) d_b_sorted, d_ib, d_jb_sorted,
+                                               NULL, // beta = 0
+                                               NULL,   0,    NULL,       NULL, NULL, // D is nothing
+                                               descrC,       (float *) d_c, d_ic, d_jc,
+                                               infoC, rs_buffer) );
+   }
 
-  // Free up the memory needed by rocsparse
-  HYPRE_HIP_CALL(hipFree(rs_buffer));
+   // Free up the memory needed by rocsparse
+   HYPRE_HIP_CALL(hipFree(rs_buffer));
 
-  *d_ic_out = d_ic;
-  *d_jc_out = d_jc;
-  *d_c_out  = d_c;
-  *nnzC_out = nnzC;
+   *d_ic_out = d_ic;
+   *d_jc_out = d_jc;
+   *d_c_out  = d_c;
+   *nnzC_out = nnzC;
 
-  hypre_TFree(d_a_sorted,  HYPRE_MEMORY_DEVICE);
-  hypre_TFree(d_b_sorted,  HYPRE_MEMORY_DEVICE);
-  hypre_TFree(d_ja_sorted, HYPRE_MEMORY_DEVICE);
-  hypre_TFree(d_jb_sorted, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(d_a_sorted,  HYPRE_MEMORY_DEVICE);
+   hypre_TFree(d_b_sorted,  HYPRE_MEMORY_DEVICE);
+   hypre_TFree(d_ja_sorted, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(d_jb_sorted, HYPRE_MEMORY_DEVICE);
 
-  return hypre_error_flag;
+   return hypre_error_flag;
 }
 
 #endif // defined(HYPRE_USING_HIP) && defined(HYPRE_USING_ROCSPARSE)
+

--- a/src/seq_mv/csr_sptrans_device.c
+++ b/src/seq_mv/csr_sptrans_device.c
@@ -20,16 +20,6 @@ hypreDevice_CSRSpTransCusparse(HYPRE_Int   m,        HYPRE_Int   n,        HYPRE
    hypre_profile_times[HYPRE_TIMER_ID_SPTRANS] -= hypre_MPI_Wtime();
 #endif
 
-   /* trivial case */
-   if (nnzA == 0)
-   {
-      *d_ic_out = hypre_CTAlloc(HYPRE_Int, n + 1, HYPRE_MEMORY_DEVICE);
-      *d_jc_out = hypre_CTAlloc(HYPRE_Int,     0, HYPRE_MEMORY_DEVICE);
-      *d_ac_out = hypre_CTAlloc(HYPRE_Complex, 0, HYPRE_MEMORY_DEVICE);
-
-      return hypre_error_flag;
-   }
-
    cusparseHandle_t handle = hypre_HandleCusparseHandle(hypre_handle());
    cusparseAction_t action = want_data ? CUSPARSE_ACTION_NUMERIC : CUSPARSE_ACTION_SYMBOLIC;
    HYPRE_Complex *csc_a;
@@ -104,16 +94,6 @@ hypreDevice_CSRSpTrans(HYPRE_Int   m,        HYPRE_Int   n,        HYPRE_Int    
                        HYPRE_Int **d_ic_out, HYPRE_Int **d_jc_out, HYPRE_Complex **d_ac_out,
                        HYPRE_Int   want_data)
 {
-   /* trivial case */
-   if (nnzA == 0)
-   {
-      *d_ic_out = hypre_CTAlloc(HYPRE_Int, n + 1, HYPRE_MEMORY_DEVICE);
-      *d_jc_out = hypre_CTAlloc(HYPRE_Int,     0, HYPRE_MEMORY_DEVICE);
-      *d_ac_out = hypre_CTAlloc(HYPRE_Complex, 0, HYPRE_MEMORY_DEVICE);
-
-      return hypre_error_flag;
-   }
-
 #ifdef HYPRE_PROFILE
    hypre_profile_times[HYPRE_TIMER_ID_SPTRANS] -= hypre_MPI_Wtime();
 #endif

--- a/src/seq_mv/csr_sptrans_device.c
+++ b/src/seq_mv/csr_sptrans_device.c
@@ -121,7 +121,8 @@ hypreDevice_CSRSpTransRocsparse(HYPRE_Int   m,        HYPRE_Int   n,        HYPR
                                                        &buffer_size) );
 
    void * buffer;
-   HYPRE_HIP_CALL( hipMalloc(&buffer, buffer_size) );
+   buffer = hypre_TAlloc(char, buffer_size, HYPRE_MEMORY_DEVICE);
+
    HYPRE_ROCSPARSE_CALL( rocsparse_dcsr2csc(handle,
                                             m, n, nnzA,
                                             d_aa, d_ia, d_ja,
@@ -129,7 +130,7 @@ hypreDevice_CSRSpTransRocsparse(HYPRE_Int   m,        HYPRE_Int   n,        HYPR
                                             action,
                                             rocsparse_index_base_zero,
                                             buffer) );
-   HYPRE_HIP_CALL( hipFree(buffer) );
+   hypre_TFree(buffer, HYPRE_MEMORY_DEVICE);
 
    *d_ic_out = csc_i;
    *d_jc_out = csc_j;

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -221,6 +221,8 @@ HYPRE_Int hypreDevice_CSRSpGemmCusparseOldAPI(HYPRE_Int m, HYPRE_Int k, HYPRE_In
 
 HYPRE_Int hypreDevice_CSRSpGemmCusparse(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n, HYPRE_Int nnzA, HYPRE_Int *d_ia, HYPRE_Int *d_ja, HYPRE_Complex *d_a, HYPRE_Int nnzB, HYPRE_Int *d_ib, HYPRE_Int *d_jb, HYPRE_Complex *d_b, HYPRE_Int *nnzC_out, HYPRE_Int **d_ic_out, HYPRE_Int **d_jc_out, HYPRE_Complex **d_c_out);
 
+HYPRE_Int hypreDevice_CSRSpGemmRocsparse(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n, HYPRE_Int nnzA, HYPRE_Int *d_ia, HYPRE_Int *d_ja, HYPRE_Complex *d_a, HYPRE_Int nnzB, HYPRE_Int *d_ib, HYPRE_Int *d_jb, HYPRE_Complex *d_b, HYPRE_Int *nnzC_out, HYPRE_Int **d_ic_out, HYPRE_Int **d_jc_out, HYPRE_Complex **d_c_out);
+
 HYPRE_Int hypre_SeqVectorElmdivpy( hypre_Vector *x, hypre_Vector *b, hypre_Vector *y );
 
 HYPRE_Int hypre_CSRMatrixSpMVDevice( HYPRE_Complex alpha, hypre_CSRMatrix *A, hypre_Vector *x, HYPRE_Complex beta, hypre_Vector *y, HYPRE_Int fill );

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -188,6 +188,8 @@ HYPRE_Int hypreDevice_CSRSpTrans(HYPRE_Int m, HYPRE_Int n, HYPRE_Int nnzA, HYPRE
 
 HYPRE_Int hypreDevice_CSRSpTransCusparse(HYPRE_Int m, HYPRE_Int n, HYPRE_Int nnzA, HYPRE_Int *d_ia, HYPRE_Int *d_ja, HYPRE_Complex *d_aa, HYPRE_Int **d_ic_out, HYPRE_Int **d_jc_out, HYPRE_Complex **d_ac_out, HYPRE_Int want_data);
 
+HYPRE_Int hypreDevice_CSRSpTransRocsparse(HYPRE_Int m, HYPRE_Int n, HYPRE_Int nnzA, HYPRE_Int *d_ia, HYPRE_Int *d_ja, HYPRE_Complex *d_aa, HYPRE_Int **d_ic_out, HYPRE_Int **d_jc_out, HYPRE_Complex **d_ac_out, HYPRE_Int want_data);
+
 HYPRE_Int hypreDevice_CSRSpGemm(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n, HYPRE_Int nnza, HYPRE_Int nnzb, HYPRE_Int *d_ia, HYPRE_Int *d_ja, HYPRE_Complex *d_a, HYPRE_Int *d_ib, HYPRE_Int *d_jb, HYPRE_Complex *d_b, HYPRE_Int **d_ic_out, HYPRE_Int **d_jc_out, HYPRE_Complex **d_c_out, HYPRE_Int *nnzC);
 
 HYPRE_Int hypre_CSRMatrixDeviceSpGemmSetRownnzEstimateMethod( HYPRE_Int value );

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -42,6 +42,7 @@ hypre_CSRMatrix* hypre_CSRMatrixIdentityDevice(HYPRE_Int n, HYPRE_Complex alp);
 HYPRE_Int hypre_CSRMatrixRemoveDiagonalDevice(hypre_CSRMatrix *A);
 HYPRE_Int hypre_CSRMatrixDropSmallEntriesDevice( hypre_CSRMatrix *A, HYPRE_Complex tol, HYPRE_Int abs, HYPRE_Int option);
 void hypre_SortCSRCusparse( HYPRE_Int n, HYPRE_Int m, HYPRE_Int nnzA, const HYPRE_Int *d_ia, HYPRE_Int *d_ja_sorted, HYPRE_Complex *d_a_sorted );
+void hypre_SortCSRRocsparse( HYPRE_Int n, HYPRE_Int m, HYPRE_Int nnzA, const HYPRE_Int *d_ia, HYPRE_Int *d_ja_sorted, HYPRE_Complex *d_a_sorted );
 HYPRE_Int hypre_CSRMatrixSortRow(hypre_CSRMatrix *A);
 HYPRE_Int hypre_CSRMatrixTriLowerUpperSolveCusparse(char uplo, hypre_CSRMatrix *A, hypre_Vector *f, hypre_Vector *u );
 

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -82,6 +82,7 @@ HYPRE_Int hypre_CSRMatrixMatvecMaskedDevice(HYPRE_Complex alpha, hypre_CSRMatrix
 HYPRE_Int hypre_CSRMatrixMatvecCusparseNewAPI( HYPRE_Int trans, HYPRE_Complex alpha, hypre_CSRMatrix *A, hypre_Vector *x, HYPRE_Complex beta, hypre_Vector *y, HYPRE_Int offset );
 HYPRE_Int hypre_CSRMatrixMatvecCusparseOldAPI( HYPRE_Int trans, HYPRE_Complex alpha, hypre_CSRMatrix *A, hypre_Vector *x, HYPRE_Complex beta, hypre_Vector *y, HYPRE_Int offset );
 HYPRE_Int hypre_CSRMatrixMatvecOMPOffload (HYPRE_Int trans, HYPRE_Complex alpha , hypre_CSRMatrix *A , hypre_Vector *x , HYPRE_Complex beta , hypre_Vector *y, HYPRE_Int offset );
+HYPRE_Int hypre_CSRMatrixMatvecRocsparse (HYPRE_Int trans, HYPRE_Complex alpha , hypre_CSRMatrix *A , hypre_Vector *x , HYPRE_Complex beta , hypre_Vector *y, HYPRE_Int offset );
 
 /* genpart.c */
 HYPRE_Int hypre_GeneratePartitioning ( HYPRE_BigInt length , HYPRE_Int num_procs , HYPRE_BigInt **part_ptr );
@@ -225,4 +226,3 @@ HYPRE_Int hypre_CSRMatrixSpMVDevice( HYPRE_Complex alpha, hypre_CSRMatrix *A, hy
 hypre_CsrsvData* hypre_CsrsvDataCreate();
 void hypre_CsrsvDataDestroy(hypre_CsrsvData* data);
 #endif
-

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -308,6 +308,7 @@ hypre_CSRMatrix* hypre_CSRMatrixIdentityDevice(HYPRE_Int n, HYPRE_Complex alp);
 HYPRE_Int hypre_CSRMatrixRemoveDiagonalDevice(hypre_CSRMatrix *A);
 HYPRE_Int hypre_CSRMatrixDropSmallEntriesDevice( hypre_CSRMatrix *A, HYPRE_Complex tol, HYPRE_Int abs, HYPRE_Int option);
 void hypre_SortCSRCusparse( HYPRE_Int n, HYPRE_Int m, HYPRE_Int nnzA, const HYPRE_Int *d_ia, HYPRE_Int *d_ja_sorted, HYPRE_Complex *d_a_sorted );
+void hypre_SortCSRRocsparse( HYPRE_Int n, HYPRE_Int m, HYPRE_Int nnzA, const HYPRE_Int *d_ia, HYPRE_Int *d_ja_sorted, HYPRE_Complex *d_a_sorted );
 HYPRE_Int hypre_CSRMatrixSortRow(hypre_CSRMatrix *A);
 HYPRE_Int hypre_CSRMatrixTriLowerUpperSolveCusparse(char uplo, hypre_CSRMatrix *A, hypre_Vector *f, hypre_Vector *u );
 

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -487,6 +487,8 @@ HYPRE_Int hypreDevice_CSRSpGemmCusparseOldAPI(HYPRE_Int m, HYPRE_Int k, HYPRE_In
 
 HYPRE_Int hypreDevice_CSRSpGemmCusparse(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n, HYPRE_Int nnzA, HYPRE_Int *d_ia, HYPRE_Int *d_ja, HYPRE_Complex *d_a, HYPRE_Int nnzB, HYPRE_Int *d_ib, HYPRE_Int *d_jb, HYPRE_Complex *d_b, HYPRE_Int *nnzC_out, HYPRE_Int **d_ic_out, HYPRE_Int **d_jc_out, HYPRE_Complex **d_c_out);
 
+HYPRE_Int hypreDevice_CSRSpGemmRocsparse(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n, HYPRE_Int nnzA, HYPRE_Int *d_ia, HYPRE_Int *d_ja, HYPRE_Complex *d_a, HYPRE_Int nnzB, HYPRE_Int *d_ib, HYPRE_Int *d_jb, HYPRE_Complex *d_b, HYPRE_Int *nnzC_out, HYPRE_Int **d_ic_out, HYPRE_Int **d_jc_out, HYPRE_Complex **d_c_out);
+
 HYPRE_Int hypre_SeqVectorElmdivpy( hypre_Vector *x, hypre_Vector *b, hypre_Vector *y );
 
 HYPRE_Int hypre_CSRMatrixSpMVDevice( HYPRE_Complex alpha, hypre_CSRMatrix *A, hypre_Vector *x, HYPRE_Complex beta, hypre_Vector *y, HYPRE_Int fill );

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -454,6 +454,8 @@ HYPRE_Int hypreDevice_CSRSpTrans(HYPRE_Int m, HYPRE_Int n, HYPRE_Int nnzA, HYPRE
 
 HYPRE_Int hypreDevice_CSRSpTransCusparse(HYPRE_Int m, HYPRE_Int n, HYPRE_Int nnzA, HYPRE_Int *d_ia, HYPRE_Int *d_ja, HYPRE_Complex *d_aa, HYPRE_Int **d_ic_out, HYPRE_Int **d_jc_out, HYPRE_Complex **d_ac_out, HYPRE_Int want_data);
 
+HYPRE_Int hypreDevice_CSRSpTransRocsparse(HYPRE_Int m, HYPRE_Int n, HYPRE_Int nnzA, HYPRE_Int *d_ia, HYPRE_Int *d_ja, HYPRE_Complex *d_aa, HYPRE_Int **d_ic_out, HYPRE_Int **d_jc_out, HYPRE_Complex **d_ac_out, HYPRE_Int want_data);
+
 HYPRE_Int hypreDevice_CSRSpGemm(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n, HYPRE_Int nnza, HYPRE_Int nnzb, HYPRE_Int *d_ia, HYPRE_Int *d_ja, HYPRE_Complex *d_a, HYPRE_Int *d_ib, HYPRE_Int *d_jb, HYPRE_Complex *d_b, HYPRE_Int **d_ic_out, HYPRE_Int **d_jc_out, HYPRE_Complex **d_c_out, HYPRE_Int *nnzC);
 
 HYPRE_Int hypre_CSRMatrixDeviceSpGemmSetRownnzEstimateMethod( HYPRE_Int value );

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -348,6 +348,7 @@ HYPRE_Int hypre_CSRMatrixMatvecMaskedDevice(HYPRE_Complex alpha, hypre_CSRMatrix
 HYPRE_Int hypre_CSRMatrixMatvecCusparseNewAPI( HYPRE_Int trans, HYPRE_Complex alpha, hypre_CSRMatrix *A, hypre_Vector *x, HYPRE_Complex beta, hypre_Vector *y, HYPRE_Int offset );
 HYPRE_Int hypre_CSRMatrixMatvecCusparseOldAPI( HYPRE_Int trans, HYPRE_Complex alpha, hypre_CSRMatrix *A, hypre_Vector *x, HYPRE_Complex beta, hypre_Vector *y, HYPRE_Int offset );
 HYPRE_Int hypre_CSRMatrixMatvecOMPOffload (HYPRE_Int trans, HYPRE_Complex alpha , hypre_CSRMatrix *A , hypre_Vector *x , HYPRE_Complex beta , hypre_Vector *y, HYPRE_Int offset );
+HYPRE_Int hypre_CSRMatrixMatvecRocsparse (HYPRE_Int trans, HYPRE_Complex alpha , hypre_CSRMatrix *A , hypre_Vector *x , HYPRE_Complex beta , hypre_Vector *y, HYPRE_Int offset );
 
 /* genpart.c */
 HYPRE_Int hypre_GeneratePartitioning ( HYPRE_BigInt length , HYPRE_Int num_procs , HYPRE_BigInt **part_ptr );
@@ -491,7 +492,6 @@ HYPRE_Int hypre_CSRMatrixSpMVDevice( HYPRE_Complex alpha, hypre_CSRMatrix *A, hy
 hypre_CsrsvData* hypre_CsrsvDataCreate();
 void hypre_CsrsvDataDestroy(hypre_CsrsvData* data);
 #endif
-
 
 #ifdef __cplusplus
 }

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1246,6 +1246,7 @@ typedef struct
 #define hypre_HandleCublasHandle(hypre_handle)                   hypre_CudaDataCublasHandle(hypre_HandleCudaData(hypre_handle))
 #define hypre_HandleCusparseHandle(hypre_handle)                 hypre_CudaDataCusparseHandle(hypre_HandleCudaData(hypre_handle))
 #define hypre_HandleCusparseMatDescr(hypre_handle)               hypre_CudaDataCusparseMatDescr(hypre_HandleCudaData(hypre_handle))
+#define hypre_HandleRocsparseMatInfo(hypre_handle)               hypre_CudaDataRocsparseMatInfo(hypre_HandleCudaData(hypre_handle))
 #define hypre_HandleCudaComputeStream(hypre_handle)              hypre_CudaDataCudaComputeStream(hypre_HandleCudaData(hypre_handle))
 #define hypre_HandleCubBinGrowth(hypre_handle)                   hypre_CudaDataCubBinGrowth(hypre_HandleCudaData(hypre_handle))
 #define hypre_HandleCubMinBin(hypre_handle)                      hypre_CudaDataCubMinBin(hypre_HandleCudaData(hypre_handle))
@@ -1284,7 +1285,6 @@ typedef struct
 #define hypre_HandleOwnUmpirePinnedPool(hypre_handle)            ((hypre_handle) -> own_umpire_pinned_pool)
 
 #endif
-
 /******************************************************************************
  * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -196,6 +196,12 @@ struct hypre_CudaData
    cusparseMatDescr_t                cusparse_mat_descr;
 #endif
 
+#if defined(HYPRE_USING_ROCSPARSE)
+  rocsparse_handle                  cusparse_handle;
+  rocsparse_mat_descr               cusparse_mat_descr;
+  rocsparse_mat_info                rocsparse_mat_info;
+#endif
+
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
    cudaStream_t                      cuda_streams[HYPRE_MAX_NUM_STREAMS];
 #elif defined(HYPRE_USING_HIP)
@@ -268,6 +274,12 @@ cublasHandle_t     hypre_CudaDataCublasHandle(hypre_CudaData *data);
 #if defined(HYPRE_USING_CUSPARSE)
 cusparseHandle_t   hypre_CudaDataCusparseHandle(hypre_CudaData *data);
 cusparseMatDescr_t hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
+#endif
+
+#if defined(HYPRE_USING_ROCSPARSE)
+rocsparse_handle    hypre_CudaDataCusparseHandle(hypre_CudaData *data);
+rocsparse_mat_descr hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
+rocsparse_mat_info  hypre_CudaDataRocsparseMatInfo(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -106,6 +106,10 @@ struct hypre_umpire_device_allocator
 
 #endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 
+#if defined(HYPRE_USING_ROCSPARSE)
+#include <rocsparse.h>
+#endif
+
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 #define HYPRE_CUDA_CALL(call) do {                                                           \
@@ -141,6 +145,14 @@ struct hypre_umpire_device_allocator
       hypre_printf("CUSPARSE ERROR (code = %d, %s) at %s:%d\n",                              \
             err, cusparseGetErrorString(err), __FILE__, __LINE__);                           \
       hypre_assert(0); exit(1);                                                              \
+   } } while(0)
+
+#define HYPRE_ROCSPARSE_CALL(call) do {                                                      \
+   rocsparse_status err = call;                                                              \
+   if (rocsparse_status_success != err) {                                                    \
+      hypre_printf("rocSPARSE ERROR (code = %d) at %s:%d\n",                                 \
+            err, __FILE__, __LINE__);                                                        \
+      assert(0); exit(1);                                                                    \
    } } while(0)
 
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -121,12 +121,12 @@ struct hypre_umpire_device_allocator
    } } while(0)
 
 #elif defined(HYPRE_USING_HIP)
-#define HYPRE_HIP_CALL(call) do {                                                           \
-   hipError_t err = call;                                                                   \
-   if (hipSuccess != err) {                                                                 \
-      hypre_printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),     \
-                   __FILE__, __LINE__);                                                     \
-      hypre_assert(0); exit(1);                                                             \
+#define HYPRE_HIP_CALL(call) do {                                                            \
+   hipError_t err = call;                                                                    \
+   if (hipSuccess != err) {                                                                  \
+      hypre_printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),      \
+                   __FILE__, __LINE__);                                                      \
+      hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
 #endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
@@ -260,20 +260,20 @@ struct hypre_CudaData
 #define hypre_CudaDataSpgemmHashType(data)                 ((data) -> spgemm_hash_type)
 #define hypre_CudaDataUmpireDeviceAllocator(data)          ((data) -> umpire_device_allocator)
 
-hypre_CudaData* hypre_CudaDataCreate();
-void hypre_CudaDataDestroy(hypre_CudaData* data);
+hypre_CudaData*     hypre_CudaDataCreate();
+void                hypre_CudaDataDestroy(hypre_CudaData* data);
 
 #if defined(HYPRE_USING_CURAND)
-curandGenerator_t  hypre_CudaDataCurandGenerator(hypre_CudaData *data);
+curandGenerator_t   hypre_CudaDataCurandGenerator(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_CUBLAS)
-cublasHandle_t     hypre_CudaDataCublasHandle(hypre_CudaData *data);
+cublasHandle_t      hypre_CudaDataCublasHandle(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_CUSPARSE)
-cusparseHandle_t   hypre_CudaDataCusparseHandle(hypre_CudaData *data);
-cusparseMatDescr_t hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
+cusparseHandle_t    hypre_CudaDataCusparseHandle(hypre_CudaData *data);
+cusparseMatDescr_t  hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_ROCSPARSE)
@@ -283,11 +283,11 @@ rocsparse_mat_info  hypre_CudaDataRocsparseMatInfo(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
-cudaStream_t       hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
-cudaStream_t       hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
+cudaStream_t        hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
+cudaStream_t        hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
 #elif defined(HYPRE_USING_HIP)
-hipStream_t        hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
-hipStream_t        hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
+hipStream_t         hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
+hipStream_t         hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
 #endif
 
 // Data structure and accessor routines for Cuda Sparse Triangular Matrices
@@ -953,7 +953,6 @@ cudaError_t hypre_CachingFreeDevice(void *ptr);
 cudaError_t hypre_CachingFreeManaged(void *ptr);
 #endif
 
-
 void hypre_CudaDataCubCachingAllocatorDestroy(hypre_CudaData *data);
 
 #endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
@@ -967,6 +966,7 @@ cusparseIndexType_t hypre_HYPREIntToCusparseIndexType();
 #endif // #if defined(HYPRE_USING_CUSPARSE)
 
 #endif /* #ifndef HYPRE_CUDA_UTILS_H */
+
 /******************************************************************************
  * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -197,9 +197,9 @@ struct hypre_CudaData
 #endif
 
 #if defined(HYPRE_USING_ROCSPARSE)
-  rocsparse_handle                  cusparse_handle;
-  rocsparse_mat_descr               cusparse_mat_descr;
-  rocsparse_mat_info                rocsparse_mat_info;
+  rocsparse_handle                   cusparse_handle;
+  rocsparse_mat_descr                cusparse_mat_descr;
+  rocsparse_mat_info                 rocsparse_mat_info;
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)

--- a/src/utilities/hypre_cuda_utils.c
+++ b/src/utilities/hypre_cuda_utils.c
@@ -919,7 +919,64 @@ hypre_CudaDataCusparseMatDescr(hypre_CudaData *data)
 
    return mat_descr;
 }
-#endif
+#endif // defined(HYPRE_USING_CUSPARSE)
+
+
+#if defined(HYPRE_USING_ROCSPARSE)
+rocsparse_handle
+hypre_CudaDataCusparseHandle(hypre_CudaData *data)
+{
+   if (data->cusparse_handle)
+   {
+      return data->cusparse_handle;
+   }
+
+   rocsparse_handle handle;
+   HYPRE_ROCSPARSE_CALL( rocsparse_create_handle(&handle) );
+
+   HYPRE_ROCSPARSE_CALL( rocsparse_set_stream(handle, hypre_CudaDataCudaComputeStream(data)) );
+
+   data->cusparse_handle = handle;
+
+   return handle;
+}
+
+rocsparse_mat_descr
+hypre_CudaDataCusparseMatDescr(hypre_CudaData *data)
+{
+   if (data->cusparse_mat_descr)
+   {
+      return data->cusparse_mat_descr;
+   }
+
+   rocsparse_mat_descr mat_descr;
+   HYPRE_ROCSPARSE_CALL( rocsparse_create_mat_descr(&mat_descr) );
+   HYPRE_ROCSPARSE_CALL( rocsparse_set_mat_type(mat_descr, rocsparse_matrix_type_general) );
+   HYPRE_ROCSPARSE_CALL( rocsparse_set_mat_index_base(mat_descr, rocsparse_index_base_zero) );
+
+   data->cusparse_mat_descr = mat_descr;
+
+   return mat_descr;
+}
+
+rocsparse_mat_info
+hypre_CudaDataRocsparseMatInfo(hypre_CudaData *data)
+{
+   if (data->rocsparse_mat_info)
+   {
+      return data->rocsparse_mat_info;
+   }
+
+   rocsparse_mat_info info;
+   HYPRE_ROCSPARSE_CALL( rocsparse_create_mat_info(&info) );
+
+   data->rocsparse_mat_info = info;
+
+   return info;
+}
+#endif // defined(HYPRE_USING_ROCSPARSE)
+
+
 
 hypre_CudaData*
 hypre_CudaDataCreate()
@@ -930,7 +987,7 @@ hypre_CudaDataCreate()
    hypre_CudaDataCudaComputeStreamNum(data)  = 0;
 
    /* SpGeMM */
-#ifdef HYPRE_USING_CUSPARSE
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
    hypre_CudaDataSpgemmUseCusparse(data) = 1;
 #else
    hypre_CudaDataSpgemmUseCusparse(data) = 0;
@@ -981,17 +1038,35 @@ hypre_CudaDataDestroy(hypre_CudaData *data)
    }
 #endif
 
-#if defined(HYPRE_USING_CUSPARSE)
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
    if (data->cusparse_handle)
    {
+#if defined(HYPRE_USING_CUSPARSE)
       HYPRE_CUSPARSE_CALL( cusparseDestroy(data->cusparse_handle) );
+#elif defined(HYPRE_USING_ROCSPARSE)
+      HYPRE_ROCSPARSE_CALL( rocsparse_destroy_handle(data->cusparse_handle) );
+#endif
+
    }
 
    if (data->cusparse_mat_descr)
    {
+#if defined(HYPRE_USING_CUSPARSE)
       HYPRE_CUSPARSE_CALL( cusparseDestroyMatDescr(data->cusparse_mat_descr) );
+#elif defined(HYPRE_USING_ROCSPARSE)
+      HYPRE_ROCSPARSE_CALL( rocsparse_destroy_mat_descr(data->cusparse_mat_descr) );
+#endif
+
+   }
+
+#if defined(HYPRE_USING_ROCSPARSE)
+   if (data->rocsparse_mat_info)
+   {
+     HYPRE_ROCSPARSE_CALL( rocsparse_destroy_mat_info(data->rocsparse_mat_info) );
    }
 #endif
+
+#endif // #if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
 
    for (HYPRE_Int i = 0; i < HYPRE_MAX_NUM_STREAMS; i++)
    {

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -131,6 +131,12 @@ struct hypre_CudaData
    cusparseMatDescr_t                cusparse_mat_descr;
 #endif
 
+#if defined(HYPRE_USING_ROCSPARSE)
+  rocsparse_handle                  cusparse_handle;
+  rocsparse_mat_descr               cusparse_mat_descr;
+  rocsparse_mat_info                rocsparse_mat_info;
+#endif
+
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
    cudaStream_t                      cuda_streams[HYPRE_MAX_NUM_STREAMS];
 #elif defined(HYPRE_USING_HIP)
@@ -203,6 +209,12 @@ cublasHandle_t     hypre_CudaDataCublasHandle(hypre_CudaData *data);
 #if defined(HYPRE_USING_CUSPARSE)
 cusparseHandle_t   hypre_CudaDataCusparseHandle(hypre_CudaData *data);
 cusparseMatDescr_t hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
+#endif
+
+#if defined(HYPRE_USING_ROCSPARSE)
+rocsparse_handle    hypre_CudaDataCusparseHandle(hypre_CudaData *data);
+rocsparse_mat_descr hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
+rocsparse_mat_info  hypre_CudaDataRocsparseMatInfo(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -132,9 +132,9 @@ struct hypre_CudaData
 #endif
 
 #if defined(HYPRE_USING_ROCSPARSE)
-  rocsparse_handle                  cusparse_handle;
-  rocsparse_mat_descr               cusparse_mat_descr;
-  rocsparse_mat_info                rocsparse_mat_info;
+  rocsparse_handle                   cusparse_handle;
+  rocsparse_mat_descr                cusparse_mat_descr;
+  rocsparse_mat_info                 rocsparse_mat_info;
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -41,6 +41,10 @@
 
 #endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 
+#if defined(HYPRE_USING_ROCSPARSE)
+#include <rocsparse.h>
+#endif
+
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 #define HYPRE_CUDA_CALL(call) do {                                                           \
@@ -76,6 +80,14 @@
       hypre_printf("CUSPARSE ERROR (code = %d, %s) at %s:%d\n",                              \
             err, cusparseGetErrorString(err), __FILE__, __LINE__);                           \
       hypre_assert(0); exit(1);                                                              \
+   } } while(0)
+
+#define HYPRE_ROCSPARSE_CALL(call) do {                                                      \
+   rocsparse_status err = call;                                                              \
+   if (rocsparse_status_success != err) {                                                    \
+      hypre_printf("rocSPARSE ERROR (code = %d) at %s:%d\n",                                 \
+            err, __FILE__, __LINE__);                                                        \
+      assert(0); exit(1);                                                                    \
    } } while(0)
 
 

--- a/src/utilities/hypre_cuda_utils.h
+++ b/src/utilities/hypre_cuda_utils.h
@@ -56,12 +56,12 @@
    } } while(0)
 
 #elif defined(HYPRE_USING_HIP)
-#define HYPRE_HIP_CALL(call) do {                                                           \
-   hipError_t err = call;                                                                   \
-   if (hipSuccess != err) {                                                                 \
-      hypre_printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),     \
-                   __FILE__, __LINE__);                                                     \
-      hypre_assert(0); exit(1);                                                             \
+#define HYPRE_HIP_CALL(call) do {                                                            \
+   hipError_t err = call;                                                                    \
+   if (hipSuccess != err) {                                                                  \
+      hypre_printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),      \
+                   __FILE__, __LINE__);                                                      \
+      hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
 #endif // defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
@@ -195,20 +195,20 @@ struct hypre_CudaData
 #define hypre_CudaDataSpgemmHashType(data)                 ((data) -> spgemm_hash_type)
 #define hypre_CudaDataUmpireDeviceAllocator(data)          ((data) -> umpire_device_allocator)
 
-hypre_CudaData* hypre_CudaDataCreate();
-void hypre_CudaDataDestroy(hypre_CudaData* data);
+hypre_CudaData*     hypre_CudaDataCreate();
+void                hypre_CudaDataDestroy(hypre_CudaData* data);
 
 #if defined(HYPRE_USING_CURAND)
-curandGenerator_t  hypre_CudaDataCurandGenerator(hypre_CudaData *data);
+curandGenerator_t   hypre_CudaDataCurandGenerator(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_CUBLAS)
-cublasHandle_t     hypre_CudaDataCublasHandle(hypre_CudaData *data);
+cublasHandle_t      hypre_CudaDataCublasHandle(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_CUSPARSE)
-cusparseHandle_t   hypre_CudaDataCusparseHandle(hypre_CudaData *data);
-cusparseMatDescr_t hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
+cusparseHandle_t    hypre_CudaDataCusparseHandle(hypre_CudaData *data);
+cusparseMatDescr_t  hypre_CudaDataCusparseMatDescr(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_ROCSPARSE)
@@ -218,11 +218,11 @@ rocsparse_mat_info  hypre_CudaDataRocsparseMatInfo(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
-cudaStream_t       hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
-cudaStream_t       hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
+cudaStream_t        hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
+cudaStream_t        hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
 #elif defined(HYPRE_USING_HIP)
-hipStream_t        hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
-hipStream_t        hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
+hipStream_t         hypre_CudaDataCudaStream(hypre_CudaData *data, HYPRE_Int i);
+hipStream_t         hypre_CudaDataCudaComputeStream(hypre_CudaData *data);
 #endif
 
 // Data structure and accessor routines for Cuda Sparse Triangular Matrices
@@ -888,7 +888,6 @@ cudaError_t hypre_CachingFreeDevice(void *ptr);
 cudaError_t hypre_CachingFreeManaged(void *ptr);
 #endif
 
-
 void hypre_CudaDataCubCachingAllocatorDestroy(hypre_CudaData *data);
 
 #endif // #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
@@ -902,3 +901,4 @@ cusparseIndexType_t hypre_HYPREIntToCusparseIndexType();
 #endif // #if defined(HYPRE_USING_CUSPARSE)
 
 #endif /* #ifndef HYPRE_CUDA_UTILS_H */
+

--- a/src/utilities/hypre_general.c
+++ b/src/utilities/hypre_general.c
@@ -202,7 +202,7 @@ HYPRE_Init()
    hypre_HandleCublasHandle(_hypre_handle);
 #endif
 
-#if defined(HYPRE_USING_CUSPARSE)
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
    hypre_HandleCusparseHandle(_hypre_handle);
    hypre_HandleCusparseMatDescr(_hypre_handle);
 #endif
@@ -513,4 +513,3 @@ HYPRE_GetExecutionPolicy(HYPRE_ExecutionPolicy *exec_policy)
 
    return hypre_error_flag;
 }
-

--- a/src/utilities/hypre_handle.h
+++ b/src/utilities/hypre_handle.h
@@ -54,6 +54,7 @@ typedef struct
 #define hypre_HandleCublasHandle(hypre_handle)                   hypre_CudaDataCublasHandle(hypre_HandleCudaData(hypre_handle))
 #define hypre_HandleCusparseHandle(hypre_handle)                 hypre_CudaDataCusparseHandle(hypre_HandleCudaData(hypre_handle))
 #define hypre_HandleCusparseMatDescr(hypre_handle)               hypre_CudaDataCusparseMatDescr(hypre_HandleCudaData(hypre_handle))
+#define hypre_HandleRocsparseMatInfo(hypre_handle)               hypre_CudaDataRocsparseMatInfo(hypre_HandleCudaData(hypre_handle))
 #define hypre_HandleCudaComputeStream(hypre_handle)              hypre_CudaDataCudaComputeStream(hypre_HandleCudaData(hypre_handle))
 #define hypre_HandleCubBinGrowth(hypre_handle)                   hypre_CudaDataCubBinGrowth(hypre_HandleCudaData(hypre_handle))
 #define hypre_HandleCubMinBin(hypre_handle)                      hypre_CudaDataCubMinBin(hypre_HandleCudaData(hypre_handle))
@@ -92,4 +93,3 @@ typedef struct
 #define hypre_HandleOwnUmpirePinnedPool(hypre_handle)            ((hypre_handle) -> own_umpire_pinned_pool)
 
 #endif
-


### PR DESCRIPTION
This PR (by @pbauman #304)  adds the first pass of rocSPARSE support. It is not complete: you will notice that there are a couple of "stubs" where I throw a runtime error message if that code path is taken and I have not yet included optimizations, e.g. the analysis API for dscrmv. Nevertheless, I am able to run BoomerAMG on AMD GPUs, specifically the `ij` test using aggressive coarsening with unified memory `./ij -n 96 96 96 -pmis -keepT 1 -rlx 18 -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 1 -interptype 6 -solver 1 -agg_nl 1` and no aggressive coarsening without unified memory `./ij -n 96 96 96 -pmis -keepT 1 -rlx 18 -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 1 -interptype 6 -solver 1 -agg_nl 0`.

That said, I'm currently chasing what seems to be a compiler bug (though I'm not entirely sure of that yet). The cases above do converge, but with optimization level `-O2`, the coarsening behaves differently than with `-O1` and `-O0`. Nevertheless, I wanted you good folks to have a look at this and with any luck I can try and pin down the issue by the time this is ready to merge. If not, then y'all can decide if you want to wait to merge or not.