### PR TITLE
Add clean-up phase to spack build in autotest

### DIFF
--- a/AUTOTEST/machine-tux-spack.sh
+++ b/AUTOTEST/machine-tux-spack.sh
@@ -59,11 +59,11 @@ spackdir=`spack location -i $spackspec`
 test.sh basic.sh ../src -co: -mo: -spack $spackdir -ro: -superlu
 ./renametest.sh basic $output_dir/basic-dsuperlu
 
-# Clean-up spack build 
+# Clean-up spack build
 spack spec --yaml $spackspec > test.yaml
-grep ' hash:' test.yaml | sed -e 's/^.*: //' -e 's/^/\//' | xargs spack mark -e
+grep ' hash:' test.yaml | sed -e 's/^.*: /\//' | xargs spack mark -e
 spack gc -y
-grep ' hash:' test.yaml | sed -e 's/^.*: //' -e 's/^/\//' | xargs spack mark -i
+grep ' hash:' test.yaml | sed -e 's/^.*: /\//' | xargs spack mark -i
 rm -f test.yaml
 spack clean --all
 spack uninstall -yR $superludistspec

--- a/AUTOTEST/machine-tux-spack.sh
+++ b/AUTOTEST/machine-tux-spack.sh
@@ -58,6 +58,14 @@ spack load    $spackspec
 spackdir=`spack location -i $spackspec`
 test.sh basic.sh ../src -co: -mo: -spack $spackdir -ro: -superlu
 ./renametest.sh basic $output_dir/basic-dsuperlu
+
+# Clean-up spack build 
+spack spec --yaml $spackspec > test.yaml
+grep ' hash:' test.yaml | sed -e 's/^.*: //' -e 's/^/\//' | xargs spack mark -e
+spack gc -y
+grep ' hash:' test.yaml | sed -e 's/^.*: //' -e 's/^/\//' | xargs spack mark -i
+rm -f test.yaml
+spack clean --all
 spack uninstall -yR $superludistspec
 
 # Echo to stderr all nonempty error files in $output_dir


### PR DESCRIPTION
This adds a "clean-up" phase within the Spack test where any outdated versions of Spack installed packages will be uninstalled and temporary build files, downloaded archives, will be deleted.

 