### PR TITLE
Fixed int types discrepancies in MPI calls.

### DIFF
--- a/src/parcsr_ls/par_cr.c
+++ b/src/parcsr_ls/par_cr.c
@@ -2562,7 +2562,7 @@ hypre_BoomerAMGIndepPMISa( hypre_ParCSRMatrix    *S,
 
       HYPRE_BigInt big_graph_size = (HYPRE_BigInt) graph_size;
       /* stop the coarsening if nothing left to be coarsened */
-      hypre_MPI_Allreduce(&big_graph_size, &global_graph_size, 1, HYPRE_MPI_INT, hypre_MPI_SUM, comm);
+      hypre_MPI_Allreduce(&big_graph_size, &global_graph_size, 1, HYPRE_MPI_BIG_INT, hypre_MPI_SUM, comm);
 
       if (global_graph_size == 0)
       {

--- a/src/parcsr_ls/par_ilu_setup.c
+++ b/src/parcsr_ls/par_ilu_setup.c
@@ -3366,7 +3366,7 @@ hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n,
 
       S_row_starts[1] = S_total_rows;
       S_row_starts[0] = S_total_rows - m;
-      hypre_MPI_Allreduce(&m, &S_total_rows, 1, HYPRE_MPI_INT, hypre_MPI_SUM, comm);
+      hypre_MPI_Allreduce(&m, &S_total_rows, 1, HYPRE_MPI_INT, hypre_MPI_SUM, comm); // TODO: m is `HYPRE_Int` and S_total_rows is `HYPRE_BigInt`
       S = hypre_ParCSRMatrixCreate( hypre_ParCSRMatrixComm(A),
                                     S_total_rows,
                                     S_total_rows,

--- a/src/parcsr_ls/par_relax.c
+++ b/src/parcsr_ls/par_relax.c
@@ -420,7 +420,7 @@ hypre_BoomerAMGRelax1GaussSeidel( hypre_ParCSRMatrix *A,
                {
                   v_buf_data[j] = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg, j)];
                }
-               hypre_MPI_Isend(&v_buf_data[vec_start], vec_len, HYPRE_MPI_REAL, ip, 0, comm, &requests[jr++]);
+               hypre_MPI_Isend(&v_buf_data[vec_start], vec_len, HYPRE_MPI_REAL, ip, 0, comm, &requests[jr++]);  // TODO: v_buf_data is `HYPRE_Complex` but `HYPRE_MPI_REAL` is exchanged
             }
          }
          hypre_MPI_Waitall(jr, requests, status);
@@ -435,7 +435,7 @@ hypre_BoomerAMGRelax1GaussSeidel( hypre_ParCSRMatrix *A,
                ip = hypre_ParCSRCommPkgRecvProc(comm_pkg, i);
                vec_start = hypre_ParCSRCommPkgRecvVecStart(comm_pkg, i);
                vec_len = hypre_ParCSRCommPkgRecvVecStart(comm_pkg, i + 1) - vec_start;
-               hypre_MPI_Irecv(&v_ext_data[vec_start], vec_len, HYPRE_MPI_REAL, ip, 0, comm, &requests[jr++]);
+               hypre_MPI_Irecv(&v_ext_data[vec_start], vec_len, HYPRE_MPI_REAL, ip, 0, comm, &requests[jr++]);  // TODO: v_ext_data is `HYPRE_Complex` but `HYPRE_MPI_REAL` is exchanged
             }
             hypre_MPI_Waitall(jr, requests, status);
          }
@@ -568,7 +568,7 @@ hypre_BoomerAMGRelax2GaussSeidel( hypre_ParCSRMatrix *A,
                {
                   v_buf_data[j] = u_data[hypre_ParCSRCommPkgSendMapElmt(comm_pkg, j)];
                }
-               hypre_MPI_Isend(&v_buf_data[vec_start], vec_len, HYPRE_MPI_REAL, ip, 0, comm, &requests[jr++]);
+               hypre_MPI_Isend(&v_buf_data[vec_start], vec_len, HYPRE_MPI_REAL, ip, 0, comm, &requests[jr++]);  // TODO: v_buf_data is `HYPRE_Complex` but `HYPRE_MPI_REAL` is exchanged
             }
          }
          hypre_MPI_Waitall(jr, requests, status);
@@ -583,7 +583,7 @@ hypre_BoomerAMGRelax2GaussSeidel( hypre_ParCSRMatrix *A,
                ip = hypre_ParCSRCommPkgRecvProc(comm_pkg, i);
                vec_start = hypre_ParCSRCommPkgRecvVecStart(comm_pkg, i);
                vec_len = hypre_ParCSRCommPkgRecvVecStart(comm_pkg, i + 1) - vec_start;
-               hypre_MPI_Irecv(&v_ext_data[vec_start], vec_len, HYPRE_MPI_REAL, ip, 0, comm, &requests[jr++]);
+               hypre_MPI_Irecv(&v_ext_data[vec_start], vec_len, HYPRE_MPI_REAL, ip, 0, comm, &requests[jr++]);  // TODO: v_ext_data is `HYPRE_Complex` but `HYPRE_MPI_REAL` is exchanged
             }
             hypre_MPI_Waitall(jr, requests, status);
          }

--- a/src/parcsr_ls/par_sv_interp_ln.c
+++ b/src/parcsr_ls/par_sv_interp_ln.c
@@ -2503,7 +2503,7 @@ HYPRE_Int hypre_BoomerAMG_LNExpandInterp( hypre_ParCSRMatrix *A,
       new_col_starts[1] = (col_starts[1] / (HYPRE_BigInt)num_functions) * (HYPRE_BigInt)new_nf;
 
       if (myid == (num_procs - 1)) { g_nc = new_col_starts[1]; }
-      hypre_MPI_Bcast(&g_nc, 1, HYPRE_MPI_BIG_INT, num_procs - 1, comm);
+      hypre_MPI_Bcast(&g_nc, 1, HYPRE_MPI_INT, num_procs - 1, comm);
    }
    else /* not first level */
    {

--- a/src/parcsr_mv/communicationT.c
+++ b/src/parcsr_mv/communicationT.c
@@ -273,7 +273,7 @@ hypre_MatTCommPkgCreate_core (
    }
 
    hypre_MPI_Allgatherv(tmp, local_info, HYPRE_MPI_BIG_INT, recv_buf, info, displs, HYPRE_MPI_INT,
-                        comm);
+                        comm);  // TODO There's a discrepancy here `HYPRE_MPI_BIG_INT`/`HYPRE_MPI_INT` but I don't know what's going on.
 
 
    /* ----------------------------------------------------------------------

--- a/src/parcsr_mv/par_csr_bool_matrix.c
+++ b/src/parcsr_mv/par_csr_bool_matrix.c
@@ -851,7 +851,7 @@ hypre_CSRBooleanMatrixToParCSRBooleanMatrix
       a_i = hypre_CSRBooleanMatrix_Get_I(A);
       a_j = hypre_CSRBooleanMatrix_Get_J(A);
    }
-   hypre_MPI_Bcast(global_data, 2, HYPRE_MPI_INT, 0, comm);
+   hypre_MPI_Bcast(global_data, 2, HYPRE_MPI_BIG_INT, 0, comm);
    global_num_rows = global_data[0];
    global_num_cols = global_data[1];
 

--- a/src/parcsr_mv/par_vector.c
+++ b/src/parcsr_mv/par_vector.c
@@ -535,7 +535,7 @@ hypre_VectorToParVector ( MPI_Comm      comm,
       global_vecstride = hypre_VectorVectorStride(v);
    }
 
-   hypre_MPI_Bcast(&global_size, 1, HYPRE_MPI_INT, 0, comm);
+   hypre_MPI_Bcast(&global_size, 1, HYPRE_MPI_BIG_INT, 0, comm);
    hypre_MPI_Bcast(&num_vectors, 1, HYPRE_MPI_INT, 0, comm);
    hypre_MPI_Bcast(&global_vecstride, 1, HYPRE_MPI_INT, 0, comm);
 

--- a/src/parcsr_mv/parchord_to_parcsr.c
+++ b/src/parcsr_mv/parchord_to_parcsr.c
@@ -108,8 +108,8 @@ void hypre_ParChordMatrix_RowStarts(
 
    /* Global number of columns */
    /*   hypre_MPI_Allreduce( &num_rdofs, global_num_cols, 1, HYPRE_MPI_INT, hypre_MPI_SUM, comm );*/
-   hypre_MPI_Allreduce( &min_rdof, &global_min_rdof, 1, HYPRE_MPI_INT, hypre_MPI_MIN, comm );
-   hypre_MPI_Allreduce( &max_rdof, &global_max_rdof, 1, HYPRE_MPI_INT, hypre_MPI_MAX, comm );
+   hypre_MPI_Allreduce( &min_rdof, &global_min_rdof, 1, HYPRE_MPI_BIG_INT, hypre_MPI_MIN, comm );
+   hypre_MPI_Allreduce( &max_rdof, &global_max_rdof, 1, HYPRE_MPI_BIG_INT, hypre_MPI_MAX, comm );
    *global_num_cols = global_max_rdof - global_min_rdof;
 }
 


### PR DESCRIPTION
Related to https://github.com/GEOSX/GEOSX/issues/2174 where we use the `--enable-mixedint` option when building `hypre`.

I've also written comments where I think there may be something tricky, but I do not know how to fix (neither if it's a real issue).

@victorapm 