### PR TITLE
Pinned Memory for Parallel SpMV

### DIFF
--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -359,6 +359,10 @@ typedef struct hypre_ParCSRMatrix_struct
    /* these two arrays are reserveed for SoC matrices on GPUs to help build interpolation */
    HYPRE_Int            *soc_diag_j;
    HYPRE_Int            *soc_offd_j;
+
+   /* These arrays are reserved for pinned data transfer */
+   char                 *send_pinned;
+   char                 *recv_pinned;
 #endif
 
 } hypre_ParCSRMatrix;
@@ -397,6 +401,8 @@ typedef struct hypre_ParCSRMatrix_struct
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 #define hypre_ParCSRMatrixSocDiagJ(matrix)               ((matrix) -> soc_diag_j)
 #define hypre_ParCSRMatrixSocOffdJ(matrix)               ((matrix) -> soc_offd_j)
+#define hypre_ParCSRMatrixSendPinned(matrix)             ((matrix) -> send_pinned)
+#define hypre_ParCSRMatrixRecvPinned(matrix)             ((matrix) -> recv_pinned)
 #endif
 
 #define hypre_ParCSRMatrixNumRows(matrix) hypre_CSRMatrixNumRows(hypre_ParCSRMatrixDiag(matrix))
@@ -866,7 +872,11 @@ hypre_ParCSRCommHandle *hypre_ParCSRCommHandleCreate ( HYPRE_Int job, hypre_ParC
 hypre_ParCSRCommHandle *hypre_ParCSRCommHandleCreate_v2 ( HYPRE_Int job,
                                                           hypre_ParCSRCommPkg *comm_pkg, HYPRE_MemoryLocation send_memory_location, void *send_data_in,
                                                           HYPRE_MemoryLocation recv_memory_location, void *recv_data_in );
+hypre_ParCSRCommHandle *hypre_ParCSRCommHandleCreate_v3 ( HYPRE_Int job,
+                                                          hypre_ParCSRCommPkg *comm_pkg, HYPRE_MemoryLocation send_memory_location, void *send_data_in, void *send_data_pinned,
+                                                          HYPRE_MemoryLocation recv_memory_location, void *recv_data_in, void *recv_data_pinned );
 HYPRE_Int hypre_ParCSRCommHandleDestroy ( hypre_ParCSRCommHandle *comm_handle );
+HYPRE_Int hypre_ParCSRCommHandleDestroy_v3 ( hypre_ParCSRCommHandle *comm_handle );
 void hypre_ParCSRCommPkgCreate_core ( MPI_Comm comm, HYPRE_BigInt *col_map_offd,
                                       HYPRE_BigInt first_col_diag, HYPRE_BigInt *col_starts, HYPRE_Int num_cols_diag,
                                       HYPRE_Int num_cols_offd, HYPRE_Int *p_num_recvs, HYPRE_Int **p_recv_procs,

--- a/src/parcsr_mv/par_csr_matrix.c
+++ b/src/parcsr_mv/par_csr_matrix.c
@@ -128,6 +128,8 @@ hypre_ParCSRMatrixCreate( MPI_Comm      comm,
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
    hypre_ParCSRMatrixSocDiagJ(matrix) = NULL;
    hypre_ParCSRMatrixSocOffdJ(matrix) = NULL;
+   hypre_ParCSRMatrixSendPinned(matrix) = NULL;
+   hypre_ParCSRMatrixRecvPinned(matrix) = NULL;
 #endif
 
    return matrix;
@@ -204,6 +206,8 @@ hypre_ParCSRMatrixDestroy( hypre_ParCSRMatrix *matrix )
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
       hypre_TFree(hypre_ParCSRMatrixSocDiagJ(matrix), HYPRE_MEMORY_DEVICE);
       hypre_TFree(hypre_ParCSRMatrixSocOffdJ(matrix), HYPRE_MEMORY_DEVICE);
+      _hypre_TFree(hypre_ParCSRMatrixSendPinned(matrix), hypre_MEMORY_HOST_PINNED);
+      _hypre_TFree(hypre_ParCSRMatrixRecvPinned(matrix), hypre_MEMORY_HOST_PINNED);
 #endif
 
       hypre_TFree(matrix, HYPRE_MEMORY_HOST);

--- a/src/parcsr_mv/protos.h
+++ b/src/parcsr_mv/protos.h
@@ -233,7 +233,11 @@ hypre_ParCSRCommHandle *hypre_ParCSRCommHandleCreate ( HYPRE_Int job, hypre_ParC
 hypre_ParCSRCommHandle *hypre_ParCSRCommHandleCreate_v2 ( HYPRE_Int job,
                                                           hypre_ParCSRCommPkg *comm_pkg, HYPRE_MemoryLocation send_memory_location, void *send_data_in,
                                                           HYPRE_MemoryLocation recv_memory_location, void *recv_data_in );
+hypre_ParCSRCommHandle *hypre_ParCSRCommHandleCreate_v3 ( HYPRE_Int job,
+                                                          hypre_ParCSRCommPkg *comm_pkg, HYPRE_MemoryLocation send_memory_location, void *send_data_in, void *send_data_pinned,
+                                                          HYPRE_MemoryLocation recv_memory_location, void *recv_data_in, void *recv_data_pinned );
 HYPRE_Int hypre_ParCSRCommHandleDestroy ( hypre_ParCSRCommHandle *comm_handle );
+HYPRE_Int hypre_ParCSRCommHandleDestroy_v3 ( hypre_ParCSRCommHandle *comm_handle );
 void hypre_ParCSRCommPkgCreate_core ( MPI_Comm comm, HYPRE_BigInt *col_map_offd,
                                       HYPRE_BigInt first_col_diag, HYPRE_BigInt *col_starts, HYPRE_Int num_cols_diag,
                                       HYPRE_Int num_cols_offd, HYPRE_Int *p_num_recvs, HYPRE_Int **p_recv_procs,

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -737,6 +737,13 @@ typedef struct
 }                                                                                                                                              \
 )
 
+#define hypre_TMemcpyAsync(dst, src, type, count, locdst, locsrc)                                     \
+(                                                                                                     \
+{                                                                                                     \
+   hypre_MemcpyAsync((void *)(dst), (void *)(src), (size_t)(sizeof(type) * (count)), locdst, locsrc); \
+}                                                                                                     \
+)
+
 #define hypre_TFree(ptr, location)                                                                                          \
 (                                                                                                                           \
 {                                                                                                                           \
@@ -777,6 +784,9 @@ typedef struct
 #define hypre_TMemcpy(dst, src, type, count, locdst, locsrc) \
 (hypre_Memcpy((void *)(dst), (void *)(src), (size_t)(sizeof(type) * (count)), locdst, locsrc))
 
+#define hypre_TMemcpyAsync(dst, src, type, count, locdst, locsrc) \
+(hypre_MemcpyAsync((void *)(dst), (void *)(src), (size_t)(sizeof(type) * (count)), locdst, locsrc))
+
 #define hypre_TFree(ptr, location) \
 ( hypre_Free((void *)ptr, location), ptr = NULL )
 
@@ -796,8 +806,11 @@ void   hypre_MemPrefetch(void *ptr, size_t size, HYPRE_MemoryLocation location);
 void * hypre_MAlloc(size_t size, HYPRE_MemoryLocation location);
 void * hypre_CAlloc( size_t count, size_t elt_size, HYPRE_MemoryLocation location);
 void   hypre_Free(void *ptr, HYPRE_MemoryLocation location);
+void * hypre_HostGetDevicePointer(void *hostPtr);
 void   hypre_Memcpy(void *dst, void *src, size_t size, HYPRE_MemoryLocation loc_dst,
                     HYPRE_MemoryLocation loc_src);
+void   hypre_MemcpyAsync(void *dst, void *src, size_t size, HYPRE_MemoryLocation loc_dst,
+                         HYPRE_MemoryLocation loc_src);
 void * hypre_ReAlloc(void *ptr, size_t size, HYPRE_MemoryLocation location);
 void * hypre_ReAlloc_v2(void *ptr, size_t old_size, size_t new_size, HYPRE_MemoryLocation location);
 

--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -325,6 +325,29 @@ hypre_UnifiedMalloc(size_t size, HYPRE_Int zeroinit)
 }
 
 static inline void *
+hypre_HostGetDevicePointer_core(void * hostPtr)
+{
+    void * devPtr = NULL;
+#if defined(HYPRE_USING_CUDA)
+    HYPRE_CUDA_CALL( cudaHostGetDevicePointer(&devPtr, hostPtr, 0) );
+#endif
+#if defined(HYPRE_USING_HIP)
+    HYPRE_HIP_CALL( hipHostGetDevicePointer(&devPtr, hostPtr, hipHostRegisterMapped) );
+#endif
+    return devPtr;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_Free
+ *--------------------------------------------------------------------------*/
+
+void *
+hypre_HostGetDevicePointer(void *hostPtr)
+{
+   return hypre_HostGetDevicePointer_core(hostPtr);
+}
+
+static inline void *
 hypre_HostPinnedMalloc(size_t size, HYPRE_Int zeroinit)
 {
    void *ptr = NULL;
@@ -334,11 +357,12 @@ hypre_HostPinnedMalloc(size_t size, HYPRE_Int zeroinit)
 #else
 
 #if defined(HYPRE_USING_CUDA)
-   HYPRE_CUDA_CALL( cudaMallocHost(&ptr, size) );
+   //HYPRE_CUDA_CALL( cudaMallocHost(&ptr, size) );
+   HYPRE_CUDA_CALL( cudaHostAlloc(&ptr, size, cudaHostAllocMapped) );
 #endif
 
 #if defined(HYPRE_USING_HIP)
-   HYPRE_HIP_CALL( hipHostMalloc(&ptr, size) );
+   HYPRE_HIP_CALL( hipHostMalloc(&ptr, size, hipHostRegisterMapped) );
 #endif
 
 #if defined(HYPRE_USING_SYCL)
@@ -548,6 +572,41 @@ _hypre_Free(void *ptr, hypre_MemoryLocation location)
    hypre_Free_core(ptr, location);
 }
 
+/*--------------------------------------------------------------------------
+ * MemcpyAsync
+ *--------------------------------------------------------------------------*/
+static inline void
+hypre_MemcpyAsync_core(void *dst, void *src, size_t size, hypre_MemoryLocation loc_dst,
+                       hypre_MemoryLocation loc_src)
+{
+   if (dst == NULL || src == NULL)
+   {
+      if (size)
+      {
+         hypre_printf("hypre_Memcpy warning: copy %ld bytes from %p to %p !\n", size, src, dst);
+         hypre_assert(0);
+      }
+
+      return;
+   }
+
+   if (dst == src)
+   {
+      return;
+   }
+
+   /* 2: UVM <-- Host, UVM <-- Pinned */
+   if (loc_dst == hypre_MEMORY_UNIFIED || loc_dst == hypre_MEMORY_DEVICE)
+   {
+#if defined(HYPRE_USING_CUDA)
+     HYPRE_CUDA_CALL( cudaMemcpyAsync(dst, src, size, cudaMemcpyHostToDevice, hypre_HandleComputeStream(hypre_handle())) );
+#endif
+#if defined(HYPRE_USING_HIP)
+      HYPRE_HIP_CALL( hipMemcpyAsync(dst, src, size, hipMemcpyDeviceToDevice, hypre_HandleComputeStream(hypre_handle())) );
+#endif
+     return;
+   }
+}
 
 /*--------------------------------------------------------------------------
  * Memcpy
@@ -931,6 +990,18 @@ hypre_Memcpy(void *dst, void *src, size_t size, HYPRE_MemoryLocation loc_dst,
 {
    hypre_Memcpy_core( dst, src, size, hypre_GetActualMemLocation(loc_dst),
                       hypre_GetActualMemLocation(loc_src) );
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_Memcpy
+ *--------------------------------------------------------------------------*/
+
+void
+hypre_MemcpyAsync(void *dst, void *src, size_t size, HYPRE_MemoryLocation loc_dst,
+                  HYPRE_MemoryLocation loc_src)
+{
+   hypre_MemcpyAsync_core( dst, src, size, hypre_GetActualMemLocation(loc_dst),
+                           hypre_GetActualMemLocation(loc_src) );
 }
 
 /*--------------------------------------------------------------------------

--- a/src/utilities/memory.h
+++ b/src/utilities/memory.h
@@ -223,6 +223,13 @@ typedef struct
 }                                                                                                                                              \
 )
 
+#define hypre_TMemcpyAsync(dst, src, type, count, locdst, locsrc)                                     \
+(                                                                                                     \
+{                                                                                                     \
+   hypre_MemcpyAsync((void *)(dst), (void *)(src), (size_t)(sizeof(type) * (count)), locdst, locsrc); \
+}                                                                                                     \
+)
+
 #define hypre_TFree(ptr, location)                                                                                          \
 (                                                                                                                           \
 {                                                                                                                           \
@@ -263,6 +270,9 @@ typedef struct
 #define hypre_TMemcpy(dst, src, type, count, locdst, locsrc) \
 (hypre_Memcpy((void *)(dst), (void *)(src), (size_t)(sizeof(type) * (count)), locdst, locsrc))
 
+#define hypre_TMemcpyAsync(dst, src, type, count, locdst, locsrc) \
+(hypre_MemcpyAsync((void *)(dst), (void *)(src), (size_t)(sizeof(type) * (count)), locdst, locsrc))
+
 #define hypre_TFree(ptr, location) \
 ( hypre_Free((void *)ptr, location), ptr = NULL )
 
@@ -282,6 +292,7 @@ void   hypre_MemPrefetch(void *ptr, size_t size, HYPRE_MemoryLocation location);
 void * hypre_MAlloc(size_t size, HYPRE_MemoryLocation location);
 void * hypre_CAlloc( size_t count, size_t elt_size, HYPRE_MemoryLocation location);
 void   hypre_Free(void *ptr, HYPRE_MemoryLocation location);
+void * hypre_HostGetDevicePointer(void *hostPtr);
 void   hypre_Memcpy(void *dst, void *src, size_t size, HYPRE_MemoryLocation loc_dst,
                     HYPRE_MemoryLocation loc_src);
 void * hypre_ReAlloc(void *ptr, size_t size, HYPRE_MemoryLocation location);


### PR DESCRIPTION
This PR adds pinned memory for data transfer during a parallel SpMV. I think this would be a good time to make a par_csr_matvec_device.c and include device code there. It would make this easier to work with rather than all the #defs.

1) Pinned pointers are added to par_csr_matrix class. These pointers are allocated on demand in par_csr_matvec.c. They are sized according to a maximum in order to be reusable in both the standard matvec and matvecT. To me, they belong in the matrix class because the data is sized according to a particular matrix's parallel SpMV layout.

2) The pinned memory buffers are allocated in memory.c with cudaHostAlloc with cudaHostAllocMapped. This enables one to write directly into pinned memory from the cuda kernels (either gather (matvec) or spmv (matvecT)).  One has to do cudaHostGetDevicePointer and pass that into the kernel execution (done in par_csr_matvec.c). This is a little wonky and needs to be cleaned up.

3) par_csr_communication has 2 new methods : hypre_ParCSRCommHandleCreate_v3, hypre_ParCSRCommHandleDestroy_v3

In the first method, we have the pinned buffers passed as input. Rather than execute a memcpyDtoH, I simply device synchronize to ensure the pinned data is ready on the host for MPI communication.

In the second method, I execute a cudaMemcpyAsync in order to allow data transfer execute in parallel overlapped kernel execution. cudaMemcpyAsync is called via hypre_TMemcpyAsync. This is a new method and is only implemented for Nvidia and AMD architectures. Tested on Summit and Crusher.