### PR TITLE
add include in fei makefile

### DIFF
--- a/src/FEI_mv/fei-hypre/Makefile
+++ b/src/FEI_mv/fei-hypre/Makefile
@@ -26,6 +26,7 @@ C_COMPILE_FLAGS = \
  -I$(srcdir)/../../utilities\
  -I$(srcdir)/../../multivector\
  -I$(srcdir)/../../krylov\
+ -I$(srcdir)/../../parcsr_block_mv\
  -I$(srcdir)/../../parcsr_mv\
  -I$(srcdir)/../../parcsr_ls\
  -I$(srcdir)/../../seq_mv\
@@ -46,6 +47,7 @@ CXX_COMPILE_FLAGS = \
  -I$(srcdir)/../../utilities\
  -I$(srcdir)/../../multivector\
  -I$(srcdir)/../../krylov\
+ -I$(srcdir)/../../parcsr_block_mv\
  -I$(srcdir)/../../parcsr_mv\
  -I$(srcdir)/../../parcsr_ls\
  -I$(srcdir)/../../seq_mv\


### PR DESCRIPTION
This PR adds an include directory in `FEI_MV`.