### PR TITLE
Fix typo in code to destroy old AMG data during setup

### DIFF
--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -389,8 +389,8 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
             A_block_array[j] = NULL;
          }
 
-         hypre_IntArrayDestroy(dof_func_array[i]);
-         dof_func_array[i] = NULL;
+         hypre_IntArrayDestroy(dof_func_array[j]);
+         dof_func_array[j] = NULL;
       }
 
       for (j = 0; j < old_num_levels-1; j++)


### PR DESCRIPTION
This is a small fix for a typo in the code for destroying the old DofFunc data when calling a new AMG setup without calling destroy.