### PR TITLE
Fix cross-compilation problem

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -105,7 +105,7 @@ AC_SUBST(HYPRE_BUGS)
 
 AC_SUBST(HYPRE_SRCDIR)
 
-AC_CHECK_FILE([$HYPRE_SRCDIR/../.git],
+AS_IF([test -d "$HYPRE_SRCDIR/../.git"],
   [
   develop_string=$(git -C $HYPRE_SRCDIR describe --match 'v*' --long --abbrev=9)
   develop_lastag=$(git -C $HYPRE_SRCDIR describe --match 'v*' --abbrev=0)

--- a/src/configure
+++ b/src/configure
@@ -2700,24 +2700,7 @@ _ACEOF
 
 
 
-as_ac_File=`$as_echo "ac_cv_file_$HYPRE_SRCDIR/../.git" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $HYPRE_SRCDIR/../.git" >&5
-$as_echo_n "checking for $HYPRE_SRCDIR/../.git... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$HYPRE_SRCDIR/../.git"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+if test -d "$HYPRE_SRCDIR/../.git"; then :
 
   develop_string=$(git -C $HYPRE_SRCDIR describe --match 'v*' --long --abbrev=9)
   develop_lastag=$(git -C $HYPRE_SRCDIR describe --match 'v*' --abbrev=0)
@@ -2758,7 +2741,6 @@ else
 $as_echo "$as_me: NOTE: Could not find .git directory" >&6;}
 
 fi
-
 
 PACKAGE_DATE=
 PACKAGE_TIME=

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -110,7 +110,7 @@ hypre_MGRSetup( void               *mgr_vdata,
 
    HYPRE_Int *use_non_galerkin_cg = (mgr_data -> use_non_galerkin_cg);
 
-//   hypre_ParCSRMatrix *A_ff_inv = (mgr_data -> A_ff_inv);
+   //   hypre_ParCSRMatrix *A_ff_inv = (mgr_data -> A_ff_inv);
 
    HYPRE_Int use_air = 0;
    HYPRE_MemoryLocation memory_location = hypre_ParCSRMatrixMemoryLocation(A);

--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -263,13 +263,13 @@ hypre_UnifiedMalloc(size_t size, HYPRE_Int zeroinit)
 
 #if defined(HYPRE_USING_DEVICE_OPENMP)
 #if defined(HYPRE_DEVICE_OPENMP_ALLOC)
-      ptr = omp_target_alloc(size, hypre__offload_device_num);
+   ptr = omp_target_alloc(size, hypre__offload_device_num);
 #else
-      ptr = malloc(size + sizeof(size_t));
-      size_t *sp = (size_t*) ptr;
-      sp[0] = size;
-      ptr = (void *) (&sp[1]);
-      HYPRE_OMPOffload(hypre__offload_device_num, ptr, size, "enter", "alloc");
+   ptr = malloc(size + sizeof(size_t));
+   size_t *sp = (size_t*) ptr;
+   sp[0] = size;
+   ptr = (void *) (&sp[1]);
+   HYPRE_OMPOffload(hypre__offload_device_num, ptr, size, "enter", "alloc");
 #endif
 #endif
 
@@ -444,9 +444,9 @@ hypre_UnifiedFree(void *ptr)
 
 #if defined(HYPRE_USING_DEVICE_OPENMP)
 #if defined(HYPRE_DEVICE_OPENMP_ALLOC)
-      omp_target_free(ptr, hypre__offload_device_num);
+   omp_target_free(ptr, hypre__offload_device_num);
 #else
-      HYPRE_OMPOffload(hypre__offload_device_num, ptr, ((size_t *) ptr)[-1], "exit", "delete");
+   HYPRE_OMPOffload(hypre__offload_device_num, ptr, ((size_t *) ptr)[-1], "exit", "delete");
 #endif
 #endif
 


### PR DESCRIPTION
This PR fixes issue #556.

`AC_CHECK_FILE` was being used to test the existence of the `.git` folder. However, according to [Autoconf manual](https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Files.html):
```
 Be aware that, like most Autoconf macros, they test a feature of the host machine, and therefore, they die when cross-compiling
```
So, this PR implements another strategy for looking for the `.git` folder which works also when doing cross-compilation.