### PR TITLE
ILU Jacobi Iterative Triangular Solve Implementation

### DIFF
--- a/src/parcsr_ls/Makefile
+++ b/src/parcsr_ls/Makefile
@@ -154,6 +154,7 @@ CUFILES =\
  par_amg_setup.c\
  par_ilu.c\
  par_ilu_setup.c \
+ par_ilu_solve_device.c\
  par_ilu_solve.c \
  par_cheby_device.c\
  par_relax_more_device.c\

--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -3121,6 +3121,10 @@ HYPRE_Int hypre_ILUSetupILUTRAS(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Rea
 HYPRE_Int hypre_ILUSolveLU(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u,
                            HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *L, HYPRE_Real* D, hypre_ParCSRMatrix *U,
                            hypre_ParVector *utemp, hypre_ParVector *ftemp);
+HYPRE_Int hypre_ILUSolveLUIter(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u,
+                               HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *L, HYPRE_Real* D, hypre_ParCSRMatrix *U,
+                               hypre_ParVector *utemp, hypre_ParVector *ftemp, hypre_Vector *xtemp,
+                               HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters);
 HYPRE_Int hypre_ILUSolveSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u,
                                    HYPRE_Int *perm, HYPRE_Int *qperm, HYPRE_Int nLU, hypre_ParCSRMatrix *L, HYPRE_Real* D,
                                    hypre_ParCSRMatrix *U, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp, hypre_ParVector *utemp,

--- a/src/parcsr_ls/par_ilu.c
+++ b/src/parcsr_ls/par_ilu.c
@@ -42,6 +42,7 @@ hypre_ILUCreate()
    hypre_ParILUDataFTempUpper(ilu_data) = NULL;
    hypre_ParILUDataUTempLower(ilu_data) = NULL;
    hypre_ParILUDataMatAFakeDiagonal(ilu_data) = NULL;
+   hypre_ParILUDataADiagDiag(ilu_data) = NULL;
 #endif
 
    /* general data */
@@ -73,6 +74,7 @@ hypre_ILUCreate()
    hypre_ParILUDataUTemp(ilu_data) = NULL;
    hypre_ParILUDataXTemp(ilu_data) = NULL;
    hypre_ParILUDataYTemp(ilu_data) = NULL;
+   hypre_ParILUDataZTemp(ilu_data) = NULL;
    hypre_ParILUDataUExt(ilu_data) = NULL;
    hypre_ParILUDataFExt(ilu_data) = NULL;
    hypre_ParILUDataResidual(ilu_data) = NULL;
@@ -255,6 +257,11 @@ hypre_ILUDestroy( void *data )
       hypre_TFree( hypre_ParILUDataMatAFakeDiagonal(ilu_data), HYPRE_MEMORY_DEVICE);
       hypre_ParILUDataMatAFakeDiagonal(ilu_data) = NULL;
    }
+   if (hypre_ParILUDataADiagDiag(ilu_data))
+   {
+      hypre_SeqVectorDestroy(hypre_ParILUDataADiagDiag(ilu_data));
+      hypre_ParILUDataADiagDiag(ilu_data) = NULL;
+   }
 #endif
 
    /* final residual vector */
@@ -288,6 +295,11 @@ hypre_ILUDestroy( void *data )
    {
       hypre_ParVectorDestroy( hypre_ParILUDataYTemp(ilu_data) );
       hypre_ParILUDataYTemp(ilu_data) = NULL;
+   }
+   if (hypre_ParILUDataZTemp(ilu_data))
+   {
+      hypre_SeqVectorDestroy(hypre_ParILUDataZTemp(ilu_data));
+      hypre_ParILUDataZTemp(ilu_data) = NULL;
    }
    if (hypre_ParILUDataUExt(ilu_data))
    {

--- a/src/parcsr_ls/par_ilu.h
+++ b/src/parcsr_ls/par_ilu.h
@@ -40,6 +40,7 @@ typedef struct hypre_ParILUData_struct
    hypre_Vector            *Ftemp_upper;
    hypre_Vector            *Utemp_lower;
    HYPRE_Int               *A_diag_fake;//fake diagonal, pretend the diagonal matrix is empty
+   hypre_Vector            *Adiag_diag;
 #endif
    //general data
    HYPRE_Int            global_solver;
@@ -89,6 +90,7 @@ typedef struct hypre_ParILUData_struct
    hypre_ParVector      *Ftemp;
    hypre_ParVector      *Xtemp;
    hypre_ParVector      *Ytemp;
+   hypre_Vector         *Ztemp;
    HYPRE_Real           *uext;
    HYPRE_Real           *fext;
 
@@ -169,6 +171,7 @@ typedef struct hypre_ParILUData_struct
 #define hypre_ParILUDataFTempUpper(ilu_data)                   ((ilu_data) -> Ftemp_upper)
 #define hypre_ParILUDataUTempLower(ilu_data)                   ((ilu_data) -> Utemp_lower)
 #define hypre_ParILUDataMatAFakeDiagonal(ilu_data)             ((ilu_data) -> A_diag_fake)
+#define hypre_ParILUDataADiagDiag(ilu_data)                    ((ilu_data) -> Adiag_diag)
 #endif
 
 #define hypre_ParILUDataGlobalSolver(ilu_data)                 ((ilu_data) -> global_solver)
@@ -209,6 +212,7 @@ typedef struct hypre_ParILUData_struct
 #define hypre_ParILUDataUEnd(ilu_data)                         ((ilu_data) -> u_end)
 #define hypre_ParILUDataXTemp(ilu_data)                        ((ilu_data) -> Xtemp)
 #define hypre_ParILUDataYTemp(ilu_data)                        ((ilu_data) -> Ytemp)
+#define hypre_ParILUDataZTemp(ilu_data)                        ((ilu_data) -> Ztemp)
 #define hypre_ParILUDataUTemp(ilu_data)                        ((ilu_data) -> Utemp)
 #define hypre_ParILUDataFTemp(ilu_data)                        ((ilu_data) -> Ftemp)
 #define hypre_ParILUDataUExt(ilu_data)                         ((ilu_data) -> uext)
@@ -338,6 +342,20 @@ typedef struct hypre_ParNSHData_struct
 
 //#define DIVIDE_TOL 1e-32
 
+#ifdef HYPRE_USING_GPU
+HYPRE_Int hypre_ILUSolveDeviceLUIter(hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d,
+                                       hypre_ParVector *f,  hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp,
+                                       hypre_ParVector *utemp, hypre_Vector *xtemp_local,
+                                       hypre_Vector **Adiag_diag, HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters);
+HYPRE_Int hypre_ILUSolveLUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *work1_local, hypre_Vector *work2_local,
+                                     hypre_Vector *inout_local, hypre_Vector *diag_diag, HYPRE_Int lower_jacobi_iters,
+									 HYPRE_Int upper_jacobi_iters, HYPRE_Int my_id);
+HYPRE_Int hypre_ILUSolveLJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_Vector *work_local,
+                                    hypre_Vector *output_local, HYPRE_Int lower_jacobi_iters);
+HYPRE_Int hypre_ILUSolveUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_Vector *work_local,
+                                    hypre_Vector *output_local, hypre_Vector *diag_diag, HYPRE_Int upper_jacobi_iters);
+#endif
+
 #ifdef HYPRE_USING_CUDA
 HYPRE_Int hypre_ILUSolveCusparseLU(hypre_ParCSRMatrix *A, cusparseMatDescr_t matL_des,
                                    cusparseMatDescr_t matU_des, csrsv2Info_t matL_info, csrsv2Info_t matU_info,
@@ -373,19 +391,19 @@ HYPRE_Int hypre_ILUSetupILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE
                                    cusparseSolvePolicy_t ilu_solve_policy, void **bufferp, csrsv2Info_t *matBL_infop,
                                    csrsv2Info_t *matBU_infop, csrsv2Info_t *matSL_infop, csrsv2Info_t *matSU_infop,
                                    hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **Eptr,
-                                   hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip);
+                                   hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve);
 HYPRE_Int hypre_ILUSetupILUKDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm,
                                    HYPRE_Int *qperm, HYPRE_Int n, HYPRE_Int nLU, cusparseMatDescr_t matL_des,
                                    cusparseMatDescr_t matU_des, cusparseSolvePolicy_t ilu_solve_policy, void **bufferp,
                                    csrsv2Info_t *matBL_infop, csrsv2Info_t *matBU_infop, csrsv2Info_t *matSL_infop,
                                    csrsv2Info_t *matSU_infop, hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr,
-                                   hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip);
+                                   hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve);
 HYPRE_Int hypre_ILUSetupILUTDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Real *tol,
                                    HYPRE_Int *perm, HYPRE_Int *qperm, HYPRE_Int n, HYPRE_Int nLU, cusparseMatDescr_t matL_des,
                                    cusparseMatDescr_t matU_des, cusparseSolvePolicy_t ilu_solve_policy, void **bufferp,
                                    csrsv2Info_t *matBL_infop, csrsv2Info_t *matBU_infop, csrsv2Info_t *matSL_infop,
                                    csrsv2Info_t *matSU_infop, hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr,
-                                   hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip);
+                                   hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve);
 HYPRE_Int hypre_ParILURAPReorder(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *rqperm,
                                  hypre_ParCSRMatrix **A_pq);
 HYPRE_Int hypre_ILUSetupLDUtoCusparse(hypre_ParCSRMatrix *L, HYPRE_Real *D, hypre_ParCSRMatrix *U,

--- a/src/parcsr_ls/par_ilu_solve_device.c
+++ b/src/parcsr_ls/par_ilu_solve_device.c
@@ -1,0 +1,168 @@
+/******************************************************************************
+ * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+#include "_hypre_parcsr_ls.h"
+#include "_hypre_utilities.hpp"
+#include "par_ilu.h"
+#include "seq_mv.hpp"
+
+/*********************************************************************************/
+/*                   hypre_ILUSolveDeviceLUIter                                  */
+/*********************************************************************************/
+/* Incomplete LU solve (GPU) using Jacobi iterative approach
+ * L, D and U factors only have local scope (no off-diagonal processor terms)
+ * so apart from the residual calculation (which uses A), the solves with the
+ * L and U factors are local.
+*/
+
+#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
+
+HYPRE_Int
+hypre_ILUSolveLJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_Vector *work_local,
+                          hypre_Vector *output_local, HYPRE_Int lower_jacobi_iters)
+{
+   HYPRE_Real              *input_data          = hypre_VectorData(input_local);
+   HYPRE_Real              *work_data           = hypre_VectorData(work_local);
+   HYPRE_Real              *output_data         = hypre_VectorData(output_local);
+   HYPRE_Int               num_rows             = hypre_CSRMatrixNumRows(A);
+   HYPRE_Int kk=0;
+
+   /* L solve - Forward solve ; u^{k+1} = f - Lu^k*/
+   /* Jacobi iteration loop */
+
+   /* Since the initial guess to the jacobi iteration is 0, the result of the first L SpMV is 0, so no need to compute
+      However, we still need to compute the transformation */
+   hypreDevice_zeqxmy(num_rows, input_data, 0.0, work_data, output_data);
+
+   /* Do the remaining iterations */
+   for( kk = 1; kk < lower_jacobi_iters; ++kk ) {
+
+       /* apply SpMV */
+       hypre_CSRMatrixSpMVDevice(0, 1.0, A, output_local, 0.0, work_local, -2);
+
+       /* transform */
+       hypreDevice_zeqxmy(num_rows, input_data, -1.0, work_data, output_data);
+   }
+
+   return hypre_error_flag;
+}
+HYPRE_Int
+hypre_ILUSolveUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_Vector *work_local,
+                          hypre_Vector *output_local, hypre_Vector *diag_diag, HYPRE_Int upper_jacobi_iters)
+{
+   HYPRE_Real              *output_data         = hypre_VectorData(output_local);
+   HYPRE_Real              *work_data           = hypre_VectorData(work_local);
+   HYPRE_Real              *input_data          = hypre_VectorData(input_local);
+   HYPRE_Real              *diag_diag_data      = hypre_VectorData(diag_diag);
+   HYPRE_Int               num_rows             = hypre_CSRMatrixNumRows(A);
+   HYPRE_Int kk=0;
+
+   /* U solve - Backward solve :  u^{k+1} = f - Uu^k */
+   /* Jacobi iteration loop */
+
+   /* Since the initial guess to the jacobi iteration is 0, the result of the first U SpMV is 0, so no need to compute
+      However, we still need to compute the transformation */
+   hypreDevice_zeqxmydd(num_rows, input_data, 0.0, work_data, output_data, diag_diag_data);
+
+   /* Do the remaining iterations */
+   for( kk = 1; kk < upper_jacobi_iters; ++kk ) {
+
+       /* apply SpMV */
+       hypre_CSRMatrixSpMVDevice(0, 1.0, A, output_local, 0.0, work_local, 2);
+
+       /* transform */
+       hypreDevice_zeqxmydd(num_rows, input_data, -1.0, work_data, output_data, diag_diag_data);
+   }
+
+   return hypre_error_flag;
+}
+
+
+HYPRE_Int
+hypre_ILUSolveLUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *work1_local,
+                           hypre_Vector *work2_local, hypre_Vector *inout_local, hypre_Vector *diag_diag,
+                           HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters, HYPRE_Int my_id)
+{
+   /* apply the iterative solve to L */
+   hypre_ILUSolveLJacobiIter(A, inout_local, work1_local, work2_local, lower_jacobi_iters);
+
+   /* apply the iterative solve to U */
+   hypre_ILUSolveUJacobiIter(A, work2_local, work1_local, inout_local, diag_diag, upper_jacobi_iters);
+
+   return hypre_error_flag;
+}
+
+
+/* Incomplete LU solve using jacobi iterations on GPU
+ * L, D and U factors only have local scope (no off-diagonal processor terms)
+ * so apart from the residual calculation (which uses A), the solves with the
+ * L and U factors are local.
+*/
+HYPRE_Int
+hypre_ILUSolveDeviceLUIter(hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d,
+                             hypre_ParVector *f,  hypre_ParVector *u, HYPRE_Int *perm,
+                             HYPRE_Int n, hypre_ParVector *ftemp, hypre_ParVector *utemp,
+                             hypre_Vector *xtemp_local, hypre_Vector **Adiag_diag,
+                             HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters)
+{
+   /* Only solve when we have stuffs to be solved */
+   if (n == 0)
+   {
+      return hypre_error_flag;
+   }
+
+   MPI_Comm             comm = hypre_ParCSRMatrixComm(A);
+   HYPRE_Int my_id;
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+   hypre_Vector            *utemp_local         = hypre_ParVectorLocalVector(utemp);
+   HYPRE_Real              *utemp_data          = hypre_VectorData(utemp_local);
+
+   hypre_Vector            *ftemp_local         = hypre_ParVectorLocalVector(ftemp);
+   HYPRE_Real              *ftemp_data          = hypre_VectorData(ftemp_local);
+
+   HYPRE_Real              alpha;
+   HYPRE_Real              beta;
+
+   /* begin */
+   alpha = -1.0;
+   beta = 1.0;
+
+   /* Grab the main diagonal from the diagonal block. Only do this once */
+   if (!(*Adiag_diag)) {
+      /* storage for the diagonal */
+      *Adiag_diag = hypre_SeqVectorCreate(n);
+      hypre_SeqVectorInitialize(*Adiag_diag);
+      /* extract with device kernel */
+      hypre_CSRMatrixExtractDiagonalDevice(matLU_d, hypre_VectorData(*Adiag_diag), 2);
+      //hypre_CSRMatrixGetMainDiag(matLU_d, *Adiag);
+   }
+
+   /* Initialize Utemp to zero.
+    * This is necessary for correctness, when we use optimized
+    * vector operations in the case where sizeof(L, D or U) < sizeof(A)
+   */
+
+   /* compute residual */
+   hypre_ParCSRMatrixMatvecOutOfPlace(alpha, A, u, beta, f, ftemp);
+
+   /* apply permutation */
+   HYPRE_THRUST_CALL(gather, perm, perm + n, ftemp_data, utemp_data);
+
+   /* apply the iterative solve to L and U */
+   hypre_ILUSolveLUJacobiIter(matLU_d, ftemp_local, xtemp_local, utemp_local, *Adiag_diag,
+                              lower_jacobi_iters, upper_jacobi_iters, my_id);
+
+   /* apply reverse permutation */
+   HYPRE_THRUST_CALL(scatter, utemp_data, utemp_data + n, perm, ftemp_data);
+
+   /* Update solution */
+   hypre_ParVectorAxpy(beta, ftemp, u);
+
+   return hypre_error_flag;
+}
+
+#endif

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -2253,6 +2253,10 @@ HYPRE_Int hypre_ILUSetupILUTRAS(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Rea
 HYPRE_Int hypre_ILUSolveLU(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u,
                            HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *L, HYPRE_Real* D, hypre_ParCSRMatrix *U,
                            hypre_ParVector *utemp, hypre_ParVector *ftemp);
+HYPRE_Int hypre_ILUSolveLUIter(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u,
+							   HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *L, HYPRE_Real* D, hypre_ParCSRMatrix *U,
+							   hypre_ParVector *utemp, hypre_ParVector *ftemp, HYPRE_int lower_jacobi_iters,
+							   HYPRE_int upper_jacobi_iters);
 HYPRE_Int hypre_ILUSolveSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u,
                                    HYPRE_Int *perm, HYPRE_Int *qperm, HYPRE_Int nLU, hypre_ParCSRMatrix *L, HYPRE_Real* D,
                                    hypre_ParCSRMatrix *U, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp, hypre_ParVector *utemp,

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1824,6 +1824,9 @@ HYPRE_Int hypreDevice_IntegerInclusiveScan(HYPRE_Int n, HYPRE_Int *d_i);
 
 HYPRE_Int hypreDevice_IntegerExclusiveScan(HYPRE_Int n, HYPRE_Int *d_i);
 
+HYPRE_Int hypreDevice_zeqxmy(HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex alpha, HYPRE_Complex *y, HYPRE_Complex *z);
+HYPRE_Int hypreDevice_zeqxmydd(HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex alpha, HYPRE_Complex *y, HYPRE_Complex *z, HYPRE_Complex *d);
+
 #endif
 
 HYPRE_Int hypre_CurandUniform( HYPRE_Int n, HYPRE_Real *urand, HYPRE_Int set_seed,

--- a/src/utilities/device_utils.c
+++ b/src/utilities/device_utils.c
@@ -2193,6 +2193,78 @@ hypreDevice_DiagScaleVector2( HYPRE_Int       n,
    return hypre_error_flag;
 }
 
+
+/*****************************************************************
+ z[i] = x[i] + alpha*y[i]
+ ******************************************************************/
+
+/*
+ */
+__global__ void
+hypreGPUKernel_zeqxmy(hypre_DeviceItem &item, HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex alpha, HYPRE_Complex *y, HYPRE_Complex *z)
+{
+   HYPRE_Int i = hypre_gpu_get_grid_thread_id<1, 1>(item);
+
+   if (i < n)
+   {
+     z[i] = x[i] + alpha * y[i];
+   }
+}
+
+/*
+ */
+HYPRE_Int
+hypreDevice_zeqxmy(HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex alpha, HYPRE_Complex *y, HYPRE_Complex *z)
+{
+   /* trivial case */
+   if (n <= 0)
+   {
+      return hypre_error_flag;
+   }
+
+   dim3 bDim = hypre_GetDefaultDeviceBlockDimension();
+   dim3 gDim = hypre_GetDefaultDeviceGridDimension(n, "thread", bDim);
+
+   HYPRE_GPU_LAUNCH( hypreGPUKernel_zeqxmy, gDim, bDim, n, x, alpha, y, z);
+
+   return hypre_error_flag;
+}
+
+
+/*****************************************************************
+ z[i] = (x[i] + alpha*y[i])/d[i]
+ ******************************************************************/
+
+__global__ void
+hypreGPUKernel_zeqxmydd(hypre_DeviceItem &item, HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex alpha, HYPRE_Complex *y, HYPRE_Complex *z, HYPRE_Complex *d)
+{
+   HYPRE_Int i = hypre_gpu_get_grid_thread_id<1, 1>(item);
+
+   if (i < n)
+   {
+     z[i] = (x[i] + alpha * y[i])*d[i];
+   }
+}
+
+/*
+ */
+HYPRE_Int
+hypreDevice_zeqxmydd(HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex alpha, HYPRE_Complex *y, HYPRE_Complex *z, HYPRE_Complex *d)
+{
+   /* trivial case */
+   if (n <= 0)
+   {
+      return hypre_error_flag;
+   }
+
+   dim3 bDim = hypre_GetDefaultDeviceBlockDimension();
+   dim3 gDim = hypre_GetDefaultDeviceGridDimension(n, "thread", bDim);
+
+   HYPRE_GPU_LAUNCH( hypreGPUKernel_zeqxmydd, gDim, bDim, n, x, alpha, y, z, d);
+
+   return hypre_error_flag;
+}
+
 /*--------------------------------------------------------------------
  * hypreGPUKernel_BigToSmallCopy
  *--------------------------------------------------------------------*/

--- a/src/utilities/protos.h
+++ b/src/utilities/protos.h
@@ -321,6 +321,9 @@ HYPRE_Int hypreDevice_IntegerInclusiveScan(HYPRE_Int n, HYPRE_Int *d_i);
 
 HYPRE_Int hypreDevice_IntegerExclusiveScan(HYPRE_Int n, HYPRE_Int *d_i);
 
+HYPRE_Int hypreDevice_zeqxmy(HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex alpha, HYPRE_Complex *y, HYPRE_Complex *z);
+HYPRE_Int hypreDevice_zeqxmydd(HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex alpha, HYPRE_Complex *y, HYPRE_Complex *z, HYPRE_Complex *d);
+
 #endif
 
 HYPRE_Int hypre_CurandUniform( HYPRE_Int n, HYPRE_Real *urand, HYPRE_Int set_seed,


### PR DESCRIPTION
Jacobi iterative solver for ILU smoother/preconditioner implemented on CPU/GPU currently for Nvidia only since we don't have AMD ILU factorization yet. This will occur in the next PR. This works with ILU0, ILU(k), and ILUT. For Schur compliment-based solves, we force tri_solve==1 during the setup and not allow iterative triangular solve during the solve phase. This will be implemented in a subsequent PR. When iterative tri solve is chosen for ILU0, ILU(k), an ILUT, one doesn't need to call solve analysis for the L and U factors. This yields a nontrivial performance gain.