### PR TITLE
hypre MPI interface without MPI and with longdouble

### DIFF
--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -194,13 +194,13 @@ extern "C" {
 #define MPI_COMM_SELF        hypre_MPI_COMM_SELF
 #define MPI_COMM_TYPE_SHARED hypre_MPI_COMM_TYPE_SHARED
 
-#define MPI_BOTTOM  	    hypre_MPI_BOTTOM
+#define MPI_BOTTOM          hypre_MPI_BOTTOM
 
 #define MPI_FLOAT           hypre_MPI_FLOAT
 #define MPI_DOUBLE          hypre_MPI_DOUBLE
 #define MPI_LONG_DOUBLE     hypre_MPI_LONG_DOUBLE
 #define MPI_INT             hypre_MPI_INT
-#define MPI_LONG_LONG_INT   hypre_MPI_INT
+#define MPI_LONG_LONG_INT   hypre_MPI_LONG_LONG_INT
 #define MPI_CHAR            hypre_MPI_CHAR
 #define MPI_LONG            hypre_MPI_LONG
 #define MPI_BYTE            hypre_MPI_BYTE
@@ -317,6 +317,7 @@ typedef HYPRE_Int  hypre_MPI_Info;
 #define  hypre_MPI_BYTE 6
 #define  hypre_MPI_REAL 7
 #define  hypre_MPI_COMPLEX 8
+#define  hypre_MPI_LONG_LONG_INT 9
 
 #define  hypre_MPI_SUM 0
 #define  hypre_MPI_MIN 1

--- a/src/utilities/mpistubs.c
+++ b/src/utilities/mpistubs.c
@@ -182,7 +182,7 @@ hypre_MPI_Allgather( void               *sendbuf,
          HYPRE_Int *csendbuf = (HYPRE_Int *)sendbuf;
          for (i = 0; i < sendcount; i++)
          {
-	    crecvbuf[i] = csendbuf[i];
+            crecvbuf[i] = csendbuf[i];
          }
       }
       break;
@@ -193,7 +193,7 @@ hypre_MPI_Allgather( void               *sendbuf,
          double *csendbuf = (double *)sendbuf;
          for (i = 0; i < sendcount; i++)
          {
-	    crecvbuf[i] = csendbuf[i];
+            crecvbuf[i] = csendbuf[i];
          }
       }
       break;
@@ -204,7 +204,7 @@ hypre_MPI_Allgather( void               *sendbuf,
          char *csendbuf = (char *)sendbuf;
          for (i = 0; i < sendcount; i++)
          {
-	    crecvbuf[i] = csendbuf[i];
+            crecvbuf[i] = csendbuf[i];
          }
       }
       break;
@@ -221,7 +221,7 @@ hypre_MPI_Allgather( void               *sendbuf,
          HYPRE_Real *csendbuf = (HYPRE_Real *)sendbuf;
          for (i = 0; i < sendcount; i++)
          {
-	    crecvbuf[i] = csendbuf[i];
+            crecvbuf[i] = csendbuf[i];
          }
       }
       break;
@@ -232,7 +232,7 @@ hypre_MPI_Allgather( void               *sendbuf,
          HYPRE_Complex *csendbuf = (HYPRE_Complex *)sendbuf;
          for (i = 0; i < sendcount; i++)
          {
-	    crecvbuf[i] = csendbuf[i];
+            crecvbuf[i] = csendbuf[i];
          }
       }
       break;
@@ -503,6 +503,17 @@ hypre_MPI_Allreduce( void              *sendbuf,
       {
          double *crecvbuf = (double *)recvbuf;
          double *csendbuf = (double *)sendbuf;
+         for (i = 0; i < count; i++)
+         {
+            crecvbuf[i] = csendbuf[i];
+         }
+      }
+      break;
+
+      case hypre_MPI_LONG_DOUBLE:
+      {
+         long double *crecvbuf = (long double *)recvbuf;
+         long double *csendbuf = (long double *)sendbuf;
          for (i = 0; i < count; i++)
          {
             crecvbuf[i] = csendbuf[i];

--- a/src/utilities/mpistubs.c
+++ b/src/utilities/mpistubs.c
@@ -198,6 +198,17 @@ hypre_MPI_Allgather( void               *sendbuf,
       }
       break;
 
+      case hypre_MPI_LONG_DOUBLE:
+      {
+         long double *crecvbuf = (long double *)recvbuf;
+         long double *csendbuf = (long double *)sendbuf;
+         for (i = 0; i < sendcount; i++)
+         {
+            crecvbuf[i] = csendbuf[i];
+         }
+      }
+      break;
+
       case hypre_MPI_CHAR:
       {
          char *crecvbuf = (char *)recvbuf;

--- a/src/utilities/mpistubs.c
+++ b/src/utilities/mpistubs.c
@@ -73,6 +73,7 @@ hypre_MPI_Comm_create( hypre_MPI_Comm   comm,
                        hypre_MPI_Group  group,
                        hypre_MPI_Comm  *newcomm )
 {
+   *newcomm = hypre_MPI_COMM_NULL;
    return(0);
 }
 
@@ -80,6 +81,7 @@ HYPRE_Int
 hypre_MPI_Comm_dup( hypre_MPI_Comm  comm,
                     hypre_MPI_Comm *newcomm )
 {
+   *newcomm = comm;
    return(0);
 }
 
@@ -187,6 +189,28 @@ hypre_MPI_Allgather( void               *sendbuf,
       }
       break;
 
+      case hypre_MPI_LONG_LONG_INT:
+      {
+         HYPRE_BigInt *crecvbuf = (HYPRE_BigInt *)recvbuf;
+         HYPRE_BigInt *csendbuf = (HYPRE_BigInt *)sendbuf;
+         for (i = 0; i < sendcount; i++)
+         {
+            crecvbuf[i] = csendbuf[i];
+         }
+      }
+      break;
+
+      case hypre_MPI_FLOAT:
+      {
+         float *crecvbuf = (float *)recvbuf;
+         float *csendbuf = (float *)sendbuf;
+         for (i = 0; i < sendcount; i++)
+         {
+            crecvbuf[i] = csendbuf[i];
+         }
+      }
+      break;
+
       case hypre_MPI_DOUBLE:
       {
          double *crecvbuf = (double *)recvbuf;
@@ -213,6 +237,17 @@ hypre_MPI_Allgather( void               *sendbuf,
       {
          char *crecvbuf = (char *)recvbuf;
          char *csendbuf = (char *)sendbuf;
+         for (i = 0; i < sendcount; i++)
+         {
+            crecvbuf[i] = csendbuf[i];
+         }
+      }
+      break;
+
+      case hypre_MPI_LONG:
+      {
+         hypre_longint *crecvbuf = (hypre_longint *)recvbuf;
+         hypre_longint *csendbuf = (hypre_longint *)sendbuf;
          for (i = 0; i < sendcount; i++)
          {
             crecvbuf[i] = csendbuf[i];
@@ -506,7 +541,28 @@ hypre_MPI_Allreduce( void              *sendbuf,
          {
             crecvbuf[i] = csendbuf[i];
          }
+      }
+      break;
 
+      case hypre_MPI_LONG_LONG_INT:
+      {
+         HYPRE_BigInt *crecvbuf = (HYPRE_BigInt *)recvbuf;
+         HYPRE_BigInt *csendbuf = (HYPRE_BigInt *)sendbuf;
+         for (i = 0; i < count; i++)
+         {
+            crecvbuf[i] = csendbuf[i];
+         }
+      }
+      break;
+
+      case hypre_MPI_FLOAT:
+      {
+         float *crecvbuf = (float *)recvbuf;
+         float *csendbuf = (float *)sendbuf;
+         for (i = 0; i < count; i++)
+         {
+            crecvbuf[i] = csendbuf[i];
+         }
       }
       break;
 
@@ -536,6 +592,17 @@ hypre_MPI_Allreduce( void              *sendbuf,
       {
          char *crecvbuf = (char *)recvbuf;
          char *csendbuf = (char *)sendbuf;
+         for (i = 0; i < count; i++)
+         {
+            crecvbuf[i] = csendbuf[i];
+         }
+      }
+      break;
+
+      case hypre_MPI_LONG:
+      {
+         hypre_longint *crecvbuf = (hypre_longint *)recvbuf;
+         hypre_longint *csendbuf = (hypre_longint *)sendbuf;
          for (i = 0; i < count; i++)
          {
             crecvbuf[i] = csendbuf[i];

--- a/src/utilities/mpistubs.h
+++ b/src/utilities/mpistubs.h
@@ -51,7 +51,7 @@ extern "C" {
 #define MPI_DOUBLE          hypre_MPI_DOUBLE
 #define MPI_LONG_DOUBLE     hypre_MPI_LONG_DOUBLE
 #define MPI_INT             hypre_MPI_INT
-#define MPI_LONG_LONG_INT   hypre_MPI_INT
+#define MPI_LONG_LONG_INT   hypre_MPI_LONG_LONG_INT
 #define MPI_CHAR            hypre_MPI_CHAR
 #define MPI_LONG            hypre_MPI_LONG
 #define MPI_BYTE            hypre_MPI_BYTE
@@ -168,6 +168,7 @@ typedef HYPRE_Int  hypre_MPI_Info;
 #define  hypre_MPI_BYTE 6
 #define  hypre_MPI_REAL 7
 #define  hypre_MPI_COMPLEX 8
+#define  hypre_MPI_LONG_LONG_INT 9
 
 #define  hypre_MPI_SUM 0
 #define  hypre_MPI_MIN 1

--- a/src/utilities/mpistubs.h
+++ b/src/utilities/mpistubs.h
@@ -45,7 +45,7 @@ extern "C" {
 #define MPI_COMM_SELF        hypre_MPI_COMM_SELF
 #define MPI_COMM_TYPE_SHARED hypre_MPI_COMM_TYPE_SHARED
 
-#define MPI_BOTTOM  	    hypre_MPI_BOTTOM
+#define MPI_BOTTOM          hypre_MPI_BOTTOM
 
 #define MPI_FLOAT           hypre_MPI_FLOAT
 #define MPI_DOUBLE          hypre_MPI_DOUBLE


### PR DESCRIPTION
This PR will fix #439 where hypre was configured with `--enable-longdouble --without-MPI`. 

- [x] Also fixed similar problems with `hypre_MPI_FLOAT` and `hypre_MPI_LONG` 