### PR TITLE
hypre_ParPrintf

### DIFF
--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -80,7 +80,6 @@ typedef double                 hypre_double;
 /* printf.c */
 // #ifdef HYPRE_BIGINT
 HYPRE_Int hypre_ndigits( HYPRE_BigInt number );
-HYPRE_Int hypre_vprintf( const char *format, va_list arg );
 HYPRE_Int hypre_printf( const char *format, ... );
 HYPRE_Int hypre_fprintf( FILE *stream, const char *format, ... );
 HYPRE_Int hypre_sprintf( char *s, const char *format, ... );

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -80,12 +80,14 @@ typedef double                 hypre_double;
 /* printf.c */
 // #ifdef HYPRE_BIGINT
 HYPRE_Int hypre_ndigits( HYPRE_BigInt number );
+HYPRE_Int hypre_vprintf( const char *format, va_list arg );
 HYPRE_Int hypre_printf( const char *format, ... );
 HYPRE_Int hypre_fprintf( FILE *stream, const char *format, ... );
 HYPRE_Int hypre_sprintf( char *s, const char *format, ... );
 HYPRE_Int hypre_scanf( const char *format, ... );
 HYPRE_Int hypre_fscanf( FILE *stream, const char *format, ... );
 HYPRE_Int hypre_sscanf( char *s, const char *format, ... );
+HYPRE_Int hypre_ParPrintf(MPI_Comm comm, const char *format, ...);
 // #else
 // #define hypre_printf  printf
 // #define hypre_fprintf fprintf

--- a/src/utilities/printf.c
+++ b/src/utilities/printf.c
@@ -128,28 +128,19 @@ hypre_ndigits( HYPRE_BigInt number )
 /* printf functions */
 
 HYPRE_Int
-hypre_vprintf( const char *format, va_list ap )
-{
-   HYPRE_Int ierr = 0;
-   char *newformat;
-
-   new_format(format, &newformat);
-   ierr = vprintf(newformat, ap);
-   free_format(newformat);
-   fflush(stdout);
-
-   return ierr;
-}
-
-HYPRE_Int
 hypre_printf( const char *format, ...)
 {
    va_list   ap;
+   char     *newformat;
    HYPRE_Int ierr = 0;
 
    va_start(ap, format);
-   ierr = hypre_vprintf(format, ap);
+   new_format(format, &newformat);
+   ierr = vprintf(newformat, ap);
+   free_format(newformat);
    va_end(ap);
+
+   fflush(stdout);
 
    return ierr;
 }
@@ -239,8 +230,8 @@ hypre_sscanf( char *s, const char *format, ...)
 HYPRE_Int
 hypre_ParPrintf(MPI_Comm comm, const char *format, ...)
 {
-   HYPRE_Int my_id, ierr;
-   ierr = hypre_MPI_Comm_rank(comm, &my_id);
+   HYPRE_Int my_id;
+   HYPRE_Int ierr = hypre_MPI_Comm_rank(comm, &my_id);
 
    if (ierr)
    {
@@ -250,9 +241,15 @@ hypre_ParPrintf(MPI_Comm comm, const char *format, ...)
    if (!my_id)
    {
       va_list ap;
+      char   *newformat;
+
       va_start(ap, format);
-      ierr = hypre_vprintf(format, ap);
+      new_format(format, &newformat);
+      ierr = vprintf(newformat, ap);
+      free_format(newformat);
       va_end(ap);
+
+      fflush(stdout);
    }
 
    return ierr;

--- a/src/utilities/printf.c
+++ b/src/utilities/printf.c
@@ -128,19 +128,28 @@ hypre_ndigits( HYPRE_BigInt number )
 /* printf functions */
 
 HYPRE_Int
-hypre_printf( const char *format, ...)
+hypre_vprintf( const char *format, va_list ap )
 {
-   va_list   ap;
-   char     *newformat;
    HYPRE_Int ierr = 0;
+   char *newformat;
 
-   va_start(ap, format);
    new_format(format, &newformat);
    ierr = vprintf(newformat, ap);
    free_format(newformat);
-   va_end(ap);
-
    fflush(stdout);
+
+   return ierr;
+}
+
+HYPRE_Int
+hypre_printf( const char *format, ...)
+{
+   va_list   ap;
+   HYPRE_Int ierr = 0;
+
+   va_start(ap, format);
+   ierr = hypre_vprintf(format, ap);
+   va_end(ap);
 
    return ierr;
 }
@@ -227,6 +236,27 @@ hypre_sscanf( char *s, const char *format, ...)
    return ierr;
 }
 
+HYPRE_Int
+hypre_ParPrintf(MPI_Comm comm, const char *format, ...)
+{
+   HYPRE_Int my_id, ierr;
+   ierr = hypre_MPI_Comm_rank(comm, &my_id);
+
+   if (ierr)
+   {
+      return ierr;
+   }
+
+   if (!my_id)
+   {
+      va_list ap;
+      va_start(ap, format);
+      ierr = hypre_vprintf(format, ap);
+      va_end(ap);
+   }
+
+   return ierr;
+}
 // #else
 //
 // /* this is used only to eliminate compiler warnings */

--- a/src/utilities/printf.h
+++ b/src/utilities/printf.h
@@ -13,12 +13,14 @@
 /* printf.c */
 // #ifdef HYPRE_BIGINT
 HYPRE_Int hypre_ndigits( HYPRE_BigInt number );
+HYPRE_Int hypre_vprintf( const char *format, va_list arg );
 HYPRE_Int hypre_printf( const char *format, ... );
 HYPRE_Int hypre_fprintf( FILE *stream, const char *format, ... );
 HYPRE_Int hypre_sprintf( char *s, const char *format, ... );
 HYPRE_Int hypre_scanf( const char *format, ... );
 HYPRE_Int hypre_fscanf( FILE *stream, const char *format, ... );
 HYPRE_Int hypre_sscanf( char *s, const char *format, ... );
+HYPRE_Int hypre_ParPrintf(MPI_Comm comm, const char *format, ...);
 // #else
 // #define hypre_printf  printf
 // #define hypre_fprintf fprintf

--- a/src/utilities/printf.h
+++ b/src/utilities/printf.h
@@ -13,7 +13,6 @@
 /* printf.c */
 // #ifdef HYPRE_BIGINT
 HYPRE_Int hypre_ndigits( HYPRE_BigInt number );
-HYPRE_Int hypre_vprintf( const char *format, va_list arg );
 HYPRE_Int hypre_printf( const char *format, ... );
 HYPRE_Int hypre_fprintf( FILE *stream, const char *format, ... );
 HYPRE_Int hypre_sprintf( char *s, const char *format, ... );


### PR DESCRIPTION
This PR adds `hypre_ParPrintf`. Prints to standard out, only from the first processor in the communicator. Calls from other processes are ignored.
