### PR TITLE
Add fflush in hypre_printf

### DIFF
--- a/src/utilities/printf.c
+++ b/src/utilities/printf.c
@@ -140,6 +140,8 @@ hypre_printf( const char *format, ...)
    free_format(newformat);
    va_end(ap);
 
+   fflush(stdout);
+
    return ierr;
 }
 


### PR DESCRIPTION
There have been cases where printing from hypre and printing from Fortran are misordered, like
```
    Cycle  5   6.268763e-08    0.064737     2.195967e-06 
    Cycle  6   3.996841e-09    0.063758     1.400105e-07 
 
 Iterations =  7
 Final Relative Residual Norm =   8.83917499E-09
 
    Cycle  7   2.523294e-10    0.063132     8.839175e-09 


 Average Convergence Factor = 0.070711

     Complexity:    grid = 1.719008
                operator = 2.360625
                   cycle = 4.716544
```
It makes the regression tests failed.

Adding `fflush(stdout)` in `hypre_printf` seems to fix this issue, whereas adding `FLUSH(output_unit)` or `FLUSH(6)`  in Fortran code doesn't. I am not sure if there are reasons that we don't want flushing at every `printf`.