### PR TITLE
Fixing bugs in hypre_BoomerAMGBuildModMultipassDevice

### DIFF
--- a/src/parcsr_ls/par_mod_multi_interp_device.c
+++ b/src/parcsr_ls/par_mod_multi_interp_device.c
@@ -677,6 +677,7 @@ hypre_BoomerAMGBuildModMultipassDevice( hypre_ParCSRMatrix  *A,
       P_offd_data = hypre_CSRMatrixData(P_offd);
       P_offd_i = hypre_CSRMatrixI(P_offd);
       P_offd_j = hypre_CSRMatrixJ(P_offd);
+      P_offd_size = hypre_CSRMatrixNumNonzeros(P_offd);
    }
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)

--- a/src/test/TEST_ij/agg_interp.jobs
+++ b/src/test/TEST_ij/agg_interp.jobs
@@ -26,6 +26,7 @@
 #    18: 2s-mod-ext interpolation all levels for systems problem hybrid approach
 #    19: 2s-mod-ee interpolation 1 levels (agg_tr 0.3)
 #    20: 2s-mod-ee interpolation all levels (agg_Pmx 4 agg_P12_mx 4)
+#    22: multipass interpolation all levels (agg_Pmx 4 agg_P12_mx 4)
 #=============================================================================
 
 mpirun -np 8 ./ij    -rhsrand -n 30 29 31 -P 2 2 2 -agg_nl 1 -agg_interp 1 -agg_Pmx 4 -solver 1 -rlx 6 \
@@ -114,3 +115,6 @@ mpirun -np 8 ./ij    -rhsrand -n 30 29 31 -P 2 2 2 -agg_nl 10 -agg_interp 7 -agg
 
 mpirun -np 2 ./ij -fromfile tst -agg_nl 1 -agg_interp 8 \
  >> agg_interp.out.21
+
+mpirun -np 8 ./ij    -rhsrand -n 30 29 31 -P 2 2 2 -agg_nl 10 -agg_interp 8 -agg_Pmx 4 -agg_P12_mx 4 -solver 1 -rlx 6 \
+ >> agg_interp.out.22

--- a/src/test/TEST_ij/agg_interp.saved
+++ b/src/test/TEST_ij/agg_interp.saved
@@ -172,3 +172,9 @@ Final Relative Residual Norm = 1.654514e-09
 BoomerAMG Iterations = 1
 Final Relative Residual Norm = 0.000000e+00
 
+# Output file: agg_interp.out.22
+
+
+Iterations = 15
+Final Relative Residual Norm = 6.535343e-09
+

--- a/src/test/TEST_ij/agg_interp.saved.lassen
+++ b/src/test/TEST_ij/agg_interp.saved.lassen
@@ -172,3 +172,9 @@ Final Relative Residual Norm = 7.981237e-09
 BoomerAMG Iterations = 9
 Final Relative Residual Norm = 2.176372e-09
 
+# Output file: agg_interp.out.22
+
+
+Iterations = 16
+Final Relative Residual Norm = 7.077723e-09
+

--- a/src/test/TEST_ij/agg_interp.sh
+++ b/src/test/TEST_ij/agg_interp.sh
@@ -42,6 +42,7 @@ FILES="\
  ${TNAME}.out.19\
  ${TNAME}.out.20\
  ${TNAME}.out.21\
+ ${TNAME}.out.22\
 "
 
 for i in $FILES


### PR DESCRIPTION
Fixed bug when using `-agg_Pmx` with ModMultipassDevice. To reproduce the issue, run `mpirun -n 8  ./ij -n 10 10 10 -P 2 2 2 -rap 0 -agg_nl 2 -agg_interp 8 -interptype 6 -agg_Pmx 2`

- [x] tux
- [x] lassen