### PR TITLE
Portability issue on MinGW

### DIFF
--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1792,7 +1792,7 @@ static inline HYPRE_Int
 first_lsb_bit_indx( hypre_uint x )
 {
    HYPRE_Int pos;
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW64__)
    if (x == 0)
    {
       pos = 0;


### PR DESCRIPTION
```
          CC fr/obj/mat/impls/hypre/mhypre.o
In file included from C:/msys64/ff-petsc/r/include/_hypre_parcsr_mv.h:9,
                 from C:/msys64/3rdparty/ff-petsc/petsc-3.16.0/include/petscmathypre.h:5,
                 from C:/msys64/3rdparty/ff-petsc/petsc-3.16.0/src/mat/impls/hypre/mhypre.c:8:
C:/msys64/ff-petsc/r/include/_hypre_utilities.h: In function 'first_lsb_bit_indx':
C:/msys64/ff-petsc/r/include/_hypre_utilities.h:1791:10: warning: implicit declaration of function 'ffs' [-Wimplicit-function-declaration]
 1791 |    pos = ffs(x);
      |          ^~~
C:/msys64/ff-petsc/r/include/_hypre_utilities.h:1791:14: warning: 'ffs' argument 1 promotes to 'hypre_uint' {aka 'unsigned int'} where 'int' is expected in a call to built-in function declared without prototype [-Wbuiltin-declaration-mismatch]
 1791 |    pos = ffs(x);
      |              ^
```