### PR TITLE
Implementation GMRES/COGMRES using MassDotpTwo, MassInnerProduct and MassAxpy.

### DIFF
--- a/src/krylov/HYPRE_gmres.c
+++ b/src/krylov/HYPRE_gmres.c
@@ -69,6 +69,24 @@ HYPRE_GMRESGetKDim( HYPRE_Solver solver,
 }
 
 /*--------------------------------------------------------------------------
+ * HYPRE_GMRESSetCGS, HYPRE_GMRESGetCGS
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_GMRESSetCGS( HYPRE_Solver solver,
+                   HYPRE_Int             cgs    )
+{
+   return( hypre_GMRESSetCGS( (void *) solver, cgs ) );
+}
+
+HYPRE_Int
+HYPRE_GMRESGetCGS( HYPRE_Solver solver,
+                   HYPRE_Int           * cgs    )
+{
+   return( hypre_GMRESGetCGS( (void *) solver, cgs ) );
+}
+
+/*--------------------------------------------------------------------------
  * HYPRE_GMRESSetTol, HYPRE_GMRESGetTol
  *--------------------------------------------------------------------------*/
 

--- a/src/krylov/HYPRE_krylov.h
+++ b/src/krylov/HYPRE_krylov.h
@@ -359,6 +359,12 @@ HYPRE_Int HYPRE_GMRESSetKDim(HYPRE_Solver solver,
                              HYPRE_Int    k_dim);
 
 /**
+ * (Optional) Set whether or not to use classical (CGS) or modified Gram-Shmidt (MGS). Default is MGS.
+ **/
+HYPRE_Int HYPRE_GMRESSetCGS(HYPRE_Solver solver,
+                            HYPRE_Int    cgs);
+
+/**
  * (Optional) Additionally require that the relative difference in
  * successive iterates be small.
  **/

--- a/src/krylov/gmres.h
+++ b/src/krylov/gmres.h
@@ -64,6 +64,8 @@ typedef struct
    HYPRE_Int    (*ClearVector)   ( void *x );
    HYPRE_Int    (*ScaleVector)   ( HYPRE_Complex alpha, void *x );
    HYPRE_Int    (*Axpy)          ( HYPRE_Complex alpha, void *x, void *y );
+   HYPRE_Int    (*MassInnerProd) ( void *x, void **p, HYPRE_Int k, HYPRE_int unroll, void *result);
+   HYPRE_Int    (*MassAxpy)      ( HYPRE_Complex *alpha, void **x, void *y, HYPRE_Int k, HYPRE_Int unroll);
 
    HYPRE_Int    (*precond)       ();
    HYPRE_Int    (*precond_setup) ();
@@ -77,6 +79,7 @@ typedef struct
 typedef struct
 {
    HYPRE_Int      k_dim;
+   HYPRE_Int      cgs;
    HYPRE_Int      min_iter;
    HYPRE_Int      max_iter;
    HYPRE_Int      rel_change;
@@ -145,6 +148,8 @@ hypre_GMRESFunctionsCreate(
    HYPRE_Int    (*ClearVector)   ( void *x ),
    HYPRE_Int    (*ScaleVector)   ( HYPRE_Complex alpha, void *x ),
    HYPRE_Int    (*Axpy)          ( HYPRE_Complex alpha, void *x, void *y ),
+   HYPRE_Int    (*MassInnerProd) ( void *x, void **p, HYPRE_Int k, HYPRE_Int unroll, void *result),
+   HYPRE_Int    (*MassAxpy)      ( HYPRE_Complex *alpha, void **x, void *y, HYPRE_Int k, HYPRE_Int unroll),
    HYPRE_Int    (*PrecondSetup)  ( void *vdata, void *A, void *b, void *x ),
    HYPRE_Int    (*Precond)       ( void *vdata, void *A, void *b, void *x )
 );

--- a/src/krylov/krylov.h
+++ b/src/krylov/krylov.h
@@ -361,101 +361,104 @@ extern "C" {
 #ifndef hypre_KRYLOV_GMRES_HEADER
 #define hypre_KRYLOV_GMRES_HEADER
 
-/*--------------------------------------------------------------------------
- *--------------------------------------------------------------------------*/
+  /*--------------------------------------------------------------------------
+   *--------------------------------------------------------------------------*/
 
-/**
- * @name Generic GMRES Interface
- *
- * A general description of the interface goes here...
- *
- * @memo A generic GMRES linear solver interface
- * @version 0.1
- * @author Jeffrey F. Painter
- **/
-/*@{*/
+  /**
+   * @name Generic GMRES Interface
+   *
+   * A general description of the interface goes here...
+   *
+   * @memo A generic GMRES linear solver interface
+   * @version 0.1
+   * @author Jeffrey F. Painter
+   **/
+  /*@{*/
 
-/*--------------------------------------------------------------------------
- *--------------------------------------------------------------------------*/
+  /*--------------------------------------------------------------------------
+   *--------------------------------------------------------------------------*/
 
-/*--------------------------------------------------------------------------
- * hypre_GMRESData and hypre_GMRESFunctions
- *--------------------------------------------------------------------------*/
+  /*--------------------------------------------------------------------------
+   * hypre_GMRESData and hypre_GMRESFunctions
+   *--------------------------------------------------------------------------*/
 
-/**
- * @name GMRES structs
- *
- * Description...
- **/
-/*@{*/
+  /**
+   * @name GMRES structs
+   *
+   * Description...
+   **/
+  /*@{*/
 
-/**
- * The {\tt hypre\_GMRESFunctions} object ...
- **/
+  /**
+   * The {\tt hypre\_GMRESFunctions} object ...
+   **/
 
-typedef struct
-{
-   void *       (*CAlloc)        ( size_t count, size_t elt_size, HYPRE_MemoryLocation location );
-   HYPRE_Int    (*Free)          ( void *ptr );
-   HYPRE_Int    (*CommInfo)      ( void  *A, HYPRE_Int   *my_id,
-                                   HYPRE_Int   *num_procs );
-   void *       (*CreateVector)  ( void *vector );
-   void *       (*CreateVectorArray)  ( HYPRE_Int size, void *vectors );
-   HYPRE_Int    (*DestroyVector) ( void *vector );
-   void *       (*MatvecCreate)  ( void *A, void *x );
-   HYPRE_Int    (*Matvec)        ( void *matvec_data, HYPRE_Complex alpha, void *A,
-                                   void *x, HYPRE_Complex beta, void *y );
-   HYPRE_Int    (*MatvecDestroy) ( void *matvec_data );
-   HYPRE_Real   (*InnerProd)     ( void *x, void *y );
-   HYPRE_Int    (*CopyVector)    ( void *x, void *y );
-   HYPRE_Int    (*ClearVector)   ( void *x );
-   HYPRE_Int    (*ScaleVector)   ( HYPRE_Complex alpha, void *x );
-   HYPRE_Int    (*Axpy)          ( HYPRE_Complex alpha, void *x, void *y );
+  typedef struct
+  {
+    void *       (*CAlloc)        ( size_t count, size_t elt_size, HYPRE_MemoryLocation location );
+    HYPRE_Int    (*Free)          ( void *ptr );
+    HYPRE_Int    (*CommInfo)      ( void  *A, HYPRE_Int   *my_id,
+        HYPRE_Int   *num_procs );
+    void *       (*CreateVector)  ( void *vector );
+    void *       (*CreateVectorArray)  ( HYPRE_Int size, void *vectors );
+    HYPRE_Int    (*DestroyVector) ( void *vector );
+    void *       (*MatvecCreate)  ( void *A, void *x );
+    HYPRE_Int    (*Matvec)        ( void *matvec_data, HYPRE_Complex alpha, void *A,
+        void *x, HYPRE_Complex beta, void *y );
+    HYPRE_Int    (*MatvecDestroy) ( void *matvec_data );
+    HYPRE_Real   (*InnerProd)     ( void *x, void *y );
+    HYPRE_Int    (*CopyVector)    ( void *x, void *y );
+    HYPRE_Int    (*ClearVector)   ( void *x );
+    HYPRE_Int    (*ScaleVector)   ( HYPRE_Complex alpha, void *x );
+    HYPRE_Int    (*Axpy)          ( HYPRE_Complex alpha, void *x, void *y );
+    HYPRE_Int    (*MassInnerProd) ( void *x, void **p, HYPRE_Int k, HYPRE_Int unroll, void *result);
+    HYPRE_Int    (*MassAxpy)      ( HYPRE_Complex *alpha, void **x, void *y, HYPRE_Int k, HYPRE_Int unroll);
 
-   HYPRE_Int    (*precond)       (void *vdata, void *A, void *b, void *x);
-   HYPRE_Int    (*precond_setup) (void *vdata, void *A, void *b, void *x);
+    HYPRE_Int    (*precond)       (void *vdata , void *A , void *b , void *x);
+    HYPRE_Int    (*precond_setup) (void *vdata , void *A , void *b , void *x);
 
-} hypre_GMRESFunctions;
+  } hypre_GMRESFunctions;
 
-/**
- * The {\tt hypre\_GMRESData} object ...
- **/
+  /**
+   * The {\tt hypre\_GMRESData} object ...
+   **/
 
-typedef struct
-{
-   HYPRE_Int      k_dim;
-   HYPRE_Int      min_iter;
-   HYPRE_Int      max_iter;
-   HYPRE_Int      rel_change;
-   HYPRE_Int      skip_real_r_check;
-   HYPRE_Int      stop_crit;
-   HYPRE_Int      converged;
-   HYPRE_Int      hybrid;
-   HYPRE_Real   tol;
-   HYPRE_Real   cf_tol;
-   HYPRE_Real   a_tol;
-   HYPRE_Real   rel_residual_norm;
+  typedef struct
+  {
+    HYPRE_Int      k_dim;
+    HYPRE_Int      cgs;
+    HYPRE_Int      min_iter;
+    HYPRE_Int      max_iter;
+    HYPRE_Int      rel_change;
+    HYPRE_Int      skip_real_r_check;
+    HYPRE_Int      stop_crit;
+    HYPRE_Int      converged;
+    HYPRE_Int      hybrid;
+    HYPRE_Real   tol;
+    HYPRE_Real   cf_tol;
+    HYPRE_Real   a_tol;
+    HYPRE_Real   rel_residual_norm;
 
-   void  *A;
-   void  *r;
-   void  *w;
-   void  *w_2;
-   void  **p;
+    void  *A;
+    void  *r;
+    void  *w;
+    void  *w_2;
+    void  **p;
 
-   void    *matvec_data;
-   void    *precond_data;
+    void    *matvec_data;
+    void    *precond_data;
 
-   hypre_GMRESFunctions * functions;
+    hypre_GMRESFunctions * functions;
 
-   /* log info (always logged) */
-   HYPRE_Int      num_iterations;
+    /* log info (always logged) */
+    HYPRE_Int      num_iterations;
 
-   HYPRE_Int     print_level; /* printing when print_level>0 */
-   HYPRE_Int     logging;  /* extra computations for logging when logging>0 */
-   HYPRE_Real  *norms;
-   char    *log_file_name;
+    HYPRE_Int     print_level; /* printing when print_level>0 */
+    HYPRE_Int     logging;  /* extra computations for logging when logging>0 */
+    HYPRE_Real  *norms;
+    char    *log_file_name;
 
-} hypre_GMRESData;
+  } hypre_GMRESData;
 
 #define hypre_GMRESDataHybrid(pcgdata)  ((pcgdata) -> hybrid)
 
@@ -463,49 +466,51 @@ typedef struct
 extern "C" {
 #endif
 
-   /**
-    * @name generic GMRES Solver
-    *
-    * Description...
-    **/
-   /*@{*/
+    /**
+     * @name generic GMRES Solver
+     *
+     * Description...
+     **/
+    /*@{*/
 
-   /**
-    * Description...
-    *
-    * @param param [IN] ...
-    **/
+    /**
+     * Description...
+     *
+     * @param param [IN] ...
+     **/
 
-   hypre_GMRESFunctions *
-   hypre_GMRESFunctionsCreate(
-      void *       (*CAlloc)        ( size_t count, size_t elt_size, HYPRE_MemoryLocation location ),
-      HYPRE_Int    (*Free)          ( void *ptr ),
-      HYPRE_Int    (*CommInfo)      ( void  *A, HYPRE_Int   *my_id,
-                                      HYPRE_Int   *num_procs ),
-      void *       (*CreateVector)  ( void *vector ),
-      void *       (*CreateVectorArray)  ( HYPRE_Int size, void *vectors ),
-      HYPRE_Int    (*DestroyVector) ( void *vector ),
-      void *       (*MatvecCreate)  ( void *A, void *x ),
-      HYPRE_Int    (*Matvec)        ( void *matvec_data, HYPRE_Complex alpha, void *A,
-                                      void *x, HYPRE_Complex beta, void *y ),
-      HYPRE_Int    (*MatvecDestroy) ( void *matvec_data ),
-      HYPRE_Real   (*InnerProd)     ( void *x, void *y ),
-      HYPRE_Int    (*CopyVector)    ( void *x, void *y ),
-      HYPRE_Int    (*ClearVector)   ( void *x ),
-      HYPRE_Int    (*ScaleVector)   ( HYPRE_Complex alpha, void *x ),
-      HYPRE_Int    (*Axpy)          ( HYPRE_Complex alpha, void *x, void *y ),
-      HYPRE_Int    (*PrecondSetup)  ( void *vdata, void *A, void *b, void *x ),
-      HYPRE_Int    (*Precond)       ( void *vdata, void *A, void *b, void *x )
-   );
+    hypre_GMRESFunctions *
+      hypre_GMRESFunctionsCreate(
+          void *       (*CAlloc)        ( size_t count, size_t elt_size, HYPRE_MemoryLocation location ),
+          HYPRE_Int    (*Free)          ( void *ptr ),
+          HYPRE_Int    (*CommInfo)      ( void  *A, HYPRE_Int   *my_id,
+            HYPRE_Int   *num_procs ),
+          void *       (*CreateVector)  ( void *vector ),
+          void *       (*CreateVectorArray)  ( HYPRE_Int size, void *vectors ),
+          HYPRE_Int    (*DestroyVector) ( void *vector ),
+          void *       (*MatvecCreate)  ( void *A, void *x ),
+          HYPRE_Int    (*Matvec)        ( void *matvec_data, HYPRE_Complex alpha, void *A,
+            void *x, HYPRE_Complex beta, void *y ),
+          HYPRE_Int    (*MatvecDestroy) ( void *matvec_data ),
+          HYPRE_Real   (*InnerProd)     ( void *x, void *y ),
+          HYPRE_Int    (*CopyVector)    ( void *x, void *y ),
+          HYPRE_Int    (*ClearVector)   ( void *x ),
+          HYPRE_Int    (*ScaleVector)   ( HYPRE_Complex alpha, void *x ),
+          HYPRE_Int    (*Axpy)          ( HYPRE_Complex alpha, void *x, void *y ),
+          HYPRE_Int    (*MassInnerProd) ( void *x, void **p, HYPRE_Int k, HYPRE_Int unroll, void *result),
+          HYPRE_Int    (*MassAxpy)      ( HYPRE_Complex *alpha, void **x, void *y, HYPRE_Int k, HYPRE_Int unroll),
+          HYPRE_Int    (*PrecondSetup)  ( void *vdata, void *A, void *b, void *x ),
+          HYPRE_Int    (*Precond)       ( void *vdata, void *A, void *b, void *x )
+          );
 
-   /**
-    * Description...
-    *
-    * @param param [IN] ...
-    **/
+    /**
+     * Description...
+     *
+     * @param param [IN] ...
+     **/
 
-   void *
-   hypre_GMRESCreate( hypre_GMRESFunctions *gmres_functions );
+    void *
+      hypre_GMRESCreate( hypre_GMRESFunctions *gmres_functions );
 
 #ifdef __cplusplus
 }
@@ -1202,445 +1207,410 @@ extern "C" {
 
 #endif
 
-/* bicgstab.c */
-void *hypre_BiCGSTABCreate ( hypre_BiCGSTABFunctions *bicgstab_functions );
-HYPRE_Int hypre_BiCGSTABDestroy ( void *bicgstab_vdata );
-HYPRE_Int hypre_BiCGSTABSetup ( void *bicgstab_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_BiCGSTABSolve ( void *bicgstab_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_BiCGSTABSetTol ( void *bicgstab_vdata, HYPRE_Real tol );
-HYPRE_Int hypre_BiCGSTABSetAbsoluteTol ( void *bicgstab_vdata, HYPRE_Real a_tol );
-HYPRE_Int hypre_BiCGSTABSetConvergenceFactorTol ( void *bicgstab_vdata, HYPRE_Real cf_tol );
-HYPRE_Int hypre_BiCGSTABSetMinIter ( void *bicgstab_vdata, HYPRE_Int min_iter );
-HYPRE_Int hypre_BiCGSTABSetMaxIter ( void *bicgstab_vdata, HYPRE_Int max_iter );
-HYPRE_Int hypre_BiCGSTABSetStopCrit ( void *bicgstab_vdata, HYPRE_Int stop_crit );
-HYPRE_Int hypre_BiCGSTABSetPrecond ( void *bicgstab_vdata, HYPRE_Int (*precond )(void*, void*,
-                                                                                 void*,
-                                                                                 void*), HYPRE_Int (*precond_setup )(void*, void*, void*, void*), void *precond_data );
-HYPRE_Int hypre_BiCGSTABGetPrecond ( void *bicgstab_vdata, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int hypre_BiCGSTABSetLogging ( void *bicgstab_vdata, HYPRE_Int logging );
-HYPRE_Int hypre_BiCGSTABSetHybrid ( void *bicgstab_vdata, HYPRE_Int logging );
-HYPRE_Int hypre_BiCGSTABSetPrintLevel ( void *bicgstab_vdata, HYPRE_Int print_level );
-HYPRE_Int hypre_BiCGSTABGetConverged ( void *bicgstab_vdata, HYPRE_Int *converged );
-HYPRE_Int hypre_BiCGSTABGetNumIterations ( void *bicgstab_vdata, HYPRE_Int *num_iterations );
-HYPRE_Int hypre_BiCGSTABGetFinalRelativeResidualNorm ( void *bicgstab_vdata,
-                                                       HYPRE_Real *relative_residual_norm );
-HYPRE_Int hypre_BiCGSTABGetResidual ( void *bicgstab_vdata, void **residual );
+  /* bicgstab.c */
+  void *hypre_BiCGSTABCreate ( hypre_BiCGSTABFunctions *bicgstab_functions );
+  HYPRE_Int hypre_BiCGSTABDestroy ( void *bicgstab_vdata );
+  HYPRE_Int hypre_BiCGSTABSetup ( void *bicgstab_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_BiCGSTABSolve ( void *bicgstab_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_BiCGSTABSetTol ( void *bicgstab_vdata , HYPRE_Real tol );
+  HYPRE_Int hypre_BiCGSTABSetAbsoluteTol ( void *bicgstab_vdata , HYPRE_Real a_tol );
+  HYPRE_Int hypre_BiCGSTABSetConvergenceFactorTol ( void *bicgstab_vdata , HYPRE_Real cf_tol );
+  HYPRE_Int hypre_BiCGSTABSetMinIter ( void *bicgstab_vdata , HYPRE_Int min_iter );
+  HYPRE_Int hypre_BiCGSTABSetMaxIter ( void *bicgstab_vdata , HYPRE_Int max_iter );
+  HYPRE_Int hypre_BiCGSTABSetStopCrit ( void *bicgstab_vdata , HYPRE_Int stop_crit );
+  HYPRE_Int hypre_BiCGSTABSetPrecond ( void *bicgstab_vdata , HYPRE_Int (*precond )(void*,void*,void*,void*), HYPRE_Int (*precond_setup )(void*,void*,void*,void*), void *precond_data );
+  HYPRE_Int hypre_BiCGSTABGetPrecond ( void *bicgstab_vdata , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int hypre_BiCGSTABSetLogging ( void *bicgstab_vdata , HYPRE_Int logging );
+  HYPRE_Int hypre_BiCGSTABSetHybrid ( void *bicgstab_vdata , HYPRE_Int logging );
+  HYPRE_Int hypre_BiCGSTABSetPrintLevel ( void *bicgstab_vdata , HYPRE_Int print_level );
+  HYPRE_Int hypre_BiCGSTABGetConverged ( void *bicgstab_vdata , HYPRE_Int *converged );
+  HYPRE_Int hypre_BiCGSTABGetNumIterations ( void *bicgstab_vdata , HYPRE_Int *num_iterations );
+  HYPRE_Int hypre_BiCGSTABGetFinalRelativeResidualNorm ( void *bicgstab_vdata , HYPRE_Real *relative_residual_norm );
+  HYPRE_Int hypre_BiCGSTABGetResidual ( void *bicgstab_vdata , void **residual );
 
-/* cgnr.c */
-void *hypre_CGNRCreate ( hypre_CGNRFunctions *cgnr_functions );
-HYPRE_Int hypre_CGNRDestroy ( void *cgnr_vdata );
-HYPRE_Int hypre_CGNRSetup ( void *cgnr_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_CGNRSolve ( void *cgnr_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_CGNRSetTol ( void *cgnr_vdata, HYPRE_Real tol );
-HYPRE_Int hypre_CGNRSetMinIter ( void *cgnr_vdata, HYPRE_Int min_iter );
-HYPRE_Int hypre_CGNRSetMaxIter ( void *cgnr_vdata, HYPRE_Int max_iter );
-HYPRE_Int hypre_CGNRSetStopCrit ( void *cgnr_vdata, HYPRE_Int stop_crit );
-HYPRE_Int hypre_CGNRSetPrecond ( void *cgnr_vdata, HYPRE_Int (*precond )(void*, void*, void*,
-                                                                         void*),
-                                 HYPRE_Int (*precondT )(void*, void*, void*, void*), HYPRE_Int (*precond_setup )(void*, void*, void*,
-                                       void*), void *precond_data );
-HYPRE_Int hypre_CGNRGetPrecond ( void *cgnr_vdata, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int hypre_CGNRSetLogging ( void *cgnr_vdata, HYPRE_Int logging );
-HYPRE_Int hypre_CGNRGetNumIterations ( void *cgnr_vdata, HYPRE_Int *num_iterations );
-HYPRE_Int hypre_CGNRGetFinalRelativeResidualNorm ( void *cgnr_vdata,
-                                                   HYPRE_Real *relative_residual_norm );
+  /* cgnr.c */
+  void *hypre_CGNRCreate ( hypre_CGNRFunctions *cgnr_functions );
+  HYPRE_Int hypre_CGNRDestroy ( void *cgnr_vdata );
+  HYPRE_Int hypre_CGNRSetup ( void *cgnr_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_CGNRSolve ( void *cgnr_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_CGNRSetTol ( void *cgnr_vdata , HYPRE_Real tol );
+  HYPRE_Int hypre_CGNRSetMinIter ( void *cgnr_vdata , HYPRE_Int min_iter );
+  HYPRE_Int hypre_CGNRSetMaxIter ( void *cgnr_vdata , HYPRE_Int max_iter );
+  HYPRE_Int hypre_CGNRSetStopCrit ( void *cgnr_vdata , HYPRE_Int stop_crit );
+  HYPRE_Int hypre_CGNRSetPrecond ( void *cgnr_vdata , HYPRE_Int (*precond )(void*,void*,void*,void*), HYPRE_Int (*precondT )(void*,void*,void*,void*), HYPRE_Int (*precond_setup )(void*,void*,void*,void*), void *precond_data );
+  HYPRE_Int hypre_CGNRGetPrecond ( void *cgnr_vdata , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int hypre_CGNRSetLogging ( void *cgnr_vdata , HYPRE_Int logging );
+  HYPRE_Int hypre_CGNRGetNumIterations ( void *cgnr_vdata , HYPRE_Int *num_iterations );
+  HYPRE_Int hypre_CGNRGetFinalRelativeResidualNorm ( void *cgnr_vdata , HYPRE_Real *relative_residual_norm );
 
-/* gmres.c */
-void *hypre_GMRESCreate ( hypre_GMRESFunctions *gmres_functions );
-HYPRE_Int hypre_GMRESDestroy ( void *gmres_vdata );
-HYPRE_Int hypre_GMRESGetResidual ( void *gmres_vdata, void **residual );
-HYPRE_Int hypre_GMRESSetup ( void *gmres_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_GMRESSolve ( void *gmres_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_GMRESSetKDim ( void *gmres_vdata, HYPRE_Int k_dim );
-HYPRE_Int hypre_GMRESGetKDim ( void *gmres_vdata, HYPRE_Int *k_dim );
-HYPRE_Int hypre_GMRESSetTol ( void *gmres_vdata, HYPRE_Real tol );
-HYPRE_Int hypre_GMRESGetTol ( void *gmres_vdata, HYPRE_Real *tol );
-HYPRE_Int hypre_GMRESSetAbsoluteTol ( void *gmres_vdata, HYPRE_Real a_tol );
-HYPRE_Int hypre_GMRESGetAbsoluteTol ( void *gmres_vdata, HYPRE_Real *a_tol );
-HYPRE_Int hypre_GMRESSetConvergenceFactorTol ( void *gmres_vdata, HYPRE_Real cf_tol );
-HYPRE_Int hypre_GMRESGetConvergenceFactorTol ( void *gmres_vdata, HYPRE_Real *cf_tol );
-HYPRE_Int hypre_GMRESSetMinIter ( void *gmres_vdata, HYPRE_Int min_iter );
-HYPRE_Int hypre_GMRESGetMinIter ( void *gmres_vdata, HYPRE_Int *min_iter );
-HYPRE_Int hypre_GMRESSetMaxIter ( void *gmres_vdata, HYPRE_Int max_iter );
-HYPRE_Int hypre_GMRESGetMaxIter ( void *gmres_vdata, HYPRE_Int *max_iter );
-HYPRE_Int hypre_GMRESSetRelChange ( void *gmres_vdata, HYPRE_Int rel_change );
-HYPRE_Int hypre_GMRESGetRelChange ( void *gmres_vdata, HYPRE_Int *rel_change );
-HYPRE_Int hypre_GMRESSetSkipRealResidualCheck ( void *gmres_vdata, HYPRE_Int skip_real_r_check );
-HYPRE_Int hypre_GMRESGetSkipRealResidualCheck ( void *gmres_vdata, HYPRE_Int *skip_real_r_check );
-HYPRE_Int hypre_GMRESSetStopCrit ( void *gmres_vdata, HYPRE_Int stop_crit );
-HYPRE_Int hypre_GMRESGetStopCrit ( void *gmres_vdata, HYPRE_Int *stop_crit );
-HYPRE_Int hypre_GMRESSetPrecond ( void *gmres_vdata, HYPRE_Int (*precond )(void*, void*, void*,
-                                                                           void*),
-                                  HYPRE_Int (*precond_setup )(void*, void*, void*, void*), void *precond_data );
-HYPRE_Int hypre_GMRESGetPrecond ( void *gmres_vdata, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int hypre_GMRESSetPrintLevel ( void *gmres_vdata, HYPRE_Int level );
-HYPRE_Int hypre_GMRESGetPrintLevel ( void *gmres_vdata, HYPRE_Int *level );
-HYPRE_Int hypre_GMRESSetLogging ( void *gmres_vdata, HYPRE_Int level );
-HYPRE_Int hypre_GMRESGetLogging ( void *gmres_vdata, HYPRE_Int *level );
-HYPRE_Int hypre_GMRESSetHybrid ( void *gmres_vdata, HYPRE_Int level );
-HYPRE_Int hypre_GMRESGetNumIterations ( void *gmres_vdata, HYPRE_Int *num_iterations );
-HYPRE_Int hypre_GMRESGetConverged ( void *gmres_vdata, HYPRE_Int *converged );
-HYPRE_Int hypre_GMRESGetFinalRelativeResidualNorm ( void *gmres_vdata,
-                                                    HYPRE_Real *relative_residual_norm );
+  /* gmres.c */
+  void *hypre_GMRESCreate ( hypre_GMRESFunctions *gmres_functions );
+  HYPRE_Int hypre_GMRESDestroy ( void *gmres_vdata );
+  HYPRE_Int hypre_GMRESGetResidual ( void *gmres_vdata , void **residual );
+  HYPRE_Int hypre_GMRESSetup ( void *gmres_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_GMRESSolve ( void *gmres_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_GMRESSetKDim ( void *gmres_vdata , HYPRE_Int k_dim );
+  HYPRE_Int hypre_GMRESGetKDim ( void *gmres_vdata , HYPRE_Int *k_dim );
+  HYPRE_Int hypre_GMRESSetCGS ( void *gmres_vdata , HYPRE_Int cgs );
+  HYPRE_Int hypre_GMRESGetCGS ( void *gmres_vdata , HYPRE_Int *cgs );
+  HYPRE_Int hypre_GMRESSetTol ( void *gmres_vdata , HYPRE_Real tol );
+  HYPRE_Int hypre_GMRESGetTol ( void *gmres_vdata , HYPRE_Real *tol );
+  HYPRE_Int hypre_GMRESSetAbsoluteTol ( void *gmres_vdata , HYPRE_Real a_tol );
+  HYPRE_Int hypre_GMRESGetAbsoluteTol ( void *gmres_vdata , HYPRE_Real *a_tol );
+  HYPRE_Int hypre_GMRESSetConvergenceFactorTol ( void *gmres_vdata , HYPRE_Real cf_tol );
+  HYPRE_Int hypre_GMRESGetConvergenceFactorTol ( void *gmres_vdata , HYPRE_Real *cf_tol );
+  HYPRE_Int hypre_GMRESSetMinIter ( void *gmres_vdata , HYPRE_Int min_iter );
+  HYPRE_Int hypre_GMRESGetMinIter ( void *gmres_vdata , HYPRE_Int *min_iter );
+  HYPRE_Int hypre_GMRESSetMaxIter ( void *gmres_vdata , HYPRE_Int max_iter );
+  HYPRE_Int hypre_GMRESGetMaxIter ( void *gmres_vdata , HYPRE_Int *max_iter );
+  HYPRE_Int hypre_GMRESSetRelChange ( void *gmres_vdata , HYPRE_Int rel_change );
+  HYPRE_Int hypre_GMRESGetRelChange ( void *gmres_vdata , HYPRE_Int *rel_change );
+  HYPRE_Int hypre_GMRESSetSkipRealResidualCheck ( void *gmres_vdata , HYPRE_Int skip_real_r_check );
+  HYPRE_Int hypre_GMRESGetSkipRealResidualCheck ( void *gmres_vdata , HYPRE_Int *skip_real_r_check );
+  HYPRE_Int hypre_GMRESSetStopCrit ( void *gmres_vdata , HYPRE_Int stop_crit );
+  HYPRE_Int hypre_GMRESGetStopCrit ( void *gmres_vdata , HYPRE_Int *stop_crit );
+  HYPRE_Int hypre_GMRESSetPrecond ( void *gmres_vdata , HYPRE_Int (*precond )(void*,void*,void*,void*), HYPRE_Int (*precond_setup )(void*,void*,void*,void*), void *precond_data );
+  HYPRE_Int hypre_GMRESGetPrecond ( void *gmres_vdata , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int hypre_GMRESSetPrintLevel ( void *gmres_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_GMRESGetPrintLevel ( void *gmres_vdata , HYPRE_Int *level );
+  HYPRE_Int hypre_GMRESSetLogging ( void *gmres_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_GMRESGetLogging ( void *gmres_vdata , HYPRE_Int *level );
+  HYPRE_Int hypre_GMRESSetHybrid ( void *gmres_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_GMRESGetNumIterations ( void *gmres_vdata , HYPRE_Int *num_iterations );
+  HYPRE_Int hypre_GMRESGetConverged ( void *gmres_vdata , HYPRE_Int *converged );
+  HYPRE_Int hypre_GMRESGetFinalRelativeResidualNorm ( void *gmres_vdata , HYPRE_Real *relative_residual_norm );
 
-/* cogmres.c */
-void *hypre_COGMRESCreate ( hypre_COGMRESFunctions *gmres_functions );
-HYPRE_Int hypre_COGMRESDestroy ( void *gmres_vdata );
-HYPRE_Int hypre_COGMRESGetResidual ( void *gmres_vdata, void **residual );
-HYPRE_Int hypre_COGMRESSetup ( void *gmres_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_COGMRESSolve ( void *gmres_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_COGMRESSetKDim ( void *gmres_vdata, HYPRE_Int k_dim );
-HYPRE_Int hypre_COGMRESGetKDim ( void *gmres_vdata, HYPRE_Int *k_dim );
-HYPRE_Int hypre_COGMRESSetUnroll ( void *gmres_vdata, HYPRE_Int unroll );
-HYPRE_Int hypre_COGMRESGetUnroll ( void *gmres_vdata, HYPRE_Int *unroll );
-HYPRE_Int hypre_COGMRESSetCGS ( void *gmres_vdata, HYPRE_Int cgs );
-HYPRE_Int hypre_COGMRESGetCGS ( void *gmres_vdata, HYPRE_Int *cgs );
-HYPRE_Int hypre_COGMRESSetTol ( void *gmres_vdata, HYPRE_Real tol );
-HYPRE_Int hypre_COGMRESGetTol ( void *gmres_vdata, HYPRE_Real *tol );
-HYPRE_Int hypre_COGMRESSetAbsoluteTol ( void *gmres_vdata, HYPRE_Real a_tol );
-HYPRE_Int hypre_COGMRESGetAbsoluteTol ( void *gmres_vdata, HYPRE_Real *a_tol );
-HYPRE_Int hypre_COGMRESSetConvergenceFactorTol ( void *gmres_vdata, HYPRE_Real cf_tol );
-HYPRE_Int hypre_COGMRESGetConvergenceFactorTol ( void *gmres_vdata, HYPRE_Real *cf_tol );
-HYPRE_Int hypre_COGMRESSetMinIter ( void *gmres_vdata, HYPRE_Int min_iter );
-HYPRE_Int hypre_COGMRESGetMinIter ( void *gmres_vdata, HYPRE_Int *min_iter );
-HYPRE_Int hypre_COGMRESSetMaxIter ( void *gmres_vdata, HYPRE_Int max_iter );
-HYPRE_Int hypre_COGMRESGetMaxIter ( void *gmres_vdata, HYPRE_Int *max_iter );
-HYPRE_Int hypre_COGMRESSetRelChange ( void *gmres_vdata, HYPRE_Int rel_change );
-HYPRE_Int hypre_COGMRESGetRelChange ( void *gmres_vdata, HYPRE_Int *rel_change );
-HYPRE_Int hypre_COGMRESSetSkipRealResidualCheck ( void *gmres_vdata, HYPRE_Int skip_real_r_check );
-HYPRE_Int hypre_COGMRESGetSkipRealResidualCheck ( void *gmres_vdata, HYPRE_Int *skip_real_r_check );
-HYPRE_Int hypre_COGMRESSetPrecond ( void *gmres_vdata, HYPRE_Int (*precond )(void*, void*, void*,
-                                                                             void*), HYPRE_Int (*precond_setup )(void*, void*, void*, void*), void *precond_data );
-HYPRE_Int hypre_COGMRESGetPrecond ( void *gmres_vdata, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int hypre_COGMRESSetPrintLevel ( void *gmres_vdata, HYPRE_Int level );
-HYPRE_Int hypre_COGMRESGetPrintLevel ( void *gmres_vdata, HYPRE_Int *level );
-HYPRE_Int hypre_COGMRESSetLogging ( void *gmres_vdata, HYPRE_Int level );
-HYPRE_Int hypre_COGMRESGetLogging ( void *gmres_vdata, HYPRE_Int *level );
-HYPRE_Int hypre_COGMRESGetNumIterations ( void *gmres_vdata, HYPRE_Int *num_iterations );
-HYPRE_Int hypre_COGMRESGetConverged ( void *gmres_vdata, HYPRE_Int *converged );
-HYPRE_Int hypre_COGMRESGetFinalRelativeResidualNorm ( void *gmres_vdata,
-                                                      HYPRE_Real *relative_residual_norm );
-HYPRE_Int hypre_COGMRESSetModifyPC ( void *fgmres_vdata, HYPRE_Int (*modify_pc )(void *precond_data,
-                                                                                 HYPRE_Int iteration, HYPRE_Real rel_residual_norm));
+  /* cogmres.c */
+  void *hypre_COGMRESCreate ( hypre_COGMRESFunctions *gmres_functions );
+  HYPRE_Int hypre_COGMRESDestroy ( void *gmres_vdata );
+  HYPRE_Int hypre_COGMRESGetResidual ( void *gmres_vdata , void **residual );
+  HYPRE_Int hypre_COGMRESSetup ( void *gmres_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_COGMRESSolve ( void *gmres_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_COGMRESSetKDim ( void *gmres_vdata , HYPRE_Int k_dim );
+  HYPRE_Int hypre_COGMRESGetKDim ( void *gmres_vdata , HYPRE_Int *k_dim );
+  HYPRE_Int hypre_COGMRESSetUnroll ( void *gmres_vdata , HYPRE_Int unroll );
+  HYPRE_Int hypre_COGMRESGetUnroll ( void *gmres_vdata , HYPRE_Int *unroll );
+  HYPRE_Int hypre_COGMRESSetCGS ( void *gmres_vdata , HYPRE_Int cgs );
+  HYPRE_Int hypre_COGMRESGetCGS ( void *gmres_vdata , HYPRE_Int *cgs );
+  HYPRE_Int hypre_COGMRESSetTol ( void *gmres_vdata , HYPRE_Real tol );
+  HYPRE_Int hypre_COGMRESGetTol ( void *gmres_vdata , HYPRE_Real *tol );
+  HYPRE_Int hypre_COGMRESSetAbsoluteTol ( void *gmres_vdata , HYPRE_Real a_tol );
+  HYPRE_Int hypre_COGMRESGetAbsoluteTol ( void *gmres_vdata , HYPRE_Real *a_tol );
+  HYPRE_Int hypre_COGMRESSetConvergenceFactorTol ( void *gmres_vdata , HYPRE_Real cf_tol );
+  HYPRE_Int hypre_COGMRESGetConvergenceFactorTol ( void *gmres_vdata , HYPRE_Real *cf_tol );
+  HYPRE_Int hypre_COGMRESSetMinIter ( void *gmres_vdata , HYPRE_Int min_iter );
+  HYPRE_Int hypre_COGMRESGetMinIter ( void *gmres_vdata , HYPRE_Int *min_iter );
+  HYPRE_Int hypre_COGMRESSetMaxIter ( void *gmres_vdata , HYPRE_Int max_iter );
+  HYPRE_Int hypre_COGMRESGetMaxIter ( void *gmres_vdata , HYPRE_Int *max_iter );
+  HYPRE_Int hypre_COGMRESSetRelChange ( void *gmres_vdata , HYPRE_Int rel_change );
+  HYPRE_Int hypre_COGMRESGetRelChange ( void *gmres_vdata , HYPRE_Int *rel_change );
+  HYPRE_Int hypre_COGMRESSetSkipRealResidualCheck ( void *gmres_vdata , HYPRE_Int skip_real_r_check );
+  HYPRE_Int hypre_COGMRESGetSkipRealResidualCheck ( void *gmres_vdata , HYPRE_Int *skip_real_r_check );
+  HYPRE_Int hypre_COGMRESSetPrecond ( void *gmres_vdata , HYPRE_Int (*precond )(void*,void*,void*,void*), HYPRE_Int (*precond_setup )(void*,void*,void*,void*), void *precond_data );
+  HYPRE_Int hypre_COGMRESGetPrecond ( void *gmres_vdata , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int hypre_COGMRESSetPrintLevel ( void *gmres_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_COGMRESGetPrintLevel ( void *gmres_vdata , HYPRE_Int *level );
+  HYPRE_Int hypre_COGMRESSetLogging ( void *gmres_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_COGMRESGetLogging ( void *gmres_vdata , HYPRE_Int *level );
+  HYPRE_Int hypre_COGMRESGetNumIterations ( void *gmres_vdata , HYPRE_Int *num_iterations );
+  HYPRE_Int hypre_COGMRESGetConverged ( void *gmres_vdata , HYPRE_Int *converged );
+  HYPRE_Int hypre_COGMRESGetFinalRelativeResidualNorm ( void *gmres_vdata , HYPRE_Real *relative_residual_norm );
+  HYPRE_Int hypre_COGMRESSetModifyPC ( void *fgmres_vdata , HYPRE_Int (*modify_pc )(void *precond_data, HYPRE_Int iteration, HYPRE_Real rel_residual_norm));
 
 
 
-/* flexgmres.c */
-void *hypre_FlexGMRESCreate ( hypre_FlexGMRESFunctions *fgmres_functions );
-HYPRE_Int hypre_FlexGMRESDestroy ( void *fgmres_vdata );
-HYPRE_Int hypre_FlexGMRESGetResidual ( void *fgmres_vdata, void **residual );
-HYPRE_Int hypre_FlexGMRESSetup ( void *fgmres_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_FlexGMRESSolve ( void *fgmres_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_FlexGMRESSetKDim ( void *fgmres_vdata, HYPRE_Int k_dim );
-HYPRE_Int hypre_FlexGMRESGetKDim ( void *fgmres_vdata, HYPRE_Int *k_dim );
-HYPRE_Int hypre_FlexGMRESSetTol ( void *fgmres_vdata, HYPRE_Real tol );
-HYPRE_Int hypre_FlexGMRESGetTol ( void *fgmres_vdata, HYPRE_Real *tol );
-HYPRE_Int hypre_FlexGMRESSetAbsoluteTol ( void *fgmres_vdata, HYPRE_Real a_tol );
-HYPRE_Int hypre_FlexGMRESGetAbsoluteTol ( void *fgmres_vdata, HYPRE_Real *a_tol );
-HYPRE_Int hypre_FlexGMRESSetConvergenceFactorTol ( void *fgmres_vdata, HYPRE_Real cf_tol );
-HYPRE_Int hypre_FlexGMRESGetConvergenceFactorTol ( void *fgmres_vdata, HYPRE_Real *cf_tol );
-HYPRE_Int hypre_FlexGMRESSetMinIter ( void *fgmres_vdata, HYPRE_Int min_iter );
-HYPRE_Int hypre_FlexGMRESGetMinIter ( void *fgmres_vdata, HYPRE_Int *min_iter );
-HYPRE_Int hypre_FlexGMRESSetMaxIter ( void *fgmres_vdata, HYPRE_Int max_iter );
-HYPRE_Int hypre_FlexGMRESGetMaxIter ( void *fgmres_vdata, HYPRE_Int *max_iter );
-HYPRE_Int hypre_FlexGMRESSetStopCrit ( void *fgmres_vdata, HYPRE_Int stop_crit );
-HYPRE_Int hypre_FlexGMRESGetStopCrit ( void *fgmres_vdata, HYPRE_Int *stop_crit );
-HYPRE_Int hypre_FlexGMRESSetPrecond ( void *fgmres_vdata, HYPRE_Int (*precond )(void*, void*, void*,
-                                                                                void*), HYPRE_Int (*precond_setup )(void*, void*, void*, void*), void *precond_data );
-HYPRE_Int hypre_FlexGMRESGetPrecond ( void *fgmres_vdata, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int hypre_FlexGMRESSetPrintLevel ( void *fgmres_vdata, HYPRE_Int level );
-HYPRE_Int hypre_FlexGMRESGetPrintLevel ( void *fgmres_vdata, HYPRE_Int *level );
-HYPRE_Int hypre_FlexGMRESSetLogging ( void *fgmres_vdata, HYPRE_Int level );
-HYPRE_Int hypre_FlexGMRESGetLogging ( void *fgmres_vdata, HYPRE_Int *level );
-HYPRE_Int hypre_FlexGMRESGetNumIterations ( void *fgmres_vdata, HYPRE_Int *num_iterations );
-HYPRE_Int hypre_FlexGMRESGetConverged ( void *fgmres_vdata, HYPRE_Int *converged );
-HYPRE_Int hypre_FlexGMRESGetFinalRelativeResidualNorm ( void *fgmres_vdata,
-                                                        HYPRE_Real *relative_residual_norm );
-HYPRE_Int hypre_FlexGMRESSetModifyPC ( void *fgmres_vdata,
-                                       HYPRE_Int (*modify_pc )(void *precond_data, HYPRE_Int iteration, HYPRE_Real rel_residual_norm));
-HYPRE_Int hypre_FlexGMRESModifyPCDefault ( void *precond_data, HYPRE_Int iteration,
-                                           HYPRE_Real rel_residual_norm );
+  /* flexgmres.c */
+  void *hypre_FlexGMRESCreate ( hypre_FlexGMRESFunctions *fgmres_functions );
+  HYPRE_Int hypre_FlexGMRESDestroy ( void *fgmres_vdata );
+  HYPRE_Int hypre_FlexGMRESGetResidual ( void *fgmres_vdata , void **residual );
+  HYPRE_Int hypre_FlexGMRESSetup ( void *fgmres_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_FlexGMRESSolve ( void *fgmres_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_FlexGMRESSetKDim ( void *fgmres_vdata , HYPRE_Int k_dim );
+  HYPRE_Int hypre_FlexGMRESGetKDim ( void *fgmres_vdata , HYPRE_Int *k_dim );
+  HYPRE_Int hypre_FlexGMRESSetTol ( void *fgmres_vdata , HYPRE_Real tol );
+  HYPRE_Int hypre_FlexGMRESGetTol ( void *fgmres_vdata , HYPRE_Real *tol );
+  HYPRE_Int hypre_FlexGMRESSetAbsoluteTol ( void *fgmres_vdata , HYPRE_Real a_tol );
+  HYPRE_Int hypre_FlexGMRESGetAbsoluteTol ( void *fgmres_vdata , HYPRE_Real *a_tol );
+  HYPRE_Int hypre_FlexGMRESSetConvergenceFactorTol ( void *fgmres_vdata , HYPRE_Real cf_tol );
+  HYPRE_Int hypre_FlexGMRESGetConvergenceFactorTol ( void *fgmres_vdata , HYPRE_Real *cf_tol );
+  HYPRE_Int hypre_FlexGMRESSetMinIter ( void *fgmres_vdata , HYPRE_Int min_iter );
+  HYPRE_Int hypre_FlexGMRESGetMinIter ( void *fgmres_vdata , HYPRE_Int *min_iter );
+  HYPRE_Int hypre_FlexGMRESSetMaxIter ( void *fgmres_vdata , HYPRE_Int max_iter );
+  HYPRE_Int hypre_FlexGMRESGetMaxIter ( void *fgmres_vdata , HYPRE_Int *max_iter );
+  HYPRE_Int hypre_FlexGMRESSetStopCrit ( void *fgmres_vdata , HYPRE_Int stop_crit );
+  HYPRE_Int hypre_FlexGMRESGetStopCrit ( void *fgmres_vdata , HYPRE_Int *stop_crit );
+  HYPRE_Int hypre_FlexGMRESSetPrecond ( void *fgmres_vdata , HYPRE_Int (*precond )(void*,void*,void*,void*), HYPRE_Int (*precond_setup )(void*,void*,void*,void*), void *precond_data );
+  HYPRE_Int hypre_FlexGMRESGetPrecond ( void *fgmres_vdata , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int hypre_FlexGMRESSetPrintLevel ( void *fgmres_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_FlexGMRESGetPrintLevel ( void *fgmres_vdata , HYPRE_Int *level );
+  HYPRE_Int hypre_FlexGMRESSetLogging ( void *fgmres_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_FlexGMRESGetLogging ( void *fgmres_vdata , HYPRE_Int *level );
+  HYPRE_Int hypre_FlexGMRESGetNumIterations ( void *fgmres_vdata , HYPRE_Int *num_iterations );
+  HYPRE_Int hypre_FlexGMRESGetConverged ( void *fgmres_vdata , HYPRE_Int *converged );
+  HYPRE_Int hypre_FlexGMRESGetFinalRelativeResidualNorm ( void *fgmres_vdata , HYPRE_Real *relative_residual_norm );
+  HYPRE_Int hypre_FlexGMRESSetModifyPC ( void *fgmres_vdata , HYPRE_Int (*modify_pc )(void *precond_data, HYPRE_Int iteration, HYPRE_Real rel_residual_norm));
+  HYPRE_Int hypre_FlexGMRESModifyPCDefault ( void *precond_data , HYPRE_Int iteration , HYPRE_Real rel_residual_norm );
 
-/* lgmres.c */
-void *hypre_LGMRESCreate ( hypre_LGMRESFunctions *lgmres_functions );
-HYPRE_Int hypre_LGMRESDestroy ( void *lgmres_vdata );
-HYPRE_Int hypre_LGMRESGetResidual ( void *lgmres_vdata, void **residual );
-HYPRE_Int hypre_LGMRESSetup ( void *lgmres_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_LGMRESSolve ( void *lgmres_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_LGMRESSetKDim ( void *lgmres_vdata, HYPRE_Int k_dim );
-HYPRE_Int hypre_LGMRESGetKDim ( void *lgmres_vdata, HYPRE_Int *k_dim );
-HYPRE_Int hypre_LGMRESSetAugDim ( void *lgmres_vdata, HYPRE_Int aug_dim );
-HYPRE_Int hypre_LGMRESGetAugDim ( void *lgmres_vdata, HYPRE_Int *aug_dim );
-HYPRE_Int hypre_LGMRESSetTol ( void *lgmres_vdata, HYPRE_Real tol );
-HYPRE_Int hypre_LGMRESGetTol ( void *lgmres_vdata, HYPRE_Real *tol );
-HYPRE_Int hypre_LGMRESSetAbsoluteTol ( void *lgmres_vdata, HYPRE_Real a_tol );
-HYPRE_Int hypre_LGMRESGetAbsoluteTol ( void *lgmres_vdata, HYPRE_Real *a_tol );
-HYPRE_Int hypre_LGMRESSetConvergenceFactorTol ( void *lgmres_vdata, HYPRE_Real cf_tol );
-HYPRE_Int hypre_LGMRESGetConvergenceFactorTol ( void *lgmres_vdata, HYPRE_Real *cf_tol );
-HYPRE_Int hypre_LGMRESSetMinIter ( void *lgmres_vdata, HYPRE_Int min_iter );
-HYPRE_Int hypre_LGMRESGetMinIter ( void *lgmres_vdata, HYPRE_Int *min_iter );
-HYPRE_Int hypre_LGMRESSetMaxIter ( void *lgmres_vdata, HYPRE_Int max_iter );
-HYPRE_Int hypre_LGMRESGetMaxIter ( void *lgmres_vdata, HYPRE_Int *max_iter );
-HYPRE_Int hypre_LGMRESSetStopCrit ( void *lgmres_vdata, HYPRE_Int stop_crit );
-HYPRE_Int hypre_LGMRESGetStopCrit ( void *lgmres_vdata, HYPRE_Int *stop_crit );
-HYPRE_Int hypre_LGMRESSetPrecond ( void *lgmres_vdata, HYPRE_Int (*precond )(void*, void*, void*,
-                                                                             void*), HYPRE_Int (*precond_setup )(void*, void*, void*, void*), void *precond_data );
-HYPRE_Int hypre_LGMRESGetPrecond ( void *lgmres_vdata, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int hypre_LGMRESSetPrintLevel ( void *lgmres_vdata, HYPRE_Int level );
-HYPRE_Int hypre_LGMRESGetPrintLevel ( void *lgmres_vdata, HYPRE_Int *level );
-HYPRE_Int hypre_LGMRESSetLogging ( void *lgmres_vdata, HYPRE_Int level );
-HYPRE_Int hypre_LGMRESGetLogging ( void *lgmres_vdata, HYPRE_Int *level );
-HYPRE_Int hypre_LGMRESGetNumIterations ( void *lgmres_vdata, HYPRE_Int *num_iterations );
-HYPRE_Int hypre_LGMRESGetConverged ( void *lgmres_vdata, HYPRE_Int *converged );
-HYPRE_Int hypre_LGMRESGetFinalRelativeResidualNorm ( void *lgmres_vdata,
-                                                     HYPRE_Real *relative_residual_norm );
+  /* lgmres.c */
+  void *hypre_LGMRESCreate ( hypre_LGMRESFunctions *lgmres_functions );
+  HYPRE_Int hypre_LGMRESDestroy ( void *lgmres_vdata );
+  HYPRE_Int hypre_LGMRESGetResidual ( void *lgmres_vdata , void **residual );
+  HYPRE_Int hypre_LGMRESSetup ( void *lgmres_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_LGMRESSolve ( void *lgmres_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_LGMRESSetKDim ( void *lgmres_vdata , HYPRE_Int k_dim );
+  HYPRE_Int hypre_LGMRESGetKDim ( void *lgmres_vdata , HYPRE_Int *k_dim );
+  HYPRE_Int hypre_LGMRESSetAugDim ( void *lgmres_vdata , HYPRE_Int aug_dim );
+  HYPRE_Int hypre_LGMRESGetAugDim ( void *lgmres_vdata , HYPRE_Int *aug_dim );
+  HYPRE_Int hypre_LGMRESSetTol ( void *lgmres_vdata , HYPRE_Real tol );
+  HYPRE_Int hypre_LGMRESGetTol ( void *lgmres_vdata , HYPRE_Real *tol );
+  HYPRE_Int hypre_LGMRESSetAbsoluteTol ( void *lgmres_vdata , HYPRE_Real a_tol );
+  HYPRE_Int hypre_LGMRESGetAbsoluteTol ( void *lgmres_vdata , HYPRE_Real *a_tol );
+  HYPRE_Int hypre_LGMRESSetConvergenceFactorTol ( void *lgmres_vdata , HYPRE_Real cf_tol );
+  HYPRE_Int hypre_LGMRESGetConvergenceFactorTol ( void *lgmres_vdata , HYPRE_Real *cf_tol );
+  HYPRE_Int hypre_LGMRESSetMinIter ( void *lgmres_vdata , HYPRE_Int min_iter );
+  HYPRE_Int hypre_LGMRESGetMinIter ( void *lgmres_vdata , HYPRE_Int *min_iter );
+  HYPRE_Int hypre_LGMRESSetMaxIter ( void *lgmres_vdata , HYPRE_Int max_iter );
+  HYPRE_Int hypre_LGMRESGetMaxIter ( void *lgmres_vdata , HYPRE_Int *max_iter );
+  HYPRE_Int hypre_LGMRESSetStopCrit ( void *lgmres_vdata , HYPRE_Int stop_crit );
+  HYPRE_Int hypre_LGMRESGetStopCrit ( void *lgmres_vdata , HYPRE_Int *stop_crit );
+  HYPRE_Int hypre_LGMRESSetPrecond ( void *lgmres_vdata , HYPRE_Int (*precond )(void*,void*,void*,void*), HYPRE_Int (*precond_setup )(void*,void*,void*,void*), void *precond_data );
+  HYPRE_Int hypre_LGMRESGetPrecond ( void *lgmres_vdata , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int hypre_LGMRESSetPrintLevel ( void *lgmres_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_LGMRESGetPrintLevel ( void *lgmres_vdata , HYPRE_Int *level );
+  HYPRE_Int hypre_LGMRESSetLogging ( void *lgmres_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_LGMRESGetLogging ( void *lgmres_vdata , HYPRE_Int *level );
+  HYPRE_Int hypre_LGMRESGetNumIterations ( void *lgmres_vdata , HYPRE_Int *num_iterations );
+  HYPRE_Int hypre_LGMRESGetConverged ( void *lgmres_vdata , HYPRE_Int *converged );
+  HYPRE_Int hypre_LGMRESGetFinalRelativeResidualNorm ( void *lgmres_vdata , HYPRE_Real *relative_residual_norm );
 
-/* HYPRE_bicgstab.c */
-HYPRE_Int HYPRE_BiCGSTABDestroy ( HYPRE_Solver solver );
-HYPRE_Int HYPRE_BiCGSTABSetup ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b,
-                                HYPRE_Vector x );
-HYPRE_Int HYPRE_BiCGSTABSolve ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b,
-                                HYPRE_Vector x );
-HYPRE_Int HYPRE_BiCGSTABSetTol ( HYPRE_Solver solver, HYPRE_Real tol );
-HYPRE_Int HYPRE_BiCGSTABSetAbsoluteTol ( HYPRE_Solver solver, HYPRE_Real a_tol );
-HYPRE_Int HYPRE_BiCGSTABSetConvergenceFactorTol ( HYPRE_Solver solver, HYPRE_Real cf_tol );
-HYPRE_Int HYPRE_BiCGSTABSetMinIter ( HYPRE_Solver solver, HYPRE_Int min_iter );
-HYPRE_Int HYPRE_BiCGSTABSetMaxIter ( HYPRE_Solver solver, HYPRE_Int max_iter );
-HYPRE_Int HYPRE_BiCGSTABSetStopCrit ( HYPRE_Solver solver, HYPRE_Int stop_crit );
-HYPRE_Int HYPRE_BiCGSTABSetPrecond ( HYPRE_Solver solver, HYPRE_PtrToSolverFcn precond,
-                                     HYPRE_PtrToSolverFcn precond_setup, HYPRE_Solver precond_solver );
-HYPRE_Int HYPRE_BiCGSTABGetPrecond ( HYPRE_Solver solver, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int HYPRE_BiCGSTABSetLogging ( HYPRE_Solver solver, HYPRE_Int logging );
-HYPRE_Int HYPRE_BiCGSTABSetPrintLevel ( HYPRE_Solver solver, HYPRE_Int print_level );
-HYPRE_Int HYPRE_BiCGSTABGetNumIterations ( HYPRE_Solver solver, HYPRE_Int *num_iterations );
-HYPRE_Int HYPRE_BiCGSTABGetFinalRelativeResidualNorm ( HYPRE_Solver solver, HYPRE_Real *norm );
-HYPRE_Int HYPRE_BiCGSTABGetResidual ( HYPRE_Solver solver, void *residual );
+  /* HYPRE_bicgstab.c */
+  HYPRE_Int HYPRE_BiCGSTABDestroy ( HYPRE_Solver solver );
+  HYPRE_Int HYPRE_BiCGSTABSetup ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_BiCGSTABSolve ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_BiCGSTABSetTol ( HYPRE_Solver solver , HYPRE_Real tol );
+  HYPRE_Int HYPRE_BiCGSTABSetAbsoluteTol ( HYPRE_Solver solver , HYPRE_Real a_tol );
+  HYPRE_Int HYPRE_BiCGSTABSetConvergenceFactorTol ( HYPRE_Solver solver , HYPRE_Real cf_tol );
+  HYPRE_Int HYPRE_BiCGSTABSetMinIter ( HYPRE_Solver solver , HYPRE_Int min_iter );
+  HYPRE_Int HYPRE_BiCGSTABSetMaxIter ( HYPRE_Solver solver , HYPRE_Int max_iter );
+  HYPRE_Int HYPRE_BiCGSTABSetStopCrit ( HYPRE_Solver solver , HYPRE_Int stop_crit );
+  HYPRE_Int HYPRE_BiCGSTABSetPrecond ( HYPRE_Solver solver , HYPRE_PtrToSolverFcn precond , HYPRE_PtrToSolverFcn precond_setup , HYPRE_Solver precond_solver );
+  HYPRE_Int HYPRE_BiCGSTABGetPrecond ( HYPRE_Solver solver , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int HYPRE_BiCGSTABSetLogging ( HYPRE_Solver solver , HYPRE_Int logging );
+  HYPRE_Int HYPRE_BiCGSTABSetPrintLevel ( HYPRE_Solver solver , HYPRE_Int print_level );
+  HYPRE_Int HYPRE_BiCGSTABGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *num_iterations );
+  HYPRE_Int HYPRE_BiCGSTABGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
+  HYPRE_Int HYPRE_BiCGSTABGetResidual ( HYPRE_Solver solver , void *residual );
 
-/* HYPRE_cgnr.c */
-HYPRE_Int HYPRE_CGNRDestroy ( HYPRE_Solver solver );
-HYPRE_Int HYPRE_CGNRSetup ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b, HYPRE_Vector x );
-HYPRE_Int HYPRE_CGNRSolve ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b, HYPRE_Vector x );
-HYPRE_Int HYPRE_CGNRSetTol ( HYPRE_Solver solver, HYPRE_Real tol );
-HYPRE_Int HYPRE_CGNRSetMinIter ( HYPRE_Solver solver, HYPRE_Int min_iter );
-HYPRE_Int HYPRE_CGNRSetMaxIter ( HYPRE_Solver solver, HYPRE_Int max_iter );
-HYPRE_Int HYPRE_CGNRSetStopCrit ( HYPRE_Solver solver, HYPRE_Int stop_crit );
-HYPRE_Int HYPRE_CGNRSetPrecond ( HYPRE_Solver solver, HYPRE_PtrToSolverFcn precond,
-                                 HYPRE_PtrToSolverFcn precondT, HYPRE_PtrToSolverFcn precond_setup, HYPRE_Solver precond_solver );
-HYPRE_Int HYPRE_CGNRGetPrecond ( HYPRE_Solver solver, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int HYPRE_CGNRSetLogging ( HYPRE_Solver solver, HYPRE_Int logging );
-HYPRE_Int HYPRE_CGNRGetNumIterations ( HYPRE_Solver solver, HYPRE_Int *num_iterations );
-HYPRE_Int HYPRE_CGNRGetFinalRelativeResidualNorm ( HYPRE_Solver solver, HYPRE_Real *norm );
+  /* HYPRE_cgnr.c */
+  HYPRE_Int HYPRE_CGNRDestroy ( HYPRE_Solver solver );
+  HYPRE_Int HYPRE_CGNRSetup ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_CGNRSolve ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_CGNRSetTol ( HYPRE_Solver solver , HYPRE_Real tol );
+  HYPRE_Int HYPRE_CGNRSetMinIter ( HYPRE_Solver solver , HYPRE_Int min_iter );
+  HYPRE_Int HYPRE_CGNRSetMaxIter ( HYPRE_Solver solver , HYPRE_Int max_iter );
+  HYPRE_Int HYPRE_CGNRSetStopCrit ( HYPRE_Solver solver , HYPRE_Int stop_crit );
+  HYPRE_Int HYPRE_CGNRSetPrecond ( HYPRE_Solver solver , HYPRE_PtrToSolverFcn precond , HYPRE_PtrToSolverFcn precondT , HYPRE_PtrToSolverFcn precond_setup , HYPRE_Solver precond_solver );
+  HYPRE_Int HYPRE_CGNRGetPrecond ( HYPRE_Solver solver , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int HYPRE_CGNRSetLogging ( HYPRE_Solver solver , HYPRE_Int logging );
+  HYPRE_Int HYPRE_CGNRGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *num_iterations );
+  HYPRE_Int HYPRE_CGNRGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
 
-/* HYPRE_gmres.c */
-HYPRE_Int HYPRE_GMRESSetup ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b, HYPRE_Vector x );
-HYPRE_Int HYPRE_GMRESSolve ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b, HYPRE_Vector x );
-HYPRE_Int HYPRE_GMRESSetKDim ( HYPRE_Solver solver, HYPRE_Int k_dim );
-HYPRE_Int HYPRE_GMRESGetKDim ( HYPRE_Solver solver, HYPRE_Int *k_dim );
-HYPRE_Int HYPRE_GMRESSetTol ( HYPRE_Solver solver, HYPRE_Real tol );
-HYPRE_Int HYPRE_GMRESGetTol ( HYPRE_Solver solver, HYPRE_Real *tol );
-HYPRE_Int HYPRE_GMRESSetAbsoluteTol ( HYPRE_Solver solver, HYPRE_Real a_tol );
-HYPRE_Int HYPRE_GMRESGetAbsoluteTol ( HYPRE_Solver solver, HYPRE_Real *a_tol );
-HYPRE_Int HYPRE_GMRESSetConvergenceFactorTol ( HYPRE_Solver solver, HYPRE_Real cf_tol );
-HYPRE_Int HYPRE_GMRESGetConvergenceFactorTol ( HYPRE_Solver solver, HYPRE_Real *cf_tol );
-HYPRE_Int HYPRE_GMRESSetMinIter ( HYPRE_Solver solver, HYPRE_Int min_iter );
-HYPRE_Int HYPRE_GMRESGetMinIter ( HYPRE_Solver solver, HYPRE_Int *min_iter );
-HYPRE_Int HYPRE_GMRESSetMaxIter ( HYPRE_Solver solver, HYPRE_Int max_iter );
-HYPRE_Int HYPRE_GMRESGetMaxIter ( HYPRE_Solver solver, HYPRE_Int *max_iter );
-HYPRE_Int HYPRE_GMRESSetStopCrit ( HYPRE_Solver solver, HYPRE_Int stop_crit );
-HYPRE_Int HYPRE_GMRESGetStopCrit ( HYPRE_Solver solver, HYPRE_Int *stop_crit );
-HYPRE_Int HYPRE_GMRESSetRelChange ( HYPRE_Solver solver, HYPRE_Int rel_change );
-HYPRE_Int HYPRE_GMRESGetRelChange ( HYPRE_Solver solver, HYPRE_Int *rel_change );
-HYPRE_Int HYPRE_GMRESSetSkipRealResidualCheck ( HYPRE_Solver solver, HYPRE_Int skip_real_r_check );
-HYPRE_Int HYPRE_GMRESGetSkipRealResidualCheck ( HYPRE_Solver solver, HYPRE_Int *skip_real_r_check );
-HYPRE_Int HYPRE_GMRESSetPrecond ( HYPRE_Solver solver, HYPRE_PtrToSolverFcn precond,
-                                  HYPRE_PtrToSolverFcn precond_setup, HYPRE_Solver precond_solver );
-HYPRE_Int HYPRE_GMRESGetPrecond ( HYPRE_Solver solver, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int HYPRE_GMRESSetPrintLevel ( HYPRE_Solver solver, HYPRE_Int level );
-HYPRE_Int HYPRE_GMRESGetPrintLevel ( HYPRE_Solver solver, HYPRE_Int *level );
-HYPRE_Int HYPRE_GMRESSetLogging ( HYPRE_Solver solver, HYPRE_Int level );
-HYPRE_Int HYPRE_GMRESGetLogging ( HYPRE_Solver solver, HYPRE_Int *level );
-HYPRE_Int HYPRE_GMRESGetNumIterations ( HYPRE_Solver solver, HYPRE_Int *num_iterations );
-HYPRE_Int HYPRE_GMRESGetConverged ( HYPRE_Solver solver, HYPRE_Int *converged );
-HYPRE_Int HYPRE_GMRESGetFinalRelativeResidualNorm ( HYPRE_Solver solver, HYPRE_Real *norm );
-HYPRE_Int HYPRE_GMRESGetResidual ( HYPRE_Solver solver, void *residual );
+  /* HYPRE_gmres.c */
+  HYPRE_Int HYPRE_GMRESSetup ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_GMRESSolve ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_GMRESSetKDim ( HYPRE_Solver solver , HYPRE_Int k_dim );
+  HYPRE_Int HYPRE_GMRESGetKDim ( HYPRE_Solver solver , HYPRE_Int *k_dim );
+  HYPRE_Int HYPRE_GMRESSetTol ( HYPRE_Solver solver , HYPRE_Real tol );
+  HYPRE_Int HYPRE_GMRESGetTol ( HYPRE_Solver solver , HYPRE_Real *tol );
+  HYPRE_Int HYPRE_GMRESSetAbsoluteTol ( HYPRE_Solver solver , HYPRE_Real a_tol );
+  HYPRE_Int HYPRE_GMRESGetAbsoluteTol ( HYPRE_Solver solver , HYPRE_Real *a_tol );
+  HYPRE_Int HYPRE_GMRESSetConvergenceFactorTol ( HYPRE_Solver solver , HYPRE_Real cf_tol );
+  HYPRE_Int HYPRE_GMRESGetConvergenceFactorTol ( HYPRE_Solver solver , HYPRE_Real *cf_tol );
+  HYPRE_Int HYPRE_GMRESSetMinIter ( HYPRE_Solver solver , HYPRE_Int min_iter );
+  HYPRE_Int HYPRE_GMRESGetMinIter ( HYPRE_Solver solver , HYPRE_Int *min_iter );
+  HYPRE_Int HYPRE_GMRESSetMaxIter ( HYPRE_Solver solver , HYPRE_Int max_iter );
+  HYPRE_Int HYPRE_GMRESGetMaxIter ( HYPRE_Solver solver , HYPRE_Int *max_iter );
+  HYPRE_Int HYPRE_GMRESSetStopCrit ( HYPRE_Solver solver , HYPRE_Int stop_crit );
+  HYPRE_Int HYPRE_GMRESGetStopCrit ( HYPRE_Solver solver , HYPRE_Int *stop_crit );
+  HYPRE_Int HYPRE_GMRESSetRelChange ( HYPRE_Solver solver , HYPRE_Int rel_change );
+  HYPRE_Int HYPRE_GMRESGetRelChange ( HYPRE_Solver solver , HYPRE_Int *rel_change );
+  HYPRE_Int HYPRE_GMRESSetSkipRealResidualCheck ( HYPRE_Solver solver , HYPRE_Int skip_real_r_check );
+  HYPRE_Int HYPRE_GMRESGetSkipRealResidualCheck ( HYPRE_Solver solver , HYPRE_Int *skip_real_r_check );
+  HYPRE_Int HYPRE_GMRESSetPrecond ( HYPRE_Solver solver , HYPRE_PtrToSolverFcn precond , HYPRE_PtrToSolverFcn precond_setup , HYPRE_Solver precond_solver );
+  HYPRE_Int HYPRE_GMRESGetPrecond ( HYPRE_Solver solver , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int HYPRE_GMRESSetPrintLevel ( HYPRE_Solver solver , HYPRE_Int level );
+  HYPRE_Int HYPRE_GMRESGetPrintLevel ( HYPRE_Solver solver , HYPRE_Int *level );
+  HYPRE_Int HYPRE_GMRESSetLogging ( HYPRE_Solver solver , HYPRE_Int level );
+  HYPRE_Int HYPRE_GMRESGetLogging ( HYPRE_Solver solver , HYPRE_Int *level );
+  HYPRE_Int HYPRE_GMRESGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *num_iterations );
+  HYPRE_Int HYPRE_GMRESGetConverged ( HYPRE_Solver solver , HYPRE_Int *converged );
+  HYPRE_Int HYPRE_GMRESGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
+  HYPRE_Int HYPRE_GMRESGetResidual ( HYPRE_Solver solver , void *residual );
 
-/* HYPRE_cogmres.c */
-HYPRE_Int HYPRE_COGMRESSetup ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b,
-                               HYPRE_Vector x );
-HYPRE_Int HYPRE_COGMRESSolve ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b,
-                               HYPRE_Vector x );
-HYPRE_Int HYPRE_COGMRESSetKDim ( HYPRE_Solver solver, HYPRE_Int k_dim );
-HYPRE_Int HYPRE_COGMRESGetKDim ( HYPRE_Solver solver, HYPRE_Int *k_dim );
-HYPRE_Int HYPRE_COGMRESSetUnroll ( HYPRE_Solver solver, HYPRE_Int unroll );
-HYPRE_Int HYPRE_COGMRESGetUnroll ( HYPRE_Solver solver, HYPRE_Int *unroll );
-HYPRE_Int HYPRE_COGMRESSetCGS ( HYPRE_Solver solver, HYPRE_Int cgs );
-HYPRE_Int HYPRE_COGMRESGetCGS ( HYPRE_Solver solver, HYPRE_Int *cgs );
-HYPRE_Int HYPRE_COGMRESSetTol ( HYPRE_Solver solver, HYPRE_Real tol );
-HYPRE_Int HYPRE_COGMRESGetTol ( HYPRE_Solver solver, HYPRE_Real *tol );
-HYPRE_Int HYPRE_COGMRESSetAbsoluteTol ( HYPRE_Solver solver, HYPRE_Real a_tol );
-HYPRE_Int HYPRE_COGMRESGetAbsoluteTol ( HYPRE_Solver solver, HYPRE_Real *a_tol );
-HYPRE_Int HYPRE_COGMRESSetConvergenceFactorTol ( HYPRE_Solver solver, HYPRE_Real cf_tol );
-HYPRE_Int HYPRE_COGMRESGetConvergenceFactorTol ( HYPRE_Solver solver, HYPRE_Real *cf_tol );
-HYPRE_Int HYPRE_COGMRESSetMinIter ( HYPRE_Solver solver, HYPRE_Int min_iter );
-HYPRE_Int HYPRE_COGMRESGetMinIter ( HYPRE_Solver solver, HYPRE_Int *min_iter );
-HYPRE_Int HYPRE_COGMRESSetMaxIter ( HYPRE_Solver solver, HYPRE_Int max_iter );
-HYPRE_Int HYPRE_COGMRESGetMaxIter ( HYPRE_Solver solver, HYPRE_Int *max_iter );
-HYPRE_Int HYPRE_COGMRESSetRelChange ( HYPRE_Solver solver, HYPRE_Int rel_change );
-HYPRE_Int HYPRE_COGMRESGetRelChange ( HYPRE_Solver solver, HYPRE_Int *rel_change );
-HYPRE_Int HYPRE_COGMRESSetSkipRealResidualCheck ( HYPRE_Solver solver,
-                                                  HYPRE_Int skip_real_r_check );
-HYPRE_Int HYPRE_COGMRESGetSkipRealResidualCheck ( HYPRE_Solver solver,
-                                                  HYPRE_Int *skip_real_r_check );
-HYPRE_Int HYPRE_COGMRESSetPrecond ( HYPRE_Solver solver, HYPRE_PtrToSolverFcn precond,
-                                    HYPRE_PtrToSolverFcn precond_setup, HYPRE_Solver precond_solver );
-HYPRE_Int HYPRE_COGMRESGetPrecond ( HYPRE_Solver solver, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int HYPRE_COGMRESSetPrintLevel ( HYPRE_Solver solver, HYPRE_Int level );
-HYPRE_Int HYPRE_COGMRESGetPrintLevel ( HYPRE_Solver solver, HYPRE_Int *level );
-HYPRE_Int HYPRE_COGMRESSetLogging ( HYPRE_Solver solver, HYPRE_Int level );
-HYPRE_Int HYPRE_COGMRESGetLogging ( HYPRE_Solver solver, HYPRE_Int *level );
-HYPRE_Int HYPRE_COGMRESGetNumIterations ( HYPRE_Solver solver, HYPRE_Int *num_iterations );
-HYPRE_Int HYPRE_COGMRESGetConverged ( HYPRE_Solver solver, HYPRE_Int *converged );
-HYPRE_Int HYPRE_COGMRESGetFinalRelativeResidualNorm ( HYPRE_Solver solver, HYPRE_Real *norm );
-HYPRE_Int HYPRE_COGMRESGetResidual ( HYPRE_Solver solver, void *residual );
+  /* HYPRE_cogmres.c */
+  HYPRE_Int HYPRE_COGMRESSetup ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_COGMRESSolve ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_COGMRESSetKDim ( HYPRE_Solver solver , HYPRE_Int k_dim );
+  HYPRE_Int HYPRE_COGMRESGetKDim ( HYPRE_Solver solver , HYPRE_Int *k_dim );
+  HYPRE_Int HYPRE_COGMRESSetUnroll ( HYPRE_Solver solver , HYPRE_Int unroll );
+  HYPRE_Int HYPRE_COGMRESGetUnroll ( HYPRE_Solver solver , HYPRE_Int *unroll );
+  HYPRE_Int HYPRE_COGMRESSetCGS ( HYPRE_Solver solver , HYPRE_Int cgs );
+  HYPRE_Int HYPRE_COGMRESGetCGS ( HYPRE_Solver solver , HYPRE_Int *cgs );
+  HYPRE_Int HYPRE_COGMRESSetTol ( HYPRE_Solver solver , HYPRE_Real tol );
+  HYPRE_Int HYPRE_COGMRESGetTol ( HYPRE_Solver solver , HYPRE_Real *tol );
+  HYPRE_Int HYPRE_COGMRESSetAbsoluteTol ( HYPRE_Solver solver , HYPRE_Real a_tol );
+  HYPRE_Int HYPRE_COGMRESGetAbsoluteTol ( HYPRE_Solver solver , HYPRE_Real *a_tol );
+  HYPRE_Int HYPRE_COGMRESSetConvergenceFactorTol ( HYPRE_Solver solver , HYPRE_Real cf_tol );
+  HYPRE_Int HYPRE_COGMRESGetConvergenceFactorTol ( HYPRE_Solver solver , HYPRE_Real *cf_tol );
+  HYPRE_Int HYPRE_COGMRESSetMinIter ( HYPRE_Solver solver , HYPRE_Int min_iter );
+  HYPRE_Int HYPRE_COGMRESGetMinIter ( HYPRE_Solver solver , HYPRE_Int *min_iter );
+  HYPRE_Int HYPRE_COGMRESSetMaxIter ( HYPRE_Solver solver , HYPRE_Int max_iter );
+  HYPRE_Int HYPRE_COGMRESGetMaxIter ( HYPRE_Solver solver , HYPRE_Int *max_iter );
+  HYPRE_Int HYPRE_COGMRESSetRelChange ( HYPRE_Solver solver , HYPRE_Int rel_change );
+  HYPRE_Int HYPRE_COGMRESGetRelChange ( HYPRE_Solver solver , HYPRE_Int *rel_change );
+  HYPRE_Int HYPRE_COGMRESSetSkipRealResidualCheck ( HYPRE_Solver solver , HYPRE_Int skip_real_r_check );
+  HYPRE_Int HYPRE_COGMRESGetSkipRealResidualCheck ( HYPRE_Solver solver , HYPRE_Int *skip_real_r_check );
+  HYPRE_Int HYPRE_COGMRESSetPrecond ( HYPRE_Solver solver , HYPRE_PtrToSolverFcn precond , HYPRE_PtrToSolverFcn precond_setup , HYPRE_Solver precond_solver );
+  HYPRE_Int HYPRE_COGMRESGetPrecond ( HYPRE_Solver solver , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int HYPRE_COGMRESSetPrintLevel ( HYPRE_Solver solver , HYPRE_Int level );
+  HYPRE_Int HYPRE_COGMRESGetPrintLevel ( HYPRE_Solver solver , HYPRE_Int *level );
+  HYPRE_Int HYPRE_COGMRESSetLogging ( HYPRE_Solver solver , HYPRE_Int level );
+  HYPRE_Int HYPRE_COGMRESGetLogging ( HYPRE_Solver solver , HYPRE_Int *level );
+  HYPRE_Int HYPRE_COGMRESGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *num_iterations );
+  HYPRE_Int HYPRE_COGMRESGetConverged ( HYPRE_Solver solver , HYPRE_Int *converged );
+  HYPRE_Int HYPRE_COGMRESGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
+  HYPRE_Int HYPRE_COGMRESGetResidual ( HYPRE_Solver solver , void *residual );
 
-/* HYPRE_flexgmres.c */
-HYPRE_Int HYPRE_FlexGMRESSetup ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b,
-                                 HYPRE_Vector x );
-HYPRE_Int HYPRE_FlexGMRESSolve ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b,
-                                 HYPRE_Vector x );
-HYPRE_Int HYPRE_FlexGMRESSetKDim ( HYPRE_Solver solver, HYPRE_Int k_dim );
-HYPRE_Int HYPRE_FlexGMRESGetKDim ( HYPRE_Solver solver, HYPRE_Int *k_dim );
-HYPRE_Int HYPRE_FlexGMRESSetTol ( HYPRE_Solver solver, HYPRE_Real tol );
-HYPRE_Int HYPRE_FlexGMRESGetTol ( HYPRE_Solver solver, HYPRE_Real *tol );
-HYPRE_Int HYPRE_FlexGMRESSetAbsoluteTol ( HYPRE_Solver solver, HYPRE_Real a_tol );
-HYPRE_Int HYPRE_FlexGMRESGetAbsoluteTol ( HYPRE_Solver solver, HYPRE_Real *a_tol );
-HYPRE_Int HYPRE_FlexGMRESSetConvergenceFactorTol ( HYPRE_Solver solver, HYPRE_Real cf_tol );
-HYPRE_Int HYPRE_FlexGMRESGetConvergenceFactorTol ( HYPRE_Solver solver, HYPRE_Real *cf_tol );
-HYPRE_Int HYPRE_FlexGMRESSetMinIter ( HYPRE_Solver solver, HYPRE_Int min_iter );
-HYPRE_Int HYPRE_FlexGMRESGetMinIter ( HYPRE_Solver solver, HYPRE_Int *min_iter );
-HYPRE_Int HYPRE_FlexGMRESSetMaxIter ( HYPRE_Solver solver, HYPRE_Int max_iter );
-HYPRE_Int HYPRE_FlexGMRESGetMaxIter ( HYPRE_Solver solver, HYPRE_Int *max_iter );
-HYPRE_Int HYPRE_FlexGMRESSetPrecond ( HYPRE_Solver solver, HYPRE_PtrToSolverFcn precond,
-                                      HYPRE_PtrToSolverFcn precond_setup, HYPRE_Solver precond_solver );
-HYPRE_Int HYPRE_FlexGMRESGetPrecond ( HYPRE_Solver solver, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int HYPRE_FlexGMRESSetPrintLevel ( HYPRE_Solver solver, HYPRE_Int level );
-HYPRE_Int HYPRE_FlexGMRESGetPrintLevel ( HYPRE_Solver solver, HYPRE_Int *level );
-HYPRE_Int HYPRE_FlexGMRESSetLogging ( HYPRE_Solver solver, HYPRE_Int level );
-HYPRE_Int HYPRE_FlexGMRESGetLogging ( HYPRE_Solver solver, HYPRE_Int *level );
-HYPRE_Int HYPRE_FlexGMRESGetNumIterations ( HYPRE_Solver solver, HYPRE_Int *num_iterations );
-HYPRE_Int HYPRE_FlexGMRESGetConverged ( HYPRE_Solver solver, HYPRE_Int *converged );
-HYPRE_Int HYPRE_FlexGMRESGetFinalRelativeResidualNorm ( HYPRE_Solver solver, HYPRE_Real *norm );
-HYPRE_Int HYPRE_FlexGMRESGetResidual ( HYPRE_Solver solver, void *residual );
-HYPRE_Int HYPRE_FlexGMRESSetModifyPC ( HYPRE_Solver solver, HYPRE_Int (*modify_pc )(HYPRE_Solver,
-                                                                                    HYPRE_Int, HYPRE_Real ));
+  /* HYPRE_flexgmres.c */
+  HYPRE_Int HYPRE_FlexGMRESSetup ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_FlexGMRESSolve ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_FlexGMRESSetKDim ( HYPRE_Solver solver , HYPRE_Int k_dim );
+  HYPRE_Int HYPRE_FlexGMRESGetKDim ( HYPRE_Solver solver , HYPRE_Int *k_dim );
+  HYPRE_Int HYPRE_FlexGMRESSetTol ( HYPRE_Solver solver , HYPRE_Real tol );
+  HYPRE_Int HYPRE_FlexGMRESGetTol ( HYPRE_Solver solver , HYPRE_Real *tol );
+  HYPRE_Int HYPRE_FlexGMRESSetAbsoluteTol ( HYPRE_Solver solver , HYPRE_Real a_tol );
+  HYPRE_Int HYPRE_FlexGMRESGetAbsoluteTol ( HYPRE_Solver solver , HYPRE_Real *a_tol );
+  HYPRE_Int HYPRE_FlexGMRESSetConvergenceFactorTol ( HYPRE_Solver solver , HYPRE_Real cf_tol );
+  HYPRE_Int HYPRE_FlexGMRESGetConvergenceFactorTol ( HYPRE_Solver solver , HYPRE_Real *cf_tol );
+  HYPRE_Int HYPRE_FlexGMRESSetMinIter ( HYPRE_Solver solver , HYPRE_Int min_iter );
+  HYPRE_Int HYPRE_FlexGMRESGetMinIter ( HYPRE_Solver solver , HYPRE_Int *min_iter );
+  HYPRE_Int HYPRE_FlexGMRESSetMaxIter ( HYPRE_Solver solver , HYPRE_Int max_iter );
+  HYPRE_Int HYPRE_FlexGMRESGetMaxIter ( HYPRE_Solver solver , HYPRE_Int *max_iter );
+  HYPRE_Int HYPRE_FlexGMRESSetPrecond ( HYPRE_Solver solver , HYPRE_PtrToSolverFcn precond , HYPRE_PtrToSolverFcn precond_setup , HYPRE_Solver precond_solver );
+  HYPRE_Int HYPRE_FlexGMRESGetPrecond ( HYPRE_Solver solver , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int HYPRE_FlexGMRESSetPrintLevel ( HYPRE_Solver solver , HYPRE_Int level );
+  HYPRE_Int HYPRE_FlexGMRESGetPrintLevel ( HYPRE_Solver solver , HYPRE_Int *level );
+  HYPRE_Int HYPRE_FlexGMRESSetLogging ( HYPRE_Solver solver , HYPRE_Int level );
+  HYPRE_Int HYPRE_FlexGMRESGetLogging ( HYPRE_Solver solver , HYPRE_Int *level );
+  HYPRE_Int HYPRE_FlexGMRESGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *num_iterations );
+  HYPRE_Int HYPRE_FlexGMRESGetConverged ( HYPRE_Solver solver , HYPRE_Int *converged );
+  HYPRE_Int HYPRE_FlexGMRESGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
+  HYPRE_Int HYPRE_FlexGMRESGetResidual ( HYPRE_Solver solver , void *residual );
+  HYPRE_Int HYPRE_FlexGMRESSetModifyPC ( HYPRE_Solver solver , HYPRE_Int (*modify_pc )(HYPRE_Solver ,HYPRE_Int ,HYPRE_Real ));
 
-/* HYPRE_lgmres.c */
-HYPRE_Int HYPRE_LGMRESSetup ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b, HYPRE_Vector x );
-HYPRE_Int HYPRE_LGMRESSolve ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b, HYPRE_Vector x );
-HYPRE_Int HYPRE_LGMRESSetKDim ( HYPRE_Solver solver, HYPRE_Int k_dim );
-HYPRE_Int HYPRE_LGMRESGetKDim ( HYPRE_Solver solver, HYPRE_Int *k_dim );
-HYPRE_Int HYPRE_LGMRESSetAugDim ( HYPRE_Solver solver, HYPRE_Int aug_dim );
-HYPRE_Int HYPRE_LGMRESGetAugDim ( HYPRE_Solver solver, HYPRE_Int *aug_dim );
-HYPRE_Int HYPRE_LGMRESSetTol ( HYPRE_Solver solver, HYPRE_Real tol );
-HYPRE_Int HYPRE_LGMRESGetTol ( HYPRE_Solver solver, HYPRE_Real *tol );
-HYPRE_Int HYPRE_LGMRESSetAbsoluteTol ( HYPRE_Solver solver, HYPRE_Real a_tol );
-HYPRE_Int HYPRE_LGMRESGetAbsoluteTol ( HYPRE_Solver solver, HYPRE_Real *a_tol );
-HYPRE_Int HYPRE_LGMRESSetConvergenceFactorTol ( HYPRE_Solver solver, HYPRE_Real cf_tol );
-HYPRE_Int HYPRE_LGMRESGetConvergenceFactorTol ( HYPRE_Solver solver, HYPRE_Real *cf_tol );
-HYPRE_Int HYPRE_LGMRESSetMinIter ( HYPRE_Solver solver, HYPRE_Int min_iter );
-HYPRE_Int HYPRE_LGMRESGetMinIter ( HYPRE_Solver solver, HYPRE_Int *min_iter );
-HYPRE_Int HYPRE_LGMRESSetMaxIter ( HYPRE_Solver solver, HYPRE_Int max_iter );
-HYPRE_Int HYPRE_LGMRESGetMaxIter ( HYPRE_Solver solver, HYPRE_Int *max_iter );
-HYPRE_Int HYPRE_LGMRESSetPrecond ( HYPRE_Solver solver, HYPRE_PtrToSolverFcn precond,
-                                   HYPRE_PtrToSolverFcn precond_setup, HYPRE_Solver precond_solver );
-HYPRE_Int HYPRE_LGMRESGetPrecond ( HYPRE_Solver solver, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int HYPRE_LGMRESSetPrintLevel ( HYPRE_Solver solver, HYPRE_Int level );
-HYPRE_Int HYPRE_LGMRESGetPrintLevel ( HYPRE_Solver solver, HYPRE_Int *level );
-HYPRE_Int HYPRE_LGMRESSetLogging ( HYPRE_Solver solver, HYPRE_Int level );
-HYPRE_Int HYPRE_LGMRESGetLogging ( HYPRE_Solver solver, HYPRE_Int *level );
-HYPRE_Int HYPRE_LGMRESGetNumIterations ( HYPRE_Solver solver, HYPRE_Int *num_iterations );
-HYPRE_Int HYPRE_LGMRESGetConverged ( HYPRE_Solver solver, HYPRE_Int *converged );
-HYPRE_Int HYPRE_LGMRESGetFinalRelativeResidualNorm ( HYPRE_Solver solver, HYPRE_Real *norm );
-HYPRE_Int HYPRE_LGMRESGetResidual ( HYPRE_Solver solver, void *residual );
+  /* HYPRE_lgmres.c */
+  HYPRE_Int HYPRE_LGMRESSetup ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_LGMRESSolve ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_LGMRESSetKDim ( HYPRE_Solver solver , HYPRE_Int k_dim );
+  HYPRE_Int HYPRE_LGMRESGetKDim ( HYPRE_Solver solver , HYPRE_Int *k_dim );
+  HYPRE_Int HYPRE_LGMRESSetAugDim ( HYPRE_Solver solver , HYPRE_Int aug_dim );
+  HYPRE_Int HYPRE_LGMRESGetAugDim ( HYPRE_Solver solver , HYPRE_Int *aug_dim );
+  HYPRE_Int HYPRE_LGMRESSetTol ( HYPRE_Solver solver , HYPRE_Real tol );
+  HYPRE_Int HYPRE_LGMRESGetTol ( HYPRE_Solver solver , HYPRE_Real *tol );
+  HYPRE_Int HYPRE_LGMRESSetAbsoluteTol ( HYPRE_Solver solver , HYPRE_Real a_tol );
+  HYPRE_Int HYPRE_LGMRESGetAbsoluteTol ( HYPRE_Solver solver , HYPRE_Real *a_tol );
+  HYPRE_Int HYPRE_LGMRESSetConvergenceFactorTol ( HYPRE_Solver solver , HYPRE_Real cf_tol );
+  HYPRE_Int HYPRE_LGMRESGetConvergenceFactorTol ( HYPRE_Solver solver , HYPRE_Real *cf_tol );
+  HYPRE_Int HYPRE_LGMRESSetMinIter ( HYPRE_Solver solver , HYPRE_Int min_iter );
+  HYPRE_Int HYPRE_LGMRESGetMinIter ( HYPRE_Solver solver , HYPRE_Int *min_iter );
+  HYPRE_Int HYPRE_LGMRESSetMaxIter ( HYPRE_Solver solver , HYPRE_Int max_iter );
+  HYPRE_Int HYPRE_LGMRESGetMaxIter ( HYPRE_Solver solver , HYPRE_Int *max_iter );
+  HYPRE_Int HYPRE_LGMRESSetPrecond ( HYPRE_Solver solver , HYPRE_PtrToSolverFcn precond , HYPRE_PtrToSolverFcn precond_setup , HYPRE_Solver precond_solver );
+  HYPRE_Int HYPRE_LGMRESGetPrecond ( HYPRE_Solver solver , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int HYPRE_LGMRESSetPrintLevel ( HYPRE_Solver solver , HYPRE_Int level );
+  HYPRE_Int HYPRE_LGMRESGetPrintLevel ( HYPRE_Solver solver , HYPRE_Int *level );
+  HYPRE_Int HYPRE_LGMRESSetLogging ( HYPRE_Solver solver , HYPRE_Int level );
+  HYPRE_Int HYPRE_LGMRESGetLogging ( HYPRE_Solver solver , HYPRE_Int *level );
+  HYPRE_Int HYPRE_LGMRESGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *num_iterations );
+  HYPRE_Int HYPRE_LGMRESGetConverged ( HYPRE_Solver solver , HYPRE_Int *converged );
+  HYPRE_Int HYPRE_LGMRESGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
+  HYPRE_Int HYPRE_LGMRESGetResidual ( HYPRE_Solver solver , void *residual );
 
-/* HYPRE_pcg.c */
-HYPRE_Int HYPRE_PCGSetup ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b, HYPRE_Vector x );
-HYPRE_Int HYPRE_PCGSolve ( HYPRE_Solver solver, HYPRE_Matrix A, HYPRE_Vector b, HYPRE_Vector x );
-HYPRE_Int HYPRE_PCGSetTol ( HYPRE_Solver solver, HYPRE_Real tol );
-HYPRE_Int HYPRE_PCGGetTol ( HYPRE_Solver solver, HYPRE_Real *tol );
-HYPRE_Int HYPRE_PCGSetAbsoluteTol ( HYPRE_Solver solver, HYPRE_Real a_tol );
-HYPRE_Int HYPRE_PCGGetAbsoluteTol ( HYPRE_Solver solver, HYPRE_Real *a_tol );
-HYPRE_Int HYPRE_PCGSetAbsoluteTolFactor ( HYPRE_Solver solver, HYPRE_Real abstolf );
-HYPRE_Int HYPRE_PCGGetAbsoluteTolFactor ( HYPRE_Solver solver, HYPRE_Real *abstolf );
-HYPRE_Int HYPRE_PCGSetResidualTol ( HYPRE_Solver solver, HYPRE_Real rtol );
-HYPRE_Int HYPRE_PCGGetResidualTol ( HYPRE_Solver solver, HYPRE_Real *rtol );
-HYPRE_Int HYPRE_PCGSetConvergenceFactorTol ( HYPRE_Solver solver, HYPRE_Real cf_tol );
-HYPRE_Int HYPRE_PCGGetConvergenceFactorTol ( HYPRE_Solver solver, HYPRE_Real *cf_tol );
-HYPRE_Int HYPRE_PCGSetMaxIter ( HYPRE_Solver solver, HYPRE_Int max_iter );
-HYPRE_Int HYPRE_PCGGetMaxIter ( HYPRE_Solver solver, HYPRE_Int *max_iter );
-HYPRE_Int HYPRE_PCGSetStopCrit ( HYPRE_Solver solver, HYPRE_Int stop_crit );
-HYPRE_Int HYPRE_PCGGetStopCrit ( HYPRE_Solver solver, HYPRE_Int *stop_crit );
-HYPRE_Int HYPRE_PCGSetTwoNorm ( HYPRE_Solver solver, HYPRE_Int two_norm );
-HYPRE_Int HYPRE_PCGGetTwoNorm ( HYPRE_Solver solver, HYPRE_Int *two_norm );
-HYPRE_Int HYPRE_PCGSetRelChange ( HYPRE_Solver solver, HYPRE_Int rel_change );
-HYPRE_Int HYPRE_PCGGetRelChange ( HYPRE_Solver solver, HYPRE_Int *rel_change );
-HYPRE_Int HYPRE_PCGSetRecomputeResidual ( HYPRE_Solver solver, HYPRE_Int recompute_residual );
-HYPRE_Int HYPRE_PCGGetRecomputeResidual ( HYPRE_Solver solver, HYPRE_Int *recompute_residual );
-HYPRE_Int HYPRE_PCGSetRecomputeResidualP ( HYPRE_Solver solver, HYPRE_Int recompute_residual_p );
-HYPRE_Int HYPRE_PCGGetRecomputeResidualP ( HYPRE_Solver solver, HYPRE_Int *recompute_residual_p );
-HYPRE_Int HYPRE_PCGSetPrecond ( HYPRE_Solver solver, HYPRE_PtrToSolverFcn precond,
-                                HYPRE_PtrToSolverFcn precond_setup, HYPRE_Solver precond_solver );
-HYPRE_Int HYPRE_PCGGetPrecond ( HYPRE_Solver solver, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int HYPRE_PCGSetLogging ( HYPRE_Solver solver, HYPRE_Int level );
-HYPRE_Int HYPRE_PCGGetLogging ( HYPRE_Solver solver, HYPRE_Int *level );
-HYPRE_Int HYPRE_PCGSetPrintLevel ( HYPRE_Solver solver, HYPRE_Int level );
-HYPRE_Int HYPRE_PCGGetPrintLevel ( HYPRE_Solver solver, HYPRE_Int *level );
-HYPRE_Int HYPRE_PCGGetNumIterations ( HYPRE_Solver solver, HYPRE_Int *num_iterations );
-HYPRE_Int HYPRE_PCGGetConverged ( HYPRE_Solver solver, HYPRE_Int *converged );
-HYPRE_Int HYPRE_PCGGetFinalRelativeResidualNorm ( HYPRE_Solver solver, HYPRE_Real *norm );
-HYPRE_Int HYPRE_PCGGetResidual ( HYPRE_Solver solver, void *residual );
+  /* HYPRE_pcg.c */
+  HYPRE_Int HYPRE_PCGSetup ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_PCGSolve ( HYPRE_Solver solver , HYPRE_Matrix A , HYPRE_Vector b , HYPRE_Vector x );
+  HYPRE_Int HYPRE_PCGSetTol ( HYPRE_Solver solver , HYPRE_Real tol );
+  HYPRE_Int HYPRE_PCGGetTol ( HYPRE_Solver solver , HYPRE_Real *tol );
+  HYPRE_Int HYPRE_PCGSetAbsoluteTol ( HYPRE_Solver solver , HYPRE_Real a_tol );
+  HYPRE_Int HYPRE_PCGGetAbsoluteTol ( HYPRE_Solver solver , HYPRE_Real *a_tol );
+  HYPRE_Int HYPRE_PCGSetAbsoluteTolFactor ( HYPRE_Solver solver , HYPRE_Real abstolf );
+  HYPRE_Int HYPRE_PCGGetAbsoluteTolFactor ( HYPRE_Solver solver , HYPRE_Real *abstolf );
+  HYPRE_Int HYPRE_PCGSetResidualTol ( HYPRE_Solver solver , HYPRE_Real rtol );
+  HYPRE_Int HYPRE_PCGGetResidualTol ( HYPRE_Solver solver , HYPRE_Real *rtol );
+  HYPRE_Int HYPRE_PCGSetConvergenceFactorTol ( HYPRE_Solver solver , HYPRE_Real cf_tol );
+  HYPRE_Int HYPRE_PCGGetConvergenceFactorTol ( HYPRE_Solver solver , HYPRE_Real *cf_tol );
+  HYPRE_Int HYPRE_PCGSetMaxIter ( HYPRE_Solver solver , HYPRE_Int max_iter );
+  HYPRE_Int HYPRE_PCGGetMaxIter ( HYPRE_Solver solver , HYPRE_Int *max_iter );
+  HYPRE_Int HYPRE_PCGSetStopCrit ( HYPRE_Solver solver , HYPRE_Int stop_crit );
+  HYPRE_Int HYPRE_PCGGetStopCrit ( HYPRE_Solver solver , HYPRE_Int *stop_crit );
+  HYPRE_Int HYPRE_PCGSetTwoNorm ( HYPRE_Solver solver , HYPRE_Int two_norm );
+  HYPRE_Int HYPRE_PCGGetTwoNorm ( HYPRE_Solver solver , HYPRE_Int *two_norm );
+  HYPRE_Int HYPRE_PCGSetRelChange ( HYPRE_Solver solver , HYPRE_Int rel_change );
+  HYPRE_Int HYPRE_PCGGetRelChange ( HYPRE_Solver solver , HYPRE_Int *rel_change );
+  HYPRE_Int HYPRE_PCGSetRecomputeResidual ( HYPRE_Solver solver , HYPRE_Int recompute_residual );
+  HYPRE_Int HYPRE_PCGGetRecomputeResidual ( HYPRE_Solver solver , HYPRE_Int *recompute_residual );
+  HYPRE_Int HYPRE_PCGSetRecomputeResidualP ( HYPRE_Solver solver , HYPRE_Int recompute_residual_p );
+  HYPRE_Int HYPRE_PCGGetRecomputeResidualP ( HYPRE_Solver solver , HYPRE_Int *recompute_residual_p );
+  HYPRE_Int HYPRE_PCGSetPrecond ( HYPRE_Solver solver , HYPRE_PtrToSolverFcn precond , HYPRE_PtrToSolverFcn precond_setup , HYPRE_Solver precond_solver );
+  HYPRE_Int HYPRE_PCGGetPrecond ( HYPRE_Solver solver , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int HYPRE_PCGSetLogging ( HYPRE_Solver solver , HYPRE_Int level );
+  HYPRE_Int HYPRE_PCGGetLogging ( HYPRE_Solver solver , HYPRE_Int *level );
+  HYPRE_Int HYPRE_PCGSetPrintLevel ( HYPRE_Solver solver , HYPRE_Int level );
+  HYPRE_Int HYPRE_PCGGetPrintLevel ( HYPRE_Solver solver , HYPRE_Int *level );
+  HYPRE_Int HYPRE_PCGGetNumIterations ( HYPRE_Solver solver , HYPRE_Int *num_iterations );
+  HYPRE_Int HYPRE_PCGGetConverged ( HYPRE_Solver solver , HYPRE_Int *converged );
+  HYPRE_Int HYPRE_PCGGetFinalRelativeResidualNorm ( HYPRE_Solver solver , HYPRE_Real *norm );
+  HYPRE_Int HYPRE_PCGGetResidual ( HYPRE_Solver solver , void *residual );
 
-/* pcg.c */
-void *hypre_PCGCreate ( hypre_PCGFunctions *pcg_functions );
-HYPRE_Int hypre_PCGDestroy ( void *pcg_vdata );
-HYPRE_Int hypre_PCGGetResidual ( void *pcg_vdata, void **residual );
-HYPRE_Int hypre_PCGSetup ( void *pcg_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_PCGSolve ( void *pcg_vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_PCGSetTol ( void *pcg_vdata, HYPRE_Real tol );
-HYPRE_Int hypre_PCGGetTol ( void *pcg_vdata, HYPRE_Real *tol );
-HYPRE_Int hypre_PCGSetAbsoluteTol ( void *pcg_vdata, HYPRE_Real a_tol );
-HYPRE_Int hypre_PCGGetAbsoluteTol ( void *pcg_vdata, HYPRE_Real *a_tol );
-HYPRE_Int hypre_PCGSetAbsoluteTolFactor ( void *pcg_vdata, HYPRE_Real atolf );
-HYPRE_Int hypre_PCGGetAbsoluteTolFactor ( void *pcg_vdata, HYPRE_Real *atolf );
-HYPRE_Int hypre_PCGSetResidualTol ( void *pcg_vdata, HYPRE_Real rtol );
-HYPRE_Int hypre_PCGGetResidualTol ( void *pcg_vdata, HYPRE_Real *rtol );
-HYPRE_Int hypre_PCGSetConvergenceFactorTol ( void *pcg_vdata, HYPRE_Real cf_tol );
-HYPRE_Int hypre_PCGGetConvergenceFactorTol ( void *pcg_vdata, HYPRE_Real *cf_tol );
-HYPRE_Int hypre_PCGSetMaxIter ( void *pcg_vdata, HYPRE_Int max_iter );
-HYPRE_Int hypre_PCGGetMaxIter ( void *pcg_vdata, HYPRE_Int *max_iter );
-HYPRE_Int hypre_PCGSetTwoNorm ( void *pcg_vdata, HYPRE_Int two_norm );
-HYPRE_Int hypre_PCGGetTwoNorm ( void *pcg_vdata, HYPRE_Int *two_norm );
-HYPRE_Int hypre_PCGSetRelChange ( void *pcg_vdata, HYPRE_Int rel_change );
-HYPRE_Int hypre_PCGGetRelChange ( void *pcg_vdata, HYPRE_Int *rel_change );
-HYPRE_Int hypre_PCGSetRecomputeResidual ( void *pcg_vdata, HYPRE_Int recompute_residual );
-HYPRE_Int hypre_PCGGetRecomputeResidual ( void *pcg_vdata, HYPRE_Int *recompute_residual );
-HYPRE_Int hypre_PCGSetRecomputeResidualP ( void *pcg_vdata, HYPRE_Int recompute_residual_p );
-HYPRE_Int hypre_PCGGetRecomputeResidualP ( void *pcg_vdata, HYPRE_Int *recompute_residual_p );
-HYPRE_Int hypre_PCGSetStopCrit ( void *pcg_vdata, HYPRE_Int stop_crit );
-HYPRE_Int hypre_PCGGetStopCrit ( void *pcg_vdata, HYPRE_Int *stop_crit );
-HYPRE_Int hypre_PCGGetPrecond ( void *pcg_vdata, HYPRE_Solver *precond_data_ptr );
-HYPRE_Int hypre_PCGSetPrecond ( void *pcg_vdata, HYPRE_Int (*precond )(void*, void*, void*, void*),
-                                HYPRE_Int (*precond_setup )(void*, void*, void*, void*), void *precond_data );
-HYPRE_Int hypre_PCGSetPrintLevel ( void *pcg_vdata, HYPRE_Int level );
-HYPRE_Int hypre_PCGGetPrintLevel ( void *pcg_vdata, HYPRE_Int *level );
-HYPRE_Int hypre_PCGSetLogging ( void *pcg_vdata, HYPRE_Int level );
-HYPRE_Int hypre_PCGGetLogging ( void *pcg_vdata, HYPRE_Int *level );
-HYPRE_Int hypre_PCGSetHybrid ( void *pcg_vdata, HYPRE_Int level );
-HYPRE_Int hypre_PCGGetNumIterations ( void *pcg_vdata, HYPRE_Int *num_iterations );
-HYPRE_Int hypre_PCGGetConverged ( void *pcg_vdata, HYPRE_Int *converged );
-HYPRE_Int hypre_PCGPrintLogging ( void *pcg_vdata, HYPRE_Int myid );
-HYPRE_Int hypre_PCGGetFinalRelativeResidualNorm ( void *pcg_vdata,
-                                                  HYPRE_Real *relative_residual_norm );
+  /* pcg.c */
+  void *hypre_PCGCreate ( hypre_PCGFunctions *pcg_functions );
+  HYPRE_Int hypre_PCGDestroy ( void *pcg_vdata );
+  HYPRE_Int hypre_PCGGetResidual ( void *pcg_vdata , void **residual );
+  HYPRE_Int hypre_PCGSetup ( void *pcg_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_PCGSolve ( void *pcg_vdata , void *A , void *b , void *x );
+  HYPRE_Int hypre_PCGSetTol ( void *pcg_vdata , HYPRE_Real tol );
+  HYPRE_Int hypre_PCGGetTol ( void *pcg_vdata , HYPRE_Real *tol );
+  HYPRE_Int hypre_PCGSetAbsoluteTol ( void *pcg_vdata , HYPRE_Real a_tol );
+  HYPRE_Int hypre_PCGGetAbsoluteTol ( void *pcg_vdata , HYPRE_Real *a_tol );
+  HYPRE_Int hypre_PCGSetAbsoluteTolFactor ( void *pcg_vdata , HYPRE_Real atolf );
+  HYPRE_Int hypre_PCGGetAbsoluteTolFactor ( void *pcg_vdata , HYPRE_Real *atolf );
+  HYPRE_Int hypre_PCGSetResidualTol ( void *pcg_vdata , HYPRE_Real rtol );
+  HYPRE_Int hypre_PCGGetResidualTol ( void *pcg_vdata , HYPRE_Real *rtol );
+  HYPRE_Int hypre_PCGSetConvergenceFactorTol ( void *pcg_vdata , HYPRE_Real cf_tol );
+  HYPRE_Int hypre_PCGGetConvergenceFactorTol ( void *pcg_vdata , HYPRE_Real *cf_tol );
+  HYPRE_Int hypre_PCGSetMaxIter ( void *pcg_vdata , HYPRE_Int max_iter );
+  HYPRE_Int hypre_PCGGetMaxIter ( void *pcg_vdata , HYPRE_Int *max_iter );
+  HYPRE_Int hypre_PCGSetTwoNorm ( void *pcg_vdata , HYPRE_Int two_norm );
+  HYPRE_Int hypre_PCGGetTwoNorm ( void *pcg_vdata , HYPRE_Int *two_norm );
+  HYPRE_Int hypre_PCGSetRelChange ( void *pcg_vdata , HYPRE_Int rel_change );
+  HYPRE_Int hypre_PCGGetRelChange ( void *pcg_vdata , HYPRE_Int *rel_change );
+  HYPRE_Int hypre_PCGSetRecomputeResidual ( void *pcg_vdata , HYPRE_Int recompute_residual );
+  HYPRE_Int hypre_PCGGetRecomputeResidual ( void *pcg_vdata , HYPRE_Int *recompute_residual );
+  HYPRE_Int hypre_PCGSetRecomputeResidualP ( void *pcg_vdata , HYPRE_Int recompute_residual_p );
+  HYPRE_Int hypre_PCGGetRecomputeResidualP ( void *pcg_vdata , HYPRE_Int *recompute_residual_p );
+  HYPRE_Int hypre_PCGSetStopCrit ( void *pcg_vdata , HYPRE_Int stop_crit );
+  HYPRE_Int hypre_PCGGetStopCrit ( void *pcg_vdata , HYPRE_Int *stop_crit );
+  HYPRE_Int hypre_PCGGetPrecond ( void *pcg_vdata , HYPRE_Solver *precond_data_ptr );
+  HYPRE_Int hypre_PCGSetPrecond ( void *pcg_vdata , HYPRE_Int (*precond )(void*,void*,void*,void*), HYPRE_Int (*precond_setup )(void*,void*,void*,void*), void *precond_data );
+  HYPRE_Int hypre_PCGSetPrintLevel ( void *pcg_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_PCGGetPrintLevel ( void *pcg_vdata , HYPRE_Int *level );
+  HYPRE_Int hypre_PCGSetLogging ( void *pcg_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_PCGGetLogging ( void *pcg_vdata , HYPRE_Int *level );
+  HYPRE_Int hypre_PCGSetHybrid ( void *pcg_vdata , HYPRE_Int level );
+  HYPRE_Int hypre_PCGGetNumIterations ( void *pcg_vdata , HYPRE_Int *num_iterations );
+  HYPRE_Int hypre_PCGGetConverged ( void *pcg_vdata , HYPRE_Int *converged );
+  HYPRE_Int hypre_PCGPrintLogging ( void *pcg_vdata , HYPRE_Int myid );
+  HYPRE_Int hypre_PCGGetFinalRelativeResidualNorm ( void *pcg_vdata , HYPRE_Real *relative_residual_norm );
 
 #ifdef __cplusplus
 }

--- a/src/parcsr_ls/F90_HYPRE_parcsr_gmres.c
+++ b/src/parcsr_ls/F90_HYPRE_parcsr_gmres.c
@@ -105,6 +105,22 @@ hypre_F90_IFACE(hypre_parcsrgmressetkdim, HYPRE_PARCSRGMRESSETKDIM)
 }
 
 /*--------------------------------------------------------------------------
+ * HYPRE_ParCSRGMRESSetCGS
+ *--------------------------------------------------------------------------*/
+
+void
+hypre_F90_IFACE(hypre_parcsrgmressetcgs, HYPRE_PARCSRGMRESSETCGS)
+   ( hypre_F90_Obj *solver,
+     hypre_F90_Int *cgs,
+     hypre_F90_Int *ierr    )
+{
+   *ierr = (hypre_F90_Int)
+      ( HYPRE_ParCSRGMRESSetCGS(
+           hypre_F90_PassObj (HYPRE_Solver, solver),
+           hypre_F90_PassInt (cgs)    ) );
+}
+
+/*--------------------------------------------------------------------------
  * HYPRE_ParCSRGMRESSetTol
  *--------------------------------------------------------------------------*/
 

--- a/src/parcsr_ls/HYPRE_parcsr_gmres.c
+++ b/src/parcsr_ls/HYPRE_parcsr_gmres.c
@@ -31,6 +31,7 @@ HYPRE_ParCSRGMRESCreate( MPI_Comm comm, HYPRE_Solver *solver )
          hypre_ParKrylovInnerProd, hypre_ParKrylovCopyVector,
          hypre_ParKrylovClearVector,
          hypre_ParKrylovScaleVector, hypre_ParKrylovAxpy,
+         hypre_ParKrylovMassInnerProd, hypre_ParKrylovMassAxpy,
          hypre_ParKrylovIdentitySetup, hypre_ParKrylovIdentity );
    *solver = ( (HYPRE_Solver) hypre_GMRESCreate( gmres_functions ) );
 
@@ -88,6 +89,17 @@ HYPRE_ParCSRGMRESSetKDim( HYPRE_Solver solver,
                           HYPRE_Int             k_dim    )
 {
    return ( HYPRE_GMRESSetKDim( solver, k_dim ) );
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_ParCSRGMRESSetCGS
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_ParCSRGMRESSetCGS( HYPRE_Solver solver,
+                         HYPRE_Int             cgs    )
+{
+   return( HYPRE_GMRESSetCGS( solver, cgs ) );
 }
 
 /*--------------------------------------------------------------------------

--- a/src/parcsr_ls/HYPRE_parcsr_ls.h
+++ b/src/parcsr_ls/HYPRE_parcsr_ls.h
@@ -2740,6 +2740,9 @@ HYPRE_Int HYPRE_ParCSRGMRESSolve(HYPRE_Solver       solver,
 HYPRE_Int HYPRE_ParCSRGMRESSetKDim(HYPRE_Solver solver,
                                    HYPRE_Int    k_dim);
 
+HYPRE_Int HYPRE_ParCSRGMRESSetCGS(HYPRE_Solver solver,
+                                  HYPRE_Int    cgs);
+
 HYPRE_Int HYPRE_ParCSRGMRESSetTol(HYPRE_Solver solver,
                                   HYPRE_Real   tol);
 

--- a/src/parcsr_ls/amg_hybrid.c
+++ b/src/parcsr_ls/amg_hybrid.c
@@ -1950,6 +1950,7 @@ hypre_AMGHybridSolve( void               *AMGhybrid_vdata,
                   hypre_ParKrylovInnerProd, hypre_ParKrylovCopyVector,
                   hypre_ParKrylovClearVector,
                   hypre_ParKrylovScaleVector, hypre_ParKrylovAxpy,
+                  hypre_ParKrylovMassInnerProd, hypre_ParKrylovMassAxpy,
                   hypre_ParKrylovIdentitySetup, hypre_ParKrylovIdentity );
             pcg_solver = hypre_GMRESCreate( gmres_functions );
 

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -343,6 +343,12 @@ HYPRE_Int hypre_CSRMatrixIntSpMVDevice( HYPRE_Int num_rows, HYPRE_Int num_nonzer
                                         HYPRE_Int *d_a, HYPRE_Int *d_x, HYPRE_Int beta,
                                         HYPRE_Int *d_y );
 
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+HYPRE_Int hypreDevice_MassAxpy(HYPRE_Int k, HYPRE_Int n, HYPRE_Complex *alpha, HYPRE_Complex *x, HYPRE_Complex *y);
+HYPRE_Int hypreDevice_MassInnerProd(HYPRE_Int k, HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex *y, HYPRE_Complex *result);
+HYPRE_Int hypreDevice_MassDotpTwo(HYPRE_Int k, HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex *y, HYPRE_Complex *z, HYPRE_Complex *result_x, HYPRE_Complex *result_y);
+#endif
+
 #if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE) || defined(HYPRE_USING_ONEMKLSPARSE)
 hypre_CsrsvData* hypre_CsrsvDataCreate();
 void hypre_CsrsvDataDestroy(hypre_CsrsvData *data);

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -619,6 +619,12 @@ HYPRE_Int hypre_CSRMatrixIntSpMVDevice( HYPRE_Int num_rows, HYPRE_Int num_nonzer
                                         HYPRE_Int *d_a, HYPRE_Int *d_x, HYPRE_Int beta,
                                         HYPRE_Int *d_y );
 
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+HYPRE_Int hypreDevice_MassAxpy(HYPRE_Int k, HYPRE_Int n, HYPRE_Complex *alpha, HYPRE_Complex *x, HYPRE_Complex *y);
+HYPRE_Int hypreDevice_MassInnerProd(HYPRE_Int k, HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex *y, HYPRE_Complex *result);
+HYPRE_Int hypreDevice_MassDotpTwo(HYPRE_Int k, HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex *y, HYPRE_Complex *z, HYPRE_Complex *result_x, HYPRE_Complex *result_y);
+#endif
+
 #if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE) || defined(HYPRE_USING_ONEMKLSPARSE)
 hypre_CsrsvData* hypre_CsrsvDataCreate();
 void hypre_CsrsvDataDestroy(hypre_CsrsvData *data);

--- a/src/seq_mv/vector_device.c
+++ b/src/seq_mv/vector_device.c
@@ -371,3 +371,478 @@ hypre_SeqVectorPrefetch( hypre_Vector        *x,
 }
 
 #endif
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+
+__global__ void
+hypreGPUKernel_MassAxpy(hypre_DeviceItem &item, const HYPRE_Int k, const HYPRE_Int n, const HYPRE_Complex * __restrict__ alpha, const HYPRE_Complex * __restrict__ x, HYPRE_Complex * __restrict__ y)
+{
+   HYPRE_Int i = hypre_gpu_get_grid_thread_id<1,1>(item);
+   HYPRE_Int j = 0;
+   HYPRE_Complex sum = 0.0, xx=0.0;
+
+   if (i < n)
+   {
+      for (j = 0; j < k; ++j)
+      {
+         xx = x[j*n+i];
+         sum += alpha[j] * xx;
+      }
+      y[i] += sum;
+   }
+}
+
+HYPRE_Int
+hypreDevice_MassAxpy(HYPRE_Int k, HYPRE_Int n, HYPRE_Complex *alpha, HYPRE_Complex *x, HYPRE_Complex *y)
+{
+   /* trivial case */
+   if (n <= 0 || k<=0)
+   {
+      return hypre_error_flag;
+   }
+
+   dim3 bDim = hypre_GetDefaultDeviceBlockDimension();
+   dim3 gDim = hypre_GetDefaultDeviceGridDimension(n, "thread", bDim);
+   HYPRE_GPU_LAUNCH( hypreGPUKernel_MassAxpy, gDim, bDim, k, n, alpha, x, y);
+   return hypre_error_flag;
+}
+
+template<HYPRE_Int B, HYPRE_Int WS>
+__global__ void
+hypreGPUKernel_MassInnerProd_kernel1(const HYPRE_Int k, const HYPRE_Int n, const HYPRE_Complex * __restrict__ x, const HYPRE_Complex * __restrict__ y, HYPRE_Complex * __restrict__ z)
+{
+   constexpr HYPRE_Int size=B/WS;
+   extern volatile __shared__ HYPRE_Complex shmem[];
+   HYPRE_Int i = 0, j = 0, ii=0;
+   HYPRE_Int tidx = threadIdx.x+blockDim.x*blockIdx.x;
+   HYPRE_Int warp_lane = threadIdx.x & (WS - 1);
+   HYPRE_Int warp_id = threadIdx.x / WS;
+   HYPRE_Complex xx = 0.0, sum = 0.0;
+
+   i=threadIdx.x;
+   while(i<size*k)
+   {
+      shmem[i] = 0.0;
+	  i+=blockDim.x;
+   }
+   __syncthreads();
+
+   for (ii=tidx; ii<n; ii+=blockDim.x*gridDim.x)
+   {
+	  xx = x[ii];
+
+      for (j=0; j<k; ++j)
+      {
+         sum = xx*y[ii+j*n];
+
+         // Warp shuffle reduce
+#pragma unroll
+         for (i = WS>>1; i > 0; i >>= 1)
+         {
+            sum += __shfl_down_sync(WS, sum, i);
+         }
+
+		 // Save in shmem for each k-value
+		 if (warp_lane==0)
+		 {
+		    shmem[warp_id+j*size] += sum;
+		 }
+	  }
+   }
+   __syncthreads();
+
+   // Complete the reduction for each k-value
+   HYPRE_Int reduce_id =   threadIdx.x / size;
+   HYPRE_Int reduce_lane = threadIdx.x % size;
+   for (j=reduce_id; j<k; j+=WS)
+   {
+      sum = shmem[reduce_lane+j*size];
+
+#pragma unroll
+      for (i = size>>1; i > 0; i >>= 1)
+      {
+         sum += __shfl_down_sync(size, sum, i);
+	  }
+
+      /* Write to global memory */
+      if (reduce_lane==0)
+      {
+         z[blockIdx.x+j*gridDim.x] = sum;
+      }
+   }
+}
+
+
+template<HYPRE_Int B, HYPRE_Int WS>
+__global__ void
+hypreGPUKernel_MassInnerProd_kernel2(const HYPRE_Int n, const HYPRE_Complex * __restrict__ z, HYPRE_Complex * __restrict__ w)
+{
+   const HYPRE_Int size=B/WS;
+   volatile __shared__ HYPRE_Complex shmem[size];
+   HYPRE_Int i = 0;
+   HYPRE_Int warp_lane = threadIdx.x & (WS - 1);
+   HYPRE_Int warp_id = threadIdx.x / WS;
+   HYPRE_Complex sum = 0.0, zz = 0.0;
+
+   for (i=threadIdx.x; i<n; i+=blockDim.x)
+   {
+      zz = z[blockIdx.x*n + i];
+      sum += zz;
+   }
+
+   // Warp shuffle reduce
+#pragma unroll
+   for (i = WS>>1; i > 0; i >>= 1)
+   {
+      sum += __shfl_down_sync(WS, sum, i);
+   }
+
+   // Combine across warps through shmem
+   __syncthreads();
+   if (warp_lane==0)
+   {
+      shmem[warp_id] = sum;
+   }
+   __syncthreads();
+
+   // Put it back in a register to finish the reduction
+   if (threadIdx.x<size)
+   {
+      sum = shmem[threadIdx.x];
+   }
+
+   // Warp shuffle reduce
+#pragma unroll
+   for (i = size>>1; i > 0; i >>= 1)
+   {
+      sum += __shfl_down_sync(size, sum, i);
+   }
+
+   /* Write to global memory */
+   if (threadIdx.x==0)
+   {
+      w[blockIdx.x] = sum;
+   }
+}
+
+
+template<HYPRE_Int B, HYPRE_Int WS>
+__global__ void
+hypreGPUKernel_MassDotpTwo_kernel1(const HYPRE_Int k, const HYPRE_Int n, const HYPRE_Complex * __restrict__ x, const HYPRE_Complex * __restrict__ y, const HYPRE_Complex * __restrict__ z, HYPRE_Complex * __restrict__ res_x, HYPRE_Complex * __restrict__ res_y)
+{
+   constexpr HYPRE_Int size=B/WS;
+   extern volatile __shared__ HYPRE_Complex shmem[];
+   HYPRE_Int i = 0, j = 0, ii=0;
+   HYPRE_Int tidx = threadIdx.x+blockDim.x*blockIdx.x;
+   HYPRE_Int warp_lane = threadIdx.x & (WS - 1);
+   HYPRE_Int warp_id = threadIdx.x / WS;
+   HYPRE_Complex xx = 0.0, yy = 0.0, zz = 0.0;
+   HYPRE_Complex sum_x = 0.0, sum_y = 0.0;
+
+   i=threadIdx.x;
+   while(i<2*size*k)
+   {
+      shmem[i] = 0.0;
+	  i+=blockDim.x;
+   }
+   __syncthreads();
+
+   for (ii=tidx; ii<n; ii+=blockDim.x*gridDim.x)
+   {
+	  xx = x[ii];
+	  yy = y[ii];
+
+      for (j=0; j<k; ++j)
+      {
+         zz = z[ii+j*n];
+         sum_x = xx*zz;
+         sum_y = yy*zz;
+
+         // Warp shuffle reduce
+#pragma unroll
+         for (i = WS>>1; i > 0; i >>= 1)
+         {
+            sum_x += __shfl_down_sync(WS, sum_x, i);
+            sum_y += __shfl_down_sync(WS, sum_y, i);
+         }
+
+		 // Save in shmem for each k-value
+		 if (warp_lane==0)
+		 {
+		    shmem[warp_id+j*size]        += sum_x;
+		    shmem[warp_id+j*size+k*size] += sum_y;
+		 }
+	  }
+   }
+   __syncthreads();
+
+   // Complete the reduction for each k-value
+   HYPRE_Int reduce_id =   threadIdx.x / size;
+   HYPRE_Int reduce_lane = threadIdx.x % size;
+   for (j=reduce_id; j<k; j+=WS)
+   {
+      sum_x = shmem[reduce_lane+j*size];
+      sum_y = shmem[reduce_lane+j*size+k*size];
+
+#pragma unroll
+      for (i = size>>1; i > 0; i >>= 1)
+      {
+         sum_x += __shfl_down_sync(size, sum_x, i);
+         sum_y += __shfl_down_sync(size, sum_y, i);
+	  }
+
+      /* Write to global memory */
+      if (reduce_lane==0)
+      {
+		 res_x[blockIdx.x+j*gridDim.x] = sum_x;
+		 res_y[blockIdx.x+j*gridDim.x] = sum_y;
+      }
+   }
+}
+
+template<HYPRE_Int B, HYPRE_Int WS>
+__global__ void
+hypreGPUKernel_MassDotpTwo_kernel2(const HYPRE_Int n, const HYPRE_Complex * __restrict__ z1, HYPRE_Complex *w1, const HYPRE_Complex * __restrict__ z2, HYPRE_Complex * __restrict__ w2)
+{
+   const HYPRE_Int size=B/WS;
+   volatile __shared__ HYPRE_Complex shmem[size*2];
+   HYPRE_Int i = 0;
+   HYPRE_Int warp_lane = threadIdx.x & (WS - 1);
+   HYPRE_Int warp_id = threadIdx.x / WS;
+   HYPRE_Complex sum1 = 0.0, sum2 = 0.0;
+   HYPRE_Complex zz1 = 0.0, zz2 = 0.0;
+
+   for (i=threadIdx.x; i<n; i+=blockDim.x)
+   {
+      zz1 = z1[blockIdx.x*n + i];
+      zz2 = z2[blockIdx.x*n + i];
+      sum1 += zz1;
+      sum2 += zz2;
+   }
+
+   // Warp shuffle reduce
+#pragma unroll
+   for (i = WS>>1; i > 0; i >>= 1)
+   {
+      sum1 += __shfl_down_sync(WS, sum1, i);
+      sum2 += __shfl_down_sync(WS, sum2, i);
+   }
+
+   // Combine across warps through shmem
+   __syncthreads();
+   if (warp_lane==0)
+   {
+      shmem[warp_id]      = sum1;
+      shmem[warp_id+size] = sum2;
+   }
+   __syncthreads();
+
+   // Put it back in a register to finish the reduction
+   if (threadIdx.x<size)
+   {
+      sum1 = shmem[threadIdx.x];
+      sum2 = shmem[threadIdx.x+size];
+   }
+
+   // Warp shuffle reduce
+#pragma unroll
+   for (i = size>>1; i > 0; i >>= 1)
+   {
+      sum1 += __shfl_down_sync(size, sum1, i);
+      sum2 += __shfl_down_sync(size, sum2, i);
+   }
+
+   /* Write to global memory */
+   if (threadIdx.x==0)
+   {
+      w1[blockIdx.x] = sum1;
+      w2[blockIdx.x] = sum2;
+   }
+}
+
+
+struct DivOp : public thrust::unary_function<HYPRE_Int,HYPRE_Int>
+{
+  HYPRE_Int _n;
+  DivOp(HYPRE_Int n) : _n(n)
+  {
+  }
+
+   __host__ __device__
+   HYPRE_Int operator()(HYPRE_Int x) const
+   {
+     return x/_n;
+   }
+};
+
+struct ModOp : public thrust::unary_function<HYPRE_Int,HYPRE_Int>
+{
+  HYPRE_Int _n;
+  ModOp(HYPRE_Int n) : _n(n)
+  {
+  }
+
+   __host__ __device__
+   HYPRE_Int operator()(HYPRE_Int x) const
+   {
+     return x%_n;
+   }
+};
+
+struct multTupleComponents : public thrust::unary_function<thrust::tuple<HYPRE_Complex, HYPRE_Complex> ,HYPRE_Complex>
+{
+  __host__ __device__
+  HYPRE_Complex operator()(thrust::tuple<HYPRE_Complex, HYPRE_Complex> x) const
+  {
+    return thrust::get<0>(x)*thrust::get<1>(x);
+  }
+};
+
+
+HYPRE_Int
+hypreDevice_MassInnerProd(HYPRE_Int k, HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex *y, HYPRE_Complex *result)
+{
+   /* trivial case */
+   if (n <= 0 || k<=0)
+   {
+      return hypre_error_flag;
+   }
+
+#if 0
+
+   HYPRE_Int * d_keys_out = hypre_CTAlloc(HYPRE_Int,k,HYPRE_MEMORY_DEVICE);
+   HYPRE_Complex * d_result = hypre_CTAlloc(HYPRE_Complex,k,HYPRE_MEMORY_DEVICE);
+
+   DivOp divOp(n);
+   ModOp modOp(n);
+   multTupleComponents mult;
+
+   typedef thrust::counting_iterator<HYPRE_Int> countIter;
+   typedef thrust::transform_iterator<ModOp, countIter> transIter;
+   typedef thrust::permutation_iterator<HYPRE_Complex *, transIter> permIter;
+   typedef thrust::tuple<HYPRE_Complex *, permIter> IterTuple;
+   typedef thrust::zip_iterator<IterTuple> zipIter;
+
+   // thrust reduce by key
+   HYPRE_THRUST_CALL(reduce_by_key,
+                     thrust::make_transform_iterator<DivOp, countIter>(thrust::make_counting_iterator(0),   divOp),
+                     thrust::make_transform_iterator<DivOp, countIter>(thrust::make_counting_iterator(k*n), divOp),
+                     thrust::make_transform_iterator<multTupleComponents, zipIter>(
+                        thrust::make_tuple(y, thrust::make_permutation_iterator(x, thrust::make_transform_iterator(thrust::make_counting_iterator(0), modOp))),
+                        mult),
+                     d_keys_out,
+                     d_result);
+
+   hypre_TMemcpy(result, d_result, HYPRE_Complex, k, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(d_keys_out,HYPRE_MEMORY_DEVICE);
+   hypre_TFree(d_result,HYPRE_MEMORY_DEVICE);
+
+#else
+
+   HYPRE_Int warpSize, dev, numSMs, maxThreads;
+#if defined(HYPRE_USING_CUDA)
+   struct cudaDeviceProp deviceProp;
+   HYPRE_CUDA_CALL( cudaGetDevice(&dev) );
+   HYPRE_CUDA_CALL( cudaGetDeviceProperties(&deviceProp, dev) );
+#endif
+
+#if defined(HYPRE_USING_HIP)
+   hipDeviceProp_t deviceProp;
+   HYPRE_HIP_CALL( hipGetDevice(&dev) );
+   HYPRE_HIP_CALL( hipGetDeviceProperties(&deviceProp, dev) );
+#endif
+
+   // Get the warpSize
+   warpSize = deviceProp.warpSize;
+   numSMs = deviceProp.multiProcessorCount;
+   maxThreads = deviceProp.maxThreadsPerMultiProcessor;
+
+   const HYPRE_Int numThreads = 256;
+   const int numBlocks = min(8*(maxThreads/numThreads)*numSMs, (n+numThreads-1)/numThreads);
+
+   HYPRE_Complex * d_result;
+   HYPRE_Int totalMem = k*numBlocks+k;
+
+   d_result = hypre_CTAlloc(HYPRE_Complex,totalMem,HYPRE_MEMORY_DEVICE);
+
+   /* Kernel 1 : Initial Reduction */
+   const HYPRE_Int shmemSize = sizeof(HYPRE_Complex)*k*(numThreads/warpSize);
+   if (warpSize==64)
+   {
+	   hypreGPUKernel_MassInnerProd_kernel1<numThreads,64><<<numBlocks,numThreads,shmemSize>>>(k, n, x, y, d_result);
+	   hypreGPUKernel_MassInnerProd_kernel2<numThreads,64><<<k,numThreads>>>(numBlocks, d_result, d_result+k*numBlocks);
+   }
+   else
+   {
+      hypreGPUKernel_MassInnerProd_kernel1<numThreads,32><<<numBlocks,numThreads,shmemSize>>>(k, n, x, y, d_result);
+	  hypreGPUKernel_MassInnerProd_kernel2<numThreads,32><<<k,numThreads>>>(numBlocks, d_result, d_result+k*numBlocks);
+   }
+   hypre_TMemcpy(result, d_result+k*numBlocks, HYPRE_Complex, k, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(d_result, HYPRE_MEMORY_DEVICE);
+
+#endif
+   return hypre_error_flag;
+}
+
+
+
+
+HYPRE_Int
+hypreDevice_MassDotpTwo(HYPRE_Int k, HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex *y, HYPRE_Complex *z, HYPRE_Complex *result_x, HYPRE_Complex *result_y)
+{
+   /* trivial case */
+   if (n <= 0 || k<=0)
+   {
+      return hypre_error_flag;
+   }
+
+   HYPRE_Int warpSize, dev, numSMs, maxThreads;
+
+#if defined(HYPRE_USING_CUDA)
+   struct cudaDeviceProp deviceProp;
+   HYPRE_CUDA_CALL( cudaGetDevice(&dev) );
+   HYPRE_CUDA_CALL( cudaGetDeviceProperties(&deviceProp, dev) );
+#endif
+
+#if defined(HYPRE_USING_HIP)
+   hipDeviceProp_t deviceProp;
+   HYPRE_HIP_CALL( hipGetDevice(&dev) );
+   HYPRE_HIP_CALL( hipGetDeviceProperties(&deviceProp, dev) );
+#endif
+
+   // Get the warpSize
+   warpSize = deviceProp.warpSize;
+   numSMs = deviceProp.multiProcessorCount;
+   maxThreads = deviceProp.maxThreadsPerMultiProcessor;
+
+   const HYPRE_Int numThreads = 256;
+   const int numBlocks = min(8*(maxThreads/numThreads)*numSMs, (n+numThreads-1)/numThreads);
+
+   HYPRE_Complex * d_result;
+   HYPRE_Int totalMem = 2*(k*numBlocks+k);
+
+   d_result = hypre_CTAlloc(HYPRE_Complex,totalMem,HYPRE_MEMORY_DEVICE);
+
+   HYPRE_Complex * d_result_x = d_result;
+   HYPRE_Complex * d_result_y = d_result + totalMem/2;
+
+   /* Kernel 1 : Initial Reduction */
+   const HYPRE_Int shmemSize = sizeof(HYPRE_Complex)*k*(numThreads/warpSize)*2;
+   if (warpSize==64)
+   {
+      hypreGPUKernel_MassDotpTwo_kernel1<numThreads,64><<<numBlocks,numThreads,shmemSize>>>(k, n, x, y, z, d_result_x, d_result_y);
+	  hypreGPUKernel_MassDotpTwo_kernel2<numThreads,64><<<k,numThreads>>>(numBlocks, d_result_x, d_result_x+k*numBlocks, d_result_y, d_result_y+k*numBlocks);
+   }
+   else
+   {
+      hypreGPUKernel_MassDotpTwo_kernel1<numThreads,32><<<numBlocks,numThreads,shmemSize>>>(k, n, x, y, z, d_result_x, d_result_y);
+	  hypreGPUKernel_MassDotpTwo_kernel2<numThreads,32><<<k,numThreads>>>(numBlocks, d_result_x, d_result_x+k*numBlocks, d_result_y, d_result_y+k*numBlocks);
+   }
+   hypre_TMemcpy(result_x, d_result_x + k*numBlocks, HYPRE_Complex, k, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+   hypre_TMemcpy(result_y, d_result_y + k*numBlocks, HYPRE_Complex, k, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(d_result, HYPRE_MEMORY_DEVICE);
+
+   return hypre_error_flag;
+}
+
+#endif // #if defined(HYPRE_USING_CUDA)  || defined(HYPRE_USING_HIP)

--- a/src/sstruct_ls/HYPRE_sstruct_gmres.c
+++ b/src/sstruct_ls/HYPRE_sstruct_gmres.c
@@ -24,6 +24,8 @@ HYPRE_SStructGMRESCreate( MPI_Comm             comm,
          hypre_SStructKrylovInnerProd, hypre_SStructKrylovCopyVector,
          hypre_SStructKrylovClearVector,
          hypre_SStructKrylovScaleVector, hypre_SStructKrylovAxpy,
+         hypre_StructKrylovMassInnerProd,
+         hypre_StructKrylovMassAxpy,
          hypre_SStructKrylovIdentitySetup, hypre_SStructKrylovIdentity );
 
    *solver = ( (HYPRE_SStructSolver) hypre_GMRESCreate( gmres_functions ) );

--- a/src/sstruct_ls/_hypre_sstruct_ls.h
+++ b/src/sstruct_ls/_hypre_sstruct_ls.h
@@ -595,9 +595,11 @@ HYPRE_Int hypre_SStructKrylovMatvecDestroy ( void *matvec_data );
 HYPRE_Real hypre_SStructKrylovInnerProd ( void *x, void *y );
 HYPRE_Int hypre_SStructKrylovCopyVector ( void *x, void *y );
 HYPRE_Int hypre_SStructKrylovClearVector ( void *x );
-HYPRE_Int hypre_SStructKrylovScaleVector ( HYPRE_Complex alpha, void *x );
-HYPRE_Int hypre_SStructKrylovAxpy ( HYPRE_Complex alpha, void *x, void *y );
-HYPRE_Int hypre_SStructKrylovCommInfo ( void *A, HYPRE_Int *my_id, HYPRE_Int *num_procs );
+HYPRE_Int hypre_SStructKrylovScaleVector ( HYPRE_Complex alpha , void *x );
+HYPRE_Int hypre_SStructKrylovAxpy ( HYPRE_Complex alpha , void *x , void *y );
+HYPRE_Int hypre_SStructKrylovCommInfo ( void *A , HYPRE_Int *my_id , HYPRE_Int *num_procs );
+HYPRE_Int hypre_SStructKrylovMassAxpy ( HYPRE_Complex *alpha, void **x, void *y, HYPRE_Int k, HYPRE_Int unroll );
+HYPRE_Int hypre_SStructKrylovMassInnerProd ( void *x , void **y, HYPRE_Int k, HYPRE_Int unroll, void *result );
 
 /* maxwell_grad.c */
 hypre_ParCSRMatrix *hypre_Maxwell_Grad ( hypre_SStructGrid *grid );

--- a/src/sstruct_ls/krylov_sstruct.c
+++ b/src/sstruct_ls/krylov_sstruct.c
@@ -273,3 +273,28 @@ hypre_SStructKrylovCommInfo( void  *A,
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_SStructKrylovMassAxpy( HYPRE_Complex *alpha,
+                             void **x,
+                             void *y,
+                             HYPRE_Int k,
+                             HYPRE_Int unroll )
+{
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int hypre_SStructKrylovMassInnerProd( void *x ,
+                                            void **y,
+                                            HYPRE_Int k,
+                                            HYPRE_Int unroll,
+                                            void *result )
+{
+   return hypre_error_flag;
+}
+

--- a/src/struct_ls/HYPRE_struct_gmres.c
+++ b/src/struct_ls/HYPRE_struct_gmres.c
@@ -23,6 +23,8 @@ HYPRE_StructGMRESCreate( MPI_Comm comm, HYPRE_StructSolver *solver )
          hypre_StructKrylovInnerProd, hypre_StructKrylovCopyVector,
          hypre_StructKrylovClearVector,
          hypre_StructKrylovScaleVector, hypre_StructKrylovAxpy,
+         hypre_StructKrylovMassInnerProd,
+         hypre_StructKrylovMassAxpy,
          hypre_StructKrylovIdentitySetup, hypre_StructKrylovIdentity );
 
    *solver = ( (HYPRE_StructSolver) hypre_GMRESCreate( gmres_functions ) );

--- a/src/struct_ls/_hypre_struct_ls.h
+++ b/src/struct_ls/_hypre_struct_ls.h
@@ -120,11 +120,13 @@ HYPRE_Int hypre_StructKrylovMatvecDestroy ( void *matvec_data );
 HYPRE_Real hypre_StructKrylovInnerProd ( void *x, void *y );
 HYPRE_Int hypre_StructKrylovCopyVector ( void *x, void *y );
 HYPRE_Int hypre_StructKrylovClearVector ( void *x );
-HYPRE_Int hypre_StructKrylovScaleVector ( HYPRE_Complex alpha, void *x );
-HYPRE_Int hypre_StructKrylovAxpy ( HYPRE_Complex alpha, void *x, void *y );
-HYPRE_Int hypre_StructKrylovIdentitySetup ( void *vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_StructKrylovIdentity ( void *vdata, void *A, void *b, void *x );
-HYPRE_Int hypre_StructKrylovCommInfo ( void *A, HYPRE_Int *my_id, HYPRE_Int *num_procs );
+HYPRE_Int hypre_StructKrylovScaleVector ( HYPRE_Complex alpha , void *x );
+HYPRE_Int hypre_StructKrylovAxpy ( HYPRE_Complex alpha , void *x , void *y );
+HYPRE_Int hypre_StructKrylovIdentitySetup ( void *vdata , void *A , void *b , void *x );
+HYPRE_Int hypre_StructKrylovIdentity ( void *vdata , void *A , void *b , void *x );
+HYPRE_Int hypre_StructKrylovCommInfo ( void *A , HYPRE_Int *my_id , HYPRE_Int *num_procs );
+HYPRE_Int hypre_StructKrylovMassAxpy ( HYPRE_Complex *alpha, void **x, void *y, HYPRE_Int k, HYPRE_Int unroll );
+HYPRE_Int hypre_StructKrylovMassInnerProd ( void *x , void **y, HYPRE_Int k, HYPRE_Int unroll, void *result );
 
 /* pfmg2_setup_rap.c */
 hypre_StructMatrix *hypre_PFMG2CreateRAPOp ( hypre_StructMatrix *R, hypre_StructMatrix *A,

--- a/src/struct_ls/hybrid.c
+++ b/src/struct_ls/hybrid.c
@@ -501,6 +501,7 @@ hypre_HybridSolveUseGMRES( hypre_HybridData  *hybrid_data )
          hypre_StructKrylovInnerProd, hypre_StructKrylovCopyVector,
          hypre_StructKrylovClearVector,
          hypre_StructKrylovScaleVector, hypre_StructKrylovAxpy,
+         hypre_StructKrylovMassInnerProd, hypre_StructKrylovMassAxpy,
          hypre_StructKrylovIdentitySetup, hypre_StructKrylovIdentity );
    krylov_solver = hypre_GMRESCreate( gmres_functions );
 

--- a/src/struct_ls/pcg_struct.c
+++ b/src/struct_ls/pcg_struct.c
@@ -222,3 +222,27 @@ hypre_StructKrylovCommInfo( void  *A,
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_StructKrylovMassAxpy( HYPRE_Complex *alpha,
+                            void **x,
+                            void *y,
+                            HYPRE_Int k,
+                            HYPRE_Int unroll )
+{
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int hypre_StructKrylovMassInnerProd( void *x ,
+                                           void **y,
+                                           HYPRE_Int k,
+                                           HYPRE_Int unroll,
+                                           void *result )
+{
+   return hypre_error_flag;
+}


### PR DESCRIPTION
    Implementation of GMRES, COGMRES GramSchmidt using MassDotpTwo, MassInnerProduct and MassAxpy.

    This includes the an option to choose classical (CGS) or modified Gram-Schmidt (MGS) in GMRES.

    There is also a Thrust and pure Cuda implementation of MassInnerProduct. The Thrust
    implementation is more than 2x slower than the pure Cuda implementation at the kernel level.
    For a Krylov iteration with 100 vectors (3e6 elements per vector) and 30 GMRES iterations, Thrust-based
    CGS is 2.4x faster than MGS. Cuda-based CGS is 3.5x faster than MGS.

    Both the Thrust and Cuda versions have been tested on Summit and Spock on multiple GPUs.

    The cogmres implementation has been fixed to have 3 possible choices
    1) cgs=0: 1 sync, with delayed norm and a CPU based triangular solve for orthogonalization. This is the
    proper implementation. It shows some scaling benefit.
    2) cgs=1: classical Gram-Schmidt. Then, cogmres is identical to gmres.
    3) otherwise: 2 sync, NO delayed norm and a CPU based triangular solve for orthogonalization. This a partial
    implementation between cgs=0 and cgs=1.
