### PR TITLE
Fix a corner-case divide-by-zero in PFMG (see github issue #332)

### DIFF
--- a/src/struct_ls/pfmg_setup.c
+++ b/src/struct_ls/pfmg_setup.c
@@ -880,7 +880,7 @@ hypre_PFMGComputeDxyz( hypre_StructMatrix *A,
       cxyz_max = 1.0;
    }
 
-   /* Set dxyz values that are scaled appropriately the coarsening routine */
+   /* Set dxyz values that are scaled appropriately for the coarsening routine */
    for (d = 0; d < 3; d++)
    {
       HYPRE_Real  max_anisotropy = HYPRE_REAL_MAX/1000;

--- a/src/struct_ls/pfmg_setup.c
+++ b/src/struct_ls/pfmg_setup.c
@@ -872,19 +872,26 @@ hypre_PFMGComputeDxyz( hypre_StructMatrix *A,
    }
    if (cxyz_max == 0.0)
    {
+      /* Do isotropic coarsening */
+      for (d = 0; d < 3; d++)
+      {
+         cxyz[d] = 1.0;
+      }
       cxyz_max = 1.0;
    }
 
+   /* Set dxyz values that are scaled appropriately the coarsening routine */
    for (d = 0; d < 3; d++)
    {
-      if (cxyz[d] > 0)
+      HYPRE_Real  max_anisotropy = HYPRE_REAL_MAX/1000;
+      if (cxyz[d] > (cxyz_max/max_anisotropy))
       {
          cxyz[d] /= cxyz_max;
          dxyz[d] = sqrt(1.0 / cxyz[d]);
       }
       else
       {
-         dxyz[d] = HYPRE_REAL_MAX/1000;
+         dxyz[d] = sqrt(max_anisotropy);
       }
    }
 

--- a/src/struct_ls/pfmg_setup.c
+++ b/src/struct_ls/pfmg_setup.c
@@ -180,9 +180,9 @@ hypre_PFMGSetup( void               *pfmg_vdata,
           *
           * Use the "square of the coefficient of variation" = (sigma/mu)^2,
           * where sigma is the standard deviation and mu is the mean.  This is
-          * equivalent to computing (d - mu^2)/mu^2 where d is the sum of the
-          * squares of the coefficients stored in 'deviation'.  Care is taken to
-          * avoid dividing by zero when the mean is zero. */
+          * equivalent to computing (d - mu^2)/mu^2 where d is the average of
+          * the squares of the coefficients stored in 'deviation'.  Care is
+          * taken to avoid dividing by zero when the mean is zero. */
 
          deviation[d] -= mean[d]*mean[d];
          if ( deviation[d] > 0.1*(mean[d]*mean[d]) )

--- a/src/struct_ls/pfmg_setup.c
+++ b/src/struct_ls/pfmg_setup.c
@@ -175,9 +175,17 @@ hypre_PFMGSetup( void               *pfmg_vdata,
 
       for (d = 0; d < ndim; d++)
       {
+         /* Set 'dxyz_flag' if the matrix-coefficient variation is "too large".
+          * This is used later to set relaxation weights for Jacobi.
+          *
+          * Use the "square of the coefficient of variation" = (sigma/mu)^2,
+          * where sigma is the standard deviation and mu is the mean.  This is
+          * equivalent to computing (d - mu^2)/mu^2 where d is the sum of the
+          * squares of the coefficients stored in 'deviation'.  Care is taken to
+          * avoid dividing by zero when the mean is zero. */
+
          deviation[d] -= mean[d]*mean[d];
-         /* square of coeff. of variation */
-         if (deviation[d]/(mean[d]*mean[d]) > .1)
+         if ( deviation[d] > 0.1*(mean[d]*mean[d]) )
          {
             dxyz_flag = 1;
             break;

--- a/src/test/TEST_sstruct/sstruct.in.7zero-x
+++ b/src/test/TEST_sstruct/sstruct.in.7zero-x
@@ -1,0 +1,67 @@
+# Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+# HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+###########################################################
+
+# GridCreate: ndim nparts
+GridCreate: 3 1
+
+# GridSetExtents: part ilower(ndim) iupper(ndim)
+GridSetExtents: 0 (1- 1- 1-) (4+ 4+ 4+)
+
+# GridSetVariables: part nvars vartypes[nvars]
+# CELL  = 0
+GridSetVariables: 0 1 [0]
+
+# GridSetPeriodic: part periodic[ndim]
+GridSetPeriodic: 0 [0 0 0]
+
+###########################################################
+
+# StencilCreate: nstencils sizes[nstencils]
+StencilCreate: 1 [7]
+
+# StencilSetEntry: stencil_num entry offset[ndim] var value
+StencilSetEntry: 0  0 [ 0  0  0] 0  4.0
+StencilSetEntry: 0  1 [-1  0  0] 0  0.0
+StencilSetEntry: 0  2 [ 1  0  0] 0  0.0
+StencilSetEntry: 0  3 [ 0 -1  0] 0 -1.0
+StencilSetEntry: 0  4 [ 0  1  0] 0 -1.0
+StencilSetEntry: 0  5 [ 0  0 -1] 0 -1.0
+StencilSetEntry: 0  6 [ 0  0  1] 0 -1.0
+
+###########################################################
+
+# GraphSetStencil: part var stencil_num
+GraphSetStencil: 0 0 0
+
+###########################################################
+
+# MatrixSetValues: \
+#   part ilower(ndim) iupper(ndim) stride[ndim] var entry value
+# west
+MatrixSetValues: 0 (1- 1- 1-) (1- 4+ 4+) [1 1 1] 0 1 0.0
+# east
+MatrixSetValues: 0 (4+ 1- 1-) (4+ 4+ 4+) [1 1 1] 0 2 0.0
+# south
+MatrixSetValues: 0 (1- 1- 1-) (4+ 1- 4+) [1 1 1] 0 3 0.0
+# north
+MatrixSetValues: 0 (1- 4+ 1-) (4+ 4+ 4+) [1 1 1] 0 4 0.0
+# lower
+MatrixSetValues: 0 (1- 1- 1-) (4+ 4+ 1-) [1 1 1] 0 5 0.0
+# upper
+MatrixSetValues: 0 (1- 1- 4+) (4+ 4+ 4+) [1 1 1] 0 6 0.0
+
+###########################################################
+
+# ProcessPoolCreate: num_pools
+ProcessPoolCreate: 1
+
+# ProcessPoolSetPart: pool part
+ProcessPoolSetPart: 0 0
+
+###########################################################
+

--- a/src/test/TEST_sstruct/sstruct.in.7zero-y
+++ b/src/test/TEST_sstruct/sstruct.in.7zero-y
@@ -1,0 +1,67 @@
+# Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+# HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+###########################################################
+
+# GridCreate: ndim nparts
+GridCreate: 3 1
+
+# GridSetExtents: part ilower(ndim) iupper(ndim)
+GridSetExtents: 0 (1- 1- 1-) (4+ 4+ 4+)
+
+# GridSetVariables: part nvars vartypes[nvars]
+# CELL  = 0
+GridSetVariables: 0 1 [0]
+
+# GridSetPeriodic: part periodic[ndim]
+GridSetPeriodic: 0 [0 0 0]
+
+###########################################################
+
+# StencilCreate: nstencils sizes[nstencils]
+StencilCreate: 1 [7]
+
+# StencilSetEntry: stencil_num entry offset[ndim] var value
+StencilSetEntry: 0  0 [ 0  0  0] 0  4.0
+StencilSetEntry: 0  1 [-1  0  0] 0 -1.0
+StencilSetEntry: 0  2 [ 1  0  0] 0 -1.0
+StencilSetEntry: 0  3 [ 0 -1  0] 0  0.0
+StencilSetEntry: 0  4 [ 0  1  0] 0  0.0
+StencilSetEntry: 0  5 [ 0  0 -1] 0 -1.0
+StencilSetEntry: 0  6 [ 0  0  1] 0 -1.0
+
+###########################################################
+
+# GraphSetStencil: part var stencil_num
+GraphSetStencil: 0 0 0
+
+###########################################################
+
+# MatrixSetValues: \
+#   part ilower(ndim) iupper(ndim) stride[ndim] var entry value
+# west
+MatrixSetValues: 0 (1- 1- 1-) (1- 4+ 4+) [1 1 1] 0 1 0.0
+# east
+MatrixSetValues: 0 (4+ 1- 1-) (4+ 4+ 4+) [1 1 1] 0 2 0.0
+# south
+MatrixSetValues: 0 (1- 1- 1-) (4+ 1- 4+) [1 1 1] 0 3 0.0
+# north
+MatrixSetValues: 0 (1- 4+ 1-) (4+ 4+ 4+) [1 1 1] 0 4 0.0
+# lower
+MatrixSetValues: 0 (1- 1- 1-) (4+ 4+ 1-) [1 1 1] 0 5 0.0
+# upper
+MatrixSetValues: 0 (1- 1- 4+) (4+ 4+ 4+) [1 1 1] 0 6 0.0
+
+###########################################################
+
+# ProcessPoolCreate: num_pools
+ProcessPoolCreate: 1
+
+# ProcessPoolSetPart: pool part
+ProcessPoolSetPart: 0 0
+
+###########################################################
+

--- a/src/test/TEST_sstruct/sstruct.in.7zero-z
+++ b/src/test/TEST_sstruct/sstruct.in.7zero-z
@@ -1,0 +1,67 @@
+# Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+# HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+###########################################################
+
+# GridCreate: ndim nparts
+GridCreate: 3 1
+
+# GridSetExtents: part ilower(ndim) iupper(ndim)
+GridSetExtents: 0 (1- 1- 1-) (4+ 4+ 4+)
+
+# GridSetVariables: part nvars vartypes[nvars]
+# CELL  = 0
+GridSetVariables: 0 1 [0]
+
+# GridSetPeriodic: part periodic[ndim]
+GridSetPeriodic: 0 [0 0 0]
+
+###########################################################
+
+# StencilCreate: nstencils sizes[nstencils]
+StencilCreate: 1 [7]
+
+# StencilSetEntry: stencil_num entry offset[ndim] var value
+StencilSetEntry: 0  0 [ 0  0  0] 0  4.0
+StencilSetEntry: 0  1 [-1  0  0] 0 -1.0
+StencilSetEntry: 0  2 [ 1  0  0] 0 -1.0
+StencilSetEntry: 0  3 [ 0 -1  0] 0 -1.0
+StencilSetEntry: 0  4 [ 0  1  0] 0 -1.0
+StencilSetEntry: 0  5 [ 0  0 -1] 0  0.0
+StencilSetEntry: 0  6 [ 0  0  1] 0  0.0
+
+###########################################################
+
+# GraphSetStencil: part var stencil_num
+GraphSetStencil: 0 0 0
+
+###########################################################
+
+# MatrixSetValues: \
+#   part ilower(ndim) iupper(ndim) stride[ndim] var entry value
+# west
+MatrixSetValues: 0 (1- 1- 1-) (1- 4+ 4+) [1 1 1] 0 1 0.0
+# east
+MatrixSetValues: 0 (4+ 1- 1-) (4+ 4+ 4+) [1 1 1] 0 2 0.0
+# south
+MatrixSetValues: 0 (1- 1- 1-) (4+ 1- 4+) [1 1 1] 0 3 0.0
+# north
+MatrixSetValues: 0 (1- 4+ 1-) (4+ 4+ 4+) [1 1 1] 0 4 0.0
+# lower
+MatrixSetValues: 0 (1- 1- 1-) (4+ 4+ 1-) [1 1 1] 0 5 0.0
+# upper
+MatrixSetValues: 0 (1- 1- 4+) (4+ 4+ 4+) [1 1 1] 0 6 0.0
+
+###########################################################
+
+# ProcessPoolCreate: num_pools
+ProcessPoolCreate: 1
+
+# ProcessPoolSetPart: pool part
+ProcessPoolSetPart: 0 0
+
+###########################################################
+

--- a/src/test/TEST_sstruct/sstruct_struct.jobs
+++ b/src/test/TEST_sstruct/sstruct_struct.jobs
@@ -19,6 +19,16 @@ mpirun -np 1  ./struct -n 12 12 12 -solver 0 -istart -3 -3 -3 -relax 1 \
 mpirun -np 1  ./sstruct -in sstruct.in.struct -solver 200 -relax 1 -rhsone \
 > sstruct_struct.out.200
 
+# Compare 2D struct run to 3D run with coefficients zeroed out in one dimension
+mpirun -np 1 ./struct -d 2 -n 40 40 1 -solver 1 -istart 10 10 10 \
+> sstruct_struct.out.2D
+mpirun -np 1 ./sstruct -in sstruct.in.7zero-x -r 10 10 10 -solver 201 -rhsone \
+> sstruct_struct.out.3Dx
+mpirun -np 1 ./sstruct -in sstruct.in.7zero-y -r 10 10 10 -solver 201 -rhsone \
+> sstruct_struct.out.3Dy
+mpirun -np 1 ./sstruct -in sstruct.in.7zero-z -r 10 10 10 -solver 201 -rhsone \
+> sstruct_struct.out.3Dz
+
 #=============================================================================
 # Compare 19pt, 7pt, positive, and negative definite
 #=============================================================================

--- a/src/test/TEST_sstruct/sstruct_struct.saved
+++ b/src/test/TEST_sstruct/sstruct_struct.saved
@@ -14,6 +14,22 @@ Final Relative Residual Norm = 2.753739e-07
 Iterations = 16
 Final Relative Residual Norm = 6.891627e-07
 
+# Output file: sstruct_struct.out.2D
+Iterations = 15
+Final Relative Residual Norm = 3.544959e-07
+
+# Output file: sstruct_struct.out.3Dx
+Iterations = 15
+Final Relative Residual Norm = 3.544959e-07
+
+# Output file: sstruct_struct.out.3Dy
+Iterations = 15
+Final Relative Residual Norm = 3.544959e-07
+
+# Output file: sstruct_struct.out.3Dz
+Iterations = 15
+Final Relative Residual Norm = 3.544959e-07
+
 # Output file: sstruct_struct.out.10
 Iterations = 8
 Final Relative Residual Norm = 3.476646e-07

--- a/src/test/TEST_sstruct/sstruct_struct.sh
+++ b/src/test/TEST_sstruct/sstruct_struct.sh
@@ -23,6 +23,16 @@ tail -3 ${TNAME}.out.201 > ${TNAME}.testdata.temp
 diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
 
 #=============================================================================
+
+tail -3 ${TNAME}.out.2D  > ${TNAME}.testdata
+tail -3 ${TNAME}.out.3Dx > ${TNAME}.testdata.temp
+diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+tail -3 ${TNAME}.out.3Dy > ${TNAME}.testdata.temp
+diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+tail -3 ${TNAME}.out.3Dz > ${TNAME}.testdata.temp
+diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+
+#=============================================================================
 # Compare 19pt, 7pt, positive, and negative definite
 #=============================================================================
 
@@ -51,6 +61,10 @@ FILES="\
  ${TNAME}.out.1\
  ${TNAME}.out.200\
  ${TNAME}.out.201\
+ ${TNAME}.out.2D\
+ ${TNAME}.out.3Dx\
+ ${TNAME}.out.3Dy\
+ ${TNAME}.out.3Dz\
  ${TNAME}.out.10\
  ${TNAME}.out.11\
  ${TNAME}.out.12\


### PR DESCRIPTION
- The 'mean' computed in PFMG can be zero, so don't divide by it.
- Added comments to better explain this part of the code.
- Added regression tests to check 3D problems that have all of the coefficients
  zeroed out in one dimension (so they are basically 2D).