### PR TITLE
Add `IJVectorSetConstantValues` for setting all values to a constant

### DIFF
--- a/src/IJ_mv/HYPRE_IJVector.c
+++ b/src/IJ_mv/HYPRE_IJVector.c
@@ -319,6 +319,33 @@ HYPRE_IJVectorSetValues( HYPRE_IJVector        vector,
 }
 
 /*--------------------------------------------------------------------------
+ * HYPRE_IJVectorSetConstantValues
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_IJVectorSetConstantValues( HYPRE_IJVector vector, HYPRE_Complex value )
+{
+   hypre_IJVector *vec = (hypre_IJVector *) vector;
+
+   if (!vec)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+
+   if ( hypre_IJVectorObjectType(vec) == HYPRE_PARCSR )
+   {
+     return ( hypre_IJVectorSetConstantValuesPar(vec, value) );
+   }
+   else
+   {
+      hypre_error_in_arg(1);
+   }
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
  * HYPRE_IJVectorAddToValues
  *--------------------------------------------------------------------------*/
 

--- a/src/IJ_mv/HYPRE_IJ_mv.h
+++ b/src/IJ_mv/HYPRE_IJ_mv.h
@@ -450,6 +450,12 @@ HYPRE_Int HYPRE_IJVectorSetValues(HYPRE_IJVector       vector,
                                   const HYPRE_Complex *values);
 
 /**
+ * Sets all values in vector to \e value
+ **/
+HYPRE_Int HYPRE_IJVectorSetConstantValues(HYPRE_IJVector vector,
+                                          HYPRE_Complex  value);
+
+/**
  * Adds to values in vector.  Usage details are analogous to
  * \ref HYPRE_IJVectorSetValues.
  * Adds to any previous values at the specified locations, or, if

--- a/src/IJ_mv/IJVector_parcsr.c
+++ b/src/IJ_mv/IJVector_parcsr.c
@@ -207,6 +207,20 @@ hypre_IJVectorDistributePar(hypre_IJVector  *vector,
 HYPRE_Int
 hypre_IJVectorZeroValuesPar(hypre_IJVector *vector)
 {
+    return hypre_IJVectorSetConstantValuesPar(vector, 0.0);
+}
+
+/******************************************************************************
+ *
+ * hypre_IJVectorSetConstantValuesPar
+ *
+ * sets all local components of an IJVectorPar to value
+ *
+ *****************************************************************************/
+
+HYPRE_Int
+hypre_IJVectorSetConstantValuesPar(hypre_IJVector *vector, HYPRE_Complex value)
+{
    HYPRE_Int my_id;
    HYPRE_BigInt vec_start, vec_stop;
 
@@ -226,7 +240,7 @@ hypre_IJVectorZeroValuesPar(hypre_IJVector *vector)
       if (print_level)
       {
          hypre_printf("par_vector == NULL -- ");
-         hypre_printf("hypre_IJVectorZeroValuesPar\n");
+         hypre_printf("hypre_IJVectorSetConstantValuesPar\n");
          hypre_printf("**** Vector storage is either unallocated or orphaned ****\n");
       }
       hypre_error_in_arg(1);
@@ -239,7 +253,7 @@ hypre_IJVectorZeroValuesPar(hypre_IJVector *vector)
       if (print_level)
       {
          hypre_printf("local_vector == NULL -- ");
-         hypre_printf("hypre_IJVectorZeroValuesPar\n");
+         hypre_printf("hypre_IJVectorSetConstantValuesPar\n");
          hypre_printf("**** Vector local data is either unallocated or orphaned ****\n");
       }
       hypre_error_in_arg(1);
@@ -254,7 +268,7 @@ hypre_IJVectorZeroValuesPar(hypre_IJVector *vector)
       if (print_level)
       {
          hypre_printf("vec_start > vec_stop -- ");
-         hypre_printf("hypre_IJVectorZeroValuesPar\n");
+         hypre_printf("hypre_IJVectorSetConstantValuesPar\n");
          hypre_printf("**** This vector partitioning should not occur ****\n");
       }
       hypre_error_in_arg(1);
@@ -263,7 +277,7 @@ hypre_IJVectorZeroValuesPar(hypre_IJVector *vector)
 
    hypre_assert(hypre_VectorSize(local_vector) == (HYPRE_Int)(vec_stop - vec_start));
 
-   hypre_SeqVectorSetConstantValues(local_vector, 0.0);
+   hypre_SeqVectorSetConstantValues(local_vector, value);
 
    return hypre_error_flag;
 }

--- a/src/IJ_mv/_hypre_IJ_mv.h
+++ b/src/IJ_mv/_hypre_IJ_mv.h
@@ -514,6 +514,7 @@ HYPRE_Int hypre_IJVectorSetMaxOffProcElmtsPar ( hypre_IJVector *vector,
                                                 HYPRE_Int max_off_proc_elmts );
 HYPRE_Int hypre_IJVectorDistributePar ( hypre_IJVector *vector, const HYPRE_Int *vec_starts );
 HYPRE_Int hypre_IJVectorZeroValuesPar ( hypre_IJVector *vector );
+HYPRE_Int hypre_IJVectorSetConstantValuesPar ( hypre_IJVector *vector, HYPRE_Complex value );
 HYPRE_Int hypre_IJVectorSetComponentPar ( hypre_IJVector *vector, HYPRE_Int component);
 HYPRE_Int hypre_IJVectorSetValuesPar ( hypre_IJVector *vector, HYPRE_Int num_values,
                                        const HYPRE_BigInt *indices, const HYPRE_Complex *values );
@@ -575,6 +576,7 @@ HYPRE_Int HYPRE_IJVectorInitialize ( HYPRE_IJVector vector );
 HYPRE_Int HYPRE_IJVectorSetPrintLevel ( HYPRE_IJVector vector, HYPRE_Int print_level );
 HYPRE_Int HYPRE_IJVectorSetValues ( HYPRE_IJVector vector, HYPRE_Int nvalues,
                                     const HYPRE_BigInt *indices, const HYPRE_Complex *values );
+HYPRE_Int HYPRE_IJVectorSetConstantValues ( HYPRE_IJVector vector, HYPRE_Complex value );
 HYPRE_Int HYPRE_IJVectorAddToValues ( HYPRE_IJVector vector, HYPRE_Int nvalues,
                                       const HYPRE_BigInt *indices, const HYPRE_Complex *values );
 HYPRE_Int HYPRE_IJVectorAssemble ( HYPRE_IJVector vector );

--- a/src/IJ_mv/protos.h
+++ b/src/IJ_mv/protos.h
@@ -144,6 +144,7 @@ HYPRE_Int hypre_IJVectorSetMaxOffProcElmtsPar ( hypre_IJVector *vector,
                                                 HYPRE_Int max_off_proc_elmts );
 HYPRE_Int hypre_IJVectorDistributePar ( hypre_IJVector *vector, const HYPRE_Int *vec_starts );
 HYPRE_Int hypre_IJVectorZeroValuesPar ( hypre_IJVector *vector );
+HYPRE_Int hypre_IJVectorSetConstantValuesPar ( hypre_IJVector *vector, HYPRE_Complex value );
 HYPRE_Int hypre_IJVectorSetComponentPar ( hypre_IJVector *vector, HYPRE_Int component);
 HYPRE_Int hypre_IJVectorSetValuesPar ( hypre_IJVector *vector, HYPRE_Int num_values,
                                        const HYPRE_BigInt *indices, const HYPRE_Complex *values );
@@ -205,6 +206,7 @@ HYPRE_Int HYPRE_IJVectorInitialize ( HYPRE_IJVector vector );
 HYPRE_Int HYPRE_IJVectorSetPrintLevel ( HYPRE_IJVector vector, HYPRE_Int print_level );
 HYPRE_Int HYPRE_IJVectorSetValues ( HYPRE_IJVector vector, HYPRE_Int nvalues,
                                     const HYPRE_BigInt *indices, const HYPRE_Complex *values );
+HYPRE_Int HYPRE_IJVectorSetConstantValues ( HYPRE_IJVector vector, HYPRE_Complex value );
 HYPRE_Int HYPRE_IJVectorAddToValues ( HYPRE_IJVector vector, HYPRE_Int nvalues,
                                       const HYPRE_BigInt *indices, const HYPRE_Complex *values );
 HYPRE_Int HYPRE_IJVectorAssemble ( HYPRE_IJVector vector );

--- a/src/examples/ex5.c
+++ b/src/examples/ex5.c
@@ -273,35 +273,28 @@ int main (int argc, char *argv[])
    HYPRE_IJMatrixGetObject(A, (void**) &parcsr_A);
 
 
-   /* Create the rhs and solution */
+   /* Create the rhs */
    HYPRE_IJVectorCreate(MPI_COMM_WORLD, ilower, iupper, &b);
    HYPRE_IJVectorSetObjectType(b, HYPRE_PARCSR);
    HYPRE_IJVectorInitialize(b);
 
-   HYPRE_IJVectorCreate(MPI_COMM_WORLD, ilower, iupper, &x);
-   HYPRE_IJVectorSetObjectType(x, HYPRE_PARCSR);
-   HYPRE_IJVectorInitialize(x);
 
-   /* Set the rhs values to h^2 and the solution to zero */
+   /* Set the rhs values to h^2 */
    {
-      double *rhs_values, *x_values;
+      double *rhs_values;
       int    *rows;
 
       rhs_values =  (double*) calloc(local_size, sizeof(double));
-      x_values =  (double*) calloc(local_size, sizeof(double));
       rows = (int*) calloc(local_size, sizeof(int));
 
       for (i = 0; i < local_size; i++)
       {
          rhs_values[i] = h2;
-         x_values[i] = 0.0;
          rows[i] = ilower + i;
       }
 
       HYPRE_IJVectorSetValues(b, local_size, rows, rhs_values);
-      HYPRE_IJVectorSetValues(x, local_size, rows, x_values);
 
-      free(x_values);
       free(rhs_values);
       free(rows);
    }
@@ -317,7 +310,12 @@ int main (int argc, char *argv[])
    */
    HYPRE_IJVectorGetObject(b, (void **) &par_b);
 
+   /* Create the solution vector with all values set to zero */
+   HYPRE_IJVectorCreate(MPI_COMM_WORLD, ilower, iupper, &x);
+   HYPRE_IJVectorSetObjectType(x, HYPRE_PARCSR);
+   HYPRE_IJVectorInitialize(x);
    HYPRE_IJVectorAssemble(x);
+   HYPRE_IJVectorSetConstantValues(x, 0.0);
    HYPRE_IJVectorGetObject(x, (void **) &par_x);
 
 


### PR DESCRIPTION
This adds a new function:

```
HYPRE_IJVectorSetConstantValues( HYPRE_IJVector vector, HYPRE_Complex value )
```

for setting all values in an `IJVector` to a constant value, analoguous to `HYPRE_IJMatrixSetConstantValues`. Internally this simply generalizes the existing `hypre_IJVectorZeroValuesPar` function to work with any value, not just zero.

---

To provide some background information: I wanted a simple way to zero out a vector (for original allocation, and for reusing when solving the next time-step, for example). However, while working on this I noticed that
```
HYPRE_IJVectorInitialize(x)
HYPRE_IJVectorAssemble(x)
```
might be enough, but [`examples/ex5.c`](https://github.com/hypre-space/hypre/blob/ea3c43a6b091a4c1f23ec86cc346c635fae09d5f/src/examples/ex5.c#L285), where all values in the solution vector is explicitly set to 0, made the impression that this might not be the case. However, since there is a corresponding function for IJMatrix, perhaps this is patch is useful regardless. Opening as a draft PR (Edit: I miss clicked, and only maintainers can convert to a draft PR, apparently.) since I want feedback whether this patch make sense, and if it does I can add some tests. Cheers!