### PR TITLE
fix memory location

### DIFF
--- a/src/distributed_ls/ParaSails/Matrix.c
+++ b/src/distributed_ls/ParaSails/Matrix.c
@@ -181,10 +181,16 @@ void MatrixSetRow(Matrix *mat, HYPRE_Int row, HYPRE_Int len, HYPRE_Int *ind, HYP
    mat->vals[row] = (HYPRE_Real *) MemAlloc(mat->mem, len*sizeof(HYPRE_Real));
 
    if (ind != NULL)
-      hypre_TMemcpy(mat->inds[row],  ind, HYPRE_Int, len, HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+   {
+      //hypre_TMemcpy(mat->inds[row], ind, HYPRE_Int, len, HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+      memcpy(mat->inds[row], ind, sizeof(HYPRE_Int) * len);
+   }
 
    if (val != NULL)
-      hypre_TMemcpy(mat->vals[row],  val, HYPRE_Real, len, HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+   {
+      //hypre_TMemcpy(mat->vals[row], val, HYPRE_Real, len, HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+      memcpy(mat->vals[row], val, sizeof(HYPRE_Real) * len);
+   }
 }
 
 /*--------------------------------------------------------------------------

--- a/src/distributed_matrix/distributed_matrix_parcsr.c
+++ b/src/distributed_matrix/distributed_matrix_parcsr.c
@@ -77,7 +77,7 @@ hypre_DistributedMatrixGetLocalRangeParCSR( hypre_DistributedMatrix *matrix,
 
 
    ierr = HYPRE_ParCSRMatrixGetLocalRange( Parcsr_matrix, row_start, row_end,
-					col_start, col_end );
+                                           col_start, col_end );
 
    return(ierr);
 }

--- a/src/parcsr_ls/par_2s_interp_device.c
+++ b/src/parcsr_ls/par_2s_interp_device.c
@@ -53,7 +53,6 @@ hypre_BoomerAMGBuildModPartialExtInterpDevice( hypre_ParCSRMatrix  *A,
    HYPRE_Complex      *A_offd_data  = hypre_CSRMatrixData(A_offd);
    HYPRE_Int          *A_offd_i     = hypre_CSRMatrixI(A_offd);
    HYPRE_Int           A_offd_nnz   = hypre_CSRMatrixNumNonzeros(A_offd);
-   HYPRE_Int          *CF_marker_dev;
    HYPRE_Complex      *Dbeta, *Dbeta_offd, *rsWA, *rsW;
    hypre_ParCSRMatrix *As_F2F, *As_FC, *W, *P;
 
@@ -62,11 +61,6 @@ hypre_BoomerAMGBuildModPartialExtInterpDevice( hypre_ParCSRMatrix  *A,
    HYPRE_Int          *Soc_diag_j   = hypre_ParCSRMatrixSocDiagJ(S);
    HYPRE_Int          *Soc_offd_j   = hypre_ParCSRMatrixSocOffdJ(S);
 
-   CF_marker_dev = hypre_TAlloc(HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE);
-   hypre_TMemcpy(CF_marker_dev, CF_marker, HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE,
-                 HYPRE_MEMORY_HOST);
-
-   //TODO use CF_marker_dev
    /* As_F2F = As_{F2, F}, As_FC = As_{F, C2} */
    hypre_ParCSRMatrixGenerateFFFC3Device(A, CF_marker, num_cpts_global, S, &As_FC, &As_F2F);
 
@@ -113,7 +107,7 @@ hypre_BoomerAMGBuildModPartialExtInterpDevice( hypre_ParCSRMatrix  *A,
                       gDim, bDim,
                       A_nr_local,
                       A_offd_nnz > 0,
-                      CF_marker_dev,
+                      CF_marker,
                       A_diag_i,
                       A_diag_data,
                       Soc_diag_j,
@@ -127,7 +121,7 @@ hypre_BoomerAMGBuildModPartialExtInterpDevice( hypre_ParCSRMatrix  *A,
    HYPRE_Complex *new_end = HYPRE_THRUST_CALL( copy_if,
                                                rsWA,
                                                rsWA + A_nr_local,
-                                               CF_marker_dev,
+                                               CF_marker,
                                                rsW,
                                                equal<HYPRE_Int>(-2) );
 
@@ -138,8 +132,8 @@ hypre_BoomerAMGBuildModPartialExtInterpDevice( hypre_ParCSRMatrix  *A,
    /* map from F2 to F */
    HYPRE_Int *map_to_F = hypre_TAlloc(HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE);
    HYPRE_THRUST_CALL( exclusive_scan,
-                      thrust::make_transform_iterator(CF_marker_dev,              is_negative<HYPRE_Int>()),
-                      thrust::make_transform_iterator(CF_marker_dev + A_nr_local, is_negative<HYPRE_Int>()),
+                      thrust::make_transform_iterator(CF_marker,              is_negative<HYPRE_Int>()),
+                      thrust::make_transform_iterator(CF_marker + A_nr_local, is_negative<HYPRE_Int>()),
                       map_to_F,
                       HYPRE_Int(0) );/* *MUST* pass init value since input and output types diff. */
 
@@ -148,7 +142,7 @@ hypre_BoomerAMGBuildModPartialExtInterpDevice( hypre_ParCSRMatrix  *A,
    HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( copy_if,
                                            map_to_F,
                                            map_to_F + A_nr_local,
-                                           CF_marker_dev,
+                                           CF_marker,
                                            map_F2_to_F,
                                            equal<HYPRE_Int>(-2) );
 
@@ -201,15 +195,13 @@ hypre_BoomerAMGBuildModPartialExtInterpDevice( hypre_ParCSRMatrix  *A,
 
    HYPRE_Int *C2F2_marker = hypre_TAlloc(HYPRE_Int, P_nr_local, HYPRE_MEMORY_DEVICE);
    tmp_end = HYPRE_THRUST_CALL( copy_if,
-                                CF_marker_dev,
-                                CF_marker_dev + A_nr_local,
-                                CF_marker_dev,
+                                CF_marker,
+                                CF_marker + A_nr_local,
+                                CF_marker,
                                 C2F2_marker,
                                 out_of_range<HYPRE_Int>(-1, 0) /* -2 or 1 */ );
 
    hypre_assert(tmp_end - C2F2_marker == P_nr_local);
-
-   hypre_TFree(CF_marker_dev, HYPRE_MEMORY_DEVICE);
 
    hypreDevice_extendWtoP( P_nr_local,
                            AF2F_nr_local,
@@ -291,7 +283,6 @@ hypre_BoomerAMGBuildModPartialExtPEInterpDevice( hypre_ParCSRMatrix  *A,
    HYPRE_Complex      *A_offd_data  = hypre_CSRMatrixData(A_offd);
    HYPRE_Int          *A_offd_i     = hypre_CSRMatrixI(A_offd);
    HYPRE_Int           A_offd_nnz   = hypre_CSRMatrixNumNonzeros(A_offd);
-   HYPRE_Int          *CF_marker_dev;
    HYPRE_Complex      *Dbeta, *rsWA, *rsW, *dlam, *dlam_offd, *dtmp, *dtmp_offd;
    hypre_ParCSRMatrix *As_F2F, *As_FF, *As_FC, *W, *P;
 
@@ -300,11 +291,6 @@ hypre_BoomerAMGBuildModPartialExtPEInterpDevice( hypre_ParCSRMatrix  *A,
    HYPRE_Int          *Soc_diag_j   = hypre_ParCSRMatrixSocDiagJ(S);
    HYPRE_Int          *Soc_offd_j   = hypre_ParCSRMatrixSocOffdJ(S);
 
-   CF_marker_dev = hypre_TAlloc(HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE);
-   hypre_TMemcpy(CF_marker_dev, CF_marker, HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE,
-                 HYPRE_MEMORY_HOST);
-
-   //TODO use CF_marker_dev
    /* As_F2F = As_{F2, F}, As_FC = As_{F, C2} */
    hypre_ParCSRMatrixGenerateFFFC3Device(A, CF_marker, num_cpts_global, S, &As_FC, &As_F2F);
 
@@ -392,7 +378,7 @@ hypre_BoomerAMGBuildModPartialExtPEInterpDevice( hypre_ParCSRMatrix  *A,
                       gDim, bDim,
                       A_nr_local,
                       A_offd_nnz > 0,
-                      CF_marker_dev,
+                      CF_marker,
                       A_diag_i,
                       A_diag_data,
                       Soc_diag_j,
@@ -406,7 +392,7 @@ hypre_BoomerAMGBuildModPartialExtPEInterpDevice( hypre_ParCSRMatrix  *A,
    HYPRE_Complex *new_end = HYPRE_THRUST_CALL( copy_if,
                                                rsWA,
                                                rsWA + A_nr_local,
-                                               CF_marker_dev,
+                                               CF_marker,
                                                rsW,
                                                equal<HYPRE_Int>(-2) );
 
@@ -417,8 +403,8 @@ hypre_BoomerAMGBuildModPartialExtPEInterpDevice( hypre_ParCSRMatrix  *A,
    /* map from F2 to F */
    HYPRE_Int *map_to_F = hypre_TAlloc(HYPRE_Int, A_nr_local, HYPRE_MEMORY_DEVICE);
    HYPRE_THRUST_CALL( exclusive_scan,
-                      thrust::make_transform_iterator(CF_marker_dev,              is_negative<HYPRE_Int>()),
-                      thrust::make_transform_iterator(CF_marker_dev + A_nr_local, is_negative<HYPRE_Int>()),
+                      thrust::make_transform_iterator(CF_marker,              is_negative<HYPRE_Int>()),
+                      thrust::make_transform_iterator(CF_marker + A_nr_local, is_negative<HYPRE_Int>()),
                       map_to_F,
                       HYPRE_Int(0) ); /* *MUST* pass init value since input and output types diff. */
    HYPRE_Int *map_F2_to_F = hypre_TAlloc(HYPRE_Int, AF2F_nr_local, HYPRE_MEMORY_DEVICE);
@@ -426,7 +412,7 @@ hypre_BoomerAMGBuildModPartialExtPEInterpDevice( hypre_ParCSRMatrix  *A,
    HYPRE_Int *tmp_end = HYPRE_THRUST_CALL( copy_if,
                                            map_to_F,
                                            map_to_F + A_nr_local,
-                                           CF_marker_dev,
+                                           CF_marker,
                                            map_F2_to_F,
                                            equal<HYPRE_Int>(-2) );
 
@@ -483,15 +469,13 @@ hypre_BoomerAMGBuildModPartialExtPEInterpDevice( hypre_ParCSRMatrix  *A,
 
    HYPRE_Int *C2F2_marker = hypre_TAlloc(HYPRE_Int, P_nr_local, HYPRE_MEMORY_DEVICE);
    tmp_end = HYPRE_THRUST_CALL( copy_if,
-                                CF_marker_dev,
-                                CF_marker_dev + A_nr_local,
-                                CF_marker_dev,
+                                CF_marker,
+                                CF_marker + A_nr_local,
+                                CF_marker,
                                 C2F2_marker,
                                 out_of_range<HYPRE_Int>(-1, 0) /* -2 or 1 */ );
 
    hypre_assert(tmp_end - C2F2_marker == P_nr_local);
-
-   hypre_TFree(CF_marker_dev, HYPRE_MEMORY_DEVICE);
 
    hypreDevice_extendWtoP( P_nr_local,
                            AF2F_nr_local,

--- a/src/parcsr_ls/par_amgdd_helpers.c
+++ b/src/parcsr_ls/par_amgdd_helpers.c
@@ -2164,7 +2164,7 @@ hypre_BoomerAMGDD_PackSendBuffer( hypre_ParAMGDDData *amgdd_data,
          total_num_nodes = hypre_AMGDDCompGridNumOwnedNodes(compGrid[level]) +
                            hypre_AMGDDCompGridNumNonOwnedNodes(compGrid[level]);
 
-         hypre_Memset(add_flag[level], 0, sizeof(HYPRE_Int)*total_num_nodes, HYPRE_MEMORY_HOST);
+         hypre_Memset(add_flag[level], 0, sizeof(HYPRE_Int)*total_num_nodes, memory_location);
          (*send_flag_buffer_size) += num_send_nodes[current_level][proc][level];
          if (level != num_levels - 1)
          {

--- a/src/parcsr_ls/par_ilu.c
+++ b/src/parcsr_ls/par_ilu.c
@@ -1515,7 +1515,7 @@ hypre_ILUGetPermddPQ(hypre_ParCSRMatrix *A, HYPRE_Int **io_pperm, HYPRE_Int **io
    }
 
    hypre_TMemcpy( rqperm, rpperm, HYPRE_Int, n, HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
-   hypre_TMemcpy( qperm, pperm, HYPRE_Int, n, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+   hypre_TMemcpy( qperm, pperm, HYPRE_Int, n, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
 
    /* we sort from small to large, so we need to go from back to start
     * we only need nB_pre to start the loop, after that we could use it for size of B

--- a/src/parcsr_ls/par_ilu_setup.c
+++ b/src/parcsr_ls/par_ilu_setup.c
@@ -3926,9 +3926,9 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix *A, HYPRE_Int *permp, HYPRE_Int *qpermp, 
          //hypre_TMemcpy(&(L_diag_j)[ctrL], iL, HYPRE_Int, lenl, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          //hypre_TMemcpy(&(L_diag_data)[ctrL], wL, HYPRE_Real, lenl, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          hypre_TMemcpy(&L_diag_j[ctrL], iL, HYPRE_Int, lenl,
-                       HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          hypre_TMemcpy(&L_diag_data[ctrL], wL, HYPRE_Real, lenl,
-                       HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       }
       L_diag_i[ii + 1] = (ctrL += lenl);
 
@@ -3954,9 +3954,9 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix *A, HYPRE_Int *permp, HYPRE_Int *qpermp, 
          //hypre_TMemcpy(&(U_diag_j)[ctrU], iU, HYPRE_Int, lenu, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          //hypre_TMemcpy(&(U_diag_data)[ctrU], wU, HYPRE_Real, lenu, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          hypre_TMemcpy(&U_diag_j[ctrU], iU, HYPRE_Int, lenu,
-                       HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          hypre_TMemcpy(&U_diag_data[ctrU], wU, HYPRE_Real, lenu,
-                       HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       }
       U_diag_i[ii + 1] = (ctrU += lenu);
 
@@ -4091,9 +4091,9 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix *A, HYPRE_Int *permp, HYPRE_Int *qpermp, 
          //hypre_TMemcpy(&(L_diag_j)[ctrL], iL, HYPRE_Int, lenl, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          //hypre_TMemcpy(&(L_diag_data)[ctrL], wL, HYPRE_Real, lenl, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          hypre_TMemcpy(&L_diag_j[ctrL], iL, HYPRE_Int, lenl,
-                       HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          hypre_TMemcpy(&L_diag_data[ctrL], wL, HYPRE_Real, lenl,
-                       HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       }
       L_diag_i[ii + 1] = (ctrL += lenl);
 
@@ -4116,7 +4116,7 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix *A, HYPRE_Int *permp, HYPRE_Int *qpermp, 
       }
       //hypre_TMemcpy(S_diag_data+ctrS+1, wU, HYPRE_Real, lenu, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(S_diag_data + ctrS + 1, wU, HYPRE_Real, lenu,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       S_diag_i[ii - nLU + 1] = ctrS += (lenu + 1);
    }
    /* Assemble LDUS matrices */
@@ -4525,7 +4525,7 @@ hypre_ILUSetupILUKSymbolic(HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j
          }
          //hypre_TMemcpy(temp_U_diag_j+ctrU,iL+ii,HYPRE_Int,k,HYPRE_MEMORY_DEVICE,HYPRE_MEMORY_HOST);
          hypre_TMemcpy(temp_U_diag_j + ctrU, iL + ii, HYPRE_Int, k,
-                       HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          hypre_TMemcpy(u_levels + ctrU, iLev + ii, HYPRE_Int, k,
                        HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
          ctrU += k;
@@ -4683,7 +4683,7 @@ hypre_ILUSetupILUKSymbolic(HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j
       temp_S_diag_j[ctrS] = ii;/* must have diagonal */
       //hypre_TMemcpy(temp_S_diag_j+ctrS+1,iL+nLU,HYPRE_Int,k-1,HYPRE_MEMORY_DEVICE,HYPRE_MEMORY_HOST);
       hypre_TMemcpy(temp_S_diag_j + ctrS + 1, iL + nLU, HYPRE_Int, k - 1,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       ctrS += k;
       S_diag_i[ii - nLU + 1] = ctrS;
 
@@ -6524,9 +6524,9 @@ hypre_ILUSetupILU0RAS(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int nLU,
       //hypre_TMemcpy(&(L_diag_j)[ctrL], iL, HYPRE_Int, lenl, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       //hypre_TMemcpy(&(L_diag_data)[ctrL], wL, HYPRE_Real, lenl, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(L_diag_j)[ctrL], iL, HYPRE_Int, lenl,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(L_diag_data)[ctrL], wL, HYPRE_Real, lenl,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       L_diag_i[ii + 1] = (ctrL += lenl);
 
       /* diagonal part (we store the inverse) */
@@ -6549,9 +6549,9 @@ hypre_ILUSetupILU0RAS(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int nLU,
       //hypre_TMemcpy(&(U_diag_j)[ctrU], iU, HYPRE_Int, lenu, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       //hypre_TMemcpy(&(U_diag_data)[ctrU], wU, HYPRE_Real, lenu, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(U_diag_j)[ctrU], iU, HYPRE_Int, lenu,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(U_diag_data)[ctrU], wU, HYPRE_Real, lenu,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       U_diag_i[ii + 1] = (ctrU += lenu);
    }
 
@@ -6679,9 +6679,9 @@ hypre_ILUSetupILU0RAS(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int nLU,
       //hypre_TMemcpy(&(L_diag_j)[ctrL], iL, HYPRE_Int, lenl, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       //hypre_TMemcpy(&(L_diag_data)[ctrL], wL, HYPRE_Real, lenl, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(L_diag_j)[ctrL], iL, HYPRE_Int, lenl,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(L_diag_data)[ctrL], wL, HYPRE_Real, lenl,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       L_diag_i[ii + 1] = (ctrL += lenl);
 
       /* diagonal part (we store the inverse) */
@@ -6704,9 +6704,9 @@ hypre_ILUSetupILU0RAS(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int nLU,
       //hypre_TMemcpy(&(U_diag_j)[ctrU], iU, HYPRE_Int, lenu, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       //hypre_TMemcpy(&(U_diag_data)[ctrU], wU, HYPRE_Real, lenu, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(U_diag_j)[ctrU], iU, HYPRE_Int, lenu,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(U_diag_data)[ctrU], wU, HYPRE_Real, lenu,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       U_diag_i[ii + 1] = (ctrU += lenu);
    }
 
@@ -6821,9 +6821,9 @@ hypre_ILUSetupILU0RAS(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int nLU,
       //hypre_TMemcpy(&(L_diag_j)[ctrL], iL, HYPRE_Int, lenl, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       //hypre_TMemcpy(&(L_diag_data)[ctrL], wL, HYPRE_Real, lenl, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(L_diag_j)[ctrL], iL, HYPRE_Int, lenl,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(L_diag_data)[ctrL], wL, HYPRE_Real, lenl,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       L_diag_i[ii + 1] = (ctrL += lenl);
 
       /* diagonal part (we store the inverse) */
@@ -6846,9 +6846,9 @@ hypre_ILUSetupILU0RAS(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int nLU,
       //hypre_TMemcpy(&(U_diag_j)[ctrU], iU, HYPRE_Int, lenu, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       //hypre_TMemcpy(&(U_diag_data)[ctrU], wU, HYPRE_Real, lenu, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(U_diag_j)[ctrU], iU, HYPRE_Int, lenu,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       hypre_TMemcpy(&(U_diag_data)[ctrU], wU, HYPRE_Real, lenu,
-                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
       U_diag_i[ii + 1] = (ctrU += lenu);
    }
 
@@ -7152,7 +7152,7 @@ hypre_ILUSetupILUKRASSymbolic(HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_dia
          }
          //hypre_TMemcpy(temp_U_diag_j+ctrU,iL+ii,HYPRE_Int,k,HYPRE_MEMORY_DEVICE,HYPRE_MEMORY_HOST);
          hypre_TMemcpy(temp_U_diag_j + ctrU, iL + ii, HYPRE_Int, k,
-                       HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          hypre_TMemcpy(u_levels + ctrU, iLev + ii, HYPRE_Int, k,
                        HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
          ctrU += k;
@@ -7316,7 +7316,7 @@ hypre_ILUSetupILUKRASSymbolic(HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_dia
          }
          //hypre_TMemcpy(temp_U_diag_j+ctrU,iL+ii,HYPRE_Int,k,HYPRE_MEMORY_DEVICE,HYPRE_MEMORY_HOST);
          hypre_TMemcpy(temp_U_diag_j + ctrU, iL + ii, HYPRE_Int, k,
-                       HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          hypre_TMemcpy(u_levels + ctrU, iLev + ii, HYPRE_Int, k,
                        HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
          ctrU += k;
@@ -7465,7 +7465,7 @@ hypre_ILUSetupILUKRASSymbolic(HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_dia
          }
          //hypre_TMemcpy(temp_U_diag_j+ctrU,iL+ii,HYPRE_Int,k,HYPRE_MEMORY_DEVICE,HYPRE_MEMORY_HOST);
          hypre_TMemcpy(temp_U_diag_j + ctrU, iL + ii, HYPRE_Int, k,
-                       HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
          hypre_TMemcpy(u_levels + ctrU, iLev + ii, HYPRE_Int, k,
                        HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
          ctrU += k;

--- a/src/parcsr_ls/par_mgr_device.c
+++ b/src/parcsr_ls/par_mgr_device.c
@@ -37,7 +37,7 @@ void hypreDevice_extendWtoP( HYPRE_Int P_nr_of_rows, HYPRE_Int W_nr_of_rows, HYP
 
 HYPRE_Int
 hypre_MGRBuildPDevice(hypre_ParCSRMatrix  *A,
-                      HYPRE_Int           *CF_marker_host,
+                      HYPRE_Int           *CF_marker,
                       HYPRE_BigInt        *num_cpts_global,
                       HYPRE_Int            method,
                       hypre_ParCSRMatrix **P_ptr)
@@ -46,7 +46,6 @@ hypre_MGRBuildPDevice(hypre_ParCSRMatrix  *A,
    HYPRE_Int           num_procs, my_id;
    HYPRE_Int           A_nr_of_rows = hypre_ParCSRMatrixNumRows(A);
 
-   HYPRE_Int          *CF_marker_dev;
    hypre_ParCSRMatrix *A_FF = NULL, *A_FC = NULL, *P = NULL;
    hypre_CSRMatrix    *W_diag = NULL, *W_offd = NULL;
    HYPRE_Int           W_nr_of_rows, P_diag_nnz, nfpoints;
@@ -57,18 +56,14 @@ hypre_MGRBuildPDevice(hypre_ParCSRMatrix  *A,
    hypre_MPI_Comm_size(comm, &num_procs);
    hypre_MPI_Comm_rank(comm, &my_id);
 
-   CF_marker_dev = hypre_TAlloc(HYPRE_Int, A_nr_of_rows, HYPRE_MEMORY_DEVICE);
-   hypre_TMemcpy(CF_marker_dev, CF_marker_host, HYPRE_Int, A_nr_of_rows,
-                 HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
-
    nfpoints = HYPRE_THRUST_CALL( count,
-                                 CF_marker_dev,
-                                 CF_marker_dev + A_nr_of_rows,
+                                 CF_marker,
+                                 CF_marker + A_nr_of_rows,
                                  -1);
 
    if (method > 0)
    {
-      hypre_ParCSRMatrixGenerateFFFCDevice(A, CF_marker_host, num_cpts_global, NULL, &A_FC, &A_FF);
+      hypre_ParCSRMatrixGenerateFFFCDevice(A, CF_marker, num_cpts_global, NULL, &A_FC, &A_FF);
       diag = hypre_CTAlloc(HYPRE_Complex, nfpoints, HYPRE_MEMORY_DEVICE);
       if (method == 1)
       {
@@ -134,7 +129,7 @@ hypre_MGRBuildPDevice(hypre_ParCSRMatrix  *A,
    hypreDevice_extendWtoP( A_nr_of_rows,
                            W_nr_of_rows,
                            hypre_CSRMatrixNumCols(W_diag),
-                           CF_marker_dev,
+                           CF_marker,
                            hypre_CSRMatrixNumNonzeros(W_diag),
                            hypre_CSRMatrixI(W_diag),
                            hypre_CSRMatrixJ(W_diag),
@@ -144,7 +139,6 @@ hypre_MGRBuildPDevice(hypre_ParCSRMatrix  *A,
                            P_diag_data,
                            hypre_CSRMatrixI(W_offd),
                            P_offd_i );
-   hypre_TFree(CF_marker_dev, HYPRE_MEMORY_DEVICE);
    //hypre_NvtxPopRange();
 
    // final P
@@ -210,27 +204,15 @@ hypre_MGRBuildPDevice(hypre_ParCSRMatrix  *A,
 HYPRE_Int
 hypre_MGRRelaxL1JacobiDevice( hypre_ParCSRMatrix *A,
                               hypre_ParVector    *f,
-                              HYPRE_Int          *CF_marker_host,
+                              HYPRE_Int          *CF_marker,
                               HYPRE_Int           relax_points,
                               HYPRE_Real          relax_weight,
                               HYPRE_Real         *l1_norms,
                               hypre_ParVector    *u,
                               hypre_ParVector    *Vtemp )
 {
-   HYPRE_Int *CF_marker_dev = NULL;
-
-   // Copy CF_marker_host to device
-   if (CF_marker_host != NULL)
-   {
-      CF_marker_dev = hypre_TAlloc(HYPRE_Int, hypre_ParCSRMatrixNumRows(A), HYPRE_MEMORY_DEVICE);
-      hypre_TMemcpy(CF_marker_dev, CF_marker_host, HYPRE_Int, hypre_ParCSRMatrixNumRows(A),
-                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
-   }
-
-   hypre_BoomerAMGRelax(A, f, CF_marker_dev, 18, relax_points, relax_weight, 1.0, l1_norms, u, Vtemp,
+   hypre_BoomerAMGRelax(A, f, CF_marker, 18, relax_points, relax_weight, 1.0, l1_norms, u, Vtemp,
                         NULL);
-
-   hypre_TFree(CF_marker_dev, HYPRE_MEMORY_DEVICE);
 
    return hypre_error_flag;
 }

--- a/src/parcsr_ls/par_strength2nd_device.c
+++ b/src/parcsr_ls/par_strength2nd_device.c
@@ -21,7 +21,7 @@
 //-----------------------------------------------------------------------
 HYPRE_Int
 hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix  *S,
-                                 HYPRE_Int           *CF_marker_host,
+                                 HYPRE_Int           *CF_marker,
                                  HYPRE_Int            num_paths,
                                  HYPRE_BigInt        *coarse_row_starts,
                                  hypre_ParCSRMatrix **S2_ptr)
@@ -33,7 +33,7 @@ hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix  *S,
    HYPRE_Int           S_offd_nnz = hypre_CSRMatrixNumNonzeros(S_offd);
    hypre_CSRMatrix    *Id, *SI_diag;
    hypre_ParCSRMatrix *S_XC, *S_CX, *S2;
-   HYPRE_Int          *CF_marker, *new_end;
+   HYPRE_Int          *new_end;
    HYPRE_Complex       coeff = 2.0;
 
    /*
@@ -42,10 +42,6 @@ hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix  *S,
    hypre_MPI_Comm_size(comm, &num_proc);
    hypre_MPI_Comm_rank(comm, &myid);
    */
-
-   CF_marker = hypre_TAlloc(HYPRE_Int, S_nr_local, HYPRE_MEMORY_DEVICE);
-   hypre_TMemcpy(CF_marker, CF_marker_host, HYPRE_Int, S_nr_local, HYPRE_MEMORY_DEVICE,
-                 HYPRE_MEMORY_HOST);
 
    /* 1. Create new matrix with added diagonal */
    hypre_GpuProfilingPushRange("Setup");
@@ -66,7 +62,7 @@ hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix  *S,
    hypre_MatvecCommPkgCreate(S);
 
    /* S(C, :) and S(:, C) */
-   hypre_ParCSRMatrixGenerate1DCFDevice(S, CF_marker_host, coarse_row_starts, NULL, &S_CX, &S_XC);
+   hypre_ParCSRMatrixGenerate1DCFDevice(S, CF_marker, coarse_row_starts, NULL, &S_CX, &S_XC);
 
    hypre_assert(S_nr_local == hypre_ParCSRMatrixNumCols(S_CX));
 
@@ -90,8 +86,6 @@ hypre_BoomerAMGCreate2ndSDevice( hypre_ParCSRMatrix  *S,
                                 is_nonnegative<HYPRE_Int>()  );
 
    hypre_assert(new_end - hypre_CSRMatrixJ(Id) == hypre_ParCSRMatrixNumRows(S_CX));
-
-   hypre_TFree(CF_marker, HYPRE_MEMORY_DEVICE);
 
    HYPRE_THRUST_CALL( fill,
                       hypre_CSRMatrixData(Id),

--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -734,11 +734,11 @@ HYPRE_Int hypre_ParCSRMatrixGenerateFFFCD3(hypre_ParCSRMatrix *A, HYPRE_Int *CF_
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFC3Device(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                                 HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr,
                                                 hypre_ParCSRMatrix **A_FF_ptr ) ;
-HYPRE_Int hypre_ParCSRMatrixGenerateCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host,
+HYPRE_Int hypre_ParCSRMatrixGenerateCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                               HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACF_ptr) ;
-HYPRE_Int hypre_ParCSRMatrixGenerateCCDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host,
+HYPRE_Int hypre_ParCSRMatrixGenerateCCDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                               HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACC_ptr) ;
-HYPRE_Int hypre_ParCSRMatrixGenerate1DCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host,
+HYPRE_Int hypre_ParCSRMatrixGenerate1DCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                                 HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACX_ptr,
                                                 hypre_ParCSRMatrix **AXC_ptr ) ;
 
@@ -945,10 +945,10 @@ hypre_CSRMatrix* hypre_ExchangeExternalRowsWait(void *vequest);
 HYPRE_Int hypre_ExchangeExternalRowsDeviceInit( hypre_CSRMatrix *B_ext,
                                                 hypre_ParCSRCommPkg *comm_pkg_A, HYPRE_Int want_data, void **request_ptr);
 hypre_CSRMatrix* hypre_ExchangeExternalRowsDeviceWait(void *vrequest);
-HYPRE_Int hypre_ParCSRMatrixGenerateFFFCDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host,
+HYPRE_Int hypre_ParCSRMatrixGenerateFFFCDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                                 HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr,
                                                 hypre_ParCSRMatrix **A_FF_ptr );
-HYPRE_Int hypre_ParCSRMatrixGenerateFFCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host,
+HYPRE_Int hypre_ParCSRMatrixGenerateFFCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                                 HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_CF_ptr,
                                                 hypre_ParCSRMatrix **A_FF_ptr );
 hypre_CSRMatrix* hypre_ConcatDiagAndOffdDevice(hypre_ParCSRMatrix *A);

--- a/src/parcsr_mv/protos.h
+++ b/src/parcsr_mv/protos.h
@@ -105,11 +105,11 @@ HYPRE_Int hypre_ParCSRMatrixGenerateFFFCD3(hypre_ParCSRMatrix *A, HYPRE_Int *CF_
 HYPRE_Int hypre_ParCSRMatrixGenerateFFFC3Device(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                                 HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr,
                                                 hypre_ParCSRMatrix **A_FF_ptr ) ;
-HYPRE_Int hypre_ParCSRMatrixGenerateCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host,
+HYPRE_Int hypre_ParCSRMatrixGenerateCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                               HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACF_ptr) ;
-HYPRE_Int hypre_ParCSRMatrixGenerateCCDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host,
+HYPRE_Int hypre_ParCSRMatrixGenerateCCDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                               HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACC_ptr) ;
-HYPRE_Int hypre_ParCSRMatrixGenerate1DCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host,
+HYPRE_Int hypre_ParCSRMatrixGenerate1DCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                                 HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **ACX_ptr,
                                                 hypre_ParCSRMatrix **AXC_ptr ) ;
 
@@ -316,10 +316,10 @@ hypre_CSRMatrix* hypre_ExchangeExternalRowsWait(void *vequest);
 HYPRE_Int hypre_ExchangeExternalRowsDeviceInit( hypre_CSRMatrix *B_ext,
                                                 hypre_ParCSRCommPkg *comm_pkg_A, HYPRE_Int want_data, void **request_ptr);
 hypre_CSRMatrix* hypre_ExchangeExternalRowsDeviceWait(void *vrequest);
-HYPRE_Int hypre_ParCSRMatrixGenerateFFFCDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host,
+HYPRE_Int hypre_ParCSRMatrixGenerateFFFCDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                                 HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_FC_ptr,
                                                 hypre_ParCSRMatrix **A_FF_ptr );
-HYPRE_Int hypre_ParCSRMatrixGenerateFFCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker_host,
+HYPRE_Int hypre_ParCSRMatrixGenerateFFCFDevice( hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker,
                                                 HYPRE_BigInt *cpts_starts, hypre_ParCSRMatrix *S, hypre_ParCSRMatrix **A_CF_ptr,
                                                 hypre_ParCSRMatrix **A_FF_ptr );
 hypre_CSRMatrix* hypre_ConcatDiagAndOffdDevice(hypre_ParCSRMatrix *A);

--- a/src/sstruct_ls/nd1_amge_interpolation.c
+++ b/src/sstruct_ls/nd1_amge_interpolation.c
@@ -78,8 +78,8 @@ HYPRE_Int hypre_ND1AMGeInterpolation (hypre_ParCSRMatrix       * Aee,
    /* sort the offproc rows to get quicker comparison for later */
    if (num_OffProcRows)
    {
-      offproc_rnums = hypre_TAlloc(HYPRE_BigInt,  num_OffProcRows, HYPRE_MEMORY_HOST);
-      swap         = hypre_TAlloc(HYPRE_Int,  num_OffProcRows, HYPRE_MEMORY_HOST);
+      offproc_rnums = hypre_TAlloc(HYPRE_BigInt, num_OffProcRows, HYPRE_MEMORY_HOST);
+      swap         = hypre_TAlloc(HYPRE_Int, num_OffProcRows, HYPRE_MEMORY_HOST);
       for (i = 0; i < num_OffProcRows; i++)
       {
          offproc_rnums[i] = (OffProcRows[i] -> row);
@@ -152,7 +152,7 @@ HYPRE_Int hypre_ND1AMGeInterpolation (hypre_ParCSRMatrix       * Aee,
       if (three_dimensional_problem)
       {
          hypre_ParCSRMatrixGetRow (ELEM_FACEidof, big_k, &size1, &col_ind0, &boolean_data);
-         col_ind1 = hypre_TAlloc(HYPRE_BigInt,  size1, HYPRE_MEMORY_HOST);
+         col_ind1 = hypre_TAlloc(HYPRE_BigInt, size1, HYPRE_MEMORY_HOST);
          for (j = 0; j < size1; j++)
          {
             col_ind1[j] = col_ind0[j];
@@ -165,7 +165,7 @@ HYPRE_Int hypre_ND1AMGeInterpolation (hypre_ParCSRMatrix       * Aee,
       }
 
       hypre_ParCSRMatrixGetRow (ELEM_EDGEidof, big_k, &size2, &col_ind0, &boolean_data);
-      col_ind2 = hypre_TAlloc(HYPRE_BigInt,  size2, HYPRE_MEMORY_HOST);
+      col_ind2 = hypre_TAlloc(HYPRE_BigInt, size2, HYPRE_MEMORY_HOST);
       for (j = 0; j < size2; j++)
       {
          col_ind2[j] = col_ind0[j];
@@ -174,12 +174,12 @@ HYPRE_Int hypre_ND1AMGeInterpolation (hypre_ParCSRMatrix       * Aee,
 
       /* Merge and sort the boundary dofs according to their global number */
       num_bdof = size1 + size2;
-      bdof = hypre_CTAlloc(HYPRE_BigInt,  num_bdof, HYPRE_MEMORY_HOST);
+      bdof = hypre_CTAlloc(HYPRE_BigInt, num_bdof, HYPRE_MEMORY_HOST);
       if (three_dimensional_problem)
       {
-         hypre_TMemcpy(bdof,  col_ind1, HYPRE_BigInt, size1, HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+         hypre_TMemcpy(bdof, col_ind1, HYPRE_BigInt, size1, HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
       }
-      hypre_TMemcpy(bdof + size1,  col_ind2, HYPRE_BigInt, size2, HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(bdof + size1, col_ind2, HYPRE_BigInt, size2, HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
 
       hypre_BigQsort0(bdof, 0, num_bdof - 1);
 
@@ -191,9 +191,11 @@ HYPRE_Int hypre_ND1AMGeInterpolation (hypre_ParCSRMatrix       * Aee,
          HYPRE_Int *I = hypre_CSRMatrixI(A);
          HYPRE_BigInt *J = hypre_CSRMatrixBigJ(A);
          HYPRE_Real *data = hypre_CSRMatrixData(A);
-
          HYPRE_BigInt *tmp_J;
          HYPRE_Real *tmp_data;
+
+         HYPRE_MemoryLocation memory_location_A = hypre_CSRMatrixMemoryLocation(A);
+         HYPRE_MemoryLocation memory_location_Aee = hypre_ParCSRMatrixMemoryLocation(Aee);
 
          I[0] = 0;
          for (j = 0; j < num_idof; j++)
@@ -203,8 +205,8 @@ HYPRE_Int hypre_ND1AMGeInterpolation (hypre_ParCSRMatrix       * Aee,
             {
                hypre_printf("getrow Aee off proc[%d] = \n", myproc);
             }
-            hypre_TMemcpy(J,  tmp_J, HYPRE_BigInt, I[j + 1], HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
-            hypre_TMemcpy(data,  tmp_data, HYPRE_Real, I[j + 1], HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+            hypre_TMemcpy(J, tmp_J, HYPRE_BigInt, I[j + 1], memory_location_A, memory_location_Aee);
+            hypre_TMemcpy(data, tmp_data, HYPRE_Real, I[j + 1], memory_location_A, memory_location_Aee);
             J += I[j + 1];
             data += I[j + 1];
             hypre_ParCSRMatrixRestoreRow (Aee, idof[j], &I[j + 1], &tmp_J, &tmp_data);
@@ -225,14 +227,17 @@ HYPRE_Int hypre_ND1AMGeInterpolation (hypre_ParCSRMatrix       * Aee,
          HYPRE_BigInt *tmp_J;
          HYPRE_Real *tmp_data;
 
+         HYPRE_MemoryLocation memory_location_P = hypre_CSRMatrixMemoryLocation(P);
+         HYPRE_MemoryLocation memory_location_d = hypre_ParCSRMatrixMemoryLocation(dof_DOF);
+
          I[0] = 0;
          for (j = 0; j < num_idof; j++)
          {
             getrow_ierr = hypre_ParCSRMatrixGetRow (dof_DOF, idof[j], &I[j + 1], &tmp_J, &tmp_data);
             if (getrow_ierr >= 0)
             {
-               hypre_TMemcpy(J,  tmp_J, HYPRE_BigInt, I[j + 1], HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
-               hypre_TMemcpy(data,  tmp_data, HYPRE_Real, I[j + 1], HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+               hypre_TMemcpy(J, tmp_J, HYPRE_BigInt, I[j + 1], memory_location_P, memory_location_d);
+               hypre_TMemcpy(data, tmp_data, HYPRE_Real, I[j + 1], memory_location_P, memory_location_d);
                J += I[j + 1];
                data += I[j + 1];
                hypre_ParCSRMatrixRestoreRow (dof_DOF, idof[j], &I[j + 1], &tmp_J, &tmp_data);
@@ -257,21 +262,20 @@ HYPRE_Int hypre_ND1AMGeInterpolation (hypre_ParCSRMatrix       * Aee,
                I[j + 1] = (OffProcRows[swap[m]] -> ncols);
                tmp_J = (OffProcRows[swap[m]] -> cols);
                tmp_data = (OffProcRows[swap[m]] -> data);
-               hypre_TMemcpy(J,  tmp_J, HYPRE_BigInt, I[j + 1], HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
-               hypre_TMemcpy(data,  tmp_data, HYPRE_Real, I[j + 1], HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+               hypre_TMemcpy(J, tmp_J, HYPRE_BigInt, I[j + 1], memory_location_P, HYPRE_MEMORY_HOST);
+               hypre_TMemcpy(data, tmp_data, HYPRE_Real, I[j + 1], memory_location_P, HYPRE_MEMORY_HOST);
                J += I[j + 1];
                data += I[j + 1];
                I[j + 1] += I[j];
             }
-
          }
          for ( ; j < num_idof + num_bdof; j++)
          {
             getrow_ierr = hypre_ParCSRMatrixGetRow (dof_DOF, bdof[j - num_idof], &I[j + 1], &tmp_J, &tmp_data);
             if (getrow_ierr >= 0)
             {
-               hypre_TMemcpy(J,  tmp_J, HYPRE_BigInt, I[j + 1], HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
-               hypre_TMemcpy(data,  tmp_data, HYPRE_Real, I[j + 1], HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+               hypre_TMemcpy(J, tmp_J, HYPRE_BigInt, I[j + 1], memory_location_P, memory_location_d);
+               hypre_TMemcpy(data, tmp_data, HYPRE_Real, I[j + 1], memory_location_P, memory_location_d);
                J += I[j + 1];
                data += I[j + 1];
                hypre_ParCSRMatrixRestoreRow (dof_DOF, bdof[j - num_idof], &I[j + 1], &tmp_J, &tmp_data);
@@ -297,8 +301,8 @@ HYPRE_Int hypre_ND1AMGeInterpolation (hypre_ParCSRMatrix       * Aee,
                I[j + 1] = (OffProcRows[swap[m]] -> ncols);
                tmp_J = (OffProcRows[swap[m]] -> cols);
                tmp_data = (OffProcRows[swap[m]] -> data);
-               hypre_TMemcpy(J,  tmp_J, HYPRE_BigInt, I[j + 1], HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
-               hypre_TMemcpy(data,  tmp_data, HYPRE_Real, I[j + 1], HYPRE_MEMORY_HOST, HYPRE_MEMORY_HOST);
+               hypre_TMemcpy(J, tmp_J, HYPRE_BigInt, I[j + 1], memory_location_P, HYPRE_MEMORY_HOST);
+               hypre_TMemcpy(data, tmp_data, HYPRE_Real, I[j + 1], memory_location_P, HYPRE_MEMORY_HOST);
                J += I[j + 1];
                data += I[j + 1];
                I[j + 1] += I[j];

--- a/src/test/TEST_ij/solvers.saved.lassen
+++ b/src/test/TEST_ij/solvers.saved.lassen
@@ -175,7 +175,7 @@ Final GMRES Relative Residual Norm = 7.870943e-09
 
 # Output file: solvers.out.117
 GMRES Iterations = 14
-Final GMRES Relative Residual Norm = 7.870944e-09
+Final GMRES Relative Residual Norm = 7.870943e-09
 
 # Output file: solvers.out.118
 GMRES Iterations = 27

--- a/src/utilities/device_utils.c
+++ b/src/utilities/device_utils.c
@@ -232,11 +232,9 @@ void hypre_CudaCompileFlagCheck()
    hypre_int *cuda_arch_compile_d = NULL;
    //cuda_arch_compile_d = hypre_TAlloc(hypre_int, 1, HYPRE_MEMORY_DEVICE);
    HYPRE_CUDA_CALL( cudaMalloc(&cuda_arch_compile_d, sizeof(hypre_int)) );
-   hypre_TMemcpy(cuda_arch_compile_d, &cuda_arch_compile, hypre_int, 1, HYPRE_MEMORY_DEVICE,
-                 HYPRE_MEMORY_HOST);
+   HYPRE_CUDA_CALL( cudaMemcpy(cuda_arch_compile_d, &cuda_arch_compile, sizeof(hypre_int), cudaMemcpyHostToDevice) );
    HYPRE_CUDA_LAUNCH( hypreCUDAKernel_CompileFlagSafetyCheck, gDim, bDim, cuda_arch_compile_d );
-   hypre_TMemcpy(&cuda_arch_compile, cuda_arch_compile_d, hypre_int, 1, HYPRE_MEMORY_HOST,
-                 HYPRE_MEMORY_DEVICE);
+   HYPRE_CUDA_CALL( cudaMemcpy(&cuda_arch_compile, cuda_arch_compile_d, sizeof(hypre_int), cudaMemcpyDeviceToHost) );
    //hypre_TFree(cuda_arch_compile_d, HYPRE_MEMORY_DEVICE);
    HYPRE_CUDA_CALL( cudaFree(cuda_arch_compile_d) );
 

--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -14,7 +14,7 @@
 #include "_hypre_utilities.h"
 #include "_hypre_utilities.hpp"
 
-#ifdef HYPRE_USE_UMALLOC
+#if defined(HYPRE_USE_UMALLOC)
 #undef HYPRE_USE_UMALLOC
 #endif
 
@@ -42,6 +42,23 @@ hypre_WrongMemoryLocation()
                      "Wrong HYPRE MEMORY location: Only HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE and HYPRE_MEMORY_HOST_PINNED are supported!\n");
    hypre_assert(0);
    fflush(stdout);
+}
+
+void
+hypre_CheckMemoryLocation(void *ptr, hypre_MemoryLocation location)
+{
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) || defined(HYPRE_USING_SYCL)
+   if (!ptr)
+   {
+      return;
+   }
+
+   hypre_MemoryLocation location_ptr;
+   hypre_GetPointerLocation(ptr, &location_ptr);
+   /* do not use hypre_assert, which has alloc and free;
+    * will create an endless loop otherwise */
+   assert(location == location_ptr);
+#endif
 }
 
 /*==========================================================================
@@ -123,14 +140,13 @@ hypre_UnifiedMemset(void *ptr, HYPRE_Int value, size_t num)
 static inline void
 hypre_UnifiedMemPrefetch(void *ptr, size_t size, hypre_MemoryLocation location)
 {
-#if defined(HYPRE_USING_GPU)
-#ifdef HYPRE_DEBUG
-   hypre_MemoryLocation tmp;
-   hypre_GetPointerLocation(ptr, &tmp);
-   /* do not use hypre_assert, which has alloc and free;
-    * will create an endless loop otherwise */
-   assert(hypre_MEMORY_UNIFIED == tmp);
-#endif
+   if (!size)
+   {
+      return;
+   }
+
+#if defined(HYPRE_DEBUG)
+   hypre_CheckMemoryLocation(ptr, hypre_MEMORY_UNIFIED);
 #endif
 
 #if defined(HYPRE_USING_CUDA)
@@ -499,14 +515,8 @@ hypre_Free_core(void *ptr, hypre_MemoryLocation location)
       return;
    }
 
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) || defined(HYPRE_USING_SYCL)
-#ifdef HYPRE_DEBUG
-   hypre_MemoryLocation tmp;
-   hypre_GetPointerLocation(ptr, &tmp);
-   /* do not use hypre_assert, which has alloc and free;
-    * will create an endless loop otherwise */
-   assert(location == tmp);
-#endif
+#if defined(HYPRE_DEBUG)
+   hypre_CheckMemoryLocation(ptr, location);
 #endif
 
    switch (location)
@@ -561,6 +571,14 @@ hypre_Memcpy_core(void *dst, void *src, size_t size, hypre_MemoryLocation loc_ds
    {
       return;
    }
+
+#if defined(HYPRE_DEBUG)
+   if (size > 0)
+   {
+      hypre_CheckMemoryLocation(dst, loc_dst);
+      hypre_CheckMemoryLocation(src, loc_src);
+   }
+#endif
 
    /* Totally 4 x 4 = 16 cases */
 
@@ -840,6 +858,10 @@ hypre_Memset(void *ptr, HYPRE_Int value, size_t num, HYPRE_MemoryLocation locati
       }
       return ptr;
    }
+
+#if defined(HYPRE_DEBUG)
+   hypre_CheckMemoryLocation(ptr, hypre_GetActualMemLocation(location));
+#endif
 
    switch (hypre_GetActualMemLocation(location))
    {
@@ -1134,7 +1156,7 @@ hypre_GetPointerLocation(const void *ptr, hypre_MemoryLocation *memory_location)
    return ierr;
 }
 
-#ifdef HYPRE_USING_MEMORY_TRACKER
+#if defined(HYPRE_USING_MEMORY_TRACKER)
 
 /*--------------------------------------------------------------------------
  * Memory tracker
@@ -1393,7 +1415,7 @@ hypre_SetCubMemPoolSize(hypre_uint cub_bin_growth,
                         size_t     cub_max_cached_bytes)
 {
 #if defined(HYPRE_USING_CUDA)
-#ifdef HYPRE_USING_DEVICE_POOL
+#if defined(HYPRE_USING_DEVICE_POOL)
    hypre_HandleCubBinGrowth(hypre_handle())      = cub_bin_growth;
    hypre_HandleCubMinBin(hypre_handle())         = cub_min_bin;
    hypre_HandleCubMaxBin(hypre_handle())         = cub_max_bin;
@@ -1424,7 +1446,7 @@ HYPRE_SetGPUMemoryPoolSize(HYPRE_Int bin_growth,
    return hypre_SetCubMemPoolSize(bin_growth, min_bin, max_bin, max_cached_bytes);
 }
 
-#ifdef HYPRE_USING_DEVICE_POOL
+#if defined(HYPRE_USING_DEVICE_POOL)
 cudaError_t
 hypre_CachingMallocDevice(void **ptr, size_t nbytes)
 {
@@ -1501,7 +1523,7 @@ hypre_DeviceDataCubCachingAllocatorDestroy(hypre_DeviceData *data)
    delete hypre_DeviceDataCubUvmAllocator(data);
 }
 
-#endif // #ifdef HYPRE_USING_DEVICE_POOL
+#endif // #if defined(HYPRE_USING_DEVICE_POOL)
 
 #if defined(HYPRE_USING_UMPIRE_HOST)
 HYPRE_Int


### PR DESCRIPTION
This PR fixes a number of memory location issues in memory copy and memset. It also adds more strict checking in `memory.c` in the debug mode.