### PR TITLE
Add rocTX Support

### DIFF
--- a/src/config/HYPRE_config.h.in
+++ b/src/config/HYPRE_config.h.in
@@ -223,6 +223,9 @@
 /* rocSPARSE being used */
 #undef HYPRE_USING_ROCSPARSE
 
+/* Define to 1 if using AMD rocTX profiling */
+#undef HYPRE_USING_ROCTX
+
 /* Define to 1 if using UMPIRE */
 #undef HYPRE_USING_UMPIRE
 

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -2085,6 +2085,13 @@ AS_IF([test x"$hypre_user_chose_hip" == x"yes"],
                HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocrand/include"
                ])
 
+        dnl rocTX tracing API
+        AS_IF([test x"$hypre_using_gpu_profiling" == x"yes"],
+              [AC_DEFINE(HYPRE_USING_ROCTX, 1, [Define to 1 if using AMD rocTX profiling])
+               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/roctracer/include"
+               HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lroctx64"
+               ])
+
       ]) dnl AS_IF([test x"$hypre_user_chose_hip" == x"yes"]
 
 

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -144,8 +144,9 @@ hypre_using_cuda=no
 hypre_using_gpu=no
 hypre_using_um=no
 hypre_gpu_mpi=no
+hypre_using_gpu_profiling=no
+
 hypre_using_cuda_streams=no
-hypre_using_nvtx=no
 hypre_using_cusparse=yes
 hypre_using_cublas=no
 hypre_using_curand=yes
@@ -385,17 +386,6 @@ AS_HELP_STRING([--enable-cuda-streams],
 [hypre_using_cuda_streams=yes]
 )
 
-AC_ARG_ENABLE(nvtx,
-AS_HELP_STRING([--enable-nvtx],
-               [Use NVTX (default is NO).]),
-[case "${enableval}" in
-    yes) hypre_using_nvtx=yes ;;
-    no)  hypre_using_nvtx=no ;;
-    *)   hypre_using_nvtx=no ;;
- esac],
-[hypre_using_nvtx=no]
-)
-
 AC_ARG_ENABLE(cusparse,
 AS_HELP_STRING([--enable-cusparse],
                [Use cuSPARSE (default is YES).]),
@@ -475,6 +465,16 @@ AS_HELP_STRING([--enable-rocrand],
 [hypre_using_rocrand=yes]
 )
 
+AC_ARG_ENABLE(gpu-profiling,
+AS_HELP_STRING([--enable-gpu-profiling],
+               [Use NVTX on CUDA, rocTX on HIP (default is NO).]),
+[case "${enableval}" in
+    yes) hypre_using_gpu_profiling=yes ;;
+    no)  hypre_using_gpu_profiling=no ;;
+    *)   hypre_using_gpu_profiling=no ;;
+ esac],
+[hypre_using_gpu_profiling=no]
+)
 
 AC_ARG_ENABLE(gpu-aware-mpi,
 AS_HELP_STRING([--enable-gpu-aware-mpi],
@@ -1941,7 +1941,7 @@ then
 
    AC_DEFINE(HYPRE_USING_CUSPARSE, 1, [Define to 1 if using cuSPARSE])
 
-   if test "$hypre_using_nvtx" = "yes"
+   if test "$hypre_using_gpu_profiling" = "yes"
    then
       AC_DEFINE(HYPRE_USING_NVTX, 1, [Define to 1 if using NVIDIA Tools Extension (NVTX)])
    fi
@@ -1999,7 +1999,7 @@ then
    LDFLAGS="-ccbin=$NVCCBIN ${HYPRE_CUDA_GENCODE} -Xcompiler \"${LDFLAGS}\""
    HYPRE_CUDA_INCLUDE="-I${HYPRE_CUDA_PATH}/include"
    HYPRE_CUDA_LIBS="-L${HYPRE_CUDA_PATH}/lib64 -lcudart"
-   if test "$hypre_using_nvtx" = "yes"
+   if test "$hypre_using_gpu_profiling" = "yes"
    then
       HYPRE_CUDA_LIBS+=" -lnvToolsExt"
    fi
@@ -2137,7 +2137,7 @@ if test "$hypre_using_device_openmp" = "yes"
 then
    AC_DEFINE(HYPRE_USING_CUSPARSE, 1, [Define to 1 if using cuSPARSE])
 
-   if test "$hypre_using_nvtx" = "yes"
+   if test "$hypre_using_gpu_profiling" = "yes"
    then
       AC_DEFINE(HYPRE_USING_NVTX, 1, [NVTX being used])
    fi
@@ -2171,7 +2171,7 @@ then
 
    HYPRE_CUDA_INCLUDE="-I${HYPRE_CUDA_PATH}/include"
    HYPRE_CUDA_LIBS="-L${HYPRE_CUDA_PATH}/lib64 -lcusparse -lcudart -lcurand"
-   if test "$hypre_using_nvtx" = "yes"
+   if test "$hypre_using_gpu_profiling" = "yes"
    then
       HYPRE_CUDA_LIBS+=" -lnvToolsExt"
    fi

--- a/src/configure
+++ b/src/configure
@@ -777,7 +777,6 @@ enable_hopscotch
 enable_fortran
 enable_unified_memory
 enable_cuda_streams
-enable_nvtx
 enable_cusparse
 enable_cub
 enable_cublas
@@ -785,6 +784,7 @@ enable_curand
 enable_rocsparse
 enable_rocblas
 enable_rocrand
+enable_gpu_profiling
 enable_gpu_aware_mpi
 with_LD
 with_LDFLAGS
@@ -1497,7 +1497,6 @@ Optional Features:
   --enable-unified-memory Use unified memory for allocating the memory
                           (default is NO).
   --enable-cuda-streams   Use CUDA streams (default is YES).
-  --enable-nvtx           Use NVTX (default is NO).
   --enable-cusparse       Use cuSPARSE (default is YES).
   --enable-cub            Use CUB Allocator (default is NO).
   --enable-cublas         Use cuBLAS (default is NO).
@@ -1505,6 +1504,7 @@ Optional Features:
   --enable-rocsparse      Use rocSPARSE (default is YES).
   --enable-rocblas        Use rocBLAS (default is NO).
   --enable-rocrand        Use rocRAND (default is YES).
+  --enable-gpu-profiling  Use NVTX on CUDA, rocTX on HIP (default is NO).
   --enable-gpu-aware-mpi  Use GPU memory aware MPI
 
 Optional Packages:
@@ -2691,8 +2691,9 @@ hypre_using_cuda=no
 hypre_using_gpu=no
 hypre_using_um=no
 hypre_gpu_mpi=no
+hypre_using_gpu_profiling=no
+
 hypre_using_cuda_streams=no
-hypre_using_nvtx=no
 hypre_using_cusparse=yes
 hypre_using_cublas=no
 hypre_using_curand=yes
@@ -3031,19 +3032,6 @@ else
 fi
 
 
-# Check whether --enable-nvtx was given.
-if test "${enable_nvtx+set}" = set; then :
-  enableval=$enable_nvtx; case "${enableval}" in
-    yes) hypre_using_nvtx=yes ;;
-    no)  hypre_using_nvtx=no ;;
-    *)   hypre_using_nvtx=no ;;
- esac
-else
-  hypre_using_nvtx=no
-
-fi
-
-
 # Check whether --enable-cusparse was given.
 if test "${enable_cusparse+set}" = set; then :
   enableval=$enable_cusparse; case "${enableval}" in
@@ -3136,6 +3124,18 @@ else
 
 fi
 
+
+# Check whether --enable-gpu-profiling was given.
+if test "${enable_gpu_profiling+set}" = set; then :
+  enableval=$enable_gpu_profiling; case "${enableval}" in
+    yes) hypre_using_gpu_profiling=yes ;;
+    no)  hypre_using_gpu_profiling=no ;;
+    *)   hypre_using_gpu_profiling=no ;;
+ esac
+else
+  hypre_using_gpu_profiling=no
+
+fi
 
 
 # Check whether --enable-gpu-aware-mpi was given.
@@ -8693,7 +8693,7 @@ $as_echo "#define HYPRE_USING_CUDA 1" >>confdefs.h
 $as_echo "#define HYPRE_USING_CUSPARSE 1" >>confdefs.h
 
 
-   if test "$hypre_using_nvtx" = "yes"
+   if test "$hypre_using_gpu_profiling" = "yes"
    then
 
 $as_echo "#define HYPRE_USING_NVTX 1" >>confdefs.h
@@ -8799,7 +8799,7 @@ done
       LDFLAGS="-ccbin=$NVCCBIN ${HYPRE_CUDA_GENCODE} -Xcompiler \"${LDFLAGS}\""
    HYPRE_CUDA_INCLUDE="-I${HYPRE_CUDA_PATH}/include"
    HYPRE_CUDA_LIBS="-L${HYPRE_CUDA_PATH}/lib64 -lcudart"
-   if test "$hypre_using_nvtx" = "yes"
+   if test "$hypre_using_gpu_profiling" = "yes"
    then
       HYPRE_CUDA_LIBS+=" -lnvToolsExt"
    fi
@@ -8915,6 +8915,15 @@ $as_echo "#define HYPRE_USING_ROCRAND 1" >>confdefs.h
 
 fi
 
+                if test x"$hypre_using_gpu_profiling" == x"yes"; then :
+
+$as_echo "#define HYPRE_USING_ROCTX 1" >>confdefs.h
+
+               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/roctracer/include"
+               HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lroctx64"
+
+fi
+
 
 fi
 
@@ -8976,7 +8985,7 @@ then
 $as_echo "#define HYPRE_USING_CUSPARSE 1" >>confdefs.h
 
 
-   if test "$hypre_using_nvtx" = "yes"
+   if test "$hypre_using_gpu_profiling" = "yes"
    then
 
 $as_echo "#define HYPRE_USING_NVTX 1" >>confdefs.h
@@ -9016,7 +9025,7 @@ $as_echo "#define HYPRE_DEVICE_OPENMP_CHECK 1" >>confdefs.h
 
    HYPRE_CUDA_INCLUDE="-I${HYPRE_CUDA_PATH}/include"
    HYPRE_CUDA_LIBS="-L${HYPRE_CUDA_PATH}/lib64 -lcusparse -lcudart -lcurand"
-   if test "$hypre_using_nvtx" = "yes"
+   if test "$hypre_using_gpu_profiling" = "yes"
    then
       HYPRE_CUDA_LIBS+=" -lnvToolsExt"
    fi

--- a/src/parcsr_ls/par_2s_interp.c
+++ b/src/parcsr_ls/par_2s_interp.c
@@ -526,7 +526,7 @@ hypre_BoomerAMGBuildModPartialExtInterp( hypre_ParCSRMatrix  *A,
                                          hypre_ParCSRMatrix **P_ptr )
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("PartialExtInterp");
+   hypre_GpuProfilingPushRange("PartialExtInterp");
 #endif
 
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(A) );
@@ -547,7 +547,7 @@ hypre_BoomerAMGBuildModPartialExtInterp( hypre_ParCSRMatrix  *A,
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return ierr;
@@ -1113,7 +1113,7 @@ hypre_BoomerAMGBuildModPartialExtPEInterp( hypre_ParCSRMatrix  *A,
                                            hypre_ParCSRMatrix **P_ptr )
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("PartialExtPEInterp");
+   hypre_GpuProfilingPushRange("PartialExtPEInterp");
 #endif
 
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(A) );
@@ -1134,7 +1134,7 @@ hypre_BoomerAMGBuildModPartialExtPEInterp( hypre_ParCSRMatrix  *A,
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return ierr;

--- a/src/parcsr_ls/par_coarsen.c
+++ b/src/parcsr_ls/par_coarsen.c
@@ -2745,7 +2745,7 @@ hypre_BoomerAMGCoarsenPMIS( hypre_ParCSRMatrix    *S,
                             HYPRE_Int            **CF_marker_ptr)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("PMIS");
+   hypre_GpuProfilingPushRange("PMIS");
 #endif
 
    HYPRE_Int ierr = 0;
@@ -2764,7 +2764,7 @@ hypre_BoomerAMGCoarsenPMIS( hypre_ParCSRMatrix    *S,
    }
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return ierr;

--- a/src/parcsr_ls/par_interp.c
+++ b/src/parcsr_ls/par_interp.c
@@ -2667,7 +2667,7 @@ hypre_BoomerAMGBuildDirInterp( hypre_ParCSRMatrix   *A,
                                hypre_ParCSRMatrix  **P_ptr)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("DirInterp");
+   hypre_GpuProfilingPushRange("DirInterp");
 #endif
 
    HYPRE_Int ierr = 0;
@@ -2689,7 +2689,7 @@ hypre_BoomerAMGBuildDirInterp( hypre_ParCSRMatrix   *A,
    }
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return ierr;

--- a/src/parcsr_ls/par_lr_interp.c
+++ b/src/parcsr_ls/par_lr_interp.c
@@ -5421,7 +5421,7 @@ hypre_BoomerAMGBuildExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                               hypre_ParCSRMatrix  **P_ptr)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("ExtInterp");
+   hypre_GpuProfilingPushRange("ExtInterp");
 #endif
 
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(A) );
@@ -5442,7 +5442,7 @@ hypre_BoomerAMGBuildExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return ierr;
@@ -5464,7 +5464,7 @@ hypre_BoomerAMGBuildExtPIInterp(hypre_ParCSRMatrix   *A,
                                 hypre_ParCSRMatrix  **P_ptr)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("ExtPIInterp");
+   hypre_GpuProfilingPushRange("ExtPIInterp");
 #endif
 
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(A) );
@@ -5485,7 +5485,7 @@ hypre_BoomerAMGBuildExtPIInterp(hypre_ParCSRMatrix   *A,
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return ierr;

--- a/src/parcsr_ls/par_mod_lr_interp.c
+++ b/src/parcsr_ls/par_mod_lr_interp.c
@@ -433,7 +433,7 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix  *A,
                                  hypre_ParCSRMatrix **P_ptr)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("ModExtInterp");
+   hypre_GpuProfilingPushRange("ModExtInterp");
 #endif
 
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(A) );
@@ -454,7 +454,7 @@ hypre_BoomerAMGBuildModExtInterp(hypre_ParCSRMatrix  *A,
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return ierr;
@@ -991,7 +991,7 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix  *A,
                                    hypre_ParCSRMatrix **P_ptr)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("ExtPIInterp");
+   hypre_GpuProfilingPushRange("ExtPIInterp");
 #endif
 
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(A) );
@@ -1012,7 +1012,7 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix  *A,
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return ierr;
@@ -1522,7 +1522,7 @@ hypre_BoomerAMGBuildModExtPEInterp(hypre_ParCSRMatrix  *A,
                                       hypre_ParCSRMatrix **P_ptr)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("ExtPEInterp");
+   hypre_GpuProfilingPushRange("ExtPEInterp");
 #endif
 
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(A) );
@@ -1543,7 +1543,7 @@ hypre_BoomerAMGBuildModExtPEInterp(hypre_ParCSRMatrix  *A,
 #endif
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return ierr;

--- a/src/parcsr_ls/par_relax_device.c
+++ b/src/parcsr_ls/par_relax_device.c
@@ -84,7 +84,7 @@ hypre_BoomerAMGRelaxTwoStageGaussSeidelDevice ( hypre_ParCSRMatrix *A,
                                                 hypre_ParVector    *z,
                                                 HYPRE_Int           num_inner_iters)
 {
-   hypre_NvtxPushRange("BoomerAMGRelaxTwoStageGaussSeidelDevice");
+   hypre_GpuProfilingPushRange("BoomerAMGRelaxTwoStageGaussSeidelDevice");
 
    hypre_CSRMatrix *A_diag       = hypre_ParCSRMatrixDiag(A);
    HYPRE_Int        num_rows     = hypre_CSRMatrixNumRows(A_diag);
@@ -124,7 +124,7 @@ hypre_BoomerAMGRelaxTwoStageGaussSeidelDevice ( hypre_ParCSRMatrix *A,
    // reset this
    hypre_VectorSize(z_local) = zsize;
 
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 
    return 0;
 }

--- a/src/parcsr_ls/par_strength.c
+++ b/src/parcsr_ls/par_strength.c
@@ -539,7 +539,7 @@ hypre_BoomerAMGCreateS(hypre_ParCSRMatrix    *A,
                        hypre_ParCSRMatrix   **S_ptr)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("CreateS");
+   hypre_GpuProfilingPushRange("CreateS");
 #endif
 
    HYPRE_Int ierr = 0;
@@ -558,7 +558,7 @@ hypre_BoomerAMGCreateS(hypre_ParCSRMatrix    *A,
    }
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return ierr;
@@ -2918,7 +2918,7 @@ hypre_BoomerAMGCreate2ndS( hypre_ParCSRMatrix  *S,
                            hypre_ParCSRMatrix **C_ptr)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("Create2ndS");
+   hypre_GpuProfilingPushRange("Create2ndS");
 #endif
 
    HYPRE_Int ierr = 0;
@@ -2937,7 +2937,7 @@ hypre_BoomerAMGCreate2ndS( hypre_ParCSRMatrix  *S,
    }
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return ierr;

--- a/src/parcsr_ls/par_strength2nd_device.c
+++ b/src/parcsr_ls/par_strength2nd_device.c
@@ -48,7 +48,7 @@ hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix  *S,
    hypre_TMemcpy(CF_marker, CF_marker_host, HYPRE_Int, S_nr_local, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
 
    /* 1. Create new matrix with added diagonal */
-   hypre_NvtxPushRangeColor("Setup", 1);
+   hypre_GpuProfilingPushRangeColor("Setup", 1);
 
    /* give S data arrays */
    hypre_CSRMatrixData(S_diag) = hypre_TAlloc(HYPRE_Complex, S_diag_nnz, HYPRE_MEMORY_DEVICE );
@@ -111,17 +111,17 @@ hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix  *S,
    hypre_CSRMatrixDestroy(hypre_ParCSRMatrixDiag(S_CX));
    hypre_ParCSRMatrixDiag(S_CX) = SI_diag;
 
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 
    /* 2. Perform matrix-matrix multiplication */
-   hypre_NvtxPushRangeColor("Matrix-matrix mult", 3);
+   hypre_GpuProfilingPushRangeColor("Matrix-matrix mult", 3);
 
    S2 = hypre_ParCSRMatMatDevice(S_CX, S_XC);
 
    hypre_ParCSRMatrixDestroy(S_CX);
    hypre_ParCSRMatrixDestroy(S_XC);
 
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 
    // Clean up matrix before returning it.
    if (num_paths == 2)

--- a/src/parcsr_mv/par_csr_triplemat.c
+++ b/src/parcsr_mv/par_csr_triplemat.c
@@ -206,7 +206,7 @@ hypre_ParCSRMatMat( hypre_ParCSRMatrix  *A,
                     hypre_ParCSRMatrix  *B )
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("Mat-Mat");
+   hypre_GpuProfilingPushRange("Mat-Mat");
 #endif
 
    hypre_ParCSRMatrix *C = NULL;
@@ -226,7 +226,7 @@ hypre_ParCSRMatMat( hypre_ParCSRMatrix  *A,
    }
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return C;
@@ -465,7 +465,7 @@ hypre_ParCSRTMatMatKT( hypre_ParCSRMatrix  *A,
                        HYPRE_Int            keep_transpose)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("Mat-T-Mat");
+   hypre_GpuProfilingPushRange("Mat-T-Mat");
 #endif
 
    hypre_ParCSRMatrix *C = NULL;
@@ -485,7 +485,7 @@ hypre_ParCSRTMatMatKT( hypre_ParCSRMatrix  *A,
    }
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return C;
@@ -927,7 +927,7 @@ hypre_ParCSRMatrixRAPKT( hypre_ParCSRMatrix  *R,
                          HYPRE_Int            keep_transpose)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("TripleMat-RAP");
+   hypre_GpuProfilingPushRange("TripleMat-RAP");
 #endif
 
    hypre_ParCSRMatrix *C = NULL;
@@ -947,7 +947,7 @@ hypre_ParCSRMatrixRAPKT( hypre_ParCSRMatrix  *R,
    }
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return C;

--- a/src/seq_mv/csr_matvec_device.c
+++ b/src/seq_mv/csr_matvec_device.c
@@ -69,7 +69,7 @@ hypre_CSRMatrixMatvecDevice( HYPRE_Int        trans,
                              HYPRE_Int        offset )
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPushRange("CSRMatrixMatvec");
+   hypre_GpuProfilingPushRange("CSRMatrixMatvec");
 #endif
 
    // TODO: RL: do we need offset > 0 at all?
@@ -115,7 +115,7 @@ hypre_CSRMatrixMatvecDevice( HYPRE_Int        trans,
    hypre_SyncCudaComputeStream(hypre_handle());
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_NvtxPopRange();
+   hypre_GpuProfilingPopRange();
 #endif
 
    return hypre_error_flag;

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -3574,7 +3574,7 @@ main( hypre_int argc,
       //cudaProfilerStart();
 
 #if defined(HYPRE_USING_NVTX)
-      hypre_NvtxPushRange("AMG-Setup-1");
+      hypre_GpuProfilingPushRange("AMG-Setup-1");
 #endif
       if (solver_id == 0)
       {
@@ -3586,7 +3586,7 @@ main( hypre_int argc,
       }
 
 #if defined(HYPRE_USING_NVTX)
-      hypre_NvtxPopRange();
+      hypre_GpuProfilingPopRange();
 #endif
 
 #if defined(HYPRE_USING_GPU)
@@ -3609,7 +3609,7 @@ main( hypre_int argc,
       hypre_BeginTiming(time_index);
 
 #if defined(HYPRE_USING_NVTX)
-      hypre_NvtxPushRange("AMG-Solve-1");
+      hypre_GpuProfilingPushRange("AMG-Solve-1");
 #endif
 
       //cudaProfilerStart();
@@ -3624,7 +3624,7 @@ main( hypre_int argc,
       //cudaProfilerStop();
 
 #if defined(HYPRE_USING_NVTX)
-      hypre_NvtxPopRange();
+      hypre_GpuProfilingPopRange();
 #endif
 
 #if defined(HYPRE_USING_GPU)
@@ -3672,7 +3672,7 @@ main( hypre_int argc,
       tt = hypre_MPI_Wtime();
 
 #if defined(HYPRE_USING_NVTX)
-      hypre_NvtxPushRange("AMG-Setup-2");
+      hypre_GpuProfilingPushRange("AMG-Setup-2");
 #endif
 
       if (solver_id == 0)
@@ -3685,7 +3685,7 @@ main( hypre_int argc,
       }
 
 #if defined(HYPRE_USING_NVTX)
-      hypre_NvtxPopRange();
+      hypre_GpuProfilingPopRange();
 #endif
 
 #if defined(HYPRE_USING_GPU)
@@ -3704,7 +3704,7 @@ main( hypre_int argc,
       tt = hypre_MPI_Wtime();
 
 #if defined(HYPRE_USING_NVTX)
-      hypre_NvtxPushRange("AMG-Solve-2");
+      hypre_GpuProfilingPushRange("AMG-Solve-2");
 #endif
 
       if (solver_id == 0)
@@ -3717,7 +3717,7 @@ main( hypre_int argc,
       }
 
 #if defined(HYPRE_USING_NVTX)
-      hypre_NvtxPopRange();
+      hypre_GpuProfilingPopRange();
 #endif
 
 #if defined(HYPRE_USING_GPU)

--- a/src/test/sstruct.c
+++ b/src/test/sstruct.c
@@ -4976,7 +4976,7 @@ main( hypre_int argc,
 #endif
 
 #if defined(HYPRE_USING_NVTX)
-      hypre_NvtxPushRange("HybridSolve");
+      hypre_GpuProfilingPushRange("HybridSolve");
 #endif
       //cudaProfilerStart();
 
@@ -5013,7 +5013,7 @@ main( hypre_int argc,
       HYPRE_ParCSRHybridDestroy(par_solver);
 
 #if defined(HYPRE_USING_NVTX)
-      hypre_NvtxPopRange();
+      hypre_GpuProfilingPopRange();
 #endif
       //cudaProfilerStop();
 

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1614,9 +1614,9 @@ HYPRE_Int hypreDevice_BigIntFilln(HYPRE_BigInt *d_x, size_t n, HYPRE_BigInt v);
 HYPRE_Int hypre_bind_device(HYPRE_Int myid, HYPRE_Int nproc, MPI_Comm comm);
 
 /* hypre_nvtx.c */
-void hypre_NvtxPushRangeColor(const char *name, HYPRE_Int cid);
-void hypre_NvtxPushRange(const char *name);
-void hypre_NvtxPopRange();
+void hypre_GpuProfilingPushRangeColor(const char *name, HYPRE_Int cid);
+void hypre_GpuProfilingPushRange(const char *name);
+void hypre_GpuProfilingPopRange();
 
 /* hypre_utilities.c */
 HYPRE_Int hypre_multmod(HYPRE_Int a, HYPRE_Int b, HYPRE_Int mod);

--- a/src/utilities/hypre_nvtx.c
+++ b/src/utilities/hypre_nvtx.c
@@ -68,7 +68,7 @@ static std::vector<std::string> hypre_nvtx_range_names;
 
 #endif // defined(HYPRE_USING_NVTX)
 
-void hypre_NvtxPushRangeColor(const char *name, HYPRE_Int color_id)
+void hypre_GpuProfilingPushRangeColor(const char *name, HYPRE_Int color_id)
 {
 #ifdef HYPRE_USING_NVTX
    color_id = color_id % hypre_nvtx_num_colors;
@@ -87,7 +87,7 @@ void hypre_NvtxPushRangeColor(const char *name, HYPRE_Int color_id)
 #endif
 }
 
-void hypre_NvtxPushRange(const char *name)
+void hypre_GpuProfilingPushRange(const char *name)
 {
 #ifdef HYPRE_USING_NVTX
    std::vector<std::string>::iterator p = std::find(hypre_nvtx_range_names.begin(),
@@ -102,7 +102,7 @@ void hypre_NvtxPushRange(const char *name)
 
    HYPRE_Int color = p - hypre_nvtx_range_names.begin();
 
-   hypre_NvtxPushRangeColor(name, color);
+   hypre_GpuProfilingPushRangeColor(name, color);
 #endif
 
 #ifdef HYPRE_USING_ROCTX
@@ -110,10 +110,10 @@ void hypre_NvtxPushRange(const char *name)
 #endif
 }
 
-void hypre_NvtxPopRange()
+void hypre_GpuProfilingPopRange()
 {
 #ifdef HYPRE_USING_NVTX
-   hypre_NvtxPushRangeColor("StreamSync0", Red);
+   hypre_GpuProfilingPushRangeColor("StreamSync0", Red);
    cudaStreamSynchronize(0);
    nvtxRangePop();
    nvtxRangePop();

--- a/src/utilities/hypre_nvtx.c
+++ b/src/utilities/hypre_nvtx.c
@@ -7,7 +7,12 @@
 
 #include "_hypre_utilities.h"
 
-#ifdef HYPRE_USING_NVTX
+#if defined(HYPRE_USING_ROCTX)
+#include "hip/hip_runtime_api.h"
+#include "roctx.h"
+#endif
+
+#if defined(HYPRE_USING_NVTX)
 
 #include <string>
 #include <algorithm>
@@ -61,7 +66,7 @@ static const uint32_t colors[] =
 static const HYPRE_Int hypre_nvtx_num_colors = sizeof(colors) / sizeof(uint32_t);
 static std::vector<std::string> hypre_nvtx_range_names;
 
-#endif
+#endif // defined(HYPRE_USING_NVTX)
 
 void hypre_NvtxPushRangeColor(const char *name, HYPRE_Int color_id)
 {
@@ -75,6 +80,10 @@ void hypre_NvtxPushRangeColor(const char *name, HYPRE_Int color_id)
    eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
    eventAttrib.message.ascii = name;
    nvtxRangePushEx(&eventAttrib);
+#endif
+
+#ifdef HYPRE_USING_ROCTX
+   roctxRangePush(name);
 #endif
 }
 
@@ -95,6 +104,10 @@ void hypre_NvtxPushRange(const char *name)
 
    hypre_NvtxPushRangeColor(name, color);
 #endif
+
+#ifdef HYPRE_USING_ROCTX
+   roctxRangePush(name);
+#endif
 }
 
 void hypre_NvtxPopRange()
@@ -105,8 +118,11 @@ void hypre_NvtxPopRange()
    nvtxRangePop();
    nvtxRangePop();
 #endif
+
+#ifdef HYPRE_USING_ROCTX
+   roctxRangePush("StreamSync0");
+   hipStreamSynchronize(0);
+   roctxRangePop();
+   roctxRangePop();
+#endif
 }
-
-
-
-//nvtxRangePushA(name);

--- a/src/utilities/protos.h
+++ b/src/utilities/protos.h
@@ -258,9 +258,9 @@ HYPRE_Int hypreDevice_BigIntFilln(HYPRE_BigInt *d_x, size_t n, HYPRE_BigInt v);
 HYPRE_Int hypre_bind_device(HYPRE_Int myid, HYPRE_Int nproc, MPI_Comm comm);
 
 /* hypre_nvtx.c */
-void hypre_NvtxPushRangeColor(const char *name, HYPRE_Int cid);
-void hypre_NvtxPushRange(const char *name);
-void hypre_NvtxPopRange();
+void hypre_GpuProfilingPushRangeColor(const char *name, HYPRE_Int cid);
+void hypre_GpuProfilingPushRange(const char *name);
+void hypre_GpuProfilingPopRange();
 
 /* hypre_utilities.c */
 HYPRE_Int hypre_multmod(HYPRE_Int a, HYPRE_Int b, HYPRE_Int mod);


### PR DESCRIPTION
This PR adds rocTX support, the ROCm analog to NVTX. There are basically three parts to this PR:

1. Change the configure option `--enable-nvtx` to `--enable-gpu-profiling` so that we hide the GPU profiling mode from the user and tie it to `--with-cuda` or `--with-hip`. And add `HYPRE_USING_ROCTX` which this is triggered and the user is using HIP.
2. Add the rocTX APIs alongside the NVTX APIs. Note that there is no analog `Color` API functionality in rocTX. This is because we visualize the timeline using Google Chrome (`chrome://tracing`). So I `#ifdef` around all the color management and just use what is necessary for the rocTX APIs in that case.
3. Change the API naming from `hypre_Nvtx` to `hypre_GpuProfiling` to help with the clarity in the library.

I tested this PR on both ROCm and CUDA 10.2 and confirmed the GPU profiling regions are captured.

This should be able to be applied independent of #304/#316 so it doesn't matter which gets merged first from my point-of-view. Thank you.