### PR TITLE
CUCC, CUFLAGS

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -142,7 +142,6 @@ hypre_using_openmp=no
 hypre_using_device_openmp=no
 hypre_using_insure=no
 hypre_using_cuda=no
-dnl hypre_user_chose_cuda=no
 hypre_using_gpu=no
 hypre_using_um=no
 hypre_gpu_mpi=no
@@ -171,7 +170,6 @@ hypre_using_memory_tracker=no
 dnl *********************************************************************
 dnl * Initialize hypre-HIP variables
 dnl *********************************************************************
-dnl hypre_user_chose_hip=no
 hypre_using_hip=no
 hypre_using_rocsparse=no
 hypre_using_rocblas=no

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -1482,6 +1482,22 @@ then
    fi
 fi
 
+if [test "x$hypre_using_cuda" = "xyes" && test "x$hypre_using_device_openmp" = "xyes"]
+then
+   AC_MSG_ERROR([--with-cuda and --with-device-openmp are mutually exclusive])
+fi
+
+if [test "x$hypre_using_cuda" = "xyes" && test "x$hypre_using_hip" = "xyes"]
+then
+   AC_MSG_ERROR([--with-cuda and --with-hip are mutually exclusive])
+fi
+
+if [test "x$hypre_using_hip" = "xyes" && test "x$hypre_using_device_openmp" = "xyes"]
+then
+   AC_MSG_ERROR([--with-hip and --with-device-openmp are mutually exclusive])
+fi
+
+
 if test "$hypre_user_chose_cudacompilers" = "no"
 then
    if test "$hypre_using_device_openmp" = "yes"

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -120,9 +120,10 @@ dnl *********************************************************************
 hypre_user_chose_mpi=no
 hypre_user_chose_blas=no
 hypre_user_chose_lapack=no
-hypre_user_chose_cuda=no
 hypre_user_chose_raja=no
+hypre_using_raja=no
 hypre_user_chose_kokkos=no
+hypre_using_kokkos=no
 
 hypre_using_c=yes
 hypre_using_cxx=yes
@@ -141,6 +142,7 @@ hypre_using_openmp=no
 hypre_using_device_openmp=no
 hypre_using_insure=no
 hypre_using_cuda=no
+dnl hypre_user_chose_cuda=no
 hypre_using_gpu=no
 hypre_using_um=no
 hypre_gpu_mpi=no
@@ -169,7 +171,7 @@ hypre_using_memory_tracker=no
 dnl *********************************************************************
 dnl * Initialize hypre-HIP variables
 dnl *********************************************************************
-hypre_user_chose_hip=no
+dnl hypre_user_chose_hip=no
 hypre_using_hip=no
 hypre_using_rocsparse=no
 hypre_using_rocblas=no
@@ -526,6 +528,8 @@ fi
 dnl *********************************************************************
 dnl * Determine if user provided CUDA compiler or flags
 dnl *********************************************************************
+AC_ARG_VAR([CUDA_HOME], [CUDA home directory])
+AC_ARG_VAR([HYPRE_CUDA_SM], [CUDA architecture])
 AC_ARG_VAR([CUCC], [CUDA compiler command])
 AC_ARG_VAR([CUFLAGS], [CUDA compiler flags])
 
@@ -1108,8 +1112,7 @@ AC_ARG_WITH(cuda,
 AS_HELP_STRING([--with-cuda],
                [Use CUDA. Require cuda-8.0 or higher (default is NO).]),
 [case "$withval" in
-    yes) hypre_user_chose_cuda=yes
-         hypre_using_cuda=yes ;;
+    yes) hypre_using_cuda=yes ;;
     no)  hypre_using_cuda=no ;;
     *)   hypre_using_cuda=no ;;
  esac],
@@ -1122,8 +1125,7 @@ AC_ARG_WITH(hip,
 AS_HELP_STRING([--with-hip],
                [Use HIP for AMD GPUs. (default is NO).]),
 [case "$withval" in
-    yes) hypre_user_chose_hip=yes
-         hypre_using_hip=yes ;;
+    yes) hypre_using_hip=yes ;;
     no)  hypre_using_hip=no ;;
     *)   hypre_using_hip=no ;;
  esac],
@@ -1157,9 +1159,9 @@ AC_ARG_WITH(raja,
 AS_HELP_STRING([--with-raja],
                [Use RAJA. Require RAJA package to be compiled properly (default is NO).]),
 [case "$withval" in
-    yes) hypre_user_chose_raja=yes;;
-    no)  hypre_user_chose_raja=no ;;
-    *)   hypre_user_chose_raja=no ;;
+    yes) hypre_using_raja=yes;;
+    no)  hypre_using_raja=no ;;
+    *)   hypre_using_raja=no ;;
  esac],
 [hypre_using_raja=no]
 )
@@ -1215,10 +1217,11 @@ AC_ARG_WITH(kokkos,
 AS_HELP_STRING([--with-kokkos],
                [Use Kokkos. Require kokkos package to be compiled properly(default is NO).]),
 [case "$withval" in
-    yes) hypre_user_chose_kokkos=yes ;;
-    no)  hypre_user_chose_kokkos=no ;;
-    *)   hypre_user_chose_kokkos=no ;;
- esac]
+    yes) hypre_using_kokkos=yes ;;
+    no)  hypre_using_kokkos=no ;;
+    *)   hypre_using_kokkos=no ;;
+ esac],
+[hypre_using_kokkos=no]
 )
 
 AC_ARG_WITH(kokkos-include,
@@ -1496,7 +1499,7 @@ then
       AC_CHECK_PROGS(CUCC, nvcc, [""], ["${CUDA_HOME}/bin"])
    fi
 
-   if test "$hypre_user_chose_hip" = "yes"
+   if test "$hypre_using_hip" = "yes"
    then
       AC_CHECK_PROGS(CUCC, hipcc)
    fi
@@ -1832,7 +1835,7 @@ dnl *********************************************************************
 if test "$hypre_using_shared" = "yes"
 then
    HYPRE_LIBSUFFIX=".so"
-   if test "$hypre_user_chose_cuda" = "yes"
+   if test "$hypre_using_cuda" = "yes"
    then
       SHARED_SET_SONAME="-Xlinker=-soname,"
       SHARED_OPTIONS="-Xlinker=-z,defs"
@@ -1868,7 +1871,7 @@ dnl   BUILD_F77_SHARED="${F77} ${SHARED_BUILD_FLAG}"
       BUILD_CC_SHARED="\${CC} ${SHARED_BUILD_FLAG}"
    fi
    BUILD_CXX_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
-   if test "$hypre_user_chose_cuda" = "yes"
+   if test "$hypre_using_cuda" = "yes"
    then
       BUILD_CC_SHARED="\${CUCC} ${SHARED_BUILD_FLAG} ${HYPRE_CUDA_GENCODE}"
    fi
@@ -1951,7 +1954,7 @@ AS_IF([ test x"$hypre_using_hip" == x"yes" ],
 dnl *********************************************************************
 dnl * Set raja options
 dnl *********************************************************************
-if test "x$hypre_user_chose_raja" = "xyes"
+if test "x$hypre_using_raja" = "xyes"
 then
    AC_DEFINE(HYPRE_USING_RAJA, 1, [Define to 1 if executing on host/device with RAJA])
 
@@ -1972,7 +1975,7 @@ fi
 dnl *********************************************************************
 dnl * Set kokkos options
 dnl *********************************************************************
-if test "x$hypre_user_chose_kokkos" = "xyes"
+if test "x$hypre_using_kokkos" = "xyes"
 then
    AC_DEFINE(HYPRE_USING_KOKKOS, 1, [Define to 1 if executing on host/device with KOKKOS])
 
@@ -2025,7 +2028,7 @@ fi
 dnl *********************************************************************
 dnl * Set cuda options
 dnl *********************************************************************
-if test "$hypre_user_chose_cuda" = "yes"
+if test "$hypre_using_cuda" = "yes"
 then
    AC_DEFINE(HYPRE_USING_GPU, 1, [Define to 1 if executing on GPU device])
 
@@ -2122,7 +2125,7 @@ fi
 dnl *********************************************************************
 dnl * Set HIP options
 dnl *********************************************************************
-AS_IF([test x"$hypre_user_chose_hip" == x"yes"],
+AS_IF([test x"$hypre_using_hip" == x"yes"],
       [
         AC_DEFINE(HYPRE_USING_GPU, 1, [Define to 1 if executing on GPU device])
         AC_DEFINE(HYPRE_USING_HIP, 1, [HIP being used])
@@ -2199,7 +2202,7 @@ AS_IF([test x"$hypre_user_chose_hip" == x"yes"],
                HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lroctx64"
                ])
 
-      ]) dnl AS_IF([test x"$hypre_user_chose_hip" == x"yes"]
+      ]) dnl AS_IF([test x"$hypre_using_hip" == x"yes"]
 
 
 
@@ -2210,19 +2213,19 @@ dnl *********************************************************************
 if test "$hypre_using_um" != "yes"
 then
    dnl Without UM
-   if test "$hypre_user_chose_cuda" = "yes"
+   if test "$hypre_using_cuda" = "yes"
    then
       AC_MSG_NOTICE([***********************************************************************])
       AC_MSG_NOTICE([Configuring with --with-cuda=yes without unified memory.])
-      AC_MSG_NOTICE([It only works for structured solvers and selective unstructured solvers])
+      AC_MSG_NOTICE([It only works for structured solvers and selected unstructured solvers])
       AC_MSG_NOTICE([Use --enable-unified-memory to compile with unified memory.])
       AC_MSG_NOTICE([***********************************************************************])
    fi
-   if test "$hypre_user_chose_hip" = "yes"
+   if test "$hypre_using_hip" = "yes"
    then
       AC_MSG_NOTICE([***********************************************************************])
       AC_MSG_NOTICE([Configuring with --with-hip=yes without unified memory.])
-      AC_MSG_NOTICE([It only works for structured solvers and selective unstructured solvers])
+      AC_MSG_NOTICE([It only works for structured solvers and selected unstructured solvers])
       AC_MSG_NOTICE([Use --enable-unified-memory to compile with unified memory.])
       AC_MSG_NOTICE([***********************************************************************])
    fi
@@ -2230,7 +2233,7 @@ then
    then
       AC_MSG_NOTICE([***********************************************************************])
       AC_MSG_NOTICE([Configuring with --with-device-openmp=yes without unified memory.])
-      AC_MSG_NOTICE([It only works for structured solvers and selective unstructured solvers])
+      AC_MSG_NOTICE([It only works for structured solvers and selected unstructured solvers])
       AC_MSG_NOTICE([Use --enable-unified-memory to compile with unified memory.])
       AC_MSG_NOTICE([***********************************************************************])
    fi
@@ -2313,7 +2316,7 @@ if test "x$hypre_using_um" = "xyes"
 then
    AC_DEFINE([HYPRE_USING_UNIFIED_MEMORY],1,[Define to 1 if using unified memory])
 else
-   if [test "x$hypre_user_chose_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes" || test "x$hypre_user_chose_hip" = "xyes"]
+   if [test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes" || test "x$hypre_using_hip" = "xyes"]
    then
       AC_DEFINE([HYPRE_USING_DEVICE_MEMORY],1,[Define to 1 if using device memory without UM])
    else

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -524,6 +524,26 @@ else
 fi
 
 dnl *********************************************************************
+dnl * Determine if user provided CUDA compiler or flags
+dnl *********************************************************************
+AC_ARG_VAR([CUCC], [CUDA compiler command])
+AC_ARG_VAR([CUFLAGS], [CUDA compiler flags])
+
+if test "x$CUCC" = "x"
+then
+   hypre_user_chose_cudacompilers=no
+else
+   hypre_user_chose_cudacompilers=yes
+fi
+
+if test "x$CUFLAGS" = "x"
+then
+   hypre_user_chose_cuflags=no
+else
+   hypre_user_chose_cuflags=yes
+fi
+
+dnl *********************************************************************
 dnl * Determine if user provided fortran compiler or flags
 dnl *********************************************************************
 if test "x$F77" != "x" && test "x$FC" = "x"
@@ -1388,11 +1408,6 @@ if test "$hypre_user_chose_ccompilers" = "no"
 then
    if test "$hypre_using_mpi" = "no"
    then
-      if test "$hypre_using_device_openmp" = "yes"
-      then
-         AC_CHECK_PROGS(CUCC, [xlc-gpu clang-gpu])
-      fi
-
       if test "$hypre_using_openmp" = "yes"
       then
          AC_CHECK_PROGS(CC, [xlc_r xlC_r xlc xlC icc icpc gcc g++ pgcc pgCC cc CC kcc KCC])
@@ -1400,11 +1415,6 @@ then
          AC_CHECK_PROGS(CC, [xlc xlC icc icpc gcc g++ pgcc pgCC cc CC kcc KCC])
       fi
    else
-      if test "$hypre_using_device_openmp" = "yes"
-      then
-         AC_CHECK_PROGS(CUCC, [mpixlc-gpu mpiclang-gpu])
-      fi
-
       if test "$hypre_using_openmp" = "yes"
       then
          AC_CHECK_PROGS(CC, [mpxlc mpixlc_r mpixlc mpiicc mpigcc mpicc mpipgcc mpipgicc])
@@ -1423,11 +1433,6 @@ if test "$hypre_user_chose_cxxcompilers" = "no"
 then
    if test "$hypre_using_mpi" = "no"
    then
-      if test "$hypre_using_device_openmp" = "yes"
-      then
-         AC_CHECK_PROGS(CUCC, [xlC-gpu clang++-gpu])
-      fi
-
       if test "$hypre_using_openmp" = "yes"
       then
          AC_CHECK_PROGS(CXX, [xlC_r xlc_r xlC xlc icpc icc g++ gcc pgCC pgcc pgc++ CC cc KCC kcc])
@@ -1435,11 +1440,6 @@ then
          AC_CHECK_PROGS(CXX, [xlC xlc icpc icc g++ gcc pgCC pgcc pgc++ CC cc KCC kcc])
       fi
    else
-      if test "$hypre_using_device_openmp" = "yes"
-      then
-         AC_CHECK_PROGS(CUCC, [mpixlC-gpu mpiclang++-gpu])
-      fi
-
       if test "$hypre_using_openmp" = "yes"
       then
          AC_CHECK_PROGS(CXX, [mpxlC mpixlcxx_r mpixlcxx mpixlC mpiicpc mpig++ mpic++ mpicxx mpiCC mpipgCC mpipgic++])
@@ -1476,6 +1476,29 @@ then
    if test "x$FC" = "x"
    then
       hypre_using_fortran=no
+   fi
+fi
+
+if test "$hypre_user_chose_cudacompilers" = "no"
+then
+   if test "$hypre_using_device_openmp" = "yes"
+   then
+      if test "$hypre_using_mpi" = "no"
+      then
+         AC_CHECK_PROGS(CUCC, [xlc-gpu clang-gpu])
+      else
+         AC_CHECK_PROGS(CUCC, [mpixlc-gpu mpiclang-gpu])
+      fi
+   fi
+
+   if test "$hypre_using_cuda" = "yes"
+   then
+      AC_CHECK_PROGS(CUCC, nvcc, [""], ["${CUDA_HOME}/bin"])
+   fi
+
+   if test "$hypre_user_chose_hip" = "yes"
+   then
+      AC_CHECK_PROGS(CUCC, hipcc)
    fi
 fi
 
@@ -1804,6 +1827,56 @@ dnl   AC_HYPRE_CHECK_USER_LAPACKLIBS
 
 
 dnl *********************************************************************
+dnl * Set flags if needed to enable shared libraries and Python, Java
+dnl *********************************************************************
+if test "$hypre_using_shared" = "yes"
+then
+   HYPRE_LIBSUFFIX=".so"
+   if test "$hypre_user_chose_cuda" = "yes"
+   then
+      SHARED_SET_SONAME="-Xlinker=-soname,"
+      SHARED_OPTIONS="-Xlinker=-z,defs"
+   else
+      SHARED_SET_SONAME="-Wl,-soname,"
+      SHARED_OPTIONS="-Wl,-z,defs"
+   fi
+   SHARED_COMPILE_FLAG="-fPIC"
+   case $hypre_platform in
+      AIX* | aix* | Aix*) SHARED_COMPILE_FLAG="-qmkshrobj"
+                          SHARED_BUILD_FLAG="-G"
+dnl                          LINK_F77="${F77} -brtl"
+                          LINK_FC='${FC} -brtl'
+                          LINK_CC='${CC} -brtl'
+                          LINK_CXX='${CXX} -brtl' ;;
+      DARWIN* | darwin* | Darwin*) SHARED_BUILD_FLAG="-dynamiclib -undefined dynamic_lookup"
+                                   HYPRE_LIBSUFFIX=".dylib"
+                                   SHARED_SET_SONAME="-install_name @rpath/"
+                                   SHARED_OPTIONS="-undefined error" ;;
+                       *) SHARED_BUILD_FLAG="-shared" ;;
+   esac
+   SHARED_BUILD_FLAG="${SHARED_BUILD_FLAG} ${EXTRA_BUILDFLAGS}"
+   FFLAGS="${FFLAGS} ${SHARED_COMPILE_FLAG}"
+   CFLAGS="${CFLAGS} ${SHARED_COMPILE_FLAG}"
+   CXXFLAGS="${CXXFLAGS} ${SHARED_COMPILE_FLAG}"
+
+dnl   BUILD_F77_SHARED="${F77} ${SHARED_BUILD_FLAG}"
+   BUILD_FC_SHARED="\${FC} ${SHARED_BUILD_FLAG}"
+   if test "$hypre_using_fei" = "yes"
+   then
+      BUILD_CC_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
+   else
+      BUILD_CC_SHARED="\${CC} ${SHARED_BUILD_FLAG}"
+   fi
+   BUILD_CXX_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
+   if test "$hypre_user_chose_cuda" = "yes"
+   then
+      BUILD_CC_SHARED="\${CUCC} ${SHARED_BUILD_FLAG} ${HYPRE_CUDA_GENCODE}"
+   fi
+   dnl TODO HIP
+fi
+
+
+dnl *********************************************************************
 dnl * Warn if caliper options are incomplete
 dnl *********************************************************************
 if test "$hypre_using_caliper" = "yes"
@@ -1986,8 +2059,6 @@ then
    fi
 
    dnl let CC/CXX and LINK be CUCC and let host compiler be CXX
-   AC_CHECK_PROGS(CUCC, nvcc, [""], ["${CUDA_HOME}/bin"])
-   NVCCBIN=${CXX}
    LINK_CC='${CUCC}'
    LINK_CXX='${CUCC}'
 
@@ -2002,23 +2073,29 @@ then
       HYPRE_CUDA_GENCODE="${HYPRE_CUDA_GENCODE} -gencode arch=compute_${sm},code=sm_${sm}"
    done
 
-   CUFLAGS+="-lineinfo -ccbin=$NVCCBIN ${HYPRE_CUDA_GENCODE} -expt-extended-lambda -dc -std=c++11 --x cu"
-   if test "$hypre_using_debug" = "yes"
+   if test "$hypre_user_chose_cuflags" = "no"
    then
-      CUFLAGS="-g -O0 ${CUFLAGS}"
-   else
-      CUFLAGS="-O2 ${CUFLAGS}"
+      CUFLAGS="-lineinfo -ccbin=\${CXX} ${HYPRE_CUDA_GENCODE} -expt-extended-lambda -dc -std=c++11 --x cu"
+      if test "$hypre_using_debug" = "yes"
+      then
+         CUFLAGS="-g -O0 ${CUFLAGS}"
+      else
+         CUFLAGS="-O2 ${CUFLAGS}"
+      fi
    fi
 
-   if [test "$NVCCBIN" = "mpixlC" || test "$NVCCBIN" = "xlC_r" || test "$NVCCBIN" = "xlC"]
+   if test "$hypre_user_chose_cxxflags" = "no"
    then
-     CXXFLAGS+=" -Wno-deprecated-register -Wenum-compare"
+      if [test "${CXX}" = "mpixlC" || test "${CXX}" = "xlC_r" || test "${CXX}" = "xlC"]
+      then
+         CXXFLAGS+=" -Wno-deprecated-register -Wenum-compare"
+      fi
    fi
 
    CUFLAGS="${CUFLAGS} -Xcompiler \"${CXXFLAGS}\""
 
    dnl CFLAGS=${CXXFLAGS}
-   LDFLAGS="-ccbin=$NVCCBIN ${HYPRE_CUDA_GENCODE} -Xcompiler \"${LDFLAGS}\""
+   LDFLAGS="-ccbin=\${CXX} ${HYPRE_CUDA_GENCODE} -Xcompiler \"${LDFLAGS}\""
    HYPRE_CUDA_INCLUDE='-I${HYPRE_CUDA_PATH}/include'
    HYPRE_CUDA_LIBS='-L${HYPRE_CUDA_PATH}/lib64 -lcudart'
    if test "$hypre_using_gpu_profiling" = "yes"
@@ -2055,14 +2132,13 @@ AS_IF([test x"$hypre_user_chose_hip" == x"yes"],
         dnl from ROCm that supports HIP and all the command line foo needed
         dnl by the compiler. You can force hipcc to emit what it actually does
         dnl by setting HIPCC_VERBOSE=7 in your environment.
-        AC_CHECK_PROGS(HIPCC, hipcc)
+        dnl AC_CHECK_PROGS(HIPCC, hipcc)
 
         dnl (Ab)Using CUCC when compiling HIP
         dnl At this time, we need the linker to be hipcc in order to link
         dnl in device code.
-        CUCC=${HIPCC}
-        LINK_CC=${HIPCC}
-        LINK_CXX=${HIPCC}
+        LINK_CC='${CUCC}'
+        LINK_CXX='${CUCC}'
 
         dnl The "-x hip" is necessary to override the detection of .c files which clang
         dnl interprets as C and therefore invokes the C compiler rather than the HIP part
@@ -2079,7 +2155,12 @@ AS_IF([test x"$hypre_user_chose_hip" == x"yes"],
 
         dnl (Ab)Use CUFLAGS to capture HIP compilation flags
         dnl Put HIPCXXFLAGS at the end so the user can override the optimization level.
-        CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS}"
+        if test "$hypre_user_chose_cuflags" = "no"
+        then
+           CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS}"
+        fi
+
+        CUFLAGS="${CUFLAGS} ${CXXFLAGS}"
 
         dnl rocThrust depends on rocPrim so we need both for Thrust on AMD GPUs.
         dnl These are header-only so no linking needed.
@@ -2131,27 +2212,27 @@ then
    dnl Without UM
    if test "$hypre_user_chose_cuda" = "yes"
    then
-      AC_MSG_NOTICE([***********************************************************])
+      AC_MSG_NOTICE([***********************************************************************])
       AC_MSG_NOTICE([Configuring with --with-cuda=yes without unified memory.])
-      AC_MSG_NOTICE([It only works for struct interface.])
+      AC_MSG_NOTICE([It only works for structured solvers and selective unstructured solvers])
       AC_MSG_NOTICE([Use --enable-unified-memory to compile with unified memory.])
-      AC_MSG_NOTICE([***********************************************************])
+      AC_MSG_NOTICE([***********************************************************************])
    fi
    if test "$hypre_user_chose_hip" = "yes"
    then
-      AC_MSG_NOTICE([***********************************************************])
+      AC_MSG_NOTICE([***********************************************************************])
       AC_MSG_NOTICE([Configuring with --with-hip=yes without unified memory.])
-      AC_MSG_NOTICE([It only works for struct interface.])
+      AC_MSG_NOTICE([It only works for structured solvers and selective unstructured solvers])
       AC_MSG_NOTICE([Use --enable-unified-memory to compile with unified memory.])
-      AC_MSG_NOTICE([***********************************************************])
+      AC_MSG_NOTICE([***********************************************************************])
    fi
    if test "$hypre_using_device_openmp" = "yes"
    then
-      AC_MSG_NOTICE([***********************************************************])
+      AC_MSG_NOTICE([***********************************************************************])
       AC_MSG_NOTICE([Configuring with --with-device-openmp=yes without unified memory.])
-      AC_MSG_NOTICE([It only works for struct interface.])
+      AC_MSG_NOTICE([It only works for structured solvers and selective unstructured solvers])
       AC_MSG_NOTICE([Use --enable-unified-memory to compile with unified memory.])
-      AC_MSG_NOTICE([***********************************************************])
+      AC_MSG_NOTICE([***********************************************************************])
    fi
 fi
 
@@ -2183,20 +2264,20 @@ then
 
    dnl AC_DEFINE(HYPRE_DEVICE_OPENMP_MAPPED, 1, [Define to 1 if using OpenMP on device [target mapped version]])
 
-   dnl AC_CHECK_PROGS(CUCC, nvcc)
-
-   dnl CFLAGS="${CFLAGS}"
-   dnl CXXFLAGS="${CXXFLAGS}"
    CUFLAGS=${CFLAGS}
 
-   if [test "$CUCC" = "clang-gpu" || test "$CUCC" = "mpiclang-gpu"]
+   if test "$hypre_user_chose_cuflags" = "no"
    then
-      CUFLAGS+=" -fopenmp-nonaliased-maps"
+      if [test "$CUCC" = "clang-gpu" || test "$CUCC" = "mpiclang-gpu"]
+      then
+         CUFLAGS+=" -fopenmp-nonaliased-maps"
+      fi
+      if [test "$CUCC" = "clang++-gpu" || test "$CUCC" = "mpiclang++-gpu"]
+      then
+         CUFLAGS+=" -fopenmp-nonaliased-maps"
+      fi
    fi
-   if [test "$CUCC" = "clang++-gpu" || test "$CUCC" = "mpiclang++-gpu"]
-   then
-      CUFLAGS+=" -fopenmp-nonaliased-maps"
-   fi
+
    if test "$hypre_using_debug" = "yes"
    then
       AC_DEFINE(HYPRE_DEVICE_OPENMP_CHECK, 1, [Define to 1 if strictly checking OpenMP offload directives])
@@ -2215,59 +2296,6 @@ then
    LINK_CXX='${CUCC}'
    dnl CXXFLAGS="-x c++ ${CXXFLAGS}"
    dnl CFLAGS=${CXXFLAGS}
-fi
-
-dnl *********************************************************************
-dnl * Set flags if needed to enable shared libraries and Python, Java
-dnl *********************************************************************
-if test "$hypre_using_shared" = "yes"
-then
-   HYPRE_LIBSUFFIX=".so"
-   if [test "x$CUCC" = "xnvcc"]
-   then
-      SHARED_SET_SONAME="-Xlinker=-soname,"
-      SHARED_OPTIONS="-Xlinker=-z,defs"
-   else
-      SHARED_SET_SONAME="-Wl,-soname,"
-      SHARED_OPTIONS="-Wl,-z,defs"
-   fi
-   SHARED_COMPILE_FLAG="-fPIC"
-   case $hypre_platform in
-      AIX* | aix* | Aix*) SHARED_COMPILE_FLAG="-qmkshrobj"
-                          SHARED_BUILD_FLAG="-G"
-dnl                          LINK_F77="${F77} -brtl"
-                          LINK_FC='${FC} -brtl'
-                          LINK_CC='${CC} -brtl'
-                          LINK_CXX='${CXX} -brtl' ;;
-      DARWIN* | darwin* | Darwin*) SHARED_BUILD_FLAG="-dynamiclib -undefined dynamic_lookup"
-                                   HYPRE_LIBSUFFIX=".dylib"
-                                   SHARED_SET_SONAME="-install_name @rpath/"
-                                   SHARED_OPTIONS="-undefined error" ;;
-                       *) SHARED_BUILD_FLAG="-shared" ;;
-   esac
-   SHARED_BUILD_FLAG="${SHARED_BUILD_FLAG} ${EXTRA_BUILDFLAGS}"
-   FFLAGS="${FFLAGS} ${SHARED_COMPILE_FLAG}"
-   CFLAGS="${CFLAGS} ${SHARED_COMPILE_FLAG}"
-   CXXFLAGS="${CXXFLAGS} ${SHARED_COMPILE_FLAG}"
-   if [test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes"]; then
-      CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
-   fi
-   if [test "x$hypre_using_hip" = "xyes"]; then
-      CUFLAGS="${CUFLAGS} ${SHARED_COMPILE_FLAG}"
-   fi
-dnl   BUILD_F77_SHARED="${F77} ${SHARED_BUILD_FLAG}"
-   BUILD_FC_SHARED="${FC} ${SHARED_BUILD_FLAG}"
-   if test "$hypre_using_fei" = "yes"
-   then
-      BUILD_CC_SHARED="${CXX} ${SHARED_BUILD_FLAG}"
-   else
-      BUILD_CC_SHARED="${CC} ${SHARED_BUILD_FLAG}"
-   fi
-   BUILD_CXX_SHARED="${CXX} ${SHARED_BUILD_FLAG}"
-   if [test "x$CUCC" != "x"]
-   then
-      BUILD_CC_SHARED="${CUCC} ${SHARED_BUILD_FLAG} ${HYPRE_CUDA_GENCODE}"
-   fi
 fi
 
 if [test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes"]

--- a/src/configure
+++ b/src/configure
@@ -4801,6 +4801,22 @@ done
    fi
 fi
 
+if test "x$hypre_using_cuda" = "xyes" && test "x$hypre_using_device_openmp" = "xyes"
+then
+   as_fn_error $? "--with-cuda and --with-device-openmp are mutually exclusive" "$LINENO" 5
+fi
+
+if test "x$hypre_using_cuda" = "xyes" && test "x$hypre_using_hip" = "xyes"
+then
+   as_fn_error $? "--with-cuda and --with-hip are mutually exclusive" "$LINENO" 5
+fi
+
+if test "x$hypre_using_hip" = "xyes" && test "x$hypre_using_device_openmp" = "xyes"
+then
+   as_fn_error $? "--with-hip and --with-device-openmp are mutually exclusive" "$LINENO" 5
+fi
+
+
 if test "$hypre_user_chose_cudacompilers" = "no"
 then
    if test "$hypre_using_device_openmp" = "yes"

--- a/src/configure
+++ b/src/configure
@@ -639,7 +639,6 @@ HYPRE_CUDA_LIBS
 HYPRE_CUDA_INCLUDE
 HYPRE_CUDA_PATH
 CUCC_FULL
-CUFLAGS
 HYPRE_UMPIRE_LIB
 HYPRE_UMPIRE_INCLUDE
 HYPRE_UMPIRE_LIB_DIR
@@ -688,7 +687,6 @@ LINK_FC
 FFLAGS
 HOSTNAME
 HYPRE_ARCH
-HIPCC
 HYPRE_ROCM_PREFIX
 EGREP
 GREP
@@ -707,10 +705,11 @@ LDFLAGS
 CFLAGS
 RANLIB
 SET_MAKE
-CUCC
 FC
 CXX
 CC
+CUFLAGS
+CUCC
 host_os
 host_vendor
 host_cpu
@@ -744,7 +743,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -859,6 +857,8 @@ with_lapack
       ac_precious_vars='build_alias
 host_alias
 target_alias
+CUCC
+CUFLAGS
 CC
 CFLAGS
 LDFLAGS
@@ -908,7 +908,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1161,15 +1160,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1307,7 +1297,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1460,7 +1450,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1720,6 +1709,8 @@ Optional Packages:
   --with-lapack           Find a system-provided LAPACK library
 
 Some influential environment variables:
+  CUCC        CUDA compiler command
+  CUFLAGS     CUDA compiler flags
   CC          C compiler command
   CFLAGS      C compiler flags
   LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
@@ -3201,6 +3192,23 @@ else
    hypre_user_chose_cxxflags=yes
 fi
 
+
+
+
+if test "x$CUCC" = "x"
+then
+   hypre_user_chose_cudacompilers=no
+else
+   hypre_user_chose_cudacompilers=yes
+fi
+
+if test "x$CUFLAGS" = "x"
+then
+   hypre_user_chose_cuflags=no
+else
+   hypre_user_chose_cuflags=yes
+fi
+
 if test "x$F77" != "x" && test "x$FC" = "x"
 then
    FC="$F77"
@@ -4221,52 +4229,6 @@ if test "$hypre_user_chose_ccompilers" = "no"
 then
    if test "$hypre_using_mpi" = "no"
    then
-      if test "$hypre_using_device_openmp" = "yes"
-      then
-         for ac_prog in xlc-gpu clang-gpu
-do
-  # Extract the first word of "$ac_prog", so it can be a program name with args.
-set dummy $ac_prog; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_CUCC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$CUCC"; then
-  ac_cv_prog_CUCC="$CUCC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_CUCC="$ac_prog"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-CUCC=$ac_cv_prog_CUCC
-if test -n "$CUCC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CUCC" >&5
-$as_echo "$CUCC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-  test -n "$CUCC" && break
-done
-
-      fi
-
       if test "$hypre_using_openmp" = "yes"
       then
          for ac_prog in xlc_r xlC_r xlc xlC icc icpc gcc g++ pgcc pgCC cc CC kcc KCC
@@ -4356,52 +4318,6 @@ done
 
       fi
    else
-      if test "$hypre_using_device_openmp" = "yes"
-      then
-         for ac_prog in mpixlc-gpu mpiclang-gpu
-do
-  # Extract the first word of "$ac_prog", so it can be a program name with args.
-set dummy $ac_prog; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_CUCC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$CUCC"; then
-  ac_cv_prog_CUCC="$CUCC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_CUCC="$ac_prog"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-CUCC=$ac_cv_prog_CUCC
-if test -n "$CUCC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CUCC" >&5
-$as_echo "$CUCC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-  test -n "$CUCC" && break
-done
-
-      fi
-
       if test "$hypre_using_openmp" = "yes"
       then
          for ac_prog in mpxlc mpixlc_r mpixlc mpiicc mpigcc mpicc mpipgcc mpipgicc
@@ -4502,52 +4418,6 @@ if test "$hypre_user_chose_cxxcompilers" = "no"
 then
    if test "$hypre_using_mpi" = "no"
    then
-      if test "$hypre_using_device_openmp" = "yes"
-      then
-         for ac_prog in xlC-gpu clang++-gpu
-do
-  # Extract the first word of "$ac_prog", so it can be a program name with args.
-set dummy $ac_prog; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_CUCC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$CUCC"; then
-  ac_cv_prog_CUCC="$CUCC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_CUCC="$ac_prog"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-CUCC=$ac_cv_prog_CUCC
-if test -n "$CUCC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CUCC" >&5
-$as_echo "$CUCC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-  test -n "$CUCC" && break
-done
-
-      fi
-
       if test "$hypre_using_openmp" = "yes"
       then
          for ac_prog in xlC_r xlc_r xlC xlc icpc icc g++ gcc pgCC pgcc pgc++ CC cc KCC kcc
@@ -4637,52 +4507,6 @@ done
 
       fi
    else
-      if test "$hypre_using_device_openmp" = "yes"
-      then
-         for ac_prog in mpixlC-gpu mpiclang++-gpu
-do
-  # Extract the first word of "$ac_prog", so it can be a program name with args.
-set dummy $ac_prog; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_CUCC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$CUCC"; then
-  ac_cv_prog_CUCC="$CUCC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_CUCC="$ac_prog"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-CUCC=$ac_cv_prog_CUCC
-if test -n "$CUCC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CUCC" >&5
-$as_echo "$CUCC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-  test -n "$CUCC" && break
-done
-
-      fi
-
       if test "$hypre_using_openmp" = "yes"
       then
          for ac_prog in mpxlC mpixlcxx_r mpixlcxx mpixlC mpiicpc mpig++ mpic++ mpicxx mpiCC mpipgCC mpipgic++
@@ -4965,6 +4789,194 @@ done
    if test "x$FC" = "x"
    then
       hypre_using_fortran=no
+   fi
+fi
+
+if test "$hypre_user_chose_cudacompilers" = "no"
+then
+   if test "$hypre_using_device_openmp" = "yes"
+   then
+      if test "$hypre_using_mpi" = "no"
+      then
+         for ac_prog in xlc-gpu clang-gpu
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CUCC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$CUCC"; then
+  ac_cv_prog_CUCC="$CUCC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_CUCC="$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+CUCC=$ac_cv_prog_CUCC
+if test -n "$CUCC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CUCC" >&5
+$as_echo "$CUCC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$CUCC" && break
+done
+
+      else
+         for ac_prog in mpixlc-gpu mpiclang-gpu
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CUCC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$CUCC"; then
+  ac_cv_prog_CUCC="$CUCC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_CUCC="$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+CUCC=$ac_cv_prog_CUCC
+if test -n "$CUCC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CUCC" >&5
+$as_echo "$CUCC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$CUCC" && break
+done
+
+      fi
+   fi
+
+   if test "$hypre_using_cuda" = "yes"
+   then
+      for ac_prog in nvcc
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CUCC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$CUCC"; then
+  ac_cv_prog_CUCC="$CUCC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in "${CUDA_HOME}/bin"
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_CUCC="$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+CUCC=$ac_cv_prog_CUCC
+if test -n "$CUCC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CUCC" >&5
+$as_echo "$CUCC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$CUCC" && break
+done
+test -n "$CUCC" || CUCC=""""
+
+   fi
+
+   if test "$hypre_user_chose_hip" = "yes"
+   then
+      for ac_prog in hipcc
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CUCC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$CUCC"; then
+  ac_cv_prog_CUCC="$CUCC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_CUCC="$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+CUCC=$ac_cv_prog_CUCC
+if test -n "$CUCC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CUCC" >&5
+$as_echo "$CUCC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$CUCC" && break
+done
+
    fi
 fi
 
@@ -8401,6 +8413,50 @@ fi
  fi
 
 
+if test "$hypre_using_shared" = "yes"
+then
+   HYPRE_LIBSUFFIX=".so"
+   if test "$hypre_user_chose_cuda" = "yes"
+   then
+      SHARED_SET_SONAME="-Xlinker=-soname,"
+      SHARED_OPTIONS="-Xlinker=-z,defs"
+   else
+      SHARED_SET_SONAME="-Wl,-soname,"
+      SHARED_OPTIONS="-Wl,-z,defs"
+   fi
+   SHARED_COMPILE_FLAG="-fPIC"
+   case $hypre_platform in
+      AIX* | aix* | Aix*) SHARED_COMPILE_FLAG="-qmkshrobj"
+                          SHARED_BUILD_FLAG="-G"
+                          LINK_FC='${FC} -brtl'
+                          LINK_CC='${CC} -brtl'
+                          LINK_CXX='${CXX} -brtl' ;;
+      DARWIN* | darwin* | Darwin*) SHARED_BUILD_FLAG="-dynamiclib -undefined dynamic_lookup"
+                                   HYPRE_LIBSUFFIX=".dylib"
+                                   SHARED_SET_SONAME="-install_name @rpath/"
+                                   SHARED_OPTIONS="-undefined error" ;;
+                       *) SHARED_BUILD_FLAG="-shared" ;;
+   esac
+   SHARED_BUILD_FLAG="${SHARED_BUILD_FLAG} ${EXTRA_BUILDFLAGS}"
+   FFLAGS="${FFLAGS} ${SHARED_COMPILE_FLAG}"
+   CFLAGS="${CFLAGS} ${SHARED_COMPILE_FLAG}"
+   CXXFLAGS="${CXXFLAGS} ${SHARED_COMPILE_FLAG}"
+
+   BUILD_FC_SHARED="\${FC} ${SHARED_BUILD_FLAG}"
+   if test "$hypre_using_fei" = "yes"
+   then
+      BUILD_CC_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
+   else
+      BUILD_CC_SHARED="\${CC} ${SHARED_BUILD_FLAG}"
+   fi
+   BUILD_CXX_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
+   if test "$hypre_user_chose_cuda" = "yes"
+   then
+      BUILD_CC_SHARED="\${CUCC} ${SHARED_BUILD_FLAG} ${HYPRE_CUDA_GENCODE}"
+   fi
+   fi
+
+
 if test "$hypre_using_caliper" = "yes"
 then
    if test "$hypre_user_gave_caliper_inc" != "yes"
@@ -8772,51 +8828,7 @@ $as_echo "#define HYPRE_USING_CURAND 1" >>confdefs.h
 
    fi
 
-      for ac_prog in nvcc
-do
-  # Extract the first word of "$ac_prog", so it can be a program name with args.
-set dummy $ac_prog; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_CUCC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$CUCC"; then
-  ac_cv_prog_CUCC="$CUCC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in "${CUDA_HOME}/bin"
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_CUCC="$ac_prog"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-CUCC=$ac_cv_prog_CUCC
-if test -n "$CUCC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CUCC" >&5
-$as_echo "$CUCC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-  test -n "$CUCC" && break
-done
-test -n "$CUCC" || CUCC=""""
-
-   NVCCBIN=${CXX}
-   LINK_CC='${CUCC}'
+      LINK_CC='${CUCC}'
    LINK_CXX='${CUCC}'
 
       if test "x$HYPRE_CUDA_SM" = "x"
@@ -8829,22 +8841,28 @@ test -n "$CUCC" || CUCC=""""
       HYPRE_CUDA_GENCODE="${HYPRE_CUDA_GENCODE} -gencode arch=compute_${sm},code=sm_${sm}"
    done
 
-   CUFLAGS+="-lineinfo -ccbin=$NVCCBIN ${HYPRE_CUDA_GENCODE} -expt-extended-lambda -dc -std=c++11 --x cu"
-   if test "$hypre_using_debug" = "yes"
+   if test "$hypre_user_chose_cuflags" = "no"
    then
-      CUFLAGS="-g -O0 ${CUFLAGS}"
-   else
-      CUFLAGS="-O2 ${CUFLAGS}"
+      CUFLAGS="-lineinfo -ccbin=\${CXX} ${HYPRE_CUDA_GENCODE} -expt-extended-lambda -dc -std=c++11 --x cu"
+      if test "$hypre_using_debug" = "yes"
+      then
+         CUFLAGS="-g -O0 ${CUFLAGS}"
+      else
+         CUFLAGS="-O2 ${CUFLAGS}"
+      fi
    fi
 
-   if test "$NVCCBIN" = "mpixlC" || test "$NVCCBIN" = "xlC_r" || test "$NVCCBIN" = "xlC"
+   if test "$hypre_user_chose_cxxflags" = "no"
    then
-     CXXFLAGS+=" -Wno-deprecated-register -Wenum-compare"
+      if test "${CXX}" = "mpixlC" || test "${CXX}" = "xlC_r" || test "${CXX}" = "xlC"
+      then
+         CXXFLAGS+=" -Wno-deprecated-register -Wenum-compare"
+      fi
    fi
 
    CUFLAGS="${CUFLAGS} -Xcompiler \"${CXXFLAGS}\""
 
-      LDFLAGS="-ccbin=$NVCCBIN ${HYPRE_CUDA_GENCODE} -Xcompiler \"${LDFLAGS}\""
+      LDFLAGS="-ccbin=\${CXX} ${HYPRE_CUDA_GENCODE} -Xcompiler \"${LDFLAGS}\""
    HYPRE_CUDA_INCLUDE='-I${HYPRE_CUDA_PATH}/include'
    HYPRE_CUDA_LIBS='-L${HYPRE_CUDA_PATH}/lib64 -lcudart'
    if test "$hypre_using_gpu_profiling" = "yes"
@@ -8877,52 +8895,9 @@ $as_echo "#define HYPRE_USING_GPU 1" >>confdefs.h
 $as_echo "#define HYPRE_USING_HIP 1" >>confdefs.h
 
 
-                                                for ac_prog in hipcc
-do
-  # Extract the first word of "$ac_prog", so it can be a program name with args.
-set dummy $ac_prog; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_HIPCC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$HIPCC"; then
-  ac_cv_prog_HIPCC="$HIPCC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_HIPCC="$ac_prog"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
 
-fi
-fi
-HIPCC=$ac_cv_prog_HIPCC
-if test -n "$HIPCC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $HIPCC" >&5
-$as_echo "$HIPCC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-  test -n "$HIPCC" && break
-done
-
-
-                                CUCC=${HIPCC}
-        LINK_CC=${HIPCC}
-        LINK_CXX=${HIPCC}
+                                LINK_CC='${CUCC}'
+        LINK_CXX='${CUCC}'
 
                                         HIPCXXFLAGS="-x hip ${HIPCXXFLAGS}"
 
@@ -8932,7 +8907,12 @@ elif HIPCXXFLAGS="-O2 ${HIPCXXFLAGS}"; then :
 
 fi
 
-                        CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS}"
+                        if test "$hypre_user_chose_cuflags" = "no"
+        then
+           CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS}"
+        fi
+
+        CUFLAGS="${CUFLAGS} ${CXXFLAGS}"
 
                         HYPRE_HIP_INCL="-I${HYPRE_ROCM_PREFIX}/rocthrust/include"
         HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocprim/include"
@@ -8983,42 +8963,42 @@ if test "$hypre_using_um" != "yes"
 then
       if test "$hypre_user_chose_cuda" = "yes"
    then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************" >&5
-$as_echo "$as_me: ***********************************************************" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************************" >&5
+$as_echo "$as_me: ***********************************************************************" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Configuring with --with-cuda=yes without unified memory." >&5
 $as_echo "$as_me: Configuring with --with-cuda=yes without unified memory." >&6;}
-      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for struct interface." >&5
-$as_echo "$as_me: It only works for struct interface." >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for structured solvers and selective unstructured solvers" >&5
+$as_echo "$as_me: It only works for structured solvers and selective unstructured solvers" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Use --enable-unified-memory to compile with unified memory." >&5
 $as_echo "$as_me: Use --enable-unified-memory to compile with unified memory." >&6;}
-      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************" >&5
-$as_echo "$as_me: ***********************************************************" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************************" >&5
+$as_echo "$as_me: ***********************************************************************" >&6;}
    fi
    if test "$hypre_user_chose_hip" = "yes"
    then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************" >&5
-$as_echo "$as_me: ***********************************************************" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************************" >&5
+$as_echo "$as_me: ***********************************************************************" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Configuring with --with-hip=yes without unified memory." >&5
 $as_echo "$as_me: Configuring with --with-hip=yes without unified memory." >&6;}
-      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for struct interface." >&5
-$as_echo "$as_me: It only works for struct interface." >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for structured solvers and selective unstructured solvers" >&5
+$as_echo "$as_me: It only works for structured solvers and selective unstructured solvers" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Use --enable-unified-memory to compile with unified memory." >&5
 $as_echo "$as_me: Use --enable-unified-memory to compile with unified memory." >&6;}
-      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************" >&5
-$as_echo "$as_me: ***********************************************************" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************************" >&5
+$as_echo "$as_me: ***********************************************************************" >&6;}
    fi
    if test "$hypre_using_device_openmp" = "yes"
    then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************" >&5
-$as_echo "$as_me: ***********************************************************" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************************" >&5
+$as_echo "$as_me: ***********************************************************************" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Configuring with --with-device-openmp=yes without unified memory." >&5
 $as_echo "$as_me: Configuring with --with-device-openmp=yes without unified memory." >&6;}
-      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for struct interface." >&5
-$as_echo "$as_me: It only works for struct interface." >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for structured solvers and selective unstructured solvers" >&5
+$as_echo "$as_me: It only works for structured solvers and selective unstructured solvers" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Use --enable-unified-memory to compile with unified memory." >&5
 $as_echo "$as_me: Use --enable-unified-memory to compile with unified memory." >&6;}
-      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************" >&5
-$as_echo "$as_me: ***********************************************************" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************************" >&5
+$as_echo "$as_me: ***********************************************************************" >&6;}
    fi
 fi
 
@@ -9055,17 +9035,20 @@ $as_echo "#define HYPRE_DEVICE_OPENMP_ALLOC 1" >>confdefs.h
 
 
 
+   CUFLAGS=${CFLAGS}
 
-         CUFLAGS=${CFLAGS}
+   if test "$hypre_user_chose_cuflags" = "no"
+   then
+      if test "$CUCC" = "clang-gpu" || test "$CUCC" = "mpiclang-gpu"
+      then
+         CUFLAGS+=" -fopenmp-nonaliased-maps"
+      fi
+      if test "$CUCC" = "clang++-gpu" || test "$CUCC" = "mpiclang++-gpu"
+      then
+         CUFLAGS+=" -fopenmp-nonaliased-maps"
+      fi
+   fi
 
-   if test "$CUCC" = "clang-gpu" || test "$CUCC" = "mpiclang-gpu"
-   then
-      CUFLAGS+=" -fopenmp-nonaliased-maps"
-   fi
-   if test "$CUCC" = "clang++-gpu" || test "$CUCC" = "mpiclang++-gpu"
-   then
-      CUFLAGS+=" -fopenmp-nonaliased-maps"
-   fi
    if test "$hypre_using_debug" = "yes"
    then
 
@@ -9083,54 +9066,6 @@ $as_echo "#define HYPRE_DEVICE_OPENMP_CHECK 1" >>confdefs.h
          LINK_CC='${CUCC}'
    LINK_CXX='${CUCC}'
       fi
-
-if test "$hypre_using_shared" = "yes"
-then
-   HYPRE_LIBSUFFIX=".so"
-   if test "x$CUCC" = "xnvcc"
-   then
-      SHARED_SET_SONAME="-Xlinker=-soname,"
-      SHARED_OPTIONS="-Xlinker=-z,defs"
-   else
-      SHARED_SET_SONAME="-Wl,-soname,"
-      SHARED_OPTIONS="-Wl,-z,defs"
-   fi
-   SHARED_COMPILE_FLAG="-fPIC"
-   case $hypre_platform in
-      AIX* | aix* | Aix*) SHARED_COMPILE_FLAG="-qmkshrobj"
-                          SHARED_BUILD_FLAG="-G"
-                          LINK_FC='${FC} -brtl'
-                          LINK_CC='${CC} -brtl'
-                          LINK_CXX='${CXX} -brtl' ;;
-      DARWIN* | darwin* | Darwin*) SHARED_BUILD_FLAG="-dynamiclib -undefined dynamic_lookup"
-                                   HYPRE_LIBSUFFIX=".dylib"
-                                   SHARED_SET_SONAME="-install_name @rpath/"
-                                   SHARED_OPTIONS="-undefined error" ;;
-                       *) SHARED_BUILD_FLAG="-shared" ;;
-   esac
-   SHARED_BUILD_FLAG="${SHARED_BUILD_FLAG} ${EXTRA_BUILDFLAGS}"
-   FFLAGS="${FFLAGS} ${SHARED_COMPILE_FLAG}"
-   CFLAGS="${CFLAGS} ${SHARED_COMPILE_FLAG}"
-   CXXFLAGS="${CXXFLAGS} ${SHARED_COMPILE_FLAG}"
-   if test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes"; then
-      CUFLAGS="${CUFLAGS} -Xcompiler \"${SHARED_COMPILE_FLAG}\""
-   fi
-   if test "x$hypre_using_hip" = "xyes"; then
-      CUFLAGS="${CUFLAGS} ${SHARED_COMPILE_FLAG}"
-   fi
-   BUILD_FC_SHARED="${FC} ${SHARED_BUILD_FLAG}"
-   if test "$hypre_using_fei" = "yes"
-   then
-      BUILD_CC_SHARED="${CXX} ${SHARED_BUILD_FLAG}"
-   else
-      BUILD_CC_SHARED="${CC} ${SHARED_BUILD_FLAG}"
-   fi
-   BUILD_CXX_SHARED="${CXX} ${SHARED_BUILD_FLAG}"
-   if test "x$CUCC" != "x"
-   then
-      BUILD_CC_SHARED="${CUCC} ${SHARED_BUILD_FLAG} ${HYPRE_CUDA_GENCODE}"
-   fi
-fi
 
 if test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes"
 then

--- a/src/configure
+++ b/src/configure
@@ -710,6 +710,8 @@ CXX
 CC
 CUFLAGS
 CUCC
+HYPRE_CUDA_SM
+CUDA_HOME
 host_os
 host_vendor
 host_cpu
@@ -857,6 +859,8 @@ with_lapack
       ac_precious_vars='build_alias
 host_alias
 target_alias
+CUDA_HOME
+HYPRE_CUDA_SM
 CUCC
 CUFLAGS
 CC
@@ -1709,6 +1713,9 @@ Optional Packages:
   --with-lapack           Find a system-provided LAPACK library
 
 Some influential environment variables:
+  CUDA_HOME   CUDA home directory
+  HYPRE_CUDA_SM
+              CUDA architecture
   CUCC        CUDA compiler command
   CUFLAGS     CUDA compiler flags
   CC          C compiler command
@@ -2680,9 +2687,10 @@ PACKAGE_BUGREPORT=
 hypre_user_chose_mpi=no
 hypre_user_chose_blas=no
 hypre_user_chose_lapack=no
-hypre_user_chose_cuda=no
 hypre_user_chose_raja=no
+hypre_using_raja=no
 hypre_user_chose_kokkos=no
+hypre_using_kokkos=no
 
 hypre_using_c=yes
 hypre_using_cxx=yes
@@ -2726,7 +2734,6 @@ hypre_using_node_aware_mpi=no
 hypre_using_memory_tracker=no
 
 
-hypre_user_chose_hip=no
 hypre_using_hip=no
 hypre_using_rocsparse=no
 hypre_using_rocblas=no
@@ -3191,6 +3198,8 @@ then
 else
    hypre_user_chose_cxxflags=yes
 fi
+
+
 
 
 
@@ -3907,8 +3916,7 @@ fi
 # Check whether --with-cuda was given.
 if test "${with_cuda+set}" = set; then :
   withval=$with_cuda; case "$withval" in
-    yes) hypre_user_chose_cuda=yes
-         hypre_using_cuda=yes ;;
+    yes) hypre_using_cuda=yes ;;
     no)  hypre_using_cuda=no ;;
     *)   hypre_using_cuda=no ;;
  esac
@@ -3923,8 +3931,7 @@ fi
 # Check whether --with-hip was given.
 if test "${with_hip+set}" = set; then :
   withval=$with_hip; case "$withval" in
-    yes) hypre_user_chose_hip=yes
-         hypre_using_hip=yes ;;
+    yes) hypre_using_hip=yes ;;
     no)  hypre_using_hip=no ;;
     *)   hypre_using_hip=no ;;
  esac
@@ -3963,9 +3970,9 @@ fi
 # Check whether --with-raja was given.
 if test "${with_raja+set}" = set; then :
   withval=$with_raja; case "$withval" in
-    yes) hypre_user_chose_raja=yes;;
-    no)  hypre_user_chose_raja=no ;;
-    *)   hypre_user_chose_raja=no ;;
+    yes) hypre_using_raja=yes;;
+    no)  hypre_using_raja=no ;;
+    *)   hypre_using_raja=no ;;
  esac
 else
   hypre_using_raja=no
@@ -4022,10 +4029,12 @@ fi
 # Check whether --with-kokkos was given.
 if test "${with_kokkos+set}" = set; then :
   withval=$with_kokkos; case "$withval" in
-    yes) hypre_user_chose_kokkos=yes ;;
-    no)  hypre_user_chose_kokkos=no ;;
-    *)   hypre_user_chose_kokkos=no ;;
+    yes) hypre_using_kokkos=yes ;;
+    no)  hypre_using_kokkos=no ;;
+    *)   hypre_using_kokkos=no ;;
  esac
+else
+  hypre_using_kokkos=no
 
 fi
 
@@ -4933,7 +4942,7 @@ test -n "$CUCC" || CUCC=""""
 
    fi
 
-   if test "$hypre_user_chose_hip" = "yes"
+   if test "$hypre_using_hip" = "yes"
    then
       for ac_prog in hipcc
 do
@@ -8416,7 +8425,7 @@ fi
 if test "$hypre_using_shared" = "yes"
 then
    HYPRE_LIBSUFFIX=".so"
-   if test "$hypre_user_chose_cuda" = "yes"
+   if test "$hypre_using_cuda" = "yes"
    then
       SHARED_SET_SONAME="-Xlinker=-soname,"
       SHARED_OPTIONS="-Xlinker=-z,defs"
@@ -8450,7 +8459,7 @@ then
       BUILD_CC_SHARED="\${CC} ${SHARED_BUILD_FLAG}"
    fi
    BUILD_CXX_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
-   if test "$hypre_user_chose_cuda" = "yes"
+   if test "$hypre_using_cuda" = "yes"
    then
       BUILD_CC_SHARED="\${CUCC} ${SHARED_BUILD_FLAG} ${HYPRE_CUDA_GENCODE}"
    fi
@@ -8702,7 +8711,7 @@ fi
 
 
 
-if test "x$hypre_user_chose_raja" = "xyes"
+if test "x$hypre_using_raja" = "xyes"
 then
 
 $as_echo "#define HYPRE_USING_RAJA 1" >>confdefs.h
@@ -8721,7 +8730,7 @@ $as_echo "#define HYPRE_USING_RAJA 1" >>confdefs.h
    CFLAGS=${CXXFLAGS}
 fi
 
-if test "x$hypre_user_chose_kokkos" = "xyes"
+if test "x$hypre_using_kokkos" = "xyes"
 then
 
 $as_echo "#define HYPRE_USING_KOKKOS 1" >>confdefs.h
@@ -8779,7 +8788,7 @@ $as_echo "#define HYPRE_USING_UMPIRE 1" >>confdefs.h
 
 fi
 
-if test "$hypre_user_chose_cuda" = "yes"
+if test "$hypre_using_cuda" = "yes"
 then
 
 $as_echo "#define HYPRE_USING_GPU 1" >>confdefs.h
@@ -8886,7 +8895,7 @@ $as_echo "#define HYPRE_USING_CURAND 1" >>confdefs.h
    fi
 fi
 
-if test x"$hypre_user_chose_hip" == x"yes"; then :
+if test x"$hypre_using_hip" == x"yes"; then :
 
 
 $as_echo "#define HYPRE_USING_GPU 1" >>confdefs.h
@@ -8961,27 +8970,27 @@ fi
 
 if test "$hypre_using_um" != "yes"
 then
-      if test "$hypre_user_chose_cuda" = "yes"
+      if test "$hypre_using_cuda" = "yes"
    then
       { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************************" >&5
 $as_echo "$as_me: ***********************************************************************" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Configuring with --with-cuda=yes without unified memory." >&5
 $as_echo "$as_me: Configuring with --with-cuda=yes without unified memory." >&6;}
-      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for structured solvers and selective unstructured solvers" >&5
-$as_echo "$as_me: It only works for structured solvers and selective unstructured solvers" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for structured solvers and selected unstructured solvers" >&5
+$as_echo "$as_me: It only works for structured solvers and selected unstructured solvers" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Use --enable-unified-memory to compile with unified memory." >&5
 $as_echo "$as_me: Use --enable-unified-memory to compile with unified memory." >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************************" >&5
 $as_echo "$as_me: ***********************************************************************" >&6;}
    fi
-   if test "$hypre_user_chose_hip" = "yes"
+   if test "$hypre_using_hip" = "yes"
    then
       { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************************" >&5
 $as_echo "$as_me: ***********************************************************************" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Configuring with --with-hip=yes without unified memory." >&5
 $as_echo "$as_me: Configuring with --with-hip=yes without unified memory." >&6;}
-      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for structured solvers and selective unstructured solvers" >&5
-$as_echo "$as_me: It only works for structured solvers and selective unstructured solvers" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for structured solvers and selected unstructured solvers" >&5
+$as_echo "$as_me: It only works for structured solvers and selected unstructured solvers" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Use --enable-unified-memory to compile with unified memory." >&5
 $as_echo "$as_me: Use --enable-unified-memory to compile with unified memory." >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************************" >&5
@@ -8993,8 +9002,8 @@ $as_echo "$as_me: **************************************************************
 $as_echo "$as_me: ***********************************************************************" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Configuring with --with-device-openmp=yes without unified memory." >&5
 $as_echo "$as_me: Configuring with --with-device-openmp=yes without unified memory." >&6;}
-      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for structured solvers and selective unstructured solvers" >&5
-$as_echo "$as_me: It only works for structured solvers and selective unstructured solvers" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: It only works for structured solvers and selected unstructured solvers" >&5
+$as_echo "$as_me: It only works for structured solvers and selected unstructured solvers" >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: Use --enable-unified-memory to compile with unified memory." >&5
 $as_echo "$as_me: Use --enable-unified-memory to compile with unified memory." >&6;}
       { $as_echo "$as_me:${as_lineno-$LINENO}: ***********************************************************************" >&5
@@ -9083,7 +9092,7 @@ then
 $as_echo "#define HYPRE_USING_UNIFIED_MEMORY 1" >>confdefs.h
 
 else
-   if test "x$hypre_user_chose_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes" || test "x$hypre_user_chose_hip" = "xyes"
+   if test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_device_openmp" = "xyes" || test "x$hypre_using_hip" = "xyes"
    then
 
 $as_echo "#define HYPRE_USING_DEVICE_MEMORY 1" >>confdefs.h


### PR DESCRIPTION
1. This PR fixes `CUCC` and `CUFLAGS`, in the cases they are provided by users. Also, make these two variables **precious** (see https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Setting-Output-Variables.html) 

```
Some influential environment variables:
  CUDA_HOME   CUDA home directory
  HYPRE_CUDA_SM
              CUDA architecture
  CUCC        CUDA compiler command
  CUFLAGS     CUDA compiler flags
  CC          C compiler command
  CFLAGS      C compiler flags
  LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
              nonstandard directory <lib dir>
  LIBS        libraries to pass to the linker, e.g. -l<library>
  CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
              you have headers in a nonstandard directory <include dir>
  CXX         C++ compiler command
  CXXFLAGS    C++ compiler flags
  FC          Fortran compiler command
  FCFLAGS     Fortran compiler flags
  CPP         C preprocessor

```

2. It changes the warning message from `configure` when without UVM to "It only works for structured solvers **and selected unstructured solvers**"