### PR TITLE
Add header to remove header-transitivity issue

### DIFF
--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -475,6 +475,7 @@ sycl::range<1> hypre_GetDefaultDeviceGridDimension( HYPRE_Int n, const char *gra
 #include <thrust/replace.h>
 #include <thrust/sequence.h>
 #include <thrust/for_each.h>
+#include <thrust/remove.h>
 
 using namespace thrust::placeholders;
 

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -418,6 +418,7 @@ sycl::range<1> hypre_GetDefaultDeviceGridDimension( HYPRE_Int n, const char *gra
 #include <thrust/replace.h>
 #include <thrust/sequence.h>
 #include <thrust/for_each.h>
+#include <thrust/remove.h>
 
 using namespace thrust::placeholders;
 


### PR DESCRIPTION
Future versions of Thrust are cleaning up their header transitivity and we need this header for `thrust::remove_if`.