### PR TITLE
Add -auxfromfile option to IJ driver

### DIFF
--- a/src/parcsr_ls/dsuperlu.c
+++ b/src/parcsr_ls/dsuperlu.c
@@ -52,7 +52,7 @@ HYPRE_Int hypre_SLUDistSetup( HYPRE_Solver *solver, hypre_ParCSRMatrix *A, HYPRE
    hypre_MPI_Comm_rank(comm, &my_id);
 
    /* destroy solver if already setup */
-//   if (solver != NULL) { hypre_SLUDistDestroy(solver); }
+   //   if (solver != NULL) { hypre_SLUDistDestroy(solver); }
    /* allocate memory for new solver */
    dslu_data = hypre_CTAlloc(hypre_DSLUData, 1, HYPRE_MEMORY_HOST);
 

--- a/src/parcsr_ls/par_ilu_setup.c
+++ b/src/parcsr_ls/par_ilu_setup.c
@@ -1640,11 +1640,13 @@ HYPRE_ILUSetupCusparseCSRILU0SetupSolve(hypre_CSRMatrix *A, cusparseMatDescr_t m
    HYPRE_CUSPARSE_CALL(cusparseCreateCsrsv2Info(&(matU_info)));
 
    /* 2. Get working array size */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, n, nnz_A,
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, n,
+                                                        nnz_A,
                                                         matL_des, A_data, A_i, A_j,
                                                         matL_info, &matL_buffersize));
 
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, n, nnz_A,
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, n,
+                                                        nnz_A,
                                                         matU_des, A_data, A_i, A_j,
                                                         matU_info, &matU_buffersize));
 
@@ -2720,7 +2722,8 @@ hypre_ParILURAPBuildRP(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *BLUm, hypre_Pa
    }
 
    /* check buffer size and create buffer */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt(handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt(handle, algo,
+                                                           CUSPARSE_OPERATION_NON_TRANSPOSE,
                                                            CUSPARSE_OPERATION_NON_TRANSPOSE,
                                                            n, m, nnz_BLUm, &alpha, matL_des, BLUm_diag_data, BLUm_diag_i,
                                                            BLUm_diag_j, rhs, n, malL_info, policy, &buffer_size));
@@ -2749,7 +2752,8 @@ hypre_ParILURAPBuildRP(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *BLUm, hypre_Pa
 
    /* check buffer size and create buffer */
 
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt(handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt(handle, algo,
+                                                           CUSPARSE_OPERATION_NON_TRANSPOSE,
                                                            CUSPARSE_OPERATION_NON_TRANSPOSE,
                                                            n, m, nnz_BLUm, &alpha, matU_des, BLUm_diag_data, BLUm_diag_i,
                                                            BLUm_diag_j, rhs, n, malU_info, policy, &buffer_size));

--- a/src/parcsr_ls/par_ilu_solve.c
+++ b/src/parcsr_ls/par_ilu_solve.c
@@ -1430,7 +1430,7 @@ hypre_ILUSolveRAPGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f,
          /* solve L^{-1} */
          if (nLU > 0)
          {
-               /* L solve */
+            /* L solve */
             HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_solve(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
                                                             nLU, BLU_nnz, &one, matL_des,
                                                             BLU_data, BLU_i, BLU_j, matBL_info,

--- a/src/seq_mv/csr_spgemm_device_rocsparse.c
+++ b/src/seq_mv/csr_spgemm_device_rocsparse.c
@@ -78,14 +78,14 @@ hypreDevice_CSRSpGemmRocsparse(HYPRE_Int           m,
    void *rs_buffer;
 
    HYPRE_ROCSPARSE_CALL( hypre_rocsparse_csrgemm_buffer_size(handle,
-                                                            transA, transB,
-                                                            m, n, k,
-                                                            &alpha, // \alpha = 1
-                                                            descrA, nnzA, d_ia, d_ja_sorted,
-                                                            descrB, nnzB, d_ib, d_jb_sorted,
-                                                            NULL, // \beta = 0
-                                                            NULL,   0,    NULL, NULL, // D is nothing
-                                                            infoC, &rs_buffer_size) );
+                                                             transA, transB,
+                                                             m, n, k,
+                                                             &alpha, // \alpha = 1
+                                                             descrA, nnzA, d_ia, d_ja_sorted,
+                                                             descrB, nnzB, d_ib, d_jb_sorted,
+                                                             NULL, // \beta = 0
+                                                             NULL,   0,    NULL, NULL, // D is nothing
+                                                             infoC, &rs_buffer_size) );
 
    rs_buffer = hypre_TAlloc(char, rs_buffer_size, HYPRE_MEMORY_DEVICE);
 

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -320,7 +320,8 @@ HYPRE_Int hypre_SeqVectorElmdivpy( hypre_Vector *x, hypre_Vector *b, hypre_Vecto
 HYPRE_Int hypre_SeqVectorElmdivpyMarked( hypre_Vector *x, hypre_Vector *b, hypre_Vector *y,
                                          HYPRE_Int *marker, HYPRE_Int marker_val );
 
-HYPRE_Int hypre_CSRMatrixSpMVDevice( HYPRE_Int trans, HYPRE_Complex alpha, hypre_CSRMatrix *A, hypre_Vector *x,
+HYPRE_Int hypre_CSRMatrixSpMVDevice( HYPRE_Int trans, HYPRE_Complex alpha, hypre_CSRMatrix *A,
+                                     hypre_Vector *x,
                                      HYPRE_Complex beta, hypre_Vector *y, HYPRE_Int *y_ind, HYPRE_Int fill );
 
 #if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE) || defined(HYPRE_USING_ONEMKLSPARSE)

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -592,7 +592,8 @@ HYPRE_Int hypre_SeqVectorElmdivpy( hypre_Vector *x, hypre_Vector *b, hypre_Vecto
 HYPRE_Int hypre_SeqVectorElmdivpyMarked( hypre_Vector *x, hypre_Vector *b, hypre_Vector *y,
                                          HYPRE_Int *marker, HYPRE_Int marker_val );
 
-HYPRE_Int hypre_CSRMatrixSpMVDevice( HYPRE_Int trans, HYPRE_Complex alpha, hypre_CSRMatrix *A, hypre_Vector *x,
+HYPRE_Int hypre_CSRMatrixSpMVDevice( HYPRE_Int trans, HYPRE_Complex alpha, hypre_CSRMatrix *A,
+                                     hypre_Vector *x,
                                      HYPRE_Complex beta, hypre_Vector *y, HYPRE_Int *y_ind, HYPRE_Int fill );
 
 #if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE) || defined(HYPRE_USING_ONEMKLSPARSE)

--- a/src/seq_mv/vector.c
+++ b/src/seq_mv/vector.c
@@ -478,7 +478,8 @@ hypre_SeqVectorScale( HYPRE_Complex alpha,
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #if defined(HYPRE_USING_CUBLAS)
-   HYPRE_CUBLAS_CALL( hypre_cublas_scal(hypre_HandleCublasHandle(hypre_handle()), size, &alpha, y_data, 1) );
+   HYPRE_CUBLAS_CALL( hypre_cublas_scal(hypre_HandleCublasHandle(hypre_handle()), size, &alpha, y_data,
+                                        1) );
 #else
    hypreDevice_ComplexScalen( y_data, size, y_data, alpha );
 #endif // #if defined(HYPRE_USING_CUBLAS)
@@ -549,7 +550,8 @@ hypre_SeqVectorAxpy( HYPRE_Complex alpha,
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #if defined(HYPRE_USING_CUBLAS)
-   HYPRE_CUBLAS_CALL( hypre_cublas_axpy(hypre_HandleCublasHandle(hypre_handle()), size, &alpha, x_data, 1,
+   HYPRE_CUBLAS_CALL( hypre_cublas_axpy(hypre_HandleCublasHandle(hypre_handle()), size, &alpha, x_data,
+                                        1,
                                         y_data, 1) );
 #else
    hypreDevice_ComplexAxpyn(x_data, size, y_data, y_data, alpha);
@@ -727,7 +729,8 @@ hypre_SeqVectorInnerProd( hypre_Vector *x,
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
 #if defined(HYPRE_USING_CUBLAS)
-   HYPRE_CUBLAS_CALL( hypre_cublas_dot(hypre_HandleCublasHandle(hypre_handle()), size, x_data, 1, y_data, 1,
+   HYPRE_CUBLAS_CALL( hypre_cublas_dot(hypre_HandleCublasHandle(hypre_handle()), size, x_data, 1,
+                                       y_data, 1,
                                        &result) );
 #else
    result = HYPRE_THRUST_CALL( inner_product, x_data, x_data + size, y_data, 0.0 );

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -4223,7 +4223,7 @@ main( hypre_int argc,
       HYPRE_IJMatrixGetObject(ij_A, &object);
       parcsr_A = (HYPRE_ParCSRMatrix) object;
 
-      HYPRE_ParaSailsSetup(pcg_precond, parcsr_A, NULL, NULL);
+      HYPRE_ParaSailsSetup(pcg_precond, parcsr_M, NULL, NULL);
       HYPRE_ParaSailsBuildIJMatrix(pcg_precond, &ij_N);
       HYPRE_IJMatrixPrint(ij_M, "parasails.out");
 

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -2855,7 +2855,7 @@ main( hypre_int argc,
    /*-----------------------------------------------------------
     * Set up the interp vector
     *-----------------------------------------------------------*/
-   if ( build_rbm)
+   if (build_rbm)
    {
       char new_file_name[80];
       /* RHS */
@@ -3512,7 +3512,7 @@ main( hypre_int argc,
    hypre_ParCSRMatrixMigrate(parcsr_A, hypre_HandleMemoryLocation(hypre_handle()));
    hypre_ParVectorMigrate(b, hypre_HandleMemoryLocation(hypre_handle()));
    hypre_ParVectorMigrate(x, hypre_HandleMemoryLocation(hypre_handle()));
-   if (parcsr_M != parcsr_A)
+   if (build_matrix_M == 1)
    {
       hypre_ParCSRMatrixMigrate(parcsr_M, hypre_HandleMemoryLocation(hypre_handle()));
    }

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -826,7 +826,8 @@ HYPRE_Int hypre_umpire_pinned_pooled_free(void *ptr);
 hypre_MemoryTracker * hypre_MemoryTrackerCreate();
 void hypre_MemoryTrackerDestroy(hypre_MemoryTracker *tracker);
 void hypre_MemoryTrackerInsert(const char *action, void *ptr, void *ptr2, size_t nbytes,
-                               hypre_MemoryLocation memory_location, hypre_MemoryLocation memory_location2, const char *filename, const char *function, HYPRE_Int line);
+                               hypre_MemoryLocation memory_location, hypre_MemoryLocation memory_location2, const char *filename,
+                               const char *function, HYPRE_Int line);
 HYPRE_Int hypre_PrintMemoryTracker();
 #endif
 

--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -1383,7 +1383,8 @@ hypre_PrintMemoryTracker()
           tracker->data[i]._memory_location == hypre_MEMORY_HOST &&
           tracker->data[i]._memory_location2 == hypre_MEMORY_DEVICE )
       {
-         fprintf(file, " %6zu %12s        %16p  %16p  %10s %16s %16s %40s (%5d) %50s  |  %12zu %12zu %12zu %12zu\n",
+         fprintf(file,
+                 " %6zu %12s        %16p  %16p  %10s %16s %16s %40s (%5d) %50s  |  %12zu %12zu %12zu %12zu\n",
                  i,
                  tracker->data[i]._action,
                  tracker->data[i]._ptr,
@@ -1398,7 +1399,7 @@ hypre_PrintMemoryTracker()
                  curr_bytes[hypre_MEMORY_HOST_PINNED],
                  curr_bytes[hypre_MEMORY_DEVICE],
                  curr_bytes[hypre_MEMORY_UNIFIED]
-               );
+                );
       }
       else
 #endif
@@ -1416,7 +1417,7 @@ hypre_PrintMemoryTracker()
                  curr_bytes[hypre_MEMORY_HOST_PINNED],
                  curr_bytes[hypre_MEMORY_DEVICE],
                  curr_bytes[hypre_MEMORY_UNIFIED]
-               );
+                );
       }
    }
 

--- a/src/utilities/memory.h
+++ b/src/utilities/memory.h
@@ -312,7 +312,8 @@ HYPRE_Int hypre_umpire_pinned_pooled_free(void *ptr);
 hypre_MemoryTracker * hypre_MemoryTrackerCreate();
 void hypre_MemoryTrackerDestroy(hypre_MemoryTracker *tracker);
 void hypre_MemoryTrackerInsert(const char *action, void *ptr, void *ptr2, size_t nbytes,
-                               hypre_MemoryLocation memory_location, hypre_MemoryLocation memory_location2, const char *filename, const char *function, HYPRE_Int line);
+                               hypre_MemoryLocation memory_location, hypre_MemoryLocation memory_location2, const char *filename,
+                               const char *function, HYPRE_Int line);
 HYPRE_Int hypre_PrintMemoryTracker();
 #endif
 


### PR DESCRIPTION
Add `-auxfromfile` option for reading an auxiliary matrix from file, which is then used to build the preconditioner. 

This is useful, for example, for the case that a filtered version of `A` is used to build the preconditioner.