### PR TITLE
docs/misc.rst: fix rst syntax for italics

### DIFF
--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -76,6 +76,12 @@ the user and reference manuals (adjust the path as needed):
     file:///home/falgout2/hypre/src/docs/usr-manual-html/index.html
     file:///home/falgout2/hypre/src/docs/ref-manual-html/index.html
 
+Alternatively, run a (local) webserver:
+
+    python3 -m http.server --directory usr-manual-html
+
+and open http://localhost:8000 in a browser.
+
 ## Some useful links
 
 Sphinx:

--- a/src/docs/usr-manual/ch-misc.rst
+++ b/src/docs/usr-manual/ch-misc.rst
@@ -287,7 +287,7 @@ Error Flags
 
 Every hypre function returns an integer, which is used to indicate errors
 during execution.  Note that the error flag returned by a given function
-reflects the errors from {\em all} previous calls to hypre functions.  In
+reflects the errors from *all* previous calls to hypre functions.  In
 particular, a value of zero means that all hypre functions up to (and
 including) the current one have completed successfully.  This new error flag
 system is being implemented throughout the library, but currently there are


### PR DESCRIPTION
This fixes the rst syntax for italics in docs/misc.rst. Currently it shows up as `{em all}`.
Also adds a tip to docs/README about viewing local docs in a Python web server.