### PR TITLE
Config without args

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -637,7 +637,8 @@ AS_HELP_STRING([--with-strict-checking],
                [Compiles without MPI ('--without-MPI') and tries to
                 find a compiler option that warns of as many non-ISO
                 features as possible.]),
-[
+[case "${withval}" in
+ yes)
  hypre_user_chose_ccompilers=yes
  hypre_user_chose_cflags=yes
  hypre_user_chose_cxxcompilers=yes
@@ -694,7 +695,9 @@ AS_HELP_STRING([--with-strict-checking],
     fi
  fi
 
- AC_DEFINE(HYPRE_SEQUENTIAL,1,[No MPI being used])]
+ AC_DEFINE(HYPRE_SEQUENTIAL,1,[No MPI being used])
+ ;;
+ esac]
 )
 
 dnl ***** MPI
@@ -1336,8 +1339,11 @@ dnl ***** Caliper
 AC_ARG_WITH(caliper,
 AS_HELP_STRING([--with-caliper],
                [Use Caliper instrumentation (default is NO).]),
-               [hypre_using_caliper=yes],
-               [hypre_using_caliper=no])
+[case "$withval" in
+    yes) hypre_using_caliper=yes;;
+    *)   hypre_using_caliper=no ;;
+esac],
+[hypre_using_caliper=no])
 
 AS_IF([test "x$with_caliper" = "xyes"],
       [AC_DEFINE(HYPRE_USING_CALIPER, 1, [Define to 1 if Caliper instrumentation is enabled])],

--- a/src/configure
+++ b/src/configure
@@ -742,6 +742,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -903,6 +904,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1155,6 +1157,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1292,7 +1303,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1445,6 +1456,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -3285,7 +3297,8 @@ fi
 
 # Check whether --with-strict-checking was given.
 if test "${with_strict_checking+set}" = set; then :
-  withval=$with_strict_checking;
+  withval=$with_strict_checking; case "${withval}" in
+ yes)
  hypre_user_chose_ccompilers=yes
  hypre_user_chose_cflags=yes
  hypre_user_chose_cxxcompilers=yes
@@ -3471,6 +3484,8 @@ test -n "$FC" || FC=""""
 
 $as_echo "#define HYPRE_SEQUENTIAL 1" >>confdefs.h
 
+ ;;
+ esac
 
 fi
 
@@ -4139,7 +4154,10 @@ fi
 
 # Check whether --with-caliper was given.
 if test "${with_caliper+set}" = set; then :
-  withval=$with_caliper; hypre_using_caliper=yes
+  withval=$with_caliper; case "$withval" in
+    yes) hypre_using_caliper=yes;;
+    *)   hypre_using_caliper=no ;;
+esac
 else
   hypre_using_caliper=no
 fi
@@ -8895,7 +8913,7 @@ fi
 
 $as_echo "#define HYPRE_USING_ROCSPARSE 1" >>confdefs.h
 
-	       HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocsparse"
+               HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocsparse"
                HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocsparse/include"
 
 fi


### PR DESCRIPTION
This PR (by @acolinisi #337) fixes hypre's `--without-caliper` and `--without-strict-checking` configure options.