### PR TITLE
Replace deprecated cudaThreadSync

### DIFF
--- a/src/seq_mv/csr_spadd_device.c
+++ b/src/seq_mv/csr_spadd_device.c
@@ -182,7 +182,7 @@ hypreDevice_CSRSpAdd( HYPRE_Int       ma, /* num of rows of A */
    *d_ac_out = d_ac;
 
 #ifdef HYPRE_PROFILE
-   cudaThreadSynchronize();
+   hypre_SyncCudaDevice(hypre_handle());
    hypre_profile_times[HYPRE_TIMER_ID_SPADD] += hypre_MPI_Wtime();
 #endif
 

--- a/src/seq_mv/csr_spgemm_device.c
+++ b/src/seq_mv/csr_spgemm_device.c
@@ -189,7 +189,7 @@ hypreDevice_CSRSpGemm(hypre_CSRMatrix  *A,
    hypre_CSRMatrixData(C)        = d_c;
 
 #ifdef HYPRE_PROFILE
-   cudaThreadSynchronize();
+   hypre_SyncCudaDevice(hypre_handle());
    hypre_profile_times[HYPRE_TIMER_ID_SPMM] += hypre_MPI_Wtime();
 #endif
 

--- a/src/seq_mv/csr_spgemm_device_confident.c
+++ b/src/seq_mv/csr_spgemm_device_confident.c
@@ -517,7 +517,7 @@ hypre_spgemm_numerical_with_rownnz( HYPRE_Int       m,
    *nnzC     = nnzC_nume;
 
 #ifdef HYPRE_PROFILE
-   cudaThreadSynchronize();
+   hypre_SyncCudaDevice(hypre_handle());
    hypre_profile_times[HYPRE_TIMER_ID_SPMM_NUMERIC] += hypre_MPI_Wtime();
 #endif
 

--- a/src/seq_mv/csr_spgemm_device_rowbound.c
+++ b/src/seq_mv/csr_spgemm_device_rowbound.c
@@ -339,7 +339,7 @@ hypre_spgemm_rownnz_attempt(HYPRE_Int  m,
    hypre_TFree(d_ghash_j, HYPRE_MEMORY_DEVICE);
 
 #ifdef HYPRE_PROFILE
-   cudaThreadSynchronize();
+   hypre_SyncCudaDevice(hypre_handle());
    hypre_profile_times[HYPRE_TIMER_ID_SPMM_SYMBOLIC] += hypre_MPI_Wtime();
 #endif
 }

--- a/src/seq_mv/csr_spgemm_device_rowest.c
+++ b/src/seq_mv/csr_spgemm_device_rowest.c
@@ -380,7 +380,7 @@ hypreDevice_CSRSpGemmRownnzEstimate(HYPRE_Int m, HYPRE_Int k, HYPRE_Int n,
    }
 
 #ifdef HYPRE_PROFILE
-   cudaThreadSynchronize();
+   hypre_SyncCudaDevice(hypre_handle());
    hypre_profile_times[HYPRE_TIMER_ID_SPMM_ROWNNZ] += hypre_MPI_Wtime();
 #endif
 

--- a/src/seq_mv/csr_sptrans_device.c
+++ b/src/seq_mv/csr_sptrans_device.c
@@ -76,7 +76,7 @@ hypreDevice_CSRSpTransCusparse(HYPRE_Int   m,        HYPRE_Int   n,        HYPRE
    *d_ac_out = csc_a;
 
 #ifdef HYPRE_PROFILE
-   cudaThreadSynchronize();
+   hypre_SyncCudaDevice(hypre_handle());
    hypre_profile_times[HYPRE_TIMER_ID_SPTRANS] += hypre_MPI_Wtime();
 #endif
 
@@ -226,7 +226,7 @@ hypreDevice_CSRSpTrans(HYPRE_Int   m,        HYPRE_Int   n,        HYPRE_Int    
    *d_ac_out = d_ac;
 
 #ifdef HYPRE_PROFILE
-   cudaThreadSynchronize();
+   hypre_SyncCudaDevice(hypre_handle());
    hypre_profile_times[HYPRE_TIMER_ID_SPTRANS] += hypre_MPI_Wtime();
 #endif
 


### PR DESCRIPTION
replaces old, deprecated cudaThreadSync with cudaDeviceSync, with back compatibility 