### PR TITLE
Fix checking Windows platform with preprocessor

### DIFF
--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1947,7 +1947,7 @@ static inline HYPRE_Int
 first_lsb_bit_indx( hypre_uint x )
 {
    HYPRE_Int pos;
-#if defined(_MSC_VER) || defined(__MINGW64__)
+#ifdef _WIN32
    if (x == 0)
    {
       pos = 0;

--- a/src/utilities/hopscotch_hash.h
+++ b/src/utilities/hopscotch_hash.h
@@ -133,7 +133,7 @@ static inline HYPRE_Int
 first_lsb_bit_indx( hypre_uint x )
 {
    HYPRE_Int pos;
-#if defined(_MSC_VER) || defined(__MINGW64__)
+#ifdef _WIN32
    if (x == 0)
    {
       pos = 0;


### PR DESCRIPTION
Check _WIN32 instead of _MSC_VER because the later one is for MSVC only.
Also __MINGW64__ is defined for 64 bit only. So, chekcing _WIN32 includes
all cases. This fixes building with 32 bit mingw-w64 toolchain.