### PR TITLE
fix _hypre_utilities.h

### DIFF
--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1103,7 +1103,7 @@ HYPRE_Real time_get_cpu_seconds_( void );
 #define hypre_EndTiming(i)
 #define hypre_PrintTiming(heading, comm)
 #define hypre_ClearTiming()
-#define hypre_GetTiming()
+#define hypre_GetTiming(heading, comm, time)
 
 /*--------------------------------------------------------------------------
  * With timing on


### PR DESCRIPTION
This PR fixed an issue in `_hypre_utilities.h` from previous PRs. Probably forgot to run `headers` in `src/utilities` or something.