### PR TITLE
Rocm52 headers

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -2365,10 +2365,10 @@ AS_IF([test x"$hypre_using_hip" == x"yes"],
            CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS}"
         fi
 
-        dnl rocThrust depends on rocPrim so we need both for Thrust on AMD GPUs.
+        dnl PB: ROCm 5.2 parked all the headers in /opt/rocm-X.Y/include so we just point there.
+        dnl     This is backwards compatible to previous ROCm versions.
         dnl These are header-only so no linking needed.
-        HYPRE_HIP_INCL="-I${HYPRE_ROCM_PREFIX}/rocthrust/include"
-        HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocprim/include"
+        HYPRE_HIP_INCL="-I${HYPRE_ROCM_PREFIX}/include"
 
         dnl HIP library
         HYPRE_HIP_LIBS="-L${HYPRE_ROCM_PREFIX}/lib -lamdhip64"
@@ -2377,7 +2377,6 @@ AS_IF([test x"$hypre_using_hip" == x"yes"],
         AS_IF([test x"$hypre_using_rocsparse" == x"yes"],
               [AC_DEFINE(HYPRE_USING_ROCSPARSE, 1, [rocSPARSE being used])
                HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocsparse"
-               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocsparse/include"
                ])
 
         dnl Note rocSPARSE requires rocBLAS, so this is only controlling
@@ -2385,20 +2384,17 @@ AS_IF([test x"$hypre_using_hip" == x"yes"],
         dnl So we don't need to add any extra libs or anything.
         AS_IF([test x"$hypre_using_rocblas" == x"yes"],
               [AC_DEFINE(HYPRE_USING_ROCBLAS, 1, [rocBLAS being used])
-              HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocblas/include"
               ])
 
         dnl rocRAND: random number generation on AMD GPUs
         AS_IF([test x"$hypre_using_rocrand" == x"yes"],
               [AC_DEFINE(HYPRE_USING_ROCRAND, 1, [rocRAND being used])
                HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocrand"
-               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocrand/include"
                ])
 
         dnl rocTX tracing API
         AS_IF([test x"$hypre_using_gpu_profiling" == x"yes"],
               [AC_DEFINE(HYPRE_USING_ROCTX, 1, [Define to 1 if using AMD rocTX profiling])
-               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/roctracer/include"
                HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lroctx64"
                ])
 

--- a/src/configure
+++ b/src/configure
@@ -9282,8 +9282,7 @@ fi
            CUFLAGS="${HIPCPPFLAGS} ${HIPCXXFLAGS}"
         fi
 
-                        HYPRE_HIP_INCL="-I${HYPRE_ROCM_PREFIX}/rocthrust/include"
-        HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocprim/include"
+                                HYPRE_HIP_INCL="-I${HYPRE_ROCM_PREFIX}/include"
 
                 HYPRE_HIP_LIBS="-L${HYPRE_ROCM_PREFIX}/lib -lamdhip64"
 
@@ -9292,7 +9291,6 @@ fi
 $as_echo "#define HYPRE_USING_ROCSPARSE 1" >>confdefs.h
 
                HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocsparse"
-               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocsparse/include"
 
 fi
 
@@ -9300,7 +9298,6 @@ fi
 
 $as_echo "#define HYPRE_USING_ROCBLAS 1" >>confdefs.h
 
-              HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocblas/include"
 
 fi
 
@@ -9309,7 +9306,6 @@ fi
 $as_echo "#define HYPRE_USING_ROCRAND 1" >>confdefs.h
 
                HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lrocrand"
-               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/rocrand/include"
 
 fi
 
@@ -9317,7 +9313,6 @@ fi
 
 $as_echo "#define HYPRE_USING_ROCTX 1" >>confdefs.h
 
-               HYPRE_HIP_INCL="${HYPRE_HIP_INCL} -I${HYPRE_ROCM_PREFIX}/roctracer/include"
                HYPRE_HIP_LIBS="${HYPRE_HIP_LIBS} -lroctx64"
 
 fi

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -119,7 +119,7 @@ using hypre_DeviceItem = void*;
 #endif
 
 #if defined(HYPRE_USING_ROCRAND)
-#include <rocrand.h>
+#include <rocrand/rocrand.h>
 #endif
 #endif // defined(HYPRE_USING_HIP)
 

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -62,7 +62,7 @@ using hypre_DeviceItem = void*;
 #endif
 
 #if defined(HYPRE_USING_ROCRAND)
-#include <rocrand.h>
+#include <rocrand/rocrand.h>
 #endif
 #endif // defined(HYPRE_USING_HIP)
 

--- a/src/utilities/nvtx.c
+++ b/src/utilities/nvtx.c
@@ -9,7 +9,7 @@
 
 #if defined(HYPRE_USING_ROCTX)
 #include "hip/hip_runtime_api.h"
-#include "roctx.h"
+#include "roctracer/roctx.h"
 #endif
 
 #if defined(HYPRE_USING_NVTX)


### PR DESCRIPTION
[Copied from #678] ROCm 5.2 changed the primary location of the headers, so updated
build system and a couple of include statements to reflect this.
The update is backward compatible to at least the previous three
ROCm releases (i.e. 4.5).