### PR TITLE
GPU Profiling Fixes

### DIFF
--- a/src/parcsr_ls/par_lr_interp_device.c
+++ b/src/parcsr_ls/par_lr_interp_device.c
@@ -85,7 +85,7 @@ hypre_BoomerAMGBuildExtInterpDevice(hypre_ParCSRMatrix  *A,
                       0 );
 
    // AFF AFC
-   hypre_GpuProfilingPushRangeColor("Extract Submatrix", 2);
+   hypre_GpuProfilingPushRange("Extract Submatrix");
    hypre_ParCSRMatrixGenerateFFFCDevice(A, CF_marker, num_cpts_global, S, &AFC, &AFF);
    hypre_GpuProfilingPopRange();
 
@@ -109,7 +109,7 @@ hypre_BoomerAMGBuildExtInterpDevice(hypre_ParCSRMatrix  *A,
 
    /* 5. Form matrix ~{A_FF}, (return twAFF in AFF data structure ) */
    /* 6. Form matrix ~{A_FC}, (return twAFC in AFC data structure) */
-   hypre_GpuProfilingPushRangeColor("Compute interp matrix", 4);
+   hypre_GpuProfilingPushRange("Compute interp matrix");
    gDim = hypre_GetDefaultCUDAGridDimension(W_nr_of_rows, "warp", bDim);
    HYPRE_CUDA_LAUNCH( hypreCUDAKernel_compute_aff_afc,
                       gDim, bDim,
@@ -130,7 +130,7 @@ hypre_BoomerAMGBuildExtInterpDevice(hypre_ParCSRMatrix  *A,
    hypre_GpuProfilingPopRange();
 
    /* 7. Perform matrix-matrix multiplication */
-   hypre_GpuProfilingPushRangeColor("Matrix-matrix mult", 3);
+   hypre_GpuProfilingPushRange("Matrix-matrix mult");
    W = hypre_ParCSRMatMatDevice(AFF, AFC);
    hypre_GpuProfilingPopRange();
 
@@ -146,7 +146,7 @@ hypre_BoomerAMGBuildExtInterpDevice(hypre_ParCSRMatrix  *A,
    P_diag_data = hypre_TAlloc(HYPRE_Complex, P_diag_nnz,     HYPRE_MEMORY_DEVICE);
    P_offd_i    = hypre_TAlloc(HYPRE_Int,     A_nr_of_rows+1, HYPRE_MEMORY_DEVICE);
 
-   hypre_GpuProfilingPushRangeColor("Extend matrix", 4);
+   hypre_GpuProfilingPushRange("Extend matrix");
    hypreDevice_extendWtoP( A_nr_of_rows,
                            W_nr_of_rows,
                            hypre_ParCSRMatrixNumCols(W),
@@ -198,7 +198,7 @@ hypre_BoomerAMGBuildExtInterpDevice(hypre_ParCSRMatrix  *A,
                                        hypre_ParCSRMatrixGlobalNumCols(W);
    hypre_ParCSRMatrixDNumNonzeros(P) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(P);
 
-   hypre_GpuProfilingPushRangeColor("Truncation", 4);
+   hypre_GpuProfilingPushRange("Truncation");
    if (trunc_factor != 0.0 || max_elmts > 0)
    {
       hypre_BoomerAMGInterpTruncationDevice(P, trunc_factor, max_elmts );
@@ -283,7 +283,7 @@ hypre_BoomerAMGBuildExtPIInterpDevice( hypre_ParCSRMatrix  *A,
                       0 );
 
    // AFF AFC
-   hypre_GpuProfilingPushRangeColor("Extract Submatrix", 2);
+   hypre_GpuProfilingPushRange("Extract Submatrix");
    hypre_ParCSRMatrixGenerateFFFCDevice(A, CF_marker, num_cpts_global, S, &AFC, &AFF);
    hypre_GpuProfilingPopRange();
 
@@ -341,7 +341,7 @@ hypre_BoomerAMGBuildExtPIInterpDevice( hypre_ParCSRMatrix  *A,
                       hypre_CSRMatrixData(hypre_ParCSRMatrixDiag(AFF)) + hypre_CSRMatrixNumNonzeros(hypre_ParCSRMatrixDiag(AFF)),
                       AFF_diag_data_old );
 
-   hypre_GpuProfilingPushRangeColor("Compute interp matrix", 4);
+   hypre_GpuProfilingPushRange("Compute interp matrix");
    gDim = hypre_GetDefaultCUDAGridDimension(W_nr_of_rows, "warp", bDim);
    HYPRE_CUDA_LAUNCH( hypreCUDAKernel_compute_twiaff_w,
                       gDim, bDim,
@@ -368,7 +368,7 @@ hypre_BoomerAMGBuildExtPIInterpDevice( hypre_ParCSRMatrix  *A,
    hypre_GpuProfilingPopRange();
 
    /* 7. Perform matrix-matrix multiplication */
-   hypre_GpuProfilingPushRangeColor("Matrix-matrix mult", 3);
+   hypre_GpuProfilingPushRange("Matrix-matrix mult");
    W = hypre_ParCSRMatMatDevice(AFF, AFC);
    hypre_GpuProfilingPopRange();
 
@@ -384,7 +384,7 @@ hypre_BoomerAMGBuildExtPIInterpDevice( hypre_ParCSRMatrix  *A,
    P_diag_data = hypre_TAlloc(HYPRE_Complex, P_diag_nnz,     HYPRE_MEMORY_DEVICE);
    P_offd_i    = hypre_TAlloc(HYPRE_Int,     A_nr_of_rows+1, HYPRE_MEMORY_DEVICE);
 
-   hypre_GpuProfilingPushRangeColor("Extend matrix", 4);
+   hypre_GpuProfilingPushRange("Extend matrix");
    hypreDevice_extendWtoP( A_nr_of_rows,
                            W_nr_of_rows,
                            hypre_ParCSRMatrixNumCols(W),
@@ -436,7 +436,7 @@ hypre_BoomerAMGBuildExtPIInterpDevice( hypre_ParCSRMatrix  *A,
                                        hypre_ParCSRMatrixGlobalNumCols(W);
    hypre_ParCSRMatrixDNumNonzeros(P) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(P);
 
-   hypre_GpuProfilingPushRangeColor("Truncation", 4);
+   hypre_GpuProfilingPushRange("Truncation");
    if (trunc_factor != 0.0 || max_elmts > 0)
    {
       hypre_BoomerAMGInterpTruncationDevice(P, trunc_factor, max_elmts );
@@ -520,7 +520,7 @@ hypre_BoomerAMGBuildExtPEInterpDevice(hypre_ParCSRMatrix  *A,
                       0 );
 
    // AFF AFC
-   hypre_GpuProfilingPushRangeColor("Extract Submatrix", 2);
+   hypre_GpuProfilingPushRange("Extract Submatrix");
    hypre_ParCSRMatrixGenerateFFFCDevice(A, CF_marker, num_cpts_global, S, &AFC, &AFF);
    hypre_GpuProfilingPopRange();
 
@@ -546,7 +546,7 @@ hypre_BoomerAMGBuildExtPEInterpDevice(hypre_ParCSRMatrix  *A,
    /* Generate D_tmp, i.e., D_mu / D_lambda */
    dlam = hypre_TAlloc(HYPRE_Complex, W_nr_of_rows, HYPRE_MEMORY_DEVICE);
    dtmp = hypre_TAlloc(HYPRE_Complex, W_nr_of_rows, HYPRE_MEMORY_DEVICE);
-   hypre_GpuProfilingPushRangeColor("Compute D_tmp", 3);
+   hypre_GpuProfilingPushRange("Compute D_tmp");
    gDim = hypre_GetDefaultCUDAGridDimension(W_nr_of_rows, "warp", bDim);
    HYPRE_CUDA_LAUNCH( hypreCUDAKernel_compute_dlam_dtmp,
                       gDim, bDim,
@@ -581,11 +581,12 @@ hypre_BoomerAMGBuildExtPEInterpDevice(hypre_ParCSRMatrix  *A,
    comm_handle = hypre_ParCSRCommHandleCreate_v2(1, comm_pkg, HYPRE_MEMORY_DEVICE, send_buf, HYPRE_MEMORY_DEVICE, dtmp_offd);
    hypre_ParCSRCommHandleDestroy(comm_handle);
    hypre_TFree(send_buf, HYPRE_MEMORY_DEVICE);
+   hypre_GpuProfilingPopRange();
 
    /* 4. Form D_tau */
    /* 5. Form matrix ~{A_FF}, (return twAFF in AFF data structure ) */
    /* 6. Form matrix ~{A_FC}, (return twAFC in AFC data structure) */
-   hypre_GpuProfilingPushRangeColor("Compute interp matrix", 4);
+   hypre_GpuProfilingPushRange("Compute interp matrix");
    gDim = hypre_GetDefaultCUDAGridDimension(W_nr_of_rows, "warp", bDim);
    HYPRE_CUDA_LAUNCH( hypreCUDAKernel_compute_aff_afc_epe,
                       gDim, bDim,
@@ -612,7 +613,7 @@ hypre_BoomerAMGBuildExtPEInterpDevice(hypre_ParCSRMatrix  *A,
    hypre_GpuProfilingPopRange();
 
    /* 7. Perform matrix-matrix multiplication */
-   hypre_GpuProfilingPushRangeColor("Matrix-matrix mult", 3);
+   hypre_GpuProfilingPushRange("Matrix-matrix mult");
    W = hypre_ParCSRMatMatDevice(AFF, AFC);
    hypre_GpuProfilingPopRange();
 
@@ -628,7 +629,7 @@ hypre_BoomerAMGBuildExtPEInterpDevice(hypre_ParCSRMatrix  *A,
    P_diag_data = hypre_TAlloc(HYPRE_Complex, P_diag_nnz,     HYPRE_MEMORY_DEVICE);
    P_offd_i    = hypre_TAlloc(HYPRE_Int,     A_nr_of_rows+1, HYPRE_MEMORY_DEVICE);
 
-   hypre_GpuProfilingPushRangeColor("Extend matrix", 4);
+   hypre_GpuProfilingPushRange("Extend matrix");
    hypreDevice_extendWtoP( A_nr_of_rows,
                            W_nr_of_rows,
                            hypre_ParCSRMatrixNumCols(W),
@@ -680,7 +681,7 @@ hypre_BoomerAMGBuildExtPEInterpDevice(hypre_ParCSRMatrix  *A,
                                        hypre_ParCSRMatrixGlobalNumCols(W);
    hypre_ParCSRMatrixDNumNonzeros(P) = (HYPRE_Real) hypre_ParCSRMatrixNumNonzeros(P);
 
-   hypre_GpuProfilingPushRangeColor("Truncation", 4);
+   hypre_GpuProfilingPushRange("Truncation");
    if (trunc_factor != 0.0 || max_elmts > 0)
    {
       hypre_BoomerAMGInterpTruncationDevice(P, trunc_factor, max_elmts );

--- a/src/parcsr_ls/par_mod_lr_interp.c
+++ b/src/parcsr_ls/par_mod_lr_interp.c
@@ -1169,7 +1169,7 @@ hypre_BoomerAMGBuildModExtPIInterp(hypre_ParCSRMatrix  *A,
                                    hypre_ParCSRMatrix **P_ptr)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_GpuProfilingPushRange("ExtPIInterp");
+   hypre_GpuProfilingPushRange("ModExtPIInterp");
 #endif
 
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(A) );
@@ -1787,7 +1787,7 @@ hypre_BoomerAMGBuildModExtPEInterp(hypre_ParCSRMatrix  *A,
                                       hypre_ParCSRMatrix **P_ptr)
 {
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
-   hypre_GpuProfilingPushRange("ExtPEInterp");
+   hypre_GpuProfilingPushRange("ModExtPEInterp");
 #endif
 
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(A) );

--- a/src/parcsr_ls/par_strength2nd_device.c
+++ b/src/parcsr_ls/par_strength2nd_device.c
@@ -48,7 +48,7 @@ hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix  *S,
    hypre_TMemcpy(CF_marker, CF_marker_host, HYPRE_Int, S_nr_local, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
 
    /* 1. Create new matrix with added diagonal */
-   hypre_GpuProfilingPushRangeColor("Setup", 1);
+   hypre_GpuProfilingPushRange("Setup");
 
    /* give S data arrays */
    hypre_CSRMatrixData(S_diag) = hypre_TAlloc(HYPRE_Complex, S_diag_nnz, HYPRE_MEMORY_DEVICE );
@@ -114,7 +114,7 @@ hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix  *S,
    hypre_GpuProfilingPopRange();
 
    /* 2. Perform matrix-matrix multiplication */
-   hypre_GpuProfilingPushRangeColor("Matrix-matrix mult", 3);
+   hypre_GpuProfilingPushRange("Matrix-matrix mult");
 
    S2 = hypre_ParCSRMatMatDevice(S_CX, S_XC);
 


### PR DESCRIPTION
This branch fixes some of the profiling code in nvtx. All PushRangeColor calls have been changed to always explicitly use PushRange version around device kernels. We allow the general method in hypre_nvtx.c to determine the correct color. Next, there was a missing PopRange() in par_mod_lr_interp.c. Finally, I changed the profiling names in par_mod_lr_interp.c as they conflicted with names in another file.