### PR TITLE
configure: update BLAS_SEARCH_DIRS and LAPACK_SEARCH_DIRS to include lib64

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -8015,7 +8015,7 @@ fi
 #***************************************************************
 #   Set path to selected BLAS library
 #***************************************************************
-  BLAS_SEARCH_DIRS="/usr/lib /usr/local/lib /lib"
+  BLAS_SEARCH_DIRS="/usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 /lib /lib64"
 
   if test "$BLASLIBS" != "null"; then
      for dir in $BLAS_SEARCH_DIRS; do
@@ -8223,7 +8223,7 @@ fi
 #***************************************************************
 #   Set path to selected LAPACK library
 #***************************************************************
-  LAPACK_SEARCH_DIRS="/usr/lib /usr/local/lib /lib"
+  LAPACK_SEARCH_DIRS="/usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 /lib /lib64"
 
   if test "$LAPACKLIBS" != "null"; then
      for dir in $LAPACK_SEARCH_DIRS; do


### PR DESCRIPTION
This should save users from having to specify `--with-blas-lib-dirs=/usr/lib64` etc. when the BLAS and Lapack libraries are located in `/usr/lib64` rather than `/usr/lib`.