### PR TITLE
Fix build on FreeBSD/powerpc*.

### DIFF
--- a/src/distributed_ls/pilut/DistributedMatrixPilutSolver.h
+++ b/src/distributed_ls/pilut/DistributedMatrixPilutSolver.h
@@ -86,7 +86,7 @@ HYPRE_Int Ul_timer;
 #define jr (globals->_jr)
 #define jw (globals->_jw)
 #define lastjr (globals->_lastjr)
-#define lr (globals->_lr)
+#define hypre_lr (globals->_lr)
 #define lastlr (globals->_lastlr)
 #define w (globals->_w)
 #define firstrow (globals->_firstrow)

--- a/src/distributed_ls/pilut/HYPRE_DistributedMatrixPilutSolver.c
+++ b/src/distributed_ls/pilut/HYPRE_DistributedMatrixPilutSolver.c
@@ -39,7 +39,7 @@ HYPRE_Int  HYPRE_NewDistributedMatrixPilutSolver(
        (hypre_PilutSolverGlobals *) hypre_CTAlloc( hypre_PilutSolverGlobals,  1 , HYPRE_MEMORY_HOST);
 
    jr = NULL;
-   lr = NULL;
+   hypre_lr = NULL;
    jw = NULL;
    w  = NULL;
 

--- a/src/distributed_ls/pilut/parilut.c
+++ b/src/distributed_ls/pilut/parilut.c
@@ -145,7 +145,7 @@ void hypre_ParILUT(DataDistType *ddist, FactorMatType *ldu,
              newperm, newiperm, vrowdist, -1);*/
   hypre_TFree(jr, HYPRE_MEMORY_HOST);
   hypre_TFree(jw, HYPRE_MEMORY_HOST);
-  hypre_TFree(lr, HYPRE_MEMORY_HOST);
+  hypre_TFree(hypre_lr, HYPRE_MEMORY_HOST);
   hypre_TFree(w, HYPRE_MEMORY_HOST);
   hypre_TFree(pilut_map, HYPRE_MEMORY_HOST);
   hypre_TFree(nrmat.rmat_rnz, HYPRE_MEMORY_HOST);
@@ -167,7 +167,7 @@ void hypre_ParILUT(DataDistType *ddist, FactorMatType *ldu,
 
   jr = NULL;
   jw = NULL;
-  lr = NULL;
+  hypre_lr = NULL;
   w  = NULL;
 
 #ifdef HYPRE_DEBUG
@@ -651,9 +651,9 @@ void hypre_ComputeRmat(FactorMatType *ldu, ReduceMatType *rmat,
       /* record L elements */
       if (IsInMIS(pilut_map[rcolind[lastjr]])) {
          if (rcolind[lastjr] >= firstrow  &&  rcolind[lastjr] < lastrow)
-            lr[lastlr] = (newiperm[rcolind[lastjr]-firstrow] << 1);
+            hypre_lr[lastlr] = (newiperm[rcolind[lastjr]-firstrow] << 1);
          else {
-            lr[lastlr] = pilut_map[rcolind[lastjr]];  /* map[] == (l<<1) | 1 */
+            hypre_lr[lastlr] = pilut_map[rcolind[lastjr]];  /* map[] == (l<<1) | 1 */
             hypre_assert(incolind[StripMIS(pilut_map[rcolind[lastjr]])+1] ==
                  rcolind[lastjr]);
          }
@@ -696,7 +696,7 @@ void hypre_ComputeRmat(FactorMatType *ldu, ReduceMatType *rmat,
             /* record L elements -- these must be local */
             if (IsInMIS(pilut_map[ucolind[l]])) {
                hypre_assert(ucolind[l] >= firstrow  &&  ucolind[l] < lastrow);
-               lr[lastlr] = (newiperm[ucolind[l]-firstrow] << 1);
+               hypre_lr[lastlr] = (newiperm[ucolind[l]-firstrow] << 1);
                lastlr++;
             }
 
@@ -736,7 +736,7 @@ void hypre_ComputeRmat(FactorMatType *ldu, ReduceMatType *rmat,
             /* record L elements -- these must be remote */
             if (IsInMIS(pilut_map[incolind[l]])) {
                hypre_assert(incolind[l] < firstrow  ||  incolind[l] >= lastrow);
-               lr[lastlr] = pilut_map[incolind[l]];  /* map[] == (l<<1) | 1 */
+               hypre_lr[lastlr] = pilut_map[incolind[l]];  /* map[] == (l<<1) | 1 */
                lastlr++;
             }
 
@@ -834,7 +834,7 @@ void hypre_FactorLocal(FactorMatType *ldu, ReduceMatType *rmat,
       if (rcolind[lastjr] >= firstrow  &&
             rcolind[lastjr] <  lastrow   &&
             newiperm[rcolind[lastjr]-firstrow] < diag) {
-         lr[lastlr] = newiperm[rcolind[lastjr]-firstrow];
+         hypre_lr[lastlr] = newiperm[rcolind[lastjr]-firstrow];
         lastlr++;
       }
 
@@ -873,7 +873,7 @@ void hypre_FactorLocal(FactorMatType *ldu, ReduceMatType *rmat,
                   ucolind[l] <  lastrow   &&
                   newiperm[ucolind[l]-firstrow] < diag) {
                hypre_assert(IsInMIS(pilut_map[ucolind[l]]));
-               lr[lastlr] = newiperm[ucolind[l]-firstrow];
+               hypre_lr[lastlr] = newiperm[ucolind[l]-firstrow];
                lastlr++;
             }
 
@@ -1353,8 +1353,8 @@ void hypre_ParINIT( ReduceMatType *nrmat, CommInfoType *cinfo, HYPRE_Int *rowdis
   /* Allocate work space */
   hypre_TFree(jr, HYPRE_MEMORY_HOST);
   jr = hypre_idx_malloc_init(nrows, -1, "hypre_ParILUT: jr");
-  hypre_TFree(lr, HYPRE_MEMORY_HOST);
-  lr = hypre_idx_malloc_init(nleft, -1, "hypre_ParILUT: lr");
+  hypre_TFree(hypre_lr, HYPRE_MEMORY_HOST);
+  hypre_lr = hypre_idx_malloc_init(nleft, -1, "hypre_ParILUT: lr");
   hypre_TFree(jw, HYPRE_MEMORY_HOST);
   jw = hypre_idx_malloc(nleft, "hypre_ParILUT: jw");
   hypre_TFree(w, HYPRE_MEMORY_HOST);

--- a/src/distributed_ls/pilut/serilut.c
+++ b/src/distributed_ls/pilut/serilut.c
@@ -70,8 +70,8 @@ HYPRE_Int hypre_SerILUT(DataDistType *ddist, HYPRE_DistributedMatrix matrix,
   /* Allocate work space */
   hypre_TFree(jr, HYPRE_MEMORY_HOST);
   jr = hypre_idx_malloc_init(nrows, -1, "hypre_SerILUT: jr");
-  hypre_TFree(lr, HYPRE_MEMORY_HOST);
-  lr = hypre_idx_malloc_init(nrows, -1, "hypre_SerILUT: lr");
+  hypre_TFree(hypre_lr, HYPRE_MEMORY_HOST);
+  hypre_lr = hypre_idx_malloc_init(nrows, -1, "hypre_SerILUT: lr");
   hypre_TFree(jw, HYPRE_MEMORY_HOST);
   jw = hypre_idx_malloc(nrows, "hypre_SerILUT: jw");
   hypre_TFree(w, HYPRE_MEMORY_HOST);
@@ -158,7 +158,7 @@ HYPRE_Int hypre_SerILUT(DataDistType *ddist, HYPRE_DistributedMatrix matrix,
 
     for (lastjr=1, lastlr=0, j=0, diag_present=0; j<row_size; j++) {
       if (iperm[ col_ind[j] - firstrow ] < iperm[i]) 
-        lr[lastlr++] = iperm[ col_ind[j]-firstrow]; /* Copy the L elements separately */
+        hypre_lr[lastlr++] = iperm[ col_ind[j]-firstrow]; /* Copy the L elements separately */
 
       if (col_ind[j] != i+firstrow) { /* Off-diagonal element */
         jr[col_ind[j]] = lastjr;
@@ -207,7 +207,7 @@ HYPRE_Int hypre_SerILUT(DataDistType *ddist, HYPRE_DistributedMatrix matrix,
 
         if (m == -1) {  /* Create fill */
           if (iperm[ucolind[l]-firstrow] < iperm[i]) 
-            lr[lastlr++] = iperm[ucolind[l]-firstrow]; /* Copy the L elements separately */
+            hypre_lr[lastlr++] = iperm[ucolind[l]-firstrow]; /* Copy the L elements separately */
 
           jr[ucolind[l]] = lastjr;
           jw[lastjr] = ucolind[l];
@@ -258,7 +258,7 @@ HYPRE_Int hypre_SerILUT(DataDistType *ddist, HYPRE_DistributedMatrix matrix,
       if (col_ind[j] >= firstrow  &&
             col_ind[j] < lastrow    &&
             iperm[col_ind[j]-firstrow] < nlocal) 
-        lr[lastlr++] = iperm[col_ind[j]-firstrow]; /* Copy the L elements separately */
+        hypre_lr[lastlr++] = iperm[col_ind[j]-firstrow]; /* Copy the L elements separately */
 
       if (col_ind[j] != i+firstrow) { /* Off-diagonal element */
         jr[col_ind[j]] = lastjr;
@@ -304,7 +304,7 @@ HYPRE_Int hypre_SerILUT(DataDistType *ddist, HYPRE_DistributedMatrix matrix,
         if (m == -1) {  /* Create fill */
            hypre_CheckBounds(firstrow, ucolind[l], lastrow, globals);
           if (iperm[ucolind[l]-firstrow] < nlocal) 
-            lr[lastlr++] = iperm[ucolind[l]-firstrow]; /* Copy the L elements separately */
+            hypre_lr[lastlr++] = iperm[ucolind[l]-firstrow]; /* Copy the L elements separately */
 
           jr[ucolind[l]] = lastjr;
           jw[lastjr] = ucolind[l];
@@ -330,11 +330,11 @@ HYPRE_Int hypre_SerILUT(DataDistType *ddist, HYPRE_DistributedMatrix matrix,
   /*hypre_free_multi(jr, jw, lr, w, -1);*/
   hypre_TFree(jr, HYPRE_MEMORY_HOST);
   hypre_TFree(jw, HYPRE_MEMORY_HOST);
-  hypre_TFree(lr, HYPRE_MEMORY_HOST);
+  hypre_TFree(hypre_lr, HYPRE_MEMORY_HOST);
   hypre_TFree(w, HYPRE_MEMORY_HOST);
   jr = NULL;
   jw = NULL;
-  lr = NULL;
+  hypre_lr = NULL;
   w = NULL;
 
   return(ierr);

--- a/src/distributed_ls/pilut/util.c
+++ b/src/distributed_ls/pilut/util.c
@@ -28,15 +28,15 @@ HYPRE_Int hypre_ExtractMinLR( hypre_PilutSolverGlobals *globals )
   HYPRE_Int i, j=0 ;
 
   for (i=1; i<lastlr; i++) {
-    if (lr[i] < lr[j])
+    if (hypre_lr[i] < hypre_lr[j])
       j = i;
   }
-  i = lr[j];
+  i = hypre_lr[j];
 
   /* Remove it */
   lastlr-- ;
   if (j < lastlr) 
-    lr[j] = lr[lastlr];
+    hypre_lr[j] = hypre_lr[lastlr];
 
   return i;
 }


### PR DESCRIPTION
`lr` collides with `lr` from `machine/frame.h` header (link register):
```
In file included from /wrkdirs/usr/ports/science/hypre/work/hypre-2.23.0/src/distributed_ls/pilut/parilut.c:53:
In file included from /wrkdirs/usr/ports/science/hypre/work/hypre-2.23.0/src/distributed_ls/pilut/ilu.h:29:
In file included from /usr/include/signal.h:40:
In file included from /usr/include/sys/signal.h:48:
In file included from /usr/include/machine/signal.h:45:
/usr/include/machine/frame.h:54:13: error: expected ')'
        register_t lr;
```
