### PR TITLE
cmake: REQUIRED packages HYPREConfig.cmake

### DIFF
--- a/src/config/HYPREConfig.cmake.in
+++ b/src/config/HYPREConfig.cmake.in
@@ -39,11 +39,11 @@ set(HYPRE_ENABLE_GPU_PROFILING @HYPRE_ENABLE_GPU_PROFILING@)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
 if(NOT HYPRE_ENABLE_HYPRE_BLAS)
-  find_dependency(BLAS)
+  find_dependency(BLAS REQUIRED)
 endif()
 
 if(NOT HYPRE_ENABLE_HYPRE_LAPACK)
-  find_dependency(LAPACK)
+  find_dependency(LAPACK REQUIRED)
 endif()
 
 if(HYPRE_USING_DSUPERLU)
@@ -52,11 +52,11 @@ endif()
 
 if(HYPRE_WITH_MPI)
   enable_language(C)
-  find_dependency(MPI @MPI_C_VERSION@ EXACT COMPONENTS C)
+  find_dependency(MPI @MPI_C_VERSION@ EXACT REQUIRED COMPONENTS C)
 endif()
 
 if(HYPRE_WITH_OPENMP)
-  find_dependency(OpenMP)
+  find_dependency(OpenMP REQUIRED)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/HYPRETargets.cmake")


### PR DESCRIPTION
When a package uses a mpi-enabled hypre, mpi is actually required, same for lapack, blas and OpenMP.

@osborn9