### PR TITLE
fix cuSPARSE version conditional

### DIFF
--- a/src/seq_mv/csr_matvec_device.c
+++ b/src/seq_mv/csr_matvec_device.c
@@ -170,7 +170,7 @@ hypre_CSRMatrixMatvecCusparseNewAPI( HYPRE_Int        trans,
                                                    &beta,
                                                    vecY,
                                                    data_type,
-#if CUSPARSE_VERSION >= 11200
+#if CUSPARSE_VERSION >= 11400
                                                    CUSPARSE_SPMV_CSR_ALG2,
 #else
                                                    CUSPARSE_CSRMV_ALG2,
@@ -190,7 +190,7 @@ hypre_CSRMatrixMatvecCusparseNewAPI( HYPRE_Int        trans,
                                      &beta,
                                      vecY,
                                      data_type,
-#if CUSPARSE_VERSION >= 11200
+#if CUSPARSE_VERSION >= 11400
                                      CUSPARSE_SPMV_CSR_ALG2,
 #else
                                      CUSPARSE_CSRMV_ALG2,


### PR DESCRIPTION
I was using version 11.2.0 of cuSPARSE
and the constant CUSPARSE_SPMV_CSR_ALG2
was definitely not available.
Looking at the CUDA toolkit documentation,
the earliest release of the CUDA toolkit
that contained a cuSPARSE version that
supports CUSPARSE_SPMV_CSR_ALG2
was CUDA 11.2.1, with cuSPARSE version
11.4.0.135.
After this change, HYPRE only tries to
use CUSPARSE_SPMV_CSR_ALG2 for
cuSPARSE 11.4.0 and newer.