### PR TITLE
Fix segfault on HYPRE_SStructGraphDestroy

### DIFF
--- a/src/sstruct_mv/HYPRE_sstruct_graph.c
+++ b/src/sstruct_mv/HYPRE_sstruct_graph.c
@@ -102,7 +102,6 @@ HYPRE_SStructGraphDestroy( HYPRE_SStructGraph graph )
    hypre_SStructUVEntry    **Uventries;
    hypre_SStructUVEntry     *Uventry;
    HYPRE_BigInt            **Uveoffsets;
-   HYPRE_Int                 a_graph_entries;
    hypre_SStructGraphEntry **graph_entries;
    HYPRE_Int                 nvars;
    HYPRE_Int                 part, var, i;
@@ -157,9 +156,8 @@ HYPRE_SStructGraphDestroy( HYPRE_SStructGraph graph )
          hypre_TFree(iUventries, HYPRE_MEMORY_HOST);
          hypre_TFree(Uventries, HYPRE_MEMORY_HOST);
          hypre_TFree(Uveoffsets, HYPRE_MEMORY_HOST);
-         a_graph_entries = hypre_SStructAGraphEntries(graph);
          graph_entries = hypre_SStructGraphEntries(graph);
-         for (i = 0; i < a_graph_entries; i++)
+         for (i = 0; i < hypre_SStructNGraphEntries(graph); i++)
          {
             hypre_TFree(graph_entries[i], HYPRE_MEMORY_HOST);
          }

--- a/src/sstruct_mv/HYPRE_sstruct_graph.c
+++ b/src/sstruct_mv/HYPRE_sstruct_graph.c
@@ -268,7 +268,7 @@ HYPRE_SStructGraphAddEntries( HYPRE_SStructGraph   graph,
    if (!a_entries)
    {
       a_entries = 1000;
-      entries = hypre_CTAlloc(hypre_SStructGraphEntry *,  a_entries, HYPRE_MEMORY_HOST);
+      entries = hypre_TAlloc(hypre_SStructGraphEntry *,  a_entries, HYPRE_MEMORY_HOST);
 
       hypre_SStructAGraphEntries(graph) = a_entries;
       hypre_SStructGraphEntries(graph) = entries;


### PR DESCRIPTION
This PR fixes a segmentation fault on `HYPRE_SStructGraphDestroy`. The error occurred when the number of graph entries added to the SStructGraph via `HYPRE_SStructGraphAddEntries` was larger than 1000. 