### PR TITLE
Include missing header file for the CUDA install

### DIFF
--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -6,6 +6,7 @@
 set(HDRS
   HYPRE_utilities.h
   _hypre_utilities.h
+  _hypre_utilities.hpp
   HYPRE_error_f.h
   fortran.h
   fortran_matrix.h


### PR DESCRIPTION
We find the _hypre_utilities.hpp is not copied into the install directory when we build with CUDA support. 