### PR TITLE
Improve SStruct RAP times

### DIFF
--- a/src/parcsr_mv/par_csr_triplemat.c
+++ b/src/parcsr_mv/par_csr_triplemat.c
@@ -853,7 +853,6 @@ hypre_ParCSRMatrixRAPKTHost( hypre_ParCSRMatrix *R,
       hypre_CSRMatrixTranspose(R_diag, &RT_diag, 1);
       C_diag = hypre_CSRMatrixMultiplyHost(RT_diag, Q_diag);
       C_offd = hypre_CSRMatrixCreate(num_cols_diag_R, 0, 0);
-      hypre_CSRMatrixNumRownnz(C_offd) = 0;
       hypre_CSRMatrixInitialize_v2(C_offd, 0, hypre_CSRMatrixMemoryLocation(C_diag));
       if (keep_transpose)
       {
@@ -872,6 +871,7 @@ hypre_ParCSRMatrixRAPKTHost( hypre_ParCSRMatrix *R,
    hypre_CSRMatrixDestroy(hypre_ParCSRMatrixDiag(C));
    hypre_CSRMatrixDestroy(hypre_ParCSRMatrixOffd(C));
    hypre_ParCSRMatrixDiag(C) = C_diag;
+   hypre_CSRMatrixSetRownnz(C_diag);
 
    if (C_offd)
    {
@@ -881,9 +881,9 @@ hypre_ParCSRMatrixRAPKTHost( hypre_ParCSRMatrix *R,
    {
       C_offd = hypre_CSRMatrixCreate(num_cols_diag_R, 0, 0);
       hypre_CSRMatrixInitialize(C_offd);
-      hypre_CSRMatrixNumRownnz(C_offd) = 0;
       hypre_ParCSRMatrixOffd(C) = C_offd;
    }
+   hypre_CSRMatrixSetRownnz(C_offd);
 
    hypre_ParCSRMatrixColMapOffd(C) = col_map_offd_C;
 

--- a/src/parcsr_mv/par_csr_triplemat.c
+++ b/src/parcsr_mv/par_csr_triplemat.c
@@ -853,6 +853,7 @@ hypre_ParCSRMatrixRAPKTHost( hypre_ParCSRMatrix *R,
       hypre_CSRMatrixTranspose(R_diag, &RT_diag, 1);
       C_diag = hypre_CSRMatrixMultiplyHost(RT_diag, Q_diag);
       C_offd = hypre_CSRMatrixCreate(num_cols_diag_R, 0, 0);
+      hypre_CSRMatrixNumRownnz(C_offd) = 0;
       hypre_CSRMatrixInitialize_v2(C_offd, 0, hypre_CSRMatrixMemoryLocation(C_diag));
       if (keep_transpose)
       {
@@ -880,6 +881,7 @@ hypre_ParCSRMatrixRAPKTHost( hypre_ParCSRMatrix *R,
    {
       C_offd = hypre_CSRMatrixCreate(num_cols_diag_R, 0, 0);
       hypre_CSRMatrixInitialize(C_offd);
+      hypre_CSRMatrixNumRownnz(C_offd) = 0;
       hypre_ParCSRMatrixOffd(C) = C_offd;
    }
 

--- a/src/seq_mv/csr_matop.c
+++ b/src/seq_mv/csr_matop.c
@@ -1596,6 +1596,8 @@ hypre_CSRMatrixReorder(hypre_CSRMatrix *A)
  * Note: The routine does not check for 0-elements which might be generated
  *       through cancellation of elements in A and B or already contained
  *       in A and B. To remove those, use hypre_CSRMatrixDeleteZeros
+ *
+ * TODO: Add OpenMP support
  *--------------------------------------------------------------------------*/
 hypre_CSRMatrix *
 hypre_CSRMatrixAddPartial( hypre_CSRMatrix *A,
@@ -2079,4 +2081,3 @@ hypre_CSRMatrixSetConstantValues( hypre_CSRMatrix *A,
 
    return hypre_error_flag;
 }
-

--- a/src/seq_mv/csr_matrix.c
+++ b/src/seq_mv/csr_matrix.c
@@ -340,12 +340,15 @@ hypre_CSRMatrixSetRownnzHost( hypre_CSRMatrix *matrix )
    HYPRE_Int i, adiag;
    HYPRE_Int irownnz = 0;
 
-   for (i = 0; i < num_rows; i++)
+   if ((A_i[num_rows] - A_i[0]) > 0)
    {
-      adiag = A_i[i + 1] - A_i[i];
-      if (adiag > 0)
+      for (i = 0; i < num_rows; i++)
       {
-         irownnz++;
+         adiag = A_i[i + 1] - A_i[i];
+         if (adiag > 0)
+         {
+            irownnz++;
+         }
       }
    }
 
@@ -1092,4 +1095,3 @@ hypre_CSRMatrixGetGPUMatData(hypre_CSRMatrix *matrix)
    return hypre_CSRMatrixGPUMatData(matrix);
 }
 #endif
-


### PR DESCRIPTION
This PR updates the calculation of the unstructured component of a SStructMatrix triple-product. Specifically, this change targets the case when interpolation does not have an unstructured component. This ultimately benefits the setup time of SSAMG.