### PR TITLE
Add convenient CMake alias

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -549,4 +549,8 @@ export(EXPORT HYPRETargets
   NAMESPACE HYPRE::
   )
 
+# Declare an alias so that consumers can depend on HYPRE::HYPRE target
+# also when using HYPRE via add_directory or FetchContent
+add_library(HYPRE::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
 export(PACKAGE ${PROJECT_NAME})


### PR DESCRIPTION
Usually consumers of HYPRE call find_package(HYPRE) and depend on
HYPRE::HYPRE target.  But they could also want to use HYPRE via
add_directory (for instance via a git submodule)) or FetchContent,
in which case they have to depend on HYPRE target.

This alias makes this usage more consistent, all users could then
depend on HYPRE::HYPRE.  See for instance
  https://cmake.org/pipermail/cmake/2018-November/068629.html