### PR TITLE
config: fix --without-* arg interpretation to NO

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -637,7 +637,8 @@ AS_HELP_STRING([--with-strict-checking],
                [Compiles without MPI ('--without-MPI') and tries to
                 find a compiler option that warns of as many non-ISO
                 features as possible.]),
-[
+[case "${withval}" in
+ yes)
  hypre_user_chose_ccompilers=yes
  hypre_user_chose_cflags=yes
  hypre_user_chose_cxxcompilers=yes
@@ -694,7 +695,9 @@ AS_HELP_STRING([--with-strict-checking],
     fi
  fi
 
- AC_DEFINE(HYPRE_SEQUENTIAL,1,[No MPI being used])]
+ AC_DEFINE(HYPRE_SEQUENTIAL,1,[No MPI being used])
+ ;;
+ esac]
 )
 
 dnl ***** MPI
@@ -1336,8 +1339,11 @@ dnl ***** Caliper
 AC_ARG_WITH(caliper,
 AS_HELP_STRING([--with-caliper],
                [Use Caliper instrumentation (default is NO).]),
-               [hypre_using_caliper=yes],
-               [hypre_using_caliper=no])
+[case "$withval" in
+    yes) hypre_using_caliper=yes;;
+    *)   hypre_using_caliper=no ;;
+esac],
+[hypre_using_caliper=no])
 
 AS_IF([test "x$with_caliper" = "xyes"],
       [AC_DEFINE(HYPRE_USING_CALIPER, 1, [Define to 1 if Caliper instrumentation is enabled])],


### PR DESCRIPTION
Namely, for --without-caliper and --without-strict-checking.


Without this patch, `--without-caliper` is interpreted as YES and a warning is printed:

```
./configure --without-caliper ...
...
+ test set = set
+ :
+ withval=no
+ hypre_using_caliper=yes
+ test xno = xyes
+ test '' = set
+ test '' = set
+ set +x 
...
+ test yes = yes
+ test no '!=' yes
+ printf '%s\n' 'configure:8367: WARNING: *******************************************************'
+ printf '%s\n' 'configure: WARNING: *******************************************************'
configure: WARNING: *******************************************************
+ printf '%s\n' 'configure:8369: WARNING: Configuring with --with-caliper=yes without providing'
+ printf '%s\n' 'configure: WARNING: Configuring with --with-caliper=yes without providing'
configure: WARNING: Configuring with --with-caliper=yes without providing
+ printf '%s\n' 'configure:8371: WARNING: --with-caliper-include=<path-to-caliper-install>.'
+ printf '%s\n' 'configure: WARNING: --with-caliper-include=<path-to-caliper-install>.'
configure: WARNING: --with-caliper-include=<path-to-caliper-install>.
```

This patch fixes those two args to be implemented like the other args with a switch statement on `$withval`. I went lax on the indenting near `--with-strict-checking` to not explode this diff with whitespace changes.