### PR TITLE
Fix MGR missing symbols issue

### DIFF
--- a/src/parcsr_ls/HYPRE_parcsr_ls.h
+++ b/src/parcsr_ls/HYPRE_parcsr_ls.h
@@ -3981,7 +3981,7 @@ HYPRE_MGRSetLevelFRelaxMethod(HYPRE_Solver solver, HYPRE_Int *relax_method );
  *    - 2 : AMG.
  **/
 HYPRE_Int
-HYPRE_MGRSetFLevelRelaxType(HYPRE_Solver solver,
+HYPRE_MGRSetLevelFRelaxType(HYPRE_Solver solver,
                             HYPRE_Int *relax_type );
 
 /**
@@ -4191,12 +4191,12 @@ HYPRE_MGRSetLevelSmoothIters( HYPRE_Solver solver,
 /**
  * (Optional) Set the smoothing order for global smoothing at each level.
  * Options for \e level_smooth_order are:
- *    - 1 : Pre-smoothing (default)
- *    - 2 : Post-smoothing
+ *    - 1 : Pre-smoothing - Down cycle (default)
+ *    - 2 : Post-smoothing - Up cycle
  **/
 HYPRE_Int
-HYPRE_MGRSetLevelSmoothOrder( HYPRE_Solver solver,
-                              HYPRE_Int level_smooth_order );
+HYPRE_MGRSetGlobalSmoothCycle( HYPRE_Solver solver,
+                              HYPRE_Int global_smooth_cycle );
 
 /**
  * (Optional) Determines type of global smoother.

--- a/src/parcsr_ls/par_mgr.c
+++ b/src/parcsr_ls/par_mgr.c
@@ -114,7 +114,7 @@ hypre_MGRCreate()
    (mgr_data -> level_smooth_iters) = NULL;
    (mgr_data -> level_smooth_type) = NULL;
    (mgr_data -> level_smoother) = NULL;
-   (mgr_data -> global_smooth_cycle) = 1; // Pre or Post global smoothing
+   (mgr_data -> global_smooth_cycle) = 1; // Pre = 1 or Post  = 2 global smoothing
 
    (mgr_data -> logging) = 0;
    (mgr_data -> print_level) = 0;


### PR DESCRIPTION
This PR fixes missing symbol issue for recent MGR interface options. This should fix the xsdk issue: [xsdk-project/xsdk-issues] trilinos-14.0.0 build error on MacOS -> hypre (Issue #182) in 
https://gitlab.com/xsdk-project/spack-xsdk/-/jobs/3108965071
