### PR TITLE
Air fixes

### DIFF
--- a/src/parcsr_ls/par_stats.c
+++ b/src/parcsr_ls/par_stats.c
@@ -390,7 +390,7 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
       }
       else if (restri_type >= 3)
       {
-         hypre_printf(" Restriction = local approximate ideal restriction (Neumann AIR-%.1f)\n", restri_type-3);
+         hypre_printf(" Restriction = local approximate ideal restriction (Neumann AIR-%d)\n", restri_type-3);
       }
 
       if (block_mode)


### PR DESCRIPTION
This PR fixes a minor valgrind error showing up on regression tests and errors in hypre_ParCSRMatrixExtractSubmatrixFC() when running with --enable-mixedint. These errors showed up with the addition of regression tests for AIR.