### PR TITLE
Need -O1 instead of -O0 for HIP in debug mode

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -2311,7 +2311,7 @@ AS_IF([test x"$hypre_using_hip" == x"yes"],
         dnl with HIPCXXFLAGS on the configure line. If in debug mode, -O0 -Wall
         dnl plus flags for debugging symbols
         AS_IF([test x"$hypre_using_debug" == x"yes"],
-              [HIPCXXFLAGS="-O0 -Wall -g -ggdb ${HIPCXXFLAGS}"],
+              [HIPCXXFLAGS="-O1 -Wall -g -ggdb ${HIPCXXFLAGS}"],
               [HIPCXXFLAGS="-O2 ${HIPCXXFLAGS}"],)
 
 

--- a/src/configure
+++ b/src/configure
@@ -9218,7 +9218,7 @@ $as_echo "#define HYPRE_USING_HIP 1" >>confdefs.h
                                         HIPCXXFLAGS="-x hip -std=c++14 ${HIPCXXFLAGS}"
 
                                 if test x"$hypre_using_debug" == x"yes"; then :
-  HIPCXXFLAGS="-O0 -Wall -g -ggdb ${HIPCXXFLAGS}"
+  HIPCXXFLAGS="-O1 -Wall -g -ggdb ${HIPCXXFLAGS}"
 elif HIPCXXFLAGS="-O2 ${HIPCXXFLAGS}"; then :
 
 fi


### PR DESCRIPTION
Unfortunately, -O0 can cause ugly issues with the code generated
by the compiler so we need to use -O1 in debug mode (`--enable-debug`) at this time.