### PR TITLE
Cusolver

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,7 @@ option(HYPRE_ENABLE_UNIFIED_MEMORY   "Use unified memory for allocating the memo
 # CUDA options
 option(HYPRE_ENABLE_CUDA_STREAMS     "Use CUDA streams" ON)
 option(HYPRE_ENABLE_CUSPARSE         "Use cuSPARSE" ON)
+option(HYPRE_ENABLE_CUSOLVER         "Use cuSOLVER" OFF)
 option(HYPRE_ENABLE_DEVICE_POOL      "Use device memory pool" OFF)
 option(HYPRE_ENABLE_CUBLAS           "Use cuBLAS" OFF)
 option(HYPRE_ENABLE_CURAND           "Use cuRAND" ON)

--- a/src/config/HYPRE_config.h.cmake.in
+++ b/src/config/HYPRE_config.h.cmake.in
@@ -82,6 +82,9 @@
 /* Use cuSPARSE */
 #cmakedefine HYPRE_USING_CUSPARSE 1
 
+/* Use cuSOLVER */
+#cmakedefine HYPRE_USING_CUSOLVER 1
+
 /* Use device memory pool */
 #cmakedefine HYPRE_USING_DEVICE_POOL 1
 

--- a/src/config/HYPRE_config.h.in
+++ b/src/config/HYPRE_config.h.in
@@ -172,6 +172,9 @@
 /* Define to 1 if using cuSPARSE */
 #undef HYPRE_USING_CUSPARSE
 
+/* Define to 1 if using cuSOLVER */
+#undef HYPRE_USING_CUSOLVER
+
 /* Define to 1 if using device async malloc */
 #undef HYPRE_USING_DEVICE_MALLOC_ASYNC
 

--- a/src/config/cmake/HYPRE_SetupCUDAToolkit.cmake
+++ b/src/config/cmake/HYPRE_SetupCUDAToolkit.cmake
@@ -50,6 +50,16 @@ if (CMAKE_VERSION VERSION_LESS 3.17)
     endif (HYPRE_SHARED)
   endif (HYPRE_ENABLE_CUBLAS)
 
+  if (HYPRE_ENABLE_CUSOLVER)
+    set(HYPRE_USING_CUSOLVER ON CACHE BOOL "" FORCE)
+    if (HYPRE_SHARED)
+      list(APPEND EXPORT_INTERFACE_CUDA_LIBS ${CUDA_cusolver_LIBRARY})
+    else ()
+      list(APPEND EXPORT_INTERFACE_CUDA_LIBS
+        ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcusolver_static.a)
+    endif ()
+  endif ()
+
   if (NOT HYPRE_SHARED)
     list(APPEND EXPORT_INTERFACE_CUDA_LIBS
       ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libculibos.a)
@@ -100,6 +110,15 @@ else()
       list(APPEND EXPORT_INTERFACE_CUDA_LIBS CUDA::cublas CUDA::cublasLt)
     endif (HYPRE_SHARED)
   endif (HYPRE_ENABLE_CUBLAS)
+
+  if (HYPRE_ENABLE_CUSOLVER)
+    set(HYPRE_USING_CUSOLVER ON CACHE BOOL "" FORCE)
+    if (HYPRE_CUDA_TOOLKIT_STATIC)
+      list(APPEND EXPORT_INTERFACE_CUDA_LIBS CUDA::cusolver_static)
+    else ()
+      list(APPEND EXPORT_INTERFACE_CUDA_LIBS CUDA::cusolver)
+    endif ()
+  endif ()
 
   if (HYPRE_CUDA_TOOLKIT_STATIC)
     list(APPEND EXPORT_INTERFACE_CUDA_LIBS CUDA::culibos)

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -175,6 +175,7 @@ hypre_using_cuda_streams=no
 hypre_using_cusparse=yes
 hypre_using_cublas=yes
 hypre_using_curand=yes
+hypre_using_cusolver=no
 hypre_using_device_pool=no
 hypre_using_device_malloc_async=no
 hypre_using_umpire=no
@@ -430,6 +431,17 @@ AS_HELP_STRING([--enable-cusparse],
     *)   hypre_using_cusparse=yes ;;
  esac],
 [hypre_using_cusparse=yes]
+)
+
+AC_ARG_ENABLE(cusolver,
+AS_HELP_STRING([--enable-cusolver],
+               [Use cusolver (default is NO).]),
+[case "${enableval}" in
+    yes) hypre_using_cusolver=yes ;;
+    no)  hypre_using_cusolver=no ;;
+    *)   hypre_using_cusolver=yes ;;
+ esac],
+[hypre_using_cusolver=no]
 )
 
 AC_ARG_ENABLE(device-memory-pool,
@@ -2268,6 +2280,12 @@ then
    then
       AC_DEFINE(HYPRE_USING_CURAND, 1, [Define to 1 if using cuRAND])
       HYPRE_CUDA_LIBS+=" -lcurand"
+   fi
+
+   if test "$hypre_using_cusolver" = "yes"
+   then
+      AC_DEFINE(HYPRE_USING_CUSOLVER, 1, [Define to 1 if using cuSolver])
+      HYPRE_CUDA_LIBS+=" -lcusolver"
    fi
 
    if test "$hypre_using_device_pool" = "yes"

--- a/src/configure
+++ b/src/configure
@@ -784,6 +784,7 @@ enable_fortran
 enable_unified_memory
 enable_cuda_streams
 enable_cusparse
+enable_cusolver
 enable_device_memory_pool
 enable_device_malloc_async
 enable_cublas
@@ -1517,6 +1518,7 @@ Optional Features:
                           (default is NO).
   --enable-cuda-streams   Use CUDA streams (default is YES).
   --enable-cusparse       Use cuSPARSE (default is YES).
+  --enable-cusolver       Use cuSOLVER (default is NO).
   --enable-device-memory-pool
                           Use device pooling allocator (default is NO).
   --enable-device-malloc-async
@@ -2787,6 +2789,7 @@ hypre_using_cuda_streams=no
 hypre_using_cusparse=yes
 hypre_using_cublas=yes
 hypre_using_curand=yes
+hypre_using_cusolver=no
 hypre_using_device_pool=no
 hypre_using_device_malloc_async=no
 hypre_using_umpire=no
@@ -3151,6 +3154,19 @@ if test "${enable_device_memory_pool+set}" = set; then :
  esac
 else
   hypre_using_device_pool=no
+
+fi
+
+
+# Check whether --enable-cusolver was given.
+if test "${enable_cusolver+set}" = set; then :
+  enableval=$enable_cusolver; case "${enableval}" in
+    yes) hypre_using_cusolver=yes ;;
+    no)  hypre_using_cusolver=no ;;
+    *)   hypre_using_cusolver=yes ;;
+ esac
+else
+  hypre_using_cusolver=no
 
 fi
 
@@ -9193,6 +9209,14 @@ $as_echo "#define HYPRE_USING_CUBLAS 1" >>confdefs.h
 $as_echo "#define HYPRE_USING_CURAND 1" >>confdefs.h
 
       HYPRE_CUDA_LIBS+=" -lcurand"
+   fi
+
+   if test "$hypre_using_cusolver" = "yes"
+   then
+
+$as_echo "#define HYPRE_USING_CUSOLVER 1" >>confdefs.h
+
+       HYPRE_CUDA_LIBS+=" -lcusolver"
    fi
 
    if test "$hypre_using_device_pool" = "yes"


### PR DESCRIPTION
Copied from #647, which adds the option of using cuSolver (https://docs.nvidia.com/cuda/cusolver/index.html), a GPU accelerated library for decompositions and linear system solutions from NVIDIA. We need the reordering algorithms (like RCM and AMD) on GPUs from cuSolver for ILU.