### PR TITLE
Softlinks

### DIFF
--- a/src/IJ_mv/Makefile
+++ b/src/IJ_mv/Makefile
@@ -85,6 +85,6 @@ libHYPRE_IJ_mv.a: ${OBJS}
 libHYPRE_IJ_mv.so libHYPRE_IJ_mv.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}

--- a/src/distributed_matrix/Makefile
+++ b/src/distributed_matrix/Makefile
@@ -64,6 +64,6 @@ libHYPRE_DistributedMatrix.a: ${OBJS}
 libHYPRE_DistributedMatrix.so libHYPRE_DistributedMatrix.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}

--- a/src/krylov/Makefile
+++ b/src/krylov/Makefile
@@ -86,6 +86,6 @@ libHYPRE_krylov.a: ${OBJS}
 libHYPRE_krylov.so libHYPRE_krylov.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -127,4 +127,4 @@ libHYPRE.a: ${FILES_HYPRE}
 libHYPRE.so libHYPRE.dylib: ${FILES_HYPRE}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${FILES_HYPRE} ${SOLIBS} ${SHARED_SET_SONAME}${SONAME} ${SHARED_OPTIONS} ${LDFLAGS}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@

--- a/src/matrix_matrix/Makefile
+++ b/src/matrix_matrix/Makefile
@@ -59,6 +59,6 @@ libHYPRE_MatrixMatrix.a: ${OBJS}
 libHYPRE_MatrixMatrix.so libHYPRE_MatrixMatrix.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}

--- a/src/multivector/Makefile
+++ b/src/multivector/Makefile
@@ -55,6 +55,6 @@ libHYPRE_multivector.a: ${OBJS}
 libHYPRE_multivector.so libHYPRE_multivector.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}

--- a/src/parcsr_block_mv/Makefile
+++ b/src/parcsr_block_mv/Makefile
@@ -111,7 +111,7 @@ libHYPRE_parcsr_block_mv.a: ${OBJS}
 libHYPRE_parcsr_block_mv.so libHYPRE_parcsr_block_mv.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}
 

--- a/src/parcsr_ls/Makefile
+++ b/src/parcsr_ls/Makefile
@@ -205,6 +205,6 @@ libHYPRE_parcsr_ls.a: ${OBJS}
 libHYPRE_parcsr_ls.so libHYPRE_parcsr_ls.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}

--- a/src/parcsr_mv/Makefile
+++ b/src/parcsr_mv/Makefile
@@ -136,7 +136,7 @@ libHYPRE_parcsr_mv.a: ${OBJS}
 libHYPRE_parcsr_mv.so libHYPRE_parcsr_mv.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}
 

--- a/src/seq_mv/Makefile
+++ b/src/seq_mv/Makefile
@@ -92,6 +92,6 @@ libHYPRE_seq_mv.a: ${OBJS}
 libHYPRE_seq_mv.so libHYPRE_seq_mv.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}

--- a/src/sstruct_ls/Makefile
+++ b/src/sstruct_ls/Makefile
@@ -142,6 +142,6 @@ libHYPRE_sstruct_ls.a: ${OBJS}
 libHYPRE_sstruct_ls.so libHYPRE_sstruct_ls.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}

--- a/src/sstruct_mv/Makefile
+++ b/src/sstruct_mv/Makefile
@@ -89,6 +89,6 @@ libHYPRE_sstruct_mv.a: ${OBJS}
 libHYPRE_sstruct_mv.so libHYPRE_sstruct_mv.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}

--- a/src/struct_ls/Makefile
+++ b/src/struct_ls/Makefile
@@ -133,6 +133,6 @@ libHYPRE_struct_ls.a: ${OBJS}
 libHYPRE_struct_ls.so libHYPRE_struct_ls.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}

--- a/src/struct_mv/Makefile
+++ b/src/struct_mv/Makefile
@@ -99,6 +99,6 @@ libHYPRE_struct_mv.a: ${OBJS}
 libHYPRE_struct_mv.so libHYPRE_struct_mv.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}

--- a/src/utilities/Makefile
+++ b/src/utilities/Makefile
@@ -112,6 +112,6 @@ libHYPRE_utilities.a: ${OBJS}
 libHYPRE_utilities.so libHYPRE_utilities.dylib: ${OBJS}
 	@echo  "Building $@ ... "
 	${BUILD_CC_SHARED} -o ${SONAME} ${OBJS} ${SHARED_SET_SONAME}${SONAME}
-	ln -s ${SONAME} $@
+	ln -s -f ${SONAME} $@
 
 ${OBJS}: ${HEADERS}


### PR DESCRIPTION
This PR (copied from #573) added -f to softlink generation to all the makefiles. After making changes to a source file, one no longer needs to manual delete a subdirectory .so.