### PR TITLE
Minor fix to add HYPRE_BRANCH_NAME to CMake generated config file

### DIFF
--- a/src/config/HYPRE_config.h.cmake.in
+++ b/src/config/HYPRE_config.h.cmake.in
@@ -15,6 +15,7 @@
 #cmakedefine HYPRE_DEVELOP_STRING  "@HYPRE_DEVELOP_STRING@"
 #cmakedefine HYPRE_DEVELOP_NUMBER   @HYPRE_DEVELOP_NUMBER@
 #cmakedefine HYPRE_DEVELOP_BRANCH  "@HYPRE_DEVELOP_BRANCH@"
+#cmakedefine HYPRE_BRANCH_NAME     "@HYPRE_BRANCH_NAME@"
 
 /* Use long long int for HYPRE_BigInt */
 #cmakedefine HYPRE_MIXEDINT 1


### PR DESCRIPTION
This is a quick fix for the CMake build when not on the main dev branch. 