### PR TITLE
Add rocRAND support

### DIFF
--- a/src/parcsr_ls/par_indepset_device.c
+++ b/src/parcsr_ls/par_indepset_device.c
@@ -196,8 +196,8 @@ hypre_BoomerAMGIndepSetDevice( hypre_ParCSRMatrix  *S,
 }
 
 /* Augments measures by some random value between 0 and 1
- * aug_rand: 1: GPU CURAND; 11: GPU SEQ CURAND
- *           2: CPU RAND;   12: CPU SEQ RAND
+ * aug_rand: 1: GPU CURAND/ROCRAND; 11: GPU SEQ CURAND/ROCRAND
+ *           2: CPU RAND;           12: CPU SEQ RAND
  */
 HYPRE_Int
 hypre_BoomerAMGIndepSetInitDevice( hypre_ParCSRMatrix *S,
@@ -211,12 +211,6 @@ hypre_BoomerAMGIndepSetInitDevice( hypre_ParCSRMatrix *S,
    HYPRE_Real      *urand;
 
    hypre_MPI_Comm_rank(comm, &my_id);
-
-   // RL: TODO
-   #if defined(HYPRE_USING_ROCRAND)
-   if (aug_rand ==  1) { aug_rand =  2; }
-   if (aug_rand == 11) { aug_rand = 12; }
-   #endif
 
    urand = hypre_TAlloc(HYPRE_Real, num_rows_diag, HYPRE_MEMORY_DEVICE);
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -167,6 +167,13 @@ struct hypre_umpire_device_allocator
       hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
+#define HYPRE_ROCRAND_CALL(call) do {                                                        \
+   rocrand_status err = call;                                                                \
+   if (ROCRAND_STATUS_SUCCESS != err) {                                                      \
+      hypre_printf("ROCRAND ERROR (code = %d) at %s:%d\n", err, __FILE__, __LINE__);         \
+      hypre_assert(0); exit(1);                                                              \
+   } } while(0)
+
 struct hypre_cub_CachingDeviceAllocator;
 typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator;
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -198,6 +198,10 @@ struct hypre_CudaData
    curandGenerator_t                 curand_generator;
 #endif
 
+#if defined(HYPRE_USING_ROCRAND)
+   rocrand_generator                 curand_generator;
+#endif
+
 #if defined(HYPRE_USING_CUBLAS)
    cublasHandle_t                    cublas_handle;
 #endif
@@ -276,6 +280,10 @@ void                hypre_CudaDataDestroy(hypre_CudaData* data);
 
 #if defined(HYPRE_USING_CURAND)
 curandGenerator_t   hypre_CudaDataCurandGenerator(hypre_CudaData *data);
+#endif
+
+#if defined(HYPRE_USING_ROCRAND)
+rocrand_generator   hypre_CudaDataCurandGenerator(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_CUBLAS)

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -110,6 +110,10 @@ struct hypre_umpire_device_allocator
 #include <rocsparse.h>
 #endif
 
+#if defined(HYPRE_USING_ROCRAND)
+#include <rocrand.h>
+#endif
+
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 #define HYPRE_CUDA_CALL(call) do {                                                           \

--- a/src/utilities/cuda_utils.c
+++ b/src/utilities/cuda_utils.c
@@ -1018,8 +1018,32 @@ hypre_CurandUniform_core( HYPRE_Int          n,
                           HYPRE_Int          set_offset,
                           hypre_ulonglongint offset)
 {
-   hypre_error_w_msg(1, "ROCRand has not been available");
-   exit(0);
+  hypre_GpuProfilingPushRange("hypre_CurandUniform_core");
+
+   rocrand_generator gen = hypre_HandleCurandGenerator(hypre_handle());
+
+   if (set_seed)
+   {
+      HYPRE_ROCRAND_CALL( rocrand_set_seed(gen, seed) );
+   }
+
+   if (set_offset)
+   {
+      HYPRE_ROCRAND_CALL( rocrand_set_offset(gen, offset) );
+   }
+
+   if (sizeof(T) == sizeof(hypre_double))
+   {
+      HYPRE_ROCRAND_CALL( rocrand_generate_uniform_double(gen, (hypre_double *) urand, n) );
+   }
+   else if (sizeof(T) == sizeof(float))
+   {
+      HYPRE_ROCRAND_CALL( rocrand_generate_uniform(gen, (float *) urand, n) );
+   }
+
+   hypre_GpuProfilingPopRange();
+
+   return hypre_error_flag;
 }
 #endif /* #if defined(HYPRE_USING_ROCRAND) */
 

--- a/src/utilities/cuda_utils.c
+++ b/src/utilities/cuda_utils.c
@@ -990,8 +990,25 @@ hypre_CurandUniform_core( HYPRE_Int          n,
 }
 #endif /* #if defined(HYPRE_USING_CURAND) */
 
-// RL: TODO
 #if defined(HYPRE_USING_ROCRAND)
+rocrand_generator
+hypre_CudaDataCurandGenerator(hypre_CudaData *data)
+{
+   if (data->curand_generator)
+   {
+      return data->curand_generator;
+   }
+
+   rocrand_generator gen;
+   HYPRE_ROCRAND_CALL( rocrand_create_generator(&gen, ROCRAND_RNG_PSEUDO_DEFAULT) );
+   HYPRE_ROCRAND_CALL( rocrand_set_seed(gen, 1234ULL) );
+   HYPRE_ROCRAND_CALL( rocrand_set_stream(gen, hypre_CudaDataCudaComputeStream(data)) );
+
+   data->curand_generator = gen;
+
+   return gen;
+}
+
 template <typename T>
 HYPRE_Int
 hypre_CurandUniform_core( HYPRE_Int          n,

--- a/src/utilities/cuda_utils.c
+++ b/src/utilities/cuda_utils.c
@@ -1158,7 +1158,7 @@ hypre_CudaDataCreate()
    hypre_CudaDataSpgemmHashType(data) = 'L';
 
    /* pmis */
-#ifdef HYPRE_USING_CURAND
+#if defined(HYPRE_USING_CURAND) || defined(HYPRE_USING_ROCRAND)
    hypre_CudaDataUseGpuRand(data) = 1;
 #else
    hypre_CudaDataUseGpuRand(data) = 0;
@@ -1193,6 +1193,13 @@ hypre_CudaDataDestroy(hypre_CudaData *data)
    if (data->curand_generator)
    {
       HYPRE_CURAND_CALL( curandDestroyGenerator(data->curand_generator) );
+   }
+#endif
+
+#if defined(HYPRE_USING_ROCRAND)
+   if (data->curand_generator)
+   {
+      HYPRE_ROCRAND_CALL( rocrand_destroy_generator(data->curand_generator) );
    }
 #endif
 

--- a/src/utilities/cuda_utils.h
+++ b/src/utilities/cuda_utils.h
@@ -45,6 +45,10 @@
 #include <rocsparse.h>
 #endif
 
+#if defined(HYPRE_USING_ROCRAND)
+#include <rocrand.h>
+#endif
+
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_DEVICE_OPENMP)
 #define HYPRE_CUDA_CALL(call) do {                                                           \

--- a/src/utilities/cuda_utils.h
+++ b/src/utilities/cuda_utils.h
@@ -102,6 +102,13 @@
       hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
+#define HYPRE_ROCRAND_CALL(call) do {                                                        \
+   rocrand_status err = call;                                                                \
+   if (ROCRAND_STATUS_SUCCESS != err) {                                                      \
+      hypre_printf("ROCRAND ERROR (code = %d) at %s:%d\n", err, __FILE__, __LINE__);         \
+      hypre_assert(0); exit(1);                                                              \
+   } } while(0)
+
 struct hypre_cub_CachingDeviceAllocator;
 typedef struct hypre_cub_CachingDeviceAllocator hypre_cub_CachingDeviceAllocator;
 

--- a/src/utilities/cuda_utils.h
+++ b/src/utilities/cuda_utils.h
@@ -133,6 +133,10 @@ struct hypre_CudaData
    curandGenerator_t                 curand_generator;
 #endif
 
+#if defined(HYPRE_USING_ROCRAND)
+   rocrand_generator                 curand_generator;
+#endif
+
 #if defined(HYPRE_USING_CUBLAS)
    cublasHandle_t                    cublas_handle;
 #endif
@@ -211,6 +215,10 @@ void                hypre_CudaDataDestroy(hypre_CudaData* data);
 
 #if defined(HYPRE_USING_CURAND)
 curandGenerator_t   hypre_CudaDataCurandGenerator(hypre_CudaData *data);
+#endif
+
+#if defined(HYPRE_USING_ROCRAND)
+rocrand_generator   hypre_CudaDataCurandGenerator(hypre_CudaData *data);
 #endif
 
 #if defined(HYPRE_USING_CUBLAS)

--- a/src/utilities/general.c
+++ b/src/utilities/general.c
@@ -208,7 +208,7 @@ HYPRE_Init()
    hypre_HandleCusparseHandle(_hypre_handle);
 #endif
 
-#if defined(HYPRE_USING_CURAND)
+#if defined(HYPRE_USING_CURAND) || defined(HYPRE_USING_ROCRAND)
    hypre_HandleCurandGenerator(_hypre_handle);
 #endif
 


### PR DESCRIPTION
This PR adds support for PRNG on AMD GPUs via rocRAND. The API follows cuRAND very closely, so this is all similar additions to existing cuRAND API. I think I got everything. I tested using `./ij -n 148 148 148 -pmis -keepT 1 -rlx 18 -exec_device -rap 1 -mod_rap2 1 -interptype 6 -solver 1 -agg_nl 0 -27pt -mxrs 0.9 -ns 2 -Pmx 8` on my Radeon VII with ROCm 4.2 and confirmed in a trace that rocRAND is called in `hypre_CurandUniform_core` function.