### PR TITLE
Benchmark IJ

### DIFF
--- a/src/test/TEST_bench/benchmark_ij.jobs
+++ b/src/test/TEST_bench/benchmark_ij.jobs
@@ -9,86 +9,85 @@
 #=============================================================================
 
 # RAP 1
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 -pout 0 \
  > benchmark_ij.out.1
 
-mpirun -np 3 ./ij -n 128 128 384 -P 1 1 3       -pmis -keepT 1 -rlx 7 -w 0.85 -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 \
+mpirun -np 3 ./ij -n 128 128 384 -P 1 1 3       -pmis -keepT 1 -rlx 7 -w 0.85 -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 -pout 0 \
  >> benchmark_ij.out.2
 
-mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 \
+mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 -pout 0 \
  >> benchmark_ij.out.3
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype 14 -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype 14 -solver 1 -pout 0 \
  >> benchmark_ij.out.4
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype  6 -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype  6 -solver 1 -pout 0 \
  >> benchmark_ij.out.5
 
-mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype 15 -solver 1 \
+mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype 15 -solver 1 -pout 0 \
  >> benchmark_ij.out.6
 
-mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype 18 -solver 1 \
+mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype 18 -solver 1 -pout 0 \
  >> benchmark_ij.out.7
 
 # RAP 0
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 -pout 0 \
  > benchmark_ij.out.8
 
-mpirun -np 3 ./ij -n 128 128 384 -P 1 1 3       -pmis -keepT 1 -rlx 7 -w 0.85 -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 \
+mpirun -np 3 ./ij -n 128 128 384 -P 1 1 3       -pmis -keepT 1 -rlx 7 -w 0.85 -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 -pout 0 \
  >> benchmark_ij.out.9
 
-mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 \
+mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  3 -solver 1 -pout 0 \
  >> benchmark_ij.out.10
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 14 -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 14 -solver 1 -pout 0 \
  >> benchmark_ij.out.11
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  6 -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype  6 -solver 1 -pout 0 \
  >> benchmark_ij.out.12
 
-mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 15 -solver 1 \
+mpirun -np 4 ./ij -n 4096 4096 1 -P 2 2 1 -9pt  -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 15 -solver 1 -pout 0 \
  >> benchmark_ij.out.13
 
-
-mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype  6 -solver 1 \
+mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -interptype  6 -solver 1 -pout 0 \
  >> benchmark_ij.out.14
 
-mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 14 -solver 1 \
+mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 14 -solver 1 -pout 0 \
  >> benchmark_ij.out.15
 
-mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 18 -solver 1 \
+mpirun -np 1 ./ij -n 256 256 256 -P 1 1 1       -pmis -keepT 1 -rlx 18        -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -interptype 18 -solver 1 -pout 0 \
  >> benchmark_ij.out.16
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 7 -w 0.85 -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 7 -w 0.85 -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -solver 1 -pout 0 \
  >> benchmark_ij.out.17
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.85 -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 7 -agg_P12_mx 4 -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.85 -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 7 -agg_P12_mx 4 -solver 1 -pout 0 \
  >> benchmark_ij.out.18
 
-mpirun -np 4 ./ij -n 128 128 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.5  -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_Pmx 4 -interptype 18 -solver 1 -sysL 3 -nf 3 \
+mpirun -np 4 ./ij -n 128 128 128 -P 2 2 1       -pmis -keepT 1 -rlx 7 -w 0.5  -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_Pmx 4 -interptype 18 -solver 1 -sysL 3 -nf 3 -pout 0 \
  >> benchmark_ij.out.19
 
-mpirun -np 2 ./ij -n 200 128 128 -P 2 1 1       -pmis -keepT 1 -rlx 7 -w 0.7  -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_Pmx 4 -interptype 18 -solver 1 -vardifconv -eps 1 \
+mpirun -np 2 ./ij -n 200 128 128 -P 2 1 1       -pmis -keepT 1 -rlx 7 -w 0.7  -exec_device -mm_cusparse 0 -agg_nl 1 -agg_interp 5 -agg_Pmx 4 -interptype 18 -solver 1 -vardifconv -eps 1 -pout 0 \
  >> benchmark_ij.out.20
 
-mpirun -np 4 ./ij -n 200 200 200 -P 2 2 1       -pmis -keepT 1 -rlx 18 -ns 2  -exec_device -mm_cusparse 0 -agg_nl 3 -agg_interp 7 -agg_P12_mx 6 -interptype 6 -solver 1 \
+mpirun -np 4 ./ij -n 200 200 200 -P 2 2 1       -pmis -keepT 1 -rlx 18 -ns 2  -exec_device -mm_cusparse 0 -agg_nl 3 -agg_interp 7 -agg_P12_mx 6 -interptype 6 -solver 1 -pout 0 \
  >> benchmark_ij.out.21
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -rlx 16 -cheby_scale 1 -cheby_eig_est 10 -exec_device -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -rlx 16 -cheby_scale 1 -cheby_eig_est 10 -exec_device -solver 1 -pout 0 \
  >> benchmark_ij.out.22
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -rlx 16 -cheby_scale 0 -cheby_eig_est 10 -exec_device -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -rlx 16 -cheby_scale 0 -cheby_eig_est 10 -exec_device -solver 1 -pout 0 \
  >> benchmark_ij.out.23
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -rlx 16 -cheby_scale 1 -cheby_eig_est 0 -exec_device -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -rlx 16 -cheby_scale 1 -cheby_eig_est 0 -exec_device -solver 1 -pout 0 \
  >> benchmark_ij.out.24
 
-mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -rlx 16 -cheby_scale 0 -cheby_eig_est 0 -exec_device -solver 1 \
+mpirun -np 4 ./ij -n 256 256 128 -P 2 2 1       -rlx 16 -cheby_scale 0 -cheby_eig_est 0 -exec_device -solver 1 -pout 0 \
  >> benchmark_ij.out.25
 
-mpirun -np 4 ./ij -n 248 248 248 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 18 -ns 2  -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -agg_nl 2 -agg_interp 8 -interptype 6 -mxrs 0.9  -Pmx 8 -solver 1 \
+mpirun -np 4 ./ij -n 248 248 248 -P 2 2 1 -27pt -pmis -keepT 1 -rlx 18 -ns 2  -exec_device -rap 1 -mod_rap2 1 -mm_cusparse 0 -agg_nl 2 -agg_interp 8 -interptype 6 -mxrs 0.9  -Pmx 8 -solver 1 -pout 0 \
  >> benchmark_ij.out.26
 
-mpirun -np 4 ./ij -n 256 256 256 -P 1 2 2 -27pt -pmis -keepT 1 -rlx 18 -ns 2  -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -agg_nl 1 -agg_interp 9 -interptype 6 -mxrs 0.9  -Pmx 8 -solver 1 \
+mpirun -np 4 ./ij -n 256 256 256 -P 1 2 2 -27pt -pmis -keepT 1 -rlx 18 -ns 2  -exec_device -rap 0 -mod_rap2 1 -mm_cusparse 0 -agg_nl 1 -agg_interp 9 -interptype 6 -mxrs 0.9  -Pmx 8 -solver 1 -pout 0 \
  >> benchmark_ij.out.27
 

--- a/src/test/TEST_bench/benchmark_ij.perf.saved.lassen
+++ b/src/test/TEST_bench/benchmark_ij.perf.saved.lassen
@@ -1,81 +1,81 @@
 # Output file: benchmark_ij.out.1
-PCG Setup wall clock time = 0.442274 seconds
-PCG Solve wall clock time = 0.586363 seconds
+PCG Setup wall clock time = 0.259651 seconds
+PCG Solve wall clock time = 0.605893 seconds
 # Output file: benchmark_ij.out.2
-PCG Setup wall clock time = 0.421415 seconds
-PCG Solve wall clock time = 0.481981 seconds
+PCG Setup wall clock time = 0.249620 seconds
+PCG Solve wall clock time = 0.498876 seconds
 # Output file: benchmark_ij.out.3
-PCG Setup wall clock time = 0.592196 seconds
-PCG Solve wall clock time = 1.116149 seconds
+PCG Setup wall clock time = 0.333260 seconds
+PCG Solve wall clock time = 1.167002 seconds
 # Output file: benchmark_ij.out.4
-PCG Setup wall clock time = 0.574467 seconds
-PCG Solve wall clock time = 0.224829 seconds
+PCG Setup wall clock time = 0.380806 seconds
+PCG Solve wall clock time = 0.240735 seconds
 # Output file: benchmark_ij.out.5
-PCG Setup wall clock time = 0.760889 seconds
-PCG Solve wall clock time = 0.208459 seconds
+PCG Setup wall clock time = 0.470697 seconds
+PCG Solve wall clock time = 0.212337 seconds
 # Output file: benchmark_ij.out.6
-PCG Setup wall clock time = 0.551022 seconds
-PCG Solve wall clock time = 1.059372 seconds
+PCG Setup wall clock time = 0.324167 seconds
+PCG Solve wall clock time = 1.091553 seconds
 # Output file: benchmark_ij.out.7
-PCG Setup wall clock time = 0.759444 seconds
-PCG Solve wall clock time = 0.265704 seconds
+PCG Setup wall clock time = 0.456757 seconds
+PCG Solve wall clock time = 0.267483 seconds
 # Output file: benchmark_ij.out.8
-PCG Setup wall clock time = 0.411739 seconds
-PCG Solve wall clock time = 0.572450 seconds
+PCG Setup wall clock time = 0.238781 seconds
+PCG Solve wall clock time = 0.593405 seconds
 # Output file: benchmark_ij.out.9
-PCG Setup wall clock time = 0.409877 seconds
-PCG Solve wall clock time = 0.485815 seconds
+PCG Setup wall clock time = 0.239434 seconds
+PCG Solve wall clock time = 0.506490 seconds
 # Output file: benchmark_ij.out.10
-PCG Setup wall clock time = 0.537107 seconds
-PCG Solve wall clock time = 1.159050 seconds
+PCG Setup wall clock time = 0.315130 seconds
+PCG Solve wall clock time = 1.194219 seconds
 # Output file: benchmark_ij.out.11
-PCG Setup wall clock time = 0.588887 seconds
-PCG Solve wall clock time = 0.225021 seconds
+PCG Setup wall clock time = 0.355021 seconds
+PCG Solve wall clock time = 0.239230 seconds
 # Output file: benchmark_ij.out.12
-PCG Setup wall clock time = 0.738114 seconds
-PCG Solve wall clock time = 0.206896 seconds
+PCG Setup wall clock time = 0.442632 seconds
+PCG Solve wall clock time = 0.212282 seconds
 # Output file: benchmark_ij.out.13
-PCG Setup wall clock time = 0.576056 seconds
-PCG Solve wall clock time = 1.061516 seconds
+PCG Setup wall clock time = 0.311922 seconds
+PCG Solve wall clock time = 1.098295 seconds
 # Output file: benchmark_ij.out.14
-PCG Setup wall clock time = 3.096025 seconds
-PCG Solve wall clock time = 0.745310 seconds
+PCG Setup wall clock time = 1.449750 seconds
+PCG Solve wall clock time = 0.747511 seconds
 # Output file: benchmark_ij.out.15
-PCG Setup wall clock time = 3.102031 seconds
-PCG Solve wall clock time = 0.794782 seconds
+PCG Setup wall clock time = 1.429561 seconds
+PCG Solve wall clock time = 0.796699 seconds
 # Output file: benchmark_ij.out.16
-PCG Setup wall clock time = 3.024356 seconds
-PCG Solve wall clock time = 0.745560 seconds
+PCG Setup wall clock time = 1.425530 seconds
+PCG Solve wall clock time = 0.748051 seconds
 # Output file: benchmark_ij.out.17
-PCG Setup wall clock time = 0.735291 seconds
-PCG Solve wall clock time = 0.199601 seconds
+PCG Setup wall clock time = 0.444488 seconds
+PCG Solve wall clock time = 0.200816 seconds
 # Output file: benchmark_ij.out.18
-PCG Setup wall clock time = 0.441699 seconds
-PCG Solve wall clock time = 0.180786 seconds
+PCG Setup wall clock time = 0.301099 seconds
+PCG Solve wall clock time = 0.168984 seconds
 # Output file: benchmark_ij.out.19
-PCG Setup wall clock time = 0.599613 seconds
-PCG Solve wall clock time = 0.423136 seconds
+PCG Setup wall clock time = 0.363469 seconds
+PCG Solve wall clock time = 0.439261 seconds
 # Output file: benchmark_ij.out.20
-PCG Setup wall clock time = 0.351212 seconds
-PCG Solve wall clock time = 0.248475 seconds
+PCG Setup wall clock time = 0.242483 seconds
+PCG Solve wall clock time = 0.260942 seconds
 # Output file: benchmark_ij.out.21
-PCG Setup wall clock time = 0.473500 seconds
-PCG Solve wall clock time = 0.245645 seconds
+PCG Setup wall clock time = 0.314690 seconds
+PCG Solve wall clock time = 0.254777 seconds
 # Output file: benchmark_ij.out.22
-PCG Setup wall clock time = 0.585721 seconds
-PCG Solve wall clock time = 0.184083 seconds
+PCG Setup wall clock time = 0.384040 seconds
+PCG Solve wall clock time = 0.197680 seconds
 # Output file: benchmark_ij.out.23
-PCG Setup wall clock time = 0.577237 seconds
-PCG Solve wall clock time = 0.187903 seconds
+PCG Setup wall clock time = 0.372455 seconds
+PCG Solve wall clock time = 0.201243 seconds
 # Output file: benchmark_ij.out.24
-PCG Setup wall clock time = 0.554462 seconds
-PCG Solve wall clock time = 0.212726 seconds
+PCG Setup wall clock time = 0.343731 seconds
+PCG Solve wall clock time = 0.225914 seconds
 # Output file: benchmark_ij.out.25
-PCG Setup wall clock time = 0.572496 seconds
-PCG Solve wall clock time = 0.214806 seconds
+PCG Setup wall clock time = 0.347147 seconds
+PCG Solve wall clock time = 0.224026 seconds
 # Output file: benchmark_ij.out.26
-PCG Setup wall clock time = 0.847806 seconds
-PCG Solve wall clock time = 0.725373 seconds
+PCG Setup wall clock time = 0.399291 seconds
+PCG Solve wall clock time = 0.721765 seconds
 # Output file: benchmark_ij.out.27
-PCG Setup wall clock time = 0.935446 seconds
-PCG Solve wall clock time = 0.493708 seconds
+PCG Setup wall clock time = 0.425114 seconds
+PCG Solve wall clock time = 0.489332 seconds

--- a/src/test/TEST_bench/benchmark_ij.perf.saved.ray
+++ b/src/test/TEST_bench/benchmark_ij.perf.saved.ray
@@ -1,81 +1,81 @@
 # Output file: benchmark_ij.out.1
-PCG Setup wall clock time = 0.285628 seconds
-PCG Solve wall clock time = 0.675470 seconds
+PCG Setup wall clock time = 0.258203 seconds
+PCG Solve wall clock time = 0.681754 seconds
 # Output file: benchmark_ij.out.2
-PCG Setup wall clock time = 0.271713 seconds
-PCG Solve wall clock time = 0.530760 seconds
+PCG Setup wall clock time = 0.250675 seconds
+PCG Solve wall clock time = 0.528896 seconds
 # Output file: benchmark_ij.out.3
-PCG Setup wall clock time = 0.369934 seconds
-PCG Solve wall clock time = 1.434116 seconds
+PCG Setup wall clock time = 0.349367 seconds
+PCG Solve wall clock time = 1.429055 seconds
 # Output file: benchmark_ij.out.4
-PCG Setup wall clock time = 0.419743 seconds
-PCG Solve wall clock time = 0.274670 seconds
+PCG Setup wall clock time = 0.390708 seconds
+PCG Solve wall clock time = 0.272203 seconds
 # Output file: benchmark_ij.out.5
-PCG Setup wall clock time = 0.505447 seconds
-PCG Solve wall clock time = 0.271109 seconds
+PCG Setup wall clock time = 0.505322 seconds
+PCG Solve wall clock time = 0.271119 seconds
 # Output file: benchmark_ij.out.6
-PCG Setup wall clock time = 0.336735 seconds
-PCG Solve wall clock time = 1.302319 seconds
+PCG Setup wall clock time = 0.341100 seconds
+PCG Solve wall clock time = 1.294457 seconds
 # Output file: benchmark_ij.out.7
-PCG Setup wall clock time = 0.522263 seconds
-PCG Solve wall clock time = 0.329536 seconds
+PCG Setup wall clock time = 0.509246 seconds
+PCG Solve wall clock time = 0.329228 seconds
 # Output file: benchmark_ij.out.8
-PCG Setup wall clock time = 0.253857 seconds
-PCG Solve wall clock time = 0.664216 seconds
+PCG Setup wall clock time = 0.245471 seconds
+PCG Solve wall clock time = 0.668823 seconds
 # Output file: benchmark_ij.out.9
-PCG Setup wall clock time = 0.234356 seconds
-PCG Solve wall clock time = 0.531410 seconds
+PCG Setup wall clock time = 0.237060 seconds
+PCG Solve wall clock time = 0.529735 seconds
 # Output file: benchmark_ij.out.10
-PCG Setup wall clock time = 0.317663 seconds
-PCG Solve wall clock time = 1.427696 seconds
+PCG Setup wall clock time = 0.318310 seconds
+PCG Solve wall clock time = 1.421941 seconds
 # Output file: benchmark_ij.out.11
-PCG Setup wall clock time = 0.396762 seconds
-PCG Solve wall clock time = 0.272800 seconds
+PCG Setup wall clock time = 0.369399 seconds
+PCG Solve wall clock time = 0.271177 seconds
 # Output file: benchmark_ij.out.12
-PCG Setup wall clock time = 0.466818 seconds
-PCG Solve wall clock time = 0.270722 seconds
+PCG Setup wall clock time = 0.467487 seconds
+PCG Solve wall clock time = 0.272468 seconds
 # Output file: benchmark_ij.out.13
-PCG Setup wall clock time = 0.315161 seconds
-PCG Solve wall clock time = 1.303698 seconds
+PCG Setup wall clock time = 0.317477 seconds
+PCG Solve wall clock time = 1.295353 seconds
 # Output file: benchmark_ij.out.14
-PCG Setup wall clock time = 1.869528 seconds
-PCG Solve wall clock time = 1.283017 seconds
+PCG Setup wall clock time = 1.869218 seconds
+PCG Solve wall clock time = 1.282999 seconds
 # Output file: benchmark_ij.out.15
-PCG Setup wall clock time = 1.794982 seconds
-PCG Solve wall clock time = 1.381710 seconds
+PCG Setup wall clock time = 1.795676 seconds
+PCG Solve wall clock time = 1.381776 seconds
 # Output file: benchmark_ij.out.16
-PCG Setup wall clock time = 1.798419 seconds
-PCG Solve wall clock time = 1.224717 seconds
+PCG Setup wall clock time = 1.802506 seconds
+PCG Solve wall clock time = 1.224601 seconds
 # Output file: benchmark_ij.out.17
-PCG Setup wall clock time = 0.464348 seconds
-PCG Solve wall clock time = 0.264035 seconds
+PCG Setup wall clock time = 0.469166 seconds
+PCG Solve wall clock time = 0.264458 seconds
 # Output file: benchmark_ij.out.18
-PCG Setup wall clock time = 0.357805 seconds
-PCG Solve wall clock time = 0.193832 seconds
+PCG Setup wall clock time = 0.339154 seconds
+PCG Solve wall clock time = 0.192239 seconds
 # Output file: benchmark_ij.out.19
-PCG Setup wall clock time = 0.443451 seconds
-PCG Solve wall clock time = 0.505555 seconds
+PCG Setup wall clock time = 0.435951 seconds
+PCG Solve wall clock time = 0.501610 seconds
 # Output file: benchmark_ij.out.20
-PCG Setup wall clock time = 0.256796 seconds
-PCG Solve wall clock time = 0.300150 seconds
+PCG Setup wall clock time = 0.263188 seconds
+PCG Solve wall clock time = 0.301571 seconds
 # Output file: benchmark_ij.out.21
-PCG Setup wall clock time = 0.349885 seconds
-PCG Solve wall clock time = 0.311006 seconds
+PCG Setup wall clock time = 0.347543 seconds
+PCG Solve wall clock time = 0.308485 seconds
 # Output file: benchmark_ij.out.22
-PCG Setup wall clock time = 0.418811 seconds
-PCG Solve wall clock time = 0.230805 seconds
+PCG Setup wall clock time = 0.417099 seconds
+PCG Solve wall clock time = 0.230357 seconds
 # Output file: benchmark_ij.out.23
-PCG Setup wall clock time = 0.406131 seconds
-PCG Solve wall clock time = 0.242079 seconds
+PCG Setup wall clock time = 0.408905 seconds
+PCG Solve wall clock time = 0.237934 seconds
 # Output file: benchmark_ij.out.24
-PCG Setup wall clock time = 0.379553 seconds
-PCG Solve wall clock time = 0.271095 seconds
+PCG Setup wall clock time = 0.380615 seconds
+PCG Solve wall clock time = 0.266691 seconds
 # Output file: benchmark_ij.out.25
-PCG Setup wall clock time = 0.373480 seconds
-PCG Solve wall clock time = 0.274352 seconds
+PCG Setup wall clock time = 0.373851 seconds
+PCG Solve wall clock time = 0.271235 seconds
 # Output file: benchmark_ij.out.26
-PCG Setup wall clock time = 0.418967 seconds
-PCG Solve wall clock time = 1.026742 seconds
+PCG Setup wall clock time = 0.416267 seconds
+PCG Solve wall clock time = 1.026347 seconds
 # Output file: benchmark_ij.out.27
-PCG Setup wall clock time = 0.451789 seconds
-PCG Solve wall clock time = 0.686671 seconds
+PCG Setup wall clock time = 0.449184 seconds
+PCG Solve wall clock time = 0.686076 seconds

--- a/src/test/TEST_bench/benchmark_ij.perf.saved.ray
+++ b/src/test/TEST_bench/benchmark_ij.perf.saved.ray
@@ -1,81 +1,81 @@
 # Output file: benchmark_ij.out.1
-PCG Setup wall clock time = 0.447182 seconds
-PCG Solve wall clock time = 0.667648 seconds
+PCG Setup wall clock time = 0.285628 seconds
+PCG Solve wall clock time = 0.675470 seconds
 # Output file: benchmark_ij.out.2
-PCG Setup wall clock time = 0.442885 seconds
-PCG Solve wall clock time = 0.525688 seconds
+PCG Setup wall clock time = 0.271713 seconds
+PCG Solve wall clock time = 0.530760 seconds
 # Output file: benchmark_ij.out.3
-PCG Setup wall clock time = 0.594930 seconds
-PCG Solve wall clock time = 1.403769 seconds
+PCG Setup wall clock time = 0.369934 seconds
+PCG Solve wall clock time = 1.434116 seconds
 # Output file: benchmark_ij.out.4
-PCG Setup wall clock time = 0.598627 seconds
-PCG Solve wall clock time = 0.272439 seconds
+PCG Setup wall clock time = 0.419743 seconds
+PCG Solve wall clock time = 0.274670 seconds
 # Output file: benchmark_ij.out.5
-PCG Setup wall clock time = 0.771948 seconds
-PCG Solve wall clock time = 0.267343 seconds
+PCG Setup wall clock time = 0.505447 seconds
+PCG Solve wall clock time = 0.271109 seconds
 # Output file: benchmark_ij.out.6
-PCG Setup wall clock time = 0.589172 seconds
-PCG Solve wall clock time = 1.272172 seconds
+PCG Setup wall clock time = 0.336735 seconds
+PCG Solve wall clock time = 1.302319 seconds
 # Output file: benchmark_ij.out.7
-PCG Setup wall clock time = 0.803751 seconds
-PCG Solve wall clock time = 0.328909 seconds
+PCG Setup wall clock time = 0.522263 seconds
+PCG Solve wall clock time = 0.329536 seconds
 # Output file: benchmark_ij.out.8
-PCG Setup wall clock time = 0.417764 seconds
-PCG Solve wall clock time = 0.655497 seconds
+PCG Setup wall clock time = 0.253857 seconds
+PCG Solve wall clock time = 0.664216 seconds
 # Output file: benchmark_ij.out.9
-PCG Setup wall clock time = 0.410270 seconds
-PCG Solve wall clock time = 0.525057 seconds
+PCG Setup wall clock time = 0.234356 seconds
+PCG Solve wall clock time = 0.531410 seconds
 # Output file: benchmark_ij.out.10
-PCG Setup wall clock time = 0.565856 seconds
-PCG Solve wall clock time = 1.398698 seconds
+PCG Setup wall clock time = 0.317663 seconds
+PCG Solve wall clock time = 1.427696 seconds
 # Output file: benchmark_ij.out.11
-PCG Setup wall clock time = 0.575358 seconds
-PCG Solve wall clock time = 0.268788 seconds
+PCG Setup wall clock time = 0.396762 seconds
+PCG Solve wall clock time = 0.272800 seconds
 # Output file: benchmark_ij.out.12
-PCG Setup wall clock time = 0.733949 seconds
-PCG Solve wall clock time = 0.266458 seconds
+PCG Setup wall clock time = 0.466818 seconds
+PCG Solve wall clock time = 0.270722 seconds
 # Output file: benchmark_ij.out.13
-PCG Setup wall clock time = 0.561592 seconds
-PCG Solve wall clock time = 1.272704 seconds
+PCG Setup wall clock time = 0.315161 seconds
+PCG Solve wall clock time = 1.303698 seconds
 # Output file: benchmark_ij.out.14
-PCG Setup wall clock time = 3.677906 seconds
-PCG Solve wall clock time = 1.281065 seconds
+PCG Setup wall clock time = 1.869528 seconds
+PCG Solve wall clock time = 1.283017 seconds
 # Output file: benchmark_ij.out.15
-PCG Setup wall clock time = 3.627375 seconds
-PCG Solve wall clock time = 1.379409 seconds
+PCG Setup wall clock time = 1.794982 seconds
+PCG Solve wall clock time = 1.381710 seconds
 # Output file: benchmark_ij.out.16
-PCG Setup wall clock time = 3.566712 seconds
-PCG Solve wall clock time = 1.223101 seconds
+PCG Setup wall clock time = 1.798419 seconds
+PCG Solve wall clock time = 1.224717 seconds
 # Output file: benchmark_ij.out.17
-PCG Setup wall clock time = 0.767321 seconds
-PCG Solve wall clock time = 0.259651 seconds
+PCG Setup wall clock time = 0.464348 seconds
+PCG Solve wall clock time = 0.264035 seconds
 # Output file: benchmark_ij.out.18
-PCG Setup wall clock time = 0.487871 seconds
-PCG Solve wall clock time = 0.194575 seconds
+PCG Setup wall clock time = 0.357805 seconds
+PCG Solve wall clock time = 0.193832 seconds
 # Output file: benchmark_ij.out.19
-PCG Setup wall clock time = 0.633908 seconds
-PCG Solve wall clock time = 0.498295 seconds
+PCG Setup wall clock time = 0.443451 seconds
+PCG Solve wall clock time = 0.505555 seconds
 # Output file: benchmark_ij.out.20
-PCG Setup wall clock time = 0.372523 seconds
-PCG Solve wall clock time = 0.292024 seconds
+PCG Setup wall clock time = 0.256796 seconds
+PCG Solve wall clock time = 0.300150 seconds
 # Output file: benchmark_ij.out.21
-PCG Setup wall clock time = 0.495310 seconds
-PCG Solve wall clock time = 0.306979 seconds
+PCG Setup wall clock time = 0.349885 seconds
+PCG Solve wall clock time = 0.311006 seconds
 # Output file: benchmark_ij.out.22
-PCG Setup wall clock time = 0.621549 seconds
-PCG Solve wall clock time = 0.237298 seconds
+PCG Setup wall clock time = 0.418811 seconds
+PCG Solve wall clock time = 0.230805 seconds
 # Output file: benchmark_ij.out.23
-PCG Setup wall clock time = 0.604897 seconds
-PCG Solve wall clock time = 0.232853 seconds
+PCG Setup wall clock time = 0.406131 seconds
+PCG Solve wall clock time = 0.242079 seconds
 # Output file: benchmark_ij.out.24
-PCG Setup wall clock time = 0.610861 seconds
-PCG Solve wall clock time = 0.261864 seconds
+PCG Setup wall clock time = 0.379553 seconds
+PCG Solve wall clock time = 0.271095 seconds
 # Output file: benchmark_ij.out.25
-PCG Setup wall clock time = 0.574478 seconds
-PCG Solve wall clock time = 0.268362 seconds
+PCG Setup wall clock time = 0.373480 seconds
+PCG Solve wall clock time = 0.274352 seconds
 # Output file: benchmark_ij.out.26
-PCG Setup wall clock time = 2.101331 seconds
-PCG Solve wall clock time = 1.054930 seconds
+PCG Setup wall clock time = 0.418967 seconds
+PCG Solve wall clock time = 1.026742 seconds
 # Output file: benchmark_ij.out.27
-PCG Setup wall clock time = 2.310642 seconds
-PCG Solve wall clock time = 0.703656 seconds
+PCG Setup wall clock time = 0.451789 seconds
+PCG Solve wall clock time = 0.686671 seconds

--- a/src/test/TEST_bench/benchmark_ij.saved.lassen
+++ b/src/test/TEST_bench/benchmark_ij.saved.lassen
@@ -1,216 +1,108 @@
 # Output file: benchmark_ij.out.1
-     Complexity:    grid = 1.386675
-                operator = 2.320880
-                memory = 2.744642
-
 Iterations = 56
 Final Relative Residual Norm = 8.307127e-09
 
 # Output file: benchmark_ij.out.2
-     Complexity:    grid = 1.387055
-                operator = 2.317302
-                memory = 2.741383
-
 Iterations = 47
 Final Relative Residual Norm = 6.442666e-09
 
 # Output file: benchmark_ij.out.3
-     Complexity:    grid = 1.233928
-                operator = 1.239456
-                memory = 1.468423
-
 Iterations = 91
 Final Relative Residual Norm = 8.690762e-09
 
 # Output file: benchmark_ij.out.4
-     Complexity:    grid = 1.364012
-                operator = 2.855853
-                memory = 3.482026
-
 Iterations = 21
 Final Relative Residual Norm = 4.058213e-09
 
 # Output file: benchmark_ij.out.5
-     Complexity:    grid = 1.091824
-                operator = 1.219624
-                memory = 1.372738
-
 Iterations = 18
 Final Relative Residual Norm = 7.323212e-09
 
 # Output file: benchmark_ij.out.6
-     Complexity:    grid = 1.233919
-                operator = 1.239480
-                memory = 1.468487
-
 Iterations = 86
 Final Relative Residual Norm = 8.703512e-09
 
 # Output file: benchmark_ij.out.7
-     Complexity:    grid = 1.223590
-                operator = 1.527021
-                memory = 1.986749
-
 Iterations = 20
 Final Relative Residual Norm = 6.987022e-09
 
 # Output file: benchmark_ij.out.8
-     Complexity:    grid = 1.386664
-                operator = 2.320762
-                memory = 2.744512
-
 Iterations = 55
 Final Relative Residual Norm = 8.845940e-09
 
 # Output file: benchmark_ij.out.9
-     Complexity:    grid = 1.387055
-                operator = 2.317302
-                memory = 2.741383
-
 Iterations = 47
 Final Relative Residual Norm = 6.443110e-09
 
 # Output file: benchmark_ij.out.10
-     Complexity:    grid = 1.233928
-                operator = 1.239458
-                memory = 1.468426
-
 Iterations = 93
 Final Relative Residual Norm = 7.570811e-09
 
 # Output file: benchmark_ij.out.11
-     Complexity:    grid = 1.364012
-                operator = 2.855853
-                memory = 3.482026
-
 Iterations = 21
 Final Relative Residual Norm = 4.058213e-09
 
 # Output file: benchmark_ij.out.12
-     Complexity:    grid = 1.091824
-                operator = 1.219624
-                memory = 1.372738
-
 Iterations = 18
 Final Relative Residual Norm = 7.323212e-09
 
 # Output file: benchmark_ij.out.13
-     Complexity:    grid = 1.233919
-                operator = 1.239480
-                memory = 1.468487
-
 Iterations = 86
 Final Relative Residual Norm = 8.703480e-09
 
 # Output file: benchmark_ij.out.14
-     Complexity:    grid = 1.353519
-                operator = 2.780828
-                memory = 3.404837
-
 Iterations = 21
 Final Relative Residual Norm = 3.421896e-09
 
 # Output file: benchmark_ij.out.15
-     Complexity:    grid = 1.363215
-                operator = 2.858849
-                memory = 3.484214
-
 Iterations = 22
 Final Relative Residual Norm = 5.645705e-09
 
 # Output file: benchmark_ij.out.16
-     Complexity:    grid = 1.353517
-                operator = 2.783027
-                memory = 3.407035
-
 Iterations = 21
 Final Relative Residual Norm = 3.301396e-09
 
 # Output file: benchmark_ij.out.17
-     Complexity:    grid = 1.015779
-                operator = 1.046674
-                memory = 1.317909
-
 Iterations = 20
 Final Relative Residual Norm = 3.328281e-09
 
 # Output file: benchmark_ij.out.18
-     Complexity:    grid = 1.070875
-                operator = 1.447982
-                memory = 1.989067
-
 Iterations = 20
 Final Relative Residual Norm = 3.966823e-09
 
 # Output file: benchmark_ij.out.19
-     Complexity:    grid = 1.079926
-                operator = 1.533788
-                memory = 1.702008
-
 Iterations = 43
 Final Relative Residual Norm = 6.701259e-09
 
 # Output file: benchmark_ij.out.20
-     Complexity:    grid = 1.082226
-                operator = 1.551614
-                memory = 2.055232
-
 Iterations = 38
 Final Relative Residual Norm = 6.553323e-09
 
 # Output file: benchmark_ij.out.21
-     Complexity:    grid = 1.061711
-                operator = 1.424330
-                memory = 2.083418
-
 Iterations = 26
 Final Relative Residual Norm = 9.192336e-09
 
 # Output file: benchmark_ij.out.22
-     Complexity:    grid = 1.354713
-                operator = 2.779966
-                memory = 3.404837
-
 Iterations = 12
 Final Relative Residual Norm = 9.479329e-09
 
 # Output file: benchmark_ij.out.23
-     Complexity:    grid = 1.354713
-                operator = 2.779966
-                memory = 3.404837
-
 Iterations = 13
 Final Relative Residual Norm = 5.649324e-09
 
 # Output file: benchmark_ij.out.24
-     Complexity:    grid = 1.354713
-                operator = 2.779966
-                memory = 3.404837
-
 Iterations = 14
 Final Relative Residual Norm = 2.350370e-09
 
 # Output file: benchmark_ij.out.25
-     Complexity:    grid = 1.354713
-                operator = 2.779966
-                memory = 3.404837
-
 Iterations = 15
 Final Relative Residual Norm = 4.896099e-09
 
 # Output file: benchmark_ij.out.26
-     Complexity:    grid = 1.014384
-                operator = 1.014703
-                memory = 1.079035
-
 Iterations = 37
 Final Relative Residual Norm = 7.069482e-09
 
 # Output file: benchmark_ij.out.27
-     Complexity:    grid = 1.016486
-                operator = 1.025189
-                memory = 1.092450
-
 Iterations = 22
 Final Relative Residual Norm = 9.619150e-09
 

--- a/src/test/TEST_bench/benchmark_ij.saved.ray
+++ b/src/test/TEST_bench/benchmark_ij.saved.ray
@@ -1,216 +1,108 @@
 # Output file: benchmark_ij.out.1
-     Complexity:    grid = 1.386675
-                operator = 2.320880
-                memory = 2.744642
-
 Iterations = 56
 Final Relative Residual Norm = 8.310273e-09
 
 # Output file: benchmark_ij.out.2
-     Complexity:    grid = 1.387054
-                operator = 2.317317
-                memory = 2.741399
-
 Iterations = 46
 Final Relative Residual Norm = 9.983060e-09
 
 # Output file: benchmark_ij.out.3
-     Complexity:    grid = 1.233935
-                operator = 1.239483
-                memory = 1.468458
-
 Iterations = 95
 Final Relative Residual Norm = 9.752976e-09
 
 # Output file: benchmark_ij.out.4
-     Complexity:    grid = 1.364009
-                operator = 2.855804
-                memory = 3.481976
-
 Iterations = 21
 Final Relative Residual Norm = 4.823877e-09
 
 # Output file: benchmark_ij.out.5
-     Complexity:    grid = 1.091841
-                operator = 1.219680
-                memory = 1.372794
-
 Iterations = 18
 Final Relative Residual Norm = 7.067935e-09
 
 # Output file: benchmark_ij.out.6
-     Complexity:    grid = 1.233924
-                operator = 1.239488
-                memory = 1.468501
-
 Iterations = 86
 Final Relative Residual Norm = 8.776839e-09
 
 # Output file: benchmark_ij.out.7
-     Complexity:    grid = 1.223589
-                operator = 1.527003
-                memory = 1.986731
-
 Iterations = 20
 Final Relative Residual Norm = 6.113255e-09
 
 # Output file: benchmark_ij.out.8
-     Complexity:    grid = 1.386664
-                operator = 2.320762
-                memory = 2.744512
-
 Iterations = 55
 Final Relative Residual Norm = 8.842660e-09
 
 # Output file: benchmark_ij.out.9
-     Complexity:    grid = 1.387054
-                operator = 2.317317
-                memory = 2.741399
-
 Iterations = 46
 Final Relative Residual Norm = 9.984042e-09
 
 # Output file: benchmark_ij.out.10
-     Complexity:    grid = 1.233941
-                operator = 1.239494
-                memory = 1.468474
-
 Iterations = 94
 Final Relative Residual Norm = 8.552975e-09
 
 # Output file: benchmark_ij.out.11
-     Complexity:    grid = 1.364009
-                operator = 2.855804
-                memory = 3.481976
-
 Iterations = 21
 Final Relative Residual Norm = 4.823877e-09
 
 # Output file: benchmark_ij.out.12
-     Complexity:    grid = 1.091841
-                operator = 1.219680
-                memory = 1.372794
-
 Iterations = 18
 Final Relative Residual Norm = 7.067935e-09
 
 # Output file: benchmark_ij.out.13
-     Complexity:    grid = 1.233924
-                operator = 1.239488
-                memory = 1.468501
-
 Iterations = 86
 Final Relative Residual Norm = 8.776848e-09
 
 # Output file: benchmark_ij.out.14
-     Complexity:    grid = 1.353525
-                operator = 2.780984
-                memory = 3.404994
-
 Iterations = 21
 Final Relative Residual Norm = 3.275619e-09
 
 # Output file: benchmark_ij.out.15
-     Complexity:    grid = 1.363207
-                operator = 2.858725
-                memory = 3.484089
-
 Iterations = 22
 Final Relative Residual Norm = 5.998149e-09
 
 # Output file: benchmark_ij.out.16
-     Complexity:    grid = 1.353543
-                operator = 2.783373
-                memory = 3.407385
-
 Iterations = 20
 Final Relative Residual Norm = 9.658787e-09
 
 # Output file: benchmark_ij.out.17
-     Complexity:    grid = 1.015779
-                operator = 1.046674
-                memory = 1.317909
-
 Iterations = 20
 Final Relative Residual Norm = 3.328281e-09
 
 # Output file: benchmark_ij.out.18
-     Complexity:    grid = 1.070876
-                operator = 1.447936
-                memory = 1.989021
-
 Iterations = 20
 Final Relative Residual Norm = 4.032191e-09
 
 # Output file: benchmark_ij.out.19
-     Complexity:    grid = 1.079936
-                operator = 1.533947
-                memory = 1.702168
-
 Iterations = 43
 Final Relative Residual Norm = 6.646561e-09
 
 # Output file: benchmark_ij.out.20
-     Complexity:    grid = 1.082238
-                operator = 1.551861
-                memory = 2.055481
-
 Iterations = 38
 Final Relative Residual Norm = 7.983322e-09
 
 # Output file: benchmark_ij.out.21
-     Complexity:    grid = 1.061719
-                operator = 1.424455
-                memory = 2.083605
-
 Iterations = 27
 Final Relative Residual Norm = 5.988024e-09
 
 # Output file: benchmark_ij.out.22
-     Complexity:    grid = 1.354729
-                operator = 2.780162
-                memory = 3.405036
-
 Iterations = 12
 Final Relative Residual Norm = 7.696220e-09
 
 # Output file: benchmark_ij.out.23
-     Complexity:    grid = 1.354729
-                operator = 2.780162
-                memory = 3.405036
-
 Iterations = 13
 Final Relative Residual Norm = 5.699345e-09
 
 # Output file: benchmark_ij.out.24
-     Complexity:    grid = 1.354729
-                operator = 2.780162
-                memory = 3.405036
-
 Iterations = 14
 Final Relative Residual Norm = 2.049078e-09
 
 # Output file: benchmark_ij.out.25
-     Complexity:    grid = 1.354729
-                operator = 2.780162
-                memory = 3.405036
-
 Iterations = 15
 Final Relative Residual Norm = 3.378361e-09
 
 # Output file: benchmark_ij.out.26
-     Complexity:    grid = 1.014384
-                operator = 1.014703
-                memory = 1.079035
-
 Iterations = 37
 Final Relative Residual Norm = 7.069482e-09
 
 # Output file: benchmark_ij.out.27
-     Complexity:    grid = 1.016486
-                operator = 1.025189
-                memory = 1.092450
-
 Iterations = 22
 Final Relative Residual Norm = 9.619150e-09
 

--- a/src/test/TEST_bench/benchmark_ij.saved.redwood
+++ b/src/test/TEST_bench/benchmark_ij.saved.redwood
@@ -1,216 +1,108 @@
 # Output file: benchmark_ij.out.1
-     Complexity:    grid = 1.386281
-                operator = 2.317626
-                memory = 2.740965
-
 Iterations = 55
 Final Relative Residual Norm = 7.846640e-09
 
 # Output file: benchmark_ij.out.2
-     Complexity:    grid = 1.386750
-                operator = 2.314724
-                memory = 2.738467
-
 Iterations = 47
 Final Relative Residual Norm = 7.463067e-09
 
 # Output file: benchmark_ij.out.3
-     Complexity:    grid = 1.234000
-                operator = 1.239607
-                memory = 1.468688
-
 Iterations = 93
 Final Relative Residual Norm = 7.952106e-09
 
 # Output file: benchmark_ij.out.4
-     Complexity:    grid = 1.363905
-                operator = 2.856171
-                memory = 3.482328
-
 Iterations = 20
 Final Relative Residual Norm = 8.258745e-09
 
 # Output file: benchmark_ij.out.5
-     Complexity:    grid = 1.091717
-                operator = 1.219345
-                memory = 1.372455
-
 Iterations = 18
 Final Relative Residual Norm = 5.554025e-09
 
 # Output file: benchmark_ij.out.6
-     Complexity:    grid = 1.234015
-                operator = 1.239642
-                memory = 1.468759
-
 Iterations = 84
 Final Relative Residual Norm = 8.011055e-09
 
 # Output file: benchmark_ij.out.7
-     Complexity:    grid = 1.223736
-                operator = 1.527425
-                memory = 1.987193
-
 Iterations = 20
 Final Relative Residual Norm = 6.626333e-09
 
 # Output file: benchmark_ij.out.8
-     Complexity:    grid = 1.386265
-                operator = 2.317442
-                memory = 2.740765
-
 Iterations = 55
 Final Relative Residual Norm = 9.474079e-09
 
 # Output file: benchmark_ij.out.9
-     Complexity:    grid = 1.386750
-                operator = 2.314724
-                memory = 2.738467
-
 Iterations = 47
 Final Relative Residual Norm = 7.463067e-09
 
 # Output file: benchmark_ij.out.10
-     Complexity:    grid = 1.233994
-                operator = 1.239593
-                memory = 1.468671
-
 Iterations = 91
 Final Relative Residual Norm = 8.206536e-09
 
 # Output file: benchmark_ij.out.11
-     Complexity:    grid = 1.363905
-                operator = 2.856171
-                memory = 3.482328
-
 Iterations = 20
 Final Relative Residual Norm = 8.258745e-09
 
 # Output file: benchmark_ij.out.12
-     Complexity:    grid = 1.091717
-                operator = 1.219345
-                memory = 1.372455
-
 Iterations = 18
 Final Relative Residual Norm = 5.554025e-09
 
 # Output file: benchmark_ij.out.13
-     Complexity:    grid = 1.234015
-                operator = 1.239642
-                memory = 1.468759
-
 Iterations = 84
 Final Relative Residual Norm = 8.011036e-09
 
 # Output file: benchmark_ij.out.14
-     Complexity:    grid = 1.353478
-                operator = 2.781080
-                memory = 3.405082
-
 Iterations = 20
 Final Relative Residual Norm = 9.331252e-09
 
 # Output file: benchmark_ij.out.15
-     Complexity:    grid = 1.363169
-                operator = 2.859458
-                memory = 3.484816
-
 Iterations = 22
 Final Relative Residual Norm = 4.989202e-09
 
 # Output file: benchmark_ij.out.16
-     Complexity:    grid = 1.353489
-                operator = 2.783363
-                memory = 3.407368
-
 Iterations = 20
 Final Relative Residual Norm = 9.799174e-09
 
 # Output file: benchmark_ij.out.17
-     Complexity:    grid = 1.015757
-                operator = 1.046616
-                memory = 1.317502
-
 Iterations = 20
 Final Relative Residual Norm = 3.591664e-09
 
 # Output file: benchmark_ij.out.18
-     Complexity:    grid = 1.070985
-                operator = 1.449032
-                memory = 1.990633
-
 Iterations = 20
 Final Relative Residual Norm = 3.426856e-09
 
 # Output file: benchmark_ij.out.19
-     Complexity:    grid = 1.079983
-                operator = 1.533983
-                memory = 1.702191
-
 Iterations = 43
 Final Relative Residual Norm = 6.495721e-09
 
 # Output file: benchmark_ij.out.20
-     Complexity:    grid = 1.082188
-                operator = 1.551144
-                memory = 2.054636
-
 Iterations = 38
 Final Relative Residual Norm = 6.437212e-09
 
 # Output file: benchmark_ij.out.21
-     Complexity:    grid = 1.061736
-                operator = 1.424757
-                memory = 2.084035
-
 Iterations = 28
 Final Relative Residual Norm = 5.555885e-09
 
 # Output file: benchmark_ij.out.22
-     Complexity:    grid = 1.354127
-                operator = 2.781838
-                memory = 3.406628
-
 Iterations = 12
 Final Relative Residual Norm = 8.710224e-09
 
 # Output file: benchmark_ij.out.23
-     Complexity:    grid = 1.354127
-                operator = 2.781838
-                memory = 3.406628
-
 Iterations = 13
 Final Relative Residual Norm = 6.320185e-09
 
 # Output file: benchmark_ij.out.24
-     Complexity:    grid = 1.354127
-                operator = 2.781838
-                memory = 3.406628
-
 Iterations = 14
 Final Relative Residual Norm = 2.238583e-09
 
 # Output file: benchmark_ij.out.25
-     Complexity:    grid = 1.354127
-                operator = 2.781838
-                memory = 3.406628
-
 Iterations = 15
 Final Relative Residual Norm = 4.854928e-09
 
 # Output file: benchmark_ij.out.26
-     Complexity:    grid = 1.014377
-                operator = 1.014669
-                memory = 1.078974
-
 Iterations = 37
 Final Relative Residual Norm = 7.386539e-09
 
 # Output file: benchmark_ij.out.27
-     Complexity:    grid = 1.016504
-                operator = 1.025273
-                memory = 1.092554
-
 Iterations = 22
 Final Relative Residual Norm = 7.869651e-09
 

--- a/src/test/TEST_bench/benchmark_ij.sh
+++ b/src/test/TEST_bench/benchmark_ij.sh
@@ -60,7 +60,7 @@ done > ${TNAME}.perf.out
 
 # Make sure that the output file is reasonable
 RUNCOUNT=`echo $FILES | wc -w`
-OUTCOUNT=`grep "Complexity" ${TNAME}.out | wc -l`
+OUTCOUNT=`grep "Iterations" ${TNAME}.out | wc -l`
 if [ "$OUTCOUNT" != "$RUNCOUNT" ]; then
    echo "Incorrect number of runs in ${TNAME}.out" >&2
 fi
@@ -71,6 +71,10 @@ case $HOST in
    lassen*)
       SavePerfExt="saved.lassen"
       rtol=0.15
+      ;;
+   ray*)
+      SavePerfExt="saved.ray"
+      rtol=0.10
       ;;
    *) SavePerfExt=""
       ;;

--- a/src/test/TEST_bench/benchmark_ij.sh
+++ b/src/test/TEST_bench/benchmark_ij.sh
@@ -74,7 +74,7 @@ case $HOST in
       ;;
    ray*)
       SavePerfExt="saved.ray"
-      rtol=0.10
+      rtol=0.15
       ;;
    *) SavePerfExt=""
       ;;

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -114,6 +114,7 @@ main( hypre_int argc,
    HYPRE_Int           recompute_res = 0;   /* What should be the default here? */
    HYPRE_Int           ioutdat;
    HYPRE_Int           poutdat;
+   HYPRE_Int           poutusr = 0; /* if user selects pout */
    HYPRE_Int           debug_flag;
    HYPRE_Int           ierr = 0;
    HYPRE_Int           i,j;
@@ -1514,6 +1515,7 @@ main( hypre_int argc,
       {
          arg_index++;
          poutdat  = atoi(argv[arg_index++]);
+         poutusr = 1;
       }
       else if ( strcmp(argv[arg_index], "-var") == 0 )
       {
@@ -3544,9 +3546,8 @@ main( hypre_int argc,
       HYPRE_BoomerAMGSetJacobiTruncThreshold(amg_solver, jacobi_trunc_threshold);
       HYPRE_BoomerAMGSetSCommPkgSwitch(amg_solver, S_commpkg_switch);
       /* note: log is written to standard output, not to file */
-      HYPRE_BoomerAMGSetPrintLevel(amg_solver, 3);
+      HYPRE_BoomerAMGSetPrintLevel(amg_solver, poutusr ? poutdat : 3);
       //HYPRE_BoomerAMGSetLogging(amg_solver, 2);
-      HYPRE_BoomerAMGSetPrintLevel(amg_solver, poutdat);
       HYPRE_BoomerAMGSetPrintFileName(amg_solver, "driver.out.log");
       HYPRE_BoomerAMGSetCycleType(amg_solver, cycle_type);
       HYPRE_BoomerAMGSetFCycle(amg_solver, fcycle);

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -3546,6 +3546,7 @@ main( hypre_int argc,
       /* note: log is written to standard output, not to file */
       HYPRE_BoomerAMGSetPrintLevel(amg_solver, 3);
       //HYPRE_BoomerAMGSetLogging(amg_solver, 2);
+      HYPRE_BoomerAMGSetPrintLevel(amg_solver, poutdat);
       HYPRE_BoomerAMGSetPrintFileName(amg_solver, "driver.out.log");
       HYPRE_BoomerAMGSetCycleType(amg_solver, cycle_type);
       HYPRE_BoomerAMGSetFCycle(amg_solver, fcycle);


### PR DESCRIPTION
This PR adds `-pout 0` in all the jobs in `TEST_bench/benchmark_ij.jobs`, which removes the cost of copying AMG hierarchy from GPU to host that is only for printing statistics, to have a more meaningful timing for the benchmarks. The `.saved` results have been updated.