### PR TITLE
Fix hip shared

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -1903,7 +1903,7 @@ dnl   BUILD_F77_SHARED="${F77} ${SHARED_BUILD_FLAG}"
       BUILD_CC_SHARED="\${CC} ${SHARED_BUILD_FLAG}"
    fi
    BUILD_CXX_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
-   if test "$hypre_using_cuda" = "yes"
+   if test "$hypre_using_cuda" == "yes" || test "$hypre_using_hip" == "yes"
    then
       dnl BUILD_CC_SHARED="\${CUCC} ${SHARED_BUILD_FLAG}"
       BUILD_CC_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
@@ -2201,6 +2201,15 @@ AS_IF([test x"$hypre_using_hip" == x"yes"],
         AS_IF([test x"$hypre_using_debug" == x"yes"],
               [HIPCXXFLAGS="-O0 -Wall -g -ggdb ${HIPCXXFLAGS}"],
               [HIPCXXFLAGS="-O2 ${HIPCXXFLAGS}"],)
+
+
+        dnl If we're doing a shared build, we need the compile flag for it
+        dnl Note we're not just using CXXFLAGS here because that can suck other
+        dnl things that don't play nice, like openmp.
+        if test "$hypre_using_shared" = "yes"
+        then
+           HIPCXXFLAGS="${SHARED_COMPILE_FLAG} ${HIPCXXFLAGS}"
+        fi
 
         dnl (Ab)Use CUFLAGS to capture HIP compilation flags
         dnl Put HIPCXXFLAGS at the end so the user can override the optimization level.

--- a/src/configure
+++ b/src/configure
@@ -8489,7 +8489,7 @@ then
       BUILD_CC_SHARED="\${CC} ${SHARED_BUILD_FLAG}"
    fi
    BUILD_CXX_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
-   if test "$hypre_using_cuda" = "yes"
+   if test "$hypre_using_cuda" == "yes" || test "$hypre_using_hip" == "yes"
    then
             BUILD_CC_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
    fi
@@ -8946,6 +8946,12 @@ $as_echo "#define HYPRE_USING_HIP 1" >>confdefs.h
 elif HIPCXXFLAGS="-O2 ${HIPCXXFLAGS}"; then :
 
 fi
+
+
+                                if test "$hypre_using_shared" = "yes"
+        then
+           HIPCXXFLAGS="${SHARED_COMPILE_FLAG} ${HIPCXXFLAGS}"
+        fi
 
                         if test "$hypre_user_chose_cuflags" = "no"
         then


### PR DESCRIPTION
This PR by @pbauman #477 fixes shared library build with HIP. 

From Paul:
> We're not sucking in CXXFLAGS because if the user enables --with-openmp,
this mucks up the compilation (with or without shared libs) because
the HIP compiler is clang under-the-hood and the clang openmp host
compilation pass does not play nice with the GCC openmp compilation
pass at link time. So instead we just manually enable the shared lib
flags for the HIP compiler.


- [x] redwood