### PR TITLE
minor fix

### DIFF
--- a/src/utilities/cuda_utils.c
+++ b/src/utilities/cuda_utils.c
@@ -497,7 +497,7 @@ hypreDevice_GenScatterAdd(HYPRE_Real *x, HYPRE_Int ny, HYPRE_Int *map, HYPRE_Rea
       /* trivial cases, n = 1, 2 */
       dim3 bDim = 1;
       dim3 gDim = 1;
-      HYPRE_CUDA_LAUNCH( hypreCUDAKernel_ScatterAddTrivial, bDim, gDim, ny, x, map, y );
+      HYPRE_CUDA_LAUNCH( hypreCUDAKernel_ScatterAddTrivial, gDim, bDim, ny, x, map, y );
    }
    else
    {


### PR DESCRIPTION
Fix the order of `gDim, bDim` in one call of `HYPRE_CUDA_LAUNCH`, which actually doesn't matter there since they are the same. But it is good to keep in mind the correct order of these two, just as in the `<<<,>>>` syntax: grid dim first, block dim second.