### PR TITLE
Add to protos and rerun headers

### DIFF
--- a/src/struct_ls/_hypre_struct_ls.h
+++ b/src/struct_ls/_hypre_struct_ls.h
@@ -450,9 +450,9 @@ HYPRE_Int hypre_SparseMSGSetupRAPOp ( hypre_StructMatrix *R , hypre_StructMatrix
 /* sparse_msg_solve.c */
 HYPRE_Int hypre_SparseMSGSolve ( void *smsg_vdata , hypre_StructMatrix *A , hypre_StructVector *b , hypre_StructVector *x );
 
-
 #ifdef __cplusplus
 }
 #endif
 
 #endif
+

--- a/src/struct_ls/protos.h
+++ b/src/struct_ls/protos.h
@@ -5,6 +5,11 @@
  * SPDX-License-Identifier: (Apache-2.0 OR MIT)
  ******************************************************************************/
 
+/* coarsen.c */
+HYPRE_Int hypre_StructMapFineToCoarse ( hypre_Index findex , hypre_Index index , hypre_Index stride , hypre_Index cindex );
+HYPRE_Int hypre_StructMapCoarseToFine ( hypre_Index cindex , hypre_Index index , hypre_Index stride , hypre_Index findex );
+HYPRE_Int hypre_StructCoarsen ( hypre_StructGrid *fgrid , hypre_Index index , hypre_Index stride , HYPRE_Int prune , hypre_StructGrid **cgrid_ptr );
+
 /* cyclic_reduction.c */
 void *hypre_CyclicReductionCreate ( MPI_Comm comm );
 hypre_StructMatrix *hypre_CycRedCreateCoarseOp ( hypre_StructMatrix *A , hypre_StructGrid *coarse_grid , HYPRE_Int cdir );


### PR DESCRIPTION
Some function declarations had been removed from the protos file in struct_ls and ./headers needed to be rerun in that directory. 