### PR TITLE
Thrust 1.10 Fixes

### DIFF
--- a/src/IJ_mv/IJMatrix_parcsr_device.c
+++ b/src/IJ_mv/IJMatrix_parcsr_device.c
@@ -228,7 +228,7 @@ hypre_IJMatrixAssembleSortAndReduce1(HYPRE_Int  N0, HYPRE_BigInt  *I0, HYPRE_Big
          make_reverse_iterator(thrust::make_zip_iterator(thrust::make_tuple(I0,    J0))),
          make_reverse_iterator(thrust::device_pointer_cast<char>(X0)+N0),
          make_reverse_iterator(thrust::device_pointer_cast<char>(X) +N0),
-         0,
+         HYPRE_BigInt(0),
          thrust::equal_to< thrust::tuple<HYPRE_BigInt, HYPRE_BigInt> >(),
          thrust::maximum<char>() );
 

--- a/src/IJ_mv/IJVector_parcsr_device.c
+++ b/src/IJ_mv/IJVector_parcsr_device.c
@@ -276,7 +276,7 @@ hypre_IJVectorAssembleSortAndReduce1(HYPRE_Int  N0, HYPRE_BigInt  *I0, char  *X0
          make_reverse_iterator(thrust::device_pointer_cast<HYPRE_BigInt>(I0)),     /* key end */
          make_reverse_iterator(thrust::device_pointer_cast<char>(X0)+N0),          /* input value begin */
          make_reverse_iterator(thrust::device_pointer_cast<char>(X) +N0),          /* output value begin */
-         0,                                                                        /* init */
+         HYPRE_BigInt(0),                                                          /* init */
          thrust::equal_to<HYPRE_BigInt>(),
          thrust::maximum<char>() );
 

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -2052,7 +2052,7 @@ AS_IF([test x"$hypre_user_chose_hip" == x"yes"],
         dnl interprets as C and therefore invokes the C compiler rather than the HIP part
         dnl of clang. Put HIPCXXFLAGS at the end so the user can override from
         dnl from the configure line.
-        HIPCXXFLAGS="-x hip ${HIPCXXFLAGS}"
+        HIPCXXFLAGS="-x hip -std=c++14 ${HIPCXXFLAGS}"
 
         dnl If not in debug mode, at least -O2, but the user can override with
         dnl with HIPCXXFLAGS on the configure line. If in debug mode, -O0 -Wall

--- a/src/configure
+++ b/src/configure
@@ -8894,7 +8894,7 @@ done
         LINK_CC=${HIPCC}
         LINK_CXX=${HIPCC}
 
-                                        HIPCXXFLAGS="-x hip ${HIPCXXFLAGS}"
+                                        HIPCXXFLAGS="-x hip -std=c++14 ${HIPCXXFLAGS}"
 
                                 if test x"$hypre_using_debug" == x"yes"; then :
   HIPCXXFLAGS="-O0 -Wall -g -ggdb ${HIPCXXFLAGS}"

--- a/src/parcsr_ls/par_2s_interp_device.c
+++ b/src/parcsr_ls/par_2s_interp_device.c
@@ -121,7 +121,9 @@ hypre_BoomerAMGBuildModPartialExtInterpDevice( hypre_ParCSRMatrix  *A,
    HYPRE_THRUST_CALL( exclusive_scan,
                       thrust::make_transform_iterator(CF_marker_dev,              is_negative<HYPRE_Int>()),
                       thrust::make_transform_iterator(CF_marker_dev + A_nr_local, is_negative<HYPRE_Int>()),
-                      map_to_F );
+                      map_to_F,
+                      HYPRE_Int(0) );/* *MUST* pass init value since input and output types diff. */
+
    HYPRE_Int *map_F2_to_F = hypre_TAlloc(HYPRE_Int, AF2F_nr_local, HYPRE_MEMORY_DEVICE);
 
    HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( copy_if,
@@ -393,7 +395,8 @@ hypre_BoomerAMGBuildModPartialExtPEInterpDevice( hypre_ParCSRMatrix  *A,
    HYPRE_THRUST_CALL( exclusive_scan,
                       thrust::make_transform_iterator(CF_marker_dev,              is_negative<HYPRE_Int>()),
                       thrust::make_transform_iterator(CF_marker_dev + A_nr_local, is_negative<HYPRE_Int>()),
-                      map_to_F );
+                      map_to_F,
+                      HYPRE_Int(0) ); /* *MUST* pass init value since input and output types diff. */
    HYPRE_Int *map_F2_to_F = hypre_TAlloc(HYPRE_Int, AF2F_nr_local, HYPRE_MEMORY_DEVICE);
 
    HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( copy_if,

--- a/src/parcsr_ls/par_interp_device.c
+++ b/src/parcsr_ls/par_interp_device.c
@@ -200,7 +200,8 @@ hypre_BoomerAMGBuildDirInterpDevice( hypre_ParCSRMatrix   *A,
    HYPRE_THRUST_CALL( exclusive_scan,
                       thrust::make_transform_iterator(CF_marker_dev,          is_nonnegative<HYPRE_Int>()),
                       thrust::make_transform_iterator(CF_marker_dev + n_fine, is_nonnegative<HYPRE_Int>()),
-                      fine_to_coarse_d );
+                      fine_to_coarse_d,
+                      HYPRE_Int(0) ); /* *MUST* pass init value since input and output types diff. */
 
    /* 4. Compute the CSR arrays P_diag_j, P_diag_data, P_offd_j, and P_offd_data */
    /*    P_diag_i and P_offd_i are now known, first allocate the remaining CSR arrays of P */

--- a/src/parcsr_mv/par_csr_fffc_device.c
+++ b/src/parcsr_mv/par_csr_fffc_device.c
@@ -294,12 +294,14 @@ hypre_ParCSRMatrixGenerateFFFCDevice_core( hypre_ParCSRMatrix  *A,
    HYPRE_THRUST_CALL( exclusive_scan,
                       thrust::make_transform_iterator(CF_marker,           is_negative<HYPRE_Int>()),
                       thrust::make_transform_iterator(CF_marker + n_local, is_negative<HYPRE_Int>()),
-                      map2FC ); /* F */
+                      map2FC, /* F */
+                      HYPRE_Int(0) ); /* *MUST* pass init value since input and output types diff. */
 
    HYPRE_THRUST_CALL( exclusive_scan,
                       thrust::make_transform_iterator(CF_marker,           is_nonnegative<HYPRE_Int>()),
                       thrust::make_transform_iterator(CF_marker + n_local, is_nonnegative<HYPRE_Int>()),
-                      itmp ); /* C */
+                      itmp, /* C */
+                      HYPRE_Int(0) ); /* *MUST* pass init value since input and output types diff. */
 
    HYPRE_THRUST_CALL( scatter_if,
                       itmp,
@@ -316,7 +318,8 @@ hypre_ParCSRMatrixGenerateFFFCDevice_core( hypre_ParCSRMatrix  *A,
       HYPRE_THRUST_CALL( exclusive_scan,
                          thrust::make_transform_iterator(CF_marker,           equal<HYPRE_Int>(-2)),
                          thrust::make_transform_iterator(CF_marker + n_local, equal<HYPRE_Int>(-2)),
-                         map2F2 ); /* F2 */
+                         map2F2, /* F2 */
+                         HYPRE_Int(0) ); /* *MUST* pass init value since input and output types diff. */
    }
 
    /* send_buf: global F/C indices. Note F-pts "x" are saved as "-x-1" */
@@ -1075,12 +1078,14 @@ hypre_ParCSRMatrixGenerate1DCFDevice( hypre_ParCSRMatrix  *A,
    HYPRE_THRUST_CALL( exclusive_scan,
                       thrust::make_transform_iterator(CF_marker,           is_negative<HYPRE_Int>()),
                       thrust::make_transform_iterator(CF_marker + n_local, is_negative<HYPRE_Int>()),
-                      map2FC ); /* F */
+                      map2FC, /* F */
+                      HYPRE_Int(0) ); /* *MUST* pass init value since input and output types diff. */
 
    HYPRE_THRUST_CALL( exclusive_scan,
                       thrust::make_transform_iterator(CF_marker,           is_nonnegative<HYPRE_Int>()),
                       thrust::make_transform_iterator(CF_marker + n_local, is_nonnegative<HYPRE_Int>()),
-                      itmp ); /* C */
+                      itmp, /* C */
+                      HYPRE_Int(0) ); /* *MUST* pass init value since input and output types diff. */
 
    HYPRE_THRUST_CALL( scatter_if,
                       itmp,


### PR DESCRIPTION
This PR addresses Thrust 1.10 breaking changes. Thrust 1.10 landed in CUDA 11.2 and will land in ROCm 4.2.

As discussed in NVIDIA/thrust#1379 (that internally references NVIDIA/thrust#1176), the behavior of `exclusive_scan` and `inclusive_scan` changed in the case where the input types and output types were not the same. There is no deprecation warning or error thrown by the compiler. Indeed, with Thrust 1.10, before this PR, the `exclusive_scan` calls that had `make_transform_iterator` used in the input types (silently!) generated incorrect results. *That means HYPRE is broken on GPUs today with CUDA 11.2 without this PR.* There are a couple of way to fix, but what I did for the fix for `exclusive_scan` was to just use the API where one specifies the initial value and that was enough to fix the issue. It did not appear to me that there were any `inclusive_scan` calls affected in HYPRE. And my tests with this PR with a ROCm 4.2 release candidate pass.

In addition, Thrust 1.10 deprecated the use of C++ before C++14 so I've added `-std=c++14` to the `HIPCXXFLAGS` argument in the `configure.in` (and bootstrapped). 

Thrust 1.12 introduces similar breakages for the `scan_by_key` cousins, see NVIDIA/thrust#1376. The fixes are similar and I dropped in explicit casts to `HYPRE_BigInt` in the (already existing) initial value for `exclusive_scan_by_key` (commit 9a3bb66). I've not tried to address `inclusive_scan_by_key` cases, but I do believe they will be broken. I strongly recommend adding unit tests for those calls and adding them to the test suite. Thrust 1.12 is supposedly going to land in CUDA 11.4 (at least according to that thrust release page). I do not know when it will land in a ROCm release.

Thank you.