### PR TITLE
hypre_ParCSRMatrixPrintIJ on device

### DIFF
--- a/src/IJ_mv/HYPRE_IJMatrix.c
+++ b/src/IJ_mv/HYPRE_IJMatrix.c
@@ -1097,20 +1097,9 @@ HYPRE_IJMatrixPrint( HYPRE_IJMatrix  matrix,
 
    void *object;
    HYPRE_IJMatrixGetObject(matrix, &object);
-   HYPRE_ParCSRMatrix par_csr = (HYPRE_ParCSRMatrix) object;
+   hypre_ParCSRMatrix *par_csr = (hypre_ParCSRMatrix*) object;
 
-   HYPRE_MemoryLocation memory_location = hypre_IJMatrixMemoryLocation(matrix);
-
-   if ( hypre_GetActualMemLocation(memory_location) == hypre_MEMORY_HOST )
-   {
-      hypre_ParCSRMatrixPrintIJ(par_csr, 0, 0, filename);
-   }
-   else
-   {
-      HYPRE_ParCSRMatrix par_csr2 = hypre_ParCSRMatrixClone_v2(par_csr, 1, HYPRE_MEMORY_HOST);
-      hypre_ParCSRMatrixPrintIJ(par_csr2, 0, 0, filename);
-      hypre_ParCSRMatrixDestroy(par_csr2);
-   }
+   hypre_ParCSRMatrixPrintIJ(par_csr, 0, 0, filename);
 
    return hypre_error_flag;
 }

--- a/src/parcsr_mv/par_csr_matrix.c
+++ b/src/parcsr_mv/par_csr_matrix.c
@@ -516,7 +516,6 @@ hypre_ParCSRMatrixRead( MPI_Comm    comm,
    {
       offd = hypre_CSRMatrixCreate(local_num_rows, 0, 0);
       hypre_CSRMatrixInitialize_v2(offd, 0, HYPRE_MEMORY_HOST);
-
    }
 
    matrix = hypre_CTAlloc(hypre_ParCSRMatrix, 1, HYPRE_MEMORY_HOST);
@@ -624,6 +623,8 @@ hypre_ParCSRMatrixPrintIJ( const hypre_ParCSRMatrix *matrix,
                            const HYPRE_Int           base_j,
                            const char               *filename )
 {
+   hypre_ParCSRMatrix  *h_matrix;
+
    MPI_Comm             comm;
    HYPRE_BigInt         first_row_index;
    HYPRE_BigInt         first_col_diag;
@@ -646,21 +647,33 @@ hypre_ParCSRMatrixPrintIJ( const hypre_ParCSRMatrix *matrix,
    HYPRE_Int            num_nonzeros_offd;
    HYPRE_BigInt         ilower, iupper, jlower, jupper;
 
+   HYPRE_MemoryLocation memory_location = hypre_ParCSRMatrixMemoryLocation((hypre_ParCSRMatrix*) matrix);
+
    if (!matrix)
    {
       hypre_error_in_arg(1);
       return hypre_error_flag;
    }
 
-   comm            = hypre_ParCSRMatrixComm(matrix);
-   first_row_index = hypre_ParCSRMatrixFirstRowIndex(matrix);
-   first_col_diag  = hypre_ParCSRMatrixFirstColDiag(matrix);
-   diag            = hypre_ParCSRMatrixDiag(matrix);
-   offd            = hypre_ParCSRMatrixOffd(matrix);
-   col_map_offd    = hypre_ParCSRMatrixColMapOffd(matrix);
-   num_rows        = hypre_ParCSRMatrixNumRows(matrix);
-   row_starts      = hypre_ParCSRMatrixRowStarts(matrix);
-   col_starts      = hypre_ParCSRMatrixColStarts(matrix);
+   /* Create temporary matrix on host memory if needed */
+   if (hypre_GetActualMemLocation(memory_location) == hypre_MEMORY_HOST)
+   {
+      h_matrix = (hypre_ParCSRMatrix *) matrix;
+   }
+   else
+   {
+      h_matrix = hypre_ParCSRMatrixClone_v2((hypre_ParCSRMatrix *) matrix, 1, HYPRE_MEMORY_HOST);
+   }
+
+   comm            = hypre_ParCSRMatrixComm(h_matrix);
+   first_row_index = hypre_ParCSRMatrixFirstRowIndex(h_matrix);
+   first_col_diag  = hypre_ParCSRMatrixFirstColDiag(h_matrix);
+   diag            = hypre_ParCSRMatrixDiag(h_matrix);
+   offd            = hypre_ParCSRMatrixOffd(h_matrix);
+   col_map_offd    = hypre_ParCSRMatrixColMapOffd(h_matrix);
+   num_rows        = hypre_ParCSRMatrixNumRows(h_matrix);
+   row_starts      = hypre_ParCSRMatrixRowStarts(h_matrix);
+   col_starts      = hypre_ParCSRMatrixColStarts(h_matrix);
    hypre_MPI_Comm_rank(comm, &myid);
    hypre_MPI_Comm_size(comm, &num_procs);
 
@@ -738,6 +751,12 @@ hypre_ParCSRMatrixPrintIJ( const hypre_ParCSRMatrix *matrix,
    }
 
    fclose(file);
+
+   /* Free temporary matrix */
+   if (hypre_GetActualMemLocation(memory_location) != hypre_MEMORY_HOST)
+   {
+      hypre_ParCSRMatrixDestroy(h_matrix);
+   }
 
    return hypre_error_flag;
 }

--- a/src/test/ij_mm.c
+++ b/src/test/ij_mm.c
@@ -140,12 +140,8 @@ void runjob1( HYPRE_ParCSRMatrix parcsr_A,
 
    if (print_system)
    {
-      if (!parcsr_A_host)
-      {
-         parcsr_A_host = hypre_ParCSRMatrixClone_v2(parcsr_A, 1, HYPRE_MEMORY_HOST);
-      }
       sprintf(fname, "%s/%s", file_dir, "IJ.out.A");
-      hypre_ParCSRMatrixPrintIJ(parcsr_A_host, 0, 0, fname);
+      hypre_ParCSRMatrixPrintIJ(parcsr_A, 0, 0, fname);
    }
 
    for (i = 0 ; i < rep; i++)
@@ -196,12 +192,8 @@ void runjob1( HYPRE_ParCSRMatrix parcsr_A,
 
    if (print_system)
    {
-      if (!parcsr_B_host2)
-      {
-         parcsr_B_host2 = hypre_ParCSRMatrixClone_v2(parcsr_B, 1, HYPRE_MEMORY_HOST);
-      }
       sprintf(fname, "%s/%s", file_dir, "IJ.out.B");
-      hypre_ParCSRMatrixPrintIJ(parcsr_B_host2, 0, 0, fname);
+      hypre_ParCSRMatrixPrintIJ(parcsr_B, 0, 0, fname);
    }
 
    hypre_ParCSRMatrixDestroy(parcsr_B);

--- a/src/test/test_mgr_gpu.c
+++ b/src/test/test_mgr_gpu.c
@@ -691,7 +691,6 @@ main( hypre_int argc,
       else
       {
          hypre_MGRBuildPDevice(parcsr_A, hypre_IntArrayData(CF_marker), coarse_pnts_global, 2, &P);
-         hypre_ParCSRMatrixMigrate(P, HYPRE_MEMORY_HOST);
          hypre_ParCSRMatrixPrintIJ(P, 0, 0, "P_device");
       }
 #endif


### PR DESCRIPTION
This PR updates `hypre_ParCSRMatrixPrintIJ` to work on the device without the need of UVM. This also eliminates the need of migrating a `hypre_ParCSRMatrix` to host before calling the print routine and thus reduces some code duplication in hypre.

This addresses https://github.com/hypre-space/hypre/issues/649#issuecomment-1157008796

Note: This will be used by GEOSX after disabling UVM from their default hypre build.