### PR TITLE
Fix sign-compare warnings

### DIFF
--- a/src/seq_mv/csr_spgemm_device_numer.h
+++ b/src/seq_mv/csr_spgemm_device_numer.h
@@ -453,10 +453,10 @@ hypre_spgemm_numerical_with_rownnz( HYPRE_Int      m,
    hypre_assert(bDim.x * bDim.y == GROUP_SIZE);
    // grid dimension (number of blocks)
    const HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
-                                           (m + bDim.z - 1) / bDim.z );
+                                           (HYPRE_Int) ((m + bDim.z - 1) / bDim.z) );
    dim3 gDim( num_blocks );
    // number of active groups
-   HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
+   HYPRE_Int num_act_groups = hypre_min((HYPRE_Int) (bDim.z * gDim.x), m);
 
    const char HASH_TYPE = HYPRE_SPGEMM_HASH_TYPE;
 
@@ -708,4 +708,3 @@ HYPRE_Int hypre_spgemm_numerical_max_num_blocks( HYPRE_Int  multiProcessorCount,
 }
 
 #endif /* HYPRE_USING_CUDA  || defined(HYPRE_USING_HIP) */
-

--- a/src/seq_mv/csr_spgemm_device_symbl.h
+++ b/src/seq_mv/csr_spgemm_device_symbl.h
@@ -353,10 +353,10 @@ hypre_spgemm_symbolic_rownnz( HYPRE_Int  m,
    hypre_assert(bDim.x * bDim.y == GROUP_SIZE);
    // grid dimension (number of blocks)
    const HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
-                                           (m + bDim.z - 1) / bDim.z );
+                                           (HYPRE_Int) ((m + bDim.z - 1) / bDim.z) );
    dim3 gDim( num_blocks );
    // number of active groups
-   HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
+   HYPRE_Int num_act_groups = hypre_min((HYPRE_Int) (bDim.z * gDim.x), m);
 
    const char HASH_TYPE = HYPRE_SPGEMM_HASH_TYPE;
    if (HASH_TYPE != 'L' && HASH_TYPE != 'Q' && HASH_TYPE != 'D')
@@ -509,4 +509,3 @@ HYPRE_Int hypre_spgemm_symbolic_max_num_blocks( HYPRE_Int  multiProcessorCount,
 }
 
 #endif /* HYPRE_USING_CUDA  || defined(HYPRE_USING_HIP) */
-


### PR DESCRIPTION
This PR fixes the compiler warnings (GPU build):
```
./csr_spgemm_device_symbl.h: In instantiation of ‘HYPRE_Int hypre_spgemm_symbolic_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, bool, char*) [with int BIN = 2; int SHMEM_HASH_SIZE = 64; int GROUP_SIZE = 4; bool HAS_RIND = true; HYPRE_Int = int]’:
csr_spgemm_device_symbl2.c:20:260:   required from here
./csr_spgemm_device_symbl.h:355:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  355 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_symbl.h:359:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  359 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_symbl.h: In instantiation of ‘HYPRE_Int hypre_spgemm_symbolic_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, bool, char*) [with int BIN = 1; int SHMEM_HASH_SIZE = 32; int GROUP_SIZE = 2; bool HAS_RIND = true; HYPRE_Int = int]’:
csr_spgemm_device_symbl1.c:20:260:   required from here
./csr_spgemm_device_symbl.h:355:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  355 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_symbl.h:359:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  359 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_numer.h: In instantiation of ‘HYPRE_Int hypre_spgemm_numerical_with_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*) [with int BIN = 1; int SHMEM_HASH_SIZE = 16; int GROUP_SIZE = 2; bool HAS_RIND = true; HYPRE_Int = int; HYPRE_Complex = double]’:
csr_spgemm_device_numer1.c:20:361:   required from here
./csr_spgemm_device_numer.h:455:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  455 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_numer.h:459:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  459 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_numer.h: In instantiation of ‘HYPRE_Int hypre_spgemm_numerical_with_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*) [with int BIN = 3; int SHMEM_HASH_SIZE = 64; int GROUP_SIZE = 8; bool HAS_RIND = true; HYPRE_Int = int; HYPRE_Complex = double]’:
csr_spgemm_device_numer3.c:20:361:   required from here
./csr_spgemm_device_numer.h:455:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  455 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_numer.h:459:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  459 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_numer.h: In instantiation of ‘HYPRE_Int hypre_spgemm_numerical_with_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*) [with int BIN = 2; int SHMEM_HASH_SIZE = 32; int GROUP_SIZE = 4; bool HAS_RIND = true; HYPRE_Int = int; HYPRE_Complex = double]’:
csr_spgemm_device_numer2.c:20:361:   required from here
./csr_spgemm_device_numer.h:455:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  455 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_numer.h:459:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  459 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_symbl.h: In instantiation of ‘HYPRE_Int hypre_spgemm_symbolic_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, bool, char*) [with int BIN = 3; int SHMEM_HASH_SIZE = 128; int GROUP_SIZE = 8; bool HAS_RIND = true; HYPRE_Int = int]’:
csr_spgemm_device_symbl3.c:20:261:   required from here
./csr_spgemm_device_symbl.h:355:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  355 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_symbl.h:359:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  359 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_numer.h: In instantiation of ‘HYPRE_Int hypre_spgemm_numerical_with_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*) [with int BIN = 4; int SHMEM_HASH_SIZE = 128; int GROUP_SIZE = 16; bool HAS_RIND = true; HYPRE_Int = int; HYPRE_Complex = double]’:
csr_spgemm_device_numer4.c:20:363:   required from here
./csr_spgemm_device_numer.h:455:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  455 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_numer.h:459:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  459 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_symbl.h: In instantiation of ‘HYPRE_Int hypre_spgemm_symbolic_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, bool, char*) [with int BIN = 4; int SHMEM_HASH_SIZE = 256; int GROUP_SIZE = 16; bool HAS_RIND = true; HYPRE_Int = int]’:
csr_spgemm_device_symbl4.c:20:262:   required from here
./csr_spgemm_device_symbl.h:355:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  355 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_symbl.h:359:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  359 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_numer.h: In instantiation of ‘HYPRE_Int hypre_spgemm_numerical_with_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*) [with int BIN = 8; int SHMEM_HASH_SIZE = 2048; int GROUP_SIZE = 256; bool HAS_RIND = true; HYPRE_Int = int; HYPRE_Complex = double]’:
csr_spgemm_device_numer8.c:20:365:   required from here
./csr_spgemm_device_numer.h:455:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  455 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_numer.h:459:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  459 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_numer.h: In instantiation of ‘HYPRE_Int hypre_spgemm_numerical_with_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*) [with int BIN = 6; int SHMEM_HASH_SIZE = 512; int GROUP_SIZE = 64; bool HAS_RIND = true; HYPRE_Int = int; HYPRE_Complex = double]’:
csr_spgemm_device_numer6.c:20:363:   required from here
./csr_spgemm_device_numer.h:455:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  455 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_numer.h:459:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  459 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_numer.h: In instantiation of ‘HYPRE_Int hypre_spgemm_numerical_with_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*) [with int BIN = 9; int SHMEM_HASH_SIZE = 4096; int GROUP_SIZE = 512; bool HAS_RIND = true; HYPRE_Int = int; HYPRE_Complex = double]’:
csr_spgemm_device_numer9.c:20:365:   required from here
./csr_spgemm_device_numer.h:455:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  455 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_numer.h:459:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  459 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_numer.h: In instantiation of ‘HYPRE_Int hypre_spgemm_numerical_with_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*) [with int BIN = 7; int SHMEM_HASH_SIZE = 1024; int GROUP_SIZE = 128; bool HAS_RIND = true; HYPRE_Int = int; HYPRE_Complex = double]’:
csr_spgemm_device_numer7.c:20:365:   required from here
./csr_spgemm_device_numer.h:455:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  455 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_numer.h:459:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  459 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_numer.h: In instantiation of ‘HYPRE_Int hypre_spgemm_numerical_with_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*) [with int BIN = 10; int SHMEM_HASH_SIZE = 8192; int GROUP_SIZE = 1024; bool HAS_RIND = true; HYPRE_Int = int; HYPRE_Complex = double]’:
csr_spgemm_device_numer10.c:20:367:   required from here
./csr_spgemm_device_numer.h:455:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  455 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_numer.h:459:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  459 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_numer.h: In instantiation of ‘HYPRE_Int hypre_spgemm_numerical_with_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*) [with int BIN = 5; int SHMEM_HASH_SIZE = 256; int GROUP_SIZE = 32; bool HAS_RIND = true; HYPRE_Int = int; HYPRE_Complex = double]’:
csr_spgemm_device_numer5.c:20:363:   required from here
./csr_spgemm_device_numer.h:455:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  455 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_numer.h:459:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  459 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_numer.h: In instantiation of ‘HYPRE_Int hypre_spgemm_numerical_with_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Complex*) [with int BIN = 5; int SHMEM_HASH_SIZE = 256; int GROUP_SIZE = 32; bool HAS_RIND = false; HYPRE_Int = int; HYPRE_Complex = double]’:
csr_spgemm_device_numer5.c:30:364:   required from here
./csr_spgemm_device_numer.h:455:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  455 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[1][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_numer.h:459:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  459 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_symbl.h: In instantiation of ‘HYPRE_Int hypre_spgemm_symbolic_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, bool, char*) [with int BIN = 9; int SHMEM_HASH_SIZE = 8192; int GROUP_SIZE = 512; bool HAS_RIND = true; HYPRE_Int = int]’:
csr_spgemm_device_symbl9.c:20:264:   required from here
./csr_spgemm_device_symbl.h:355:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  355 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_symbl.h:359:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  359 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_symbl.h: In instantiation of ‘HYPRE_Int hypre_spgemm_symbolic_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, bool, char*) [with int BIN = 6; int SHMEM_HASH_SIZE = 1024; int GROUP_SIZE = 64; bool HAS_RIND = true; HYPRE_Int = int]’:
csr_spgemm_device_symbl6.c:20:263:   required from here
./csr_spgemm_device_symbl.h:355:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  355 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_symbl.h:359:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  359 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_symbl.h: In instantiation of ‘HYPRE_Int hypre_spgemm_symbolic_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, bool, char*) [with int BIN = 10; int SHMEM_HASH_SIZE = 16384; int GROUP_SIZE = 1024; bool HAS_RIND = true; HYPRE_Int = int]’:
csr_spgemm_device_symbl10.c:20:267:   required from here
./csr_spgemm_device_symbl.h:355:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  355 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_symbl.h:359:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  359 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_symbl.h: In instantiation of ‘HYPRE_Int hypre_spgemm_symbolic_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, bool, char*) [with int BIN = 7; int SHMEM_HASH_SIZE = 2048; int GROUP_SIZE = 128; bool HAS_RIND = true; HYPRE_Int = int]’:
csr_spgemm_device_symbl7.c:20:264:   required from here
./csr_spgemm_device_symbl.h:355:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  355 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_symbl.h:359:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  359 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_symbl.h: In instantiation of ‘HYPRE_Int hypre_spgemm_symbolic_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, bool, char*) [with int BIN = 8; int SHMEM_HASH_SIZE = 4096; int GROUP_SIZE = 256; bool HAS_RIND = true; HYPRE_Int = int]’:
csr_spgemm_device_symbl8.c:20:264:   required from here
./csr_spgemm_device_symbl.h:355:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  355 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_symbl.h:359:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  359 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_symbl.h: In instantiation of ‘HYPRE_Int hypre_spgemm_symbolic_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, bool, char*) [with int BIN = 5; int SHMEM_HASH_SIZE = 512; int GROUP_SIZE = 32; bool HAS_RIND = true; HYPRE_Int = int]’:
csr_spgemm_device_symbl5.c:20:262:   required from here
./csr_spgemm_device_symbl.h:355:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  355 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_symbl.h:359:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  359 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./csr_spgemm_device_symbl.h: In instantiation of ‘HYPRE_Int hypre_spgemm_symbolic_rownnz(HYPRE_Int, HYPRE_Int*, HYPRE_Int, HYPRE_Int, bool, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, HYPRE_Int*, bool, char*) [with int BIN = 5; int SHMEM_HASH_SIZE = 512; int GROUP_SIZE = 32; bool HAS_RIND = false; HYPRE_Int = int]’:
csr_spgemm_device_symbl5.c:28:263:   required from here
./csr_spgemm_device_symbl.h:355:97: warning: comparison of integer expressions of different signedness: ‘HYPRE_Int’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
  355 | nst HYPRE_Int num_blocks = hypre_min( hypre_HandleSpgemmBlockNumDim(hypre_handle())[0][BIN],
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

./csr_spgemm_device_symbl.h:359:51: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘HYPRE_Int’ {aka ‘int’} [-Wsign-compare]
  359 |    HYPRE_Int num_act_groups = hypre_min(bDim.z * gDim.x, m);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~
```