### PR TITLE
Chebyshev polynomial fix for nearly-singular matrices 

### DIFF
--- a/src/parcsr_ls/par_cheby.c
+++ b/src/parcsr_ls/par_cheby.c
@@ -68,7 +68,7 @@ hypre_ParCSRRelax_Cheby_Setup(hypre_ParCSRMatrix *A,         /* matrix to relax 
    hypre_CSRMatrix *A_diag       = hypre_ParCSRMatrixDiag(A);
    HYPRE_Real       theta, delta;
    HYPRE_Real       den;
-   HYPRE_Real       upper_bound = 0.0, lower_bound = 0.0;
+   HYPRE_Real       upper_bound, lower_bound;
    HYPRE_Int        num_rows     = hypre_CSRMatrixNumRows(A_diag);
    HYPRE_Real      *coefs        = NULL;
    HYPRE_Int        cheby_order;
@@ -89,17 +89,17 @@ hypre_ParCSRRelax_Cheby_Setup(hypre_ParCSRMatrix *A,         /* matrix to relax 
    /* we are using the order of p(A) */
    cheby_order = order - 1;
 
-   if (min_eig >= 0.0)
+   if (max_eig <= 0.0)
+   {
+      upper_bound = min_eig * 1.1;
+      lower_bound = max_eig - (max_eig - upper_bound) * fraction;
+   }
+   else
    {
       /* make sure we are large enough - Adams et al. 2003 */
       upper_bound = max_eig * 1.1;
       /* lower_bound = max_eig/fraction; */
       lower_bound = (upper_bound - min_eig) * fraction + min_eig;
-   }
-   else if (max_eig <= 0.0)
-   {
-      upper_bound = min_eig * 1.1;
-      lower_bound = max_eig - (max_eig - upper_bound) * fraction;
    }
 
    /* theta and delta */


### PR DESCRIPTION
Our current Chebyshev implementation can fail for singular/nearly-singular matrices. This happens because the eigenvalue computation in 
https://github.com/hypre-space/hypre/blob/9b4c1336e7a0371ed1ffa168e8d6034aff2013d7/src/parcsr_ls/par_relax_more.c#L382
may return a negative `lambda_min` close to zero while `lambda_max > 0`, causing problems later on when setting `lower_bound`  and `upper_bound` at 
https://github.com/hypre-space/hypre/blob/b58585e0f041525a1579e046c2148a6ca189a318/src/parcsr_ls/par_cheby.c#L92-L103 (the bounds are never computed)

This PR fixes this issue by always computing the bounds regardless of the sign of `min_eig`

Question to @rfalgout: Should we add regression tests with singular matrices so that we can catch errors like this?