### PR TITLE
Early break in CG Eig

### DIFF
--- a/src/parcsr_ls/par_relax_more.c
+++ b/src/parcsr_ls/par_relax_more.c
@@ -308,6 +308,11 @@ hypre_ParCSRMaxEigEstimateCGHost( hypre_ParCSRMatrix *A,     /* matrix to relax 
       gamma_old = gamma;
       gamma = hypre_ParVectorInnerProd(r, s);
 
+      if (gamma < HYPRE_REAL_EPSILON)
+      {
+         break;
+      }
+
       if (i == 0)
       {
          beta = 1.0;
@@ -368,7 +373,7 @@ hypre_ParCSRMaxEigEstimateCGHost( hypre_ParCSRMatrix *A,     /* matrix to relax 
       /* don't need */
 
       /* r = r - alpha*s */
-      hypre_ParVectorAxpy( -alpha, s, r);
+      hypre_ParVectorAxpy(-alpha, s, r);
 
       i++;
    }

--- a/src/parcsr_ls/par_relax_more_device.c
+++ b/src/parcsr_ls/par_relax_more_device.c
@@ -378,6 +378,11 @@ hypre_ParCSRMaxEigEstimateCGDevice(hypre_ParCSRMatrix *A,     /* matrix to relax
       gamma_old = gamma;
       gamma     = hypre_ParVectorInnerProd(r, s);
 
+      if (gamma < HYPRE_REAL_EPSILON)
+      {
+         break;
+      }
+
       if (i == 0)
       {
          beta = 1.0;

--- a/src/test/TEST_ij/smoother.saved
+++ b/src/test/TEST_ij/smoother.saved
@@ -60,11 +60,11 @@ Final Relative Residual Norm = 2.509163e-09
 
 # Output file: smoother.out.12
 Iterations = 6
-Final Relative Residual Norm = 2.510138e-09
+Final Relative Residual Norm = 2.510130e-09
 
 # Output file: smoother.out.13
 Iterations = 5
-Final Relative Residual Norm = 6.702216e-09
+Final Relative Residual Norm = 6.702200e-09
 
 # Output file: smoother.out.14
 Iterations = 6


### PR DESCRIPTION
This PR adds early break in CG for eigenvalue estimations. The early break occurs when Krylov subspace is invariant with less than `n` iterations (`n` is the dimension of the matrix).  The current code hangs under certain circumstances, see #531.