### PR TITLE
cmake: fix config for CXX-only consumers

### DIFF
--- a/src/config/HYPREConfig.cmake.in
+++ b/src/config/HYPREConfig.cmake.in
@@ -51,7 +51,8 @@ if(HYPRE_USING_DSUPERLU)
 endif()
 
 if(HYPRE_WITH_MPI)
-  find_dependency(MPI @MPI_C_VERSION@ EXACT)
+  enable_language(C)
+  find_dependency(MPI @MPI_C_VERSION@ EXACT COMPONENTS C)
 endif()
 
 if(HYPRE_WITH_OPENMP)


### PR DESCRIPTION
Some consumers only have CXX enabled hence find_dependency(MPI) won't define a MPI::MPI_C target.
Explicitly enabling the C language will fix that.

Issue found here: https://github.com/ECP-copa/Cabana/pull/426#discussion_r661902293