### PR TITLE
Hip fix

### DIFF
--- a/src/test/ij_assembly.c
+++ b/src/test/ij_assembly.c
@@ -430,8 +430,10 @@ main( hypre_int  argc,
    hypre_MPI_Finalize();
 
    /* when using cuda-memcheck --leak-check full, uncomment this */
-#if defined(HYPRE_USING_GPU)
+#if defined(HYPRE_USING_CUDA)
    cudaDeviceReset();
+#elif defined(HYPRE_USING_HIP)
+   hipDeviceReset();
 #endif
 
    return (0);


### PR DESCRIPTION
This PR (copied from #364) fixes `ij_assemble.c` when compiled with HIP