### PR TITLE
Add vector resizing functions

### DIFF
--- a/src/parcsr_ls/par_amg_solve.c
+++ b/src/parcsr_ls/par_amg_solve.c
@@ -112,7 +112,7 @@ hypre_BoomerAMGSolve( void               *amg_vdata,
 
    /* Update work vectors when solving for RHS vectors with multiple components */
    num_vectors = hypre_ParVectorNumVectors(F_array[0]);
-   if (num_vectors > hypre_ParVectorNumVectors(F_array[1]))
+   if (num_vectors != hypre_ParVectorNumVectors(F_array[1]))
    {
       size = hypre_VectorSize(hypre_ParVectorLocalVector(F_array[0]));
       hypre_ParVectorResize(Vtemp, num_vectors, size);

--- a/src/parcsr_ls/par_amg_solve.c
+++ b/src/parcsr_ls/par_amg_solve.c
@@ -98,6 +98,8 @@ hypre_BoomerAMGSolve( void               *amg_vdata,
    block_mode       = hypre_ParAMGDataBlockMode(amg_data);
    A_block_array    = hypre_ParAMGDataABlockArray(amg_data);
    Vtemp            = hypre_ParAMGDataVtemp(amg_data);
+   num_vectors      = hypre_ParVectorNumVectors(f);
+   size             = hypre_VectorSize(hypre_ParVectorLocalVector(f));
 
    A_array[0] = A;
    F_array[0] = f;
@@ -111,19 +113,13 @@ hypre_BoomerAMGSolve( void               *amg_vdata,
    }
 
    /* Update work vectors when solving for RHS vectors with multiple components */
-   num_vectors = hypre_ParVectorNumVectors(F_array[0]);
-   if (num_vectors != hypre_ParVectorNumVectors(F_array[1]))
+   hypre_ParVectorResize(Vtemp, num_vectors, size);
+   for (j = 1; j < num_levels; j++)
    {
-      size = hypre_VectorSize(hypre_ParVectorLocalVector(F_array[0]));
-      hypre_ParVectorResize(Vtemp, num_vectors, size);
+      size = hypre_VectorSize(hypre_ParVectorLocalVector(F_array[j]));
 
-      for (j = 1; j < num_levels; j++)
-      {
-         size = hypre_VectorSize(hypre_ParVectorLocalVector(F_array[j]));
-
-         hypre_ParVectorResize(F_array[j], num_vectors, size);
-         hypre_ParVectorResize(U_array[j], num_vectors, size);
-      }
+      hypre_ParVectorResize(F_array[j], num_vectors, size);
+      hypre_ParVectorResize(U_array[j], num_vectors, size);
    }
 
    /*-----------------------------------------------------------------------

--- a/src/parcsr_ls/par_amg_solve.c
+++ b/src/parcsr_ls/par_amg_solve.c
@@ -51,7 +51,7 @@ hypre_BoomerAMGSolve( void               *amg_vdata,
    HYPRE_Int           j;
    HYPRE_Int           Solve_err_flag;
    HYPRE_Int           num_procs, my_id;
-   HYPRE_Int           size, num_vectors;
+   HYPRE_Int           num_vectors;
    HYPRE_Real          alpha = 1.0;
    HYPRE_Real          beta = -1.0;
    HYPRE_Real          cycle_op_count;
@@ -105,34 +105,32 @@ hypre_BoomerAMGSolve( void               *amg_vdata,
    Ptemp            = hypre_ParAMGDataPtemp(amg_data);
    Ztemp            = hypre_ParAMGDataZtemp(amg_data);
    num_vectors      = hypre_ParVectorNumVectors(f);
-   size             = hypre_VectorSize(hypre_ParVectorLocalVector(f));
 
    A_array[0] = A;
    F_array[0] = f;
    U_array[0] = u;
 
    /* Verify that the number of vectors held by f and u match */
-   if (hypre_ParVectorNumVectors(f) != hypre_ParVectorNumVectors(u))
+   if (hypre_ParVectorNumVectors(f) !=
+       hypre_ParVectorNumVectors(u))
    {
       hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Error: num_vectors for RHS and LHS do not match!\n");
       return hypre_error_flag;
    }
 
-   /* Update work vectors when solving for multicomponent vectors */
-   hypre_ParVectorResize(Vtemp, num_vectors, size);
-   hypre_ParVectorResize(Rtemp, num_vectors, size);
-   hypre_ParVectorResize(Ptemp, num_vectors, size);
-   hypre_ParVectorResize(Ztemp, num_vectors, size);
+   /* Update work vectors */
+   hypre_ParVectorResize(Vtemp, num_vectors);
+   hypre_ParVectorResize(Rtemp, num_vectors);
+   hypre_ParVectorResize(Ptemp, num_vectors);
+   hypre_ParVectorResize(Ztemp, num_vectors);
    if (amg_logging > 1)
    {
-      hypre_ParVectorResize(Residual, num_vectors, size);
+      hypre_ParVectorResize(Residual, num_vectors);
    }
    for (j = 1; j < num_levels; j++)
    {
-      size = hypre_VectorSize(hypre_ParVectorLocalVector(F_array[j]));
-
-      hypre_ParVectorResize(F_array[j], num_vectors, size);
-      hypre_ParVectorResize(U_array[j], num_vectors, size);
+      hypre_ParVectorResize(F_array[j], num_vectors);
+      hypre_ParVectorResize(U_array[j], num_vectors);
    }
 
    /*-----------------------------------------------------------------------

--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -1199,7 +1199,7 @@ HYPRE_Int hypre_ParVectorSetDataOwner ( hypre_ParVector *vector, HYPRE_Int owns_
 HYPRE_Int hypre_ParVectorSetLocalSize ( hypre_ParVector *vector, HYPRE_Int local_size );
 HYPRE_Int hypre_ParVectorSetNumVectors ( hypre_ParVector *vector, HYPRE_Int num_vectors );
 HYPRE_Int hypre_ParVectorSetComponent ( hypre_ParVector *vector, HYPRE_Int component );
-HYPRE_Int hypre_ParVectorResize ( hypre_ParVector *vector, HYPRE_Int num_vectors, HYPRE_Int size );
+HYPRE_Int hypre_ParVectorResize ( hypre_ParVector *vector, HYPRE_Int num_vectors );
 hypre_ParVector *hypre_ParVectorRead ( MPI_Comm comm, const char *file_name );
 HYPRE_Int hypre_ParVectorPrint ( hypre_ParVector *vector, const char *file_name );
 HYPRE_Int hypre_ParVectorSetConstantValues ( hypre_ParVector *v, HYPRE_Complex value );

--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -1199,6 +1199,7 @@ HYPRE_Int hypre_ParVectorSetDataOwner ( hypre_ParVector *vector, HYPRE_Int owns_
 HYPRE_Int hypre_ParVectorSetLocalSize ( hypre_ParVector *vector, HYPRE_Int local_size );
 HYPRE_Int hypre_ParVectorSetNumVectors ( hypre_ParVector *vector, HYPRE_Int num_vectors );
 HYPRE_Int hypre_ParVectorSetComponent ( hypre_ParVector *vector, HYPRE_Int component );
+HYPRE_Int hypre_ParVectorResize ( hypre_ParVector *vector, HYPRE_Int num_vectors, HYPRE_Int size );
 hypre_ParVector *hypre_ParVectorRead ( MPI_Comm comm, const char *file_name );
 HYPRE_Int hypre_ParVectorPrint ( hypre_ParVector *vector, const char *file_name );
 HYPRE_Int hypre_ParVectorSetConstantValues ( hypre_ParVector *v, HYPRE_Complex value );

--- a/src/parcsr_mv/par_vector.c
+++ b/src/parcsr_mv/par_vector.c
@@ -218,12 +218,12 @@ hypre_ParVectorSetNumVectors( hypre_ParVector *vector,
 
 HYPRE_Int
 hypre_ParVectorResize( hypre_ParVector *vector,
-                       HYPRE_Int        num_vectors,
-                       HYPRE_Int        size )
+                       HYPRE_Int        num_vectors )
 {
-   hypre_Vector *local_vector = hypre_ParVectorLocalVector(vector);
-
-   hypre_SeqVectorResize(local_vector, num_vectors, size);
+   if (vector)
+   {
+      hypre_SeqVectorResize(hypre_ParVectorLocalVector(vector), num_vectors);
+   }
 
    return hypre_error_flag;
 }

--- a/src/parcsr_mv/par_vector.c
+++ b/src/parcsr_mv/par_vector.c
@@ -18,11 +18,11 @@ HYPRE_Int hypre_FillResponseParToVectorAll(void*, HYPRE_Int, HYPRE_Int, void*, M
 
 /*--------------------------------------------------------------------------
  * hypre_ParVectorCreate
+ *
+ * If create is called and partitioning is NOT null, then it is assumed that it
+ * is array of length 2 containing the start row of the calling processor
+ * followed by the start row of the next processor - AHB 6/05
  *--------------------------------------------------------------------------*/
-
-/* If create is called and partitioning is NOT null, then it is assumed that it
-   is array of length 2 containing the start row of the calling processor
-   followed by the start row of the next processor - AHB 6/05 */
 
 hypre_ParVector *
 hypre_ParVectorCreate( MPI_Comm      comm,
@@ -213,6 +213,22 @@ hypre_ParVectorSetNumVectors( hypre_ParVector *vector,
 #endif
 
 /*--------------------------------------------------------------------------
+ * hypre_ParVectorResize
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_ParVectorResize( hypre_ParVector *vector,
+                       HYPRE_Int        num_vectors,
+                       HYPRE_Int        size )
+{
+   hypre_Vector *local_vector = hypre_ParVectorLocalVector(vector);
+
+   hypre_SeqVectorResize(local_vector, num_vectors, size);
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
  * hypre_ParVectorRead
  *--------------------------------------------------------------------------*/
 
@@ -311,6 +327,10 @@ hypre_ParVectorSetConstantValues( hypre_ParVector *v,
    return hypre_SeqVectorSetConstantValues(v_local, value);
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_ParVectorSetZeros
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_ParVectorSetZeros( hypre_ParVector *v )
 {
@@ -353,7 +373,8 @@ hypre_ParVectorCopy( hypre_ParVector *x,
 
 /*--------------------------------------------------------------------------
  * hypre_ParVectorCloneShallow
- * returns a complete copy of a hypre_ParVector x - a shallow copy, re-using
+ *
+ * Returns a complete copy of a hypre_ParVector x - a shallow copy, re-using
  * the partitioning and data arrays of x
  *--------------------------------------------------------------------------*/
 
@@ -374,6 +395,10 @@ hypre_ParVectorCloneShallow( hypre_ParVector *x )
    return y;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_ParVectorCloneDeep_v2
+ *--------------------------------------------------------------------------*/
+
 hypre_ParVector *
 hypre_ParVectorCloneDeep_v2( hypre_ParVector *x, HYPRE_MemoryLocation memory_location )
 {
@@ -389,6 +414,10 @@ hypre_ParVectorCloneDeep_v2( hypre_ParVector *x, HYPRE_MemoryLocation memory_loc
 
    return y;
 }
+
+/*--------------------------------------------------------------------------
+ * hypre_ParVectorMigrate
+ *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_ParVectorMigrate(hypre_ParVector *x, HYPRE_MemoryLocation memory_location)
@@ -412,7 +441,6 @@ hypre_ParVectorMigrate(hypre_ParVector *x, HYPRE_MemoryLocation memory_location)
 
    return hypre_error_flag;
 }
-
 
 /*--------------------------------------------------------------------------
  * hypre_ParVectorScale
@@ -471,6 +499,7 @@ hypre_ParVectorInnerProd( hypre_ParVector *x,
 
 /*--------------------------------------------------------------------------
  * hypre_ParVectorElmdivpy
+ *
  * y = y + x ./ b [MATLAB Notation]
  *--------------------------------------------------------------------------*/
 
@@ -488,6 +517,7 @@ hypre_ParVectorElmdivpy( hypre_ParVector *x,
 
 /*--------------------------------------------------------------------------
  * hypre_ParVectorElmdivpyMarked
+ *
  * y[i] += x[i] / b[i] where marker[i] == marker_val
  *--------------------------------------------------------------------------*/
 
@@ -506,8 +536,9 @@ hypre_ParVectorElmdivpyMarked( hypre_ParVector *x,
 }
 
 /*--------------------------------------------------------------------------
- * hypre_VectorToParVector:
- * generates a ParVector from a Vector on proc 0 and distributes the pieces
+ * hypre_VectorToParVector
+ *
+ * Generates a ParVector from a Vector on proc 0 and distributes the pieces
  * to the other procs in comm
  *--------------------------------------------------------------------------*/
 
@@ -629,8 +660,9 @@ hypre_VectorToParVector ( MPI_Comm      comm,
 }
 
 /*--------------------------------------------------------------------------
- * hypre_ParVectorToVectorAll:
- * generates a Vector on every proc which has a piece of the data
+ * hypre_ParVectorToVectorAll
+ *
+ * Generates a Vector on every proc which has a piece of the data
  * from a ParVector on several procs in comm,
  * vec_starts needs to contain the partitioning across all procs in comm
  *--------------------------------------------------------------------------*/

--- a/src/parcsr_mv/protos.h
+++ b/src/parcsr_mv/protos.h
@@ -546,6 +546,7 @@ HYPRE_Int hypre_ParVectorSetDataOwner ( hypre_ParVector *vector, HYPRE_Int owns_
 HYPRE_Int hypre_ParVectorSetLocalSize ( hypre_ParVector *vector, HYPRE_Int local_size );
 HYPRE_Int hypre_ParVectorSetNumVectors ( hypre_ParVector *vector, HYPRE_Int num_vectors );
 HYPRE_Int hypre_ParVectorSetComponent ( hypre_ParVector *vector, HYPRE_Int component );
+HYPRE_Int hypre_ParVectorResize ( hypre_ParVector *vector, HYPRE_Int num_vectors, HYPRE_Int size );
 hypre_ParVector *hypre_ParVectorRead ( MPI_Comm comm, const char *file_name );
 HYPRE_Int hypre_ParVectorPrint ( hypre_ParVector *vector, const char *file_name );
 HYPRE_Int hypre_ParVectorSetConstantValues ( hypre_ParVector *v, HYPRE_Complex value );

--- a/src/parcsr_mv/protos.h
+++ b/src/parcsr_mv/protos.h
@@ -546,7 +546,7 @@ HYPRE_Int hypre_ParVectorSetDataOwner ( hypre_ParVector *vector, HYPRE_Int owns_
 HYPRE_Int hypre_ParVectorSetLocalSize ( hypre_ParVector *vector, HYPRE_Int local_size );
 HYPRE_Int hypre_ParVectorSetNumVectors ( hypre_ParVector *vector, HYPRE_Int num_vectors );
 HYPRE_Int hypre_ParVectorSetComponent ( hypre_ParVector *vector, HYPRE_Int component );
-HYPRE_Int hypre_ParVectorResize ( hypre_ParVector *vector, HYPRE_Int num_vectors, HYPRE_Int size );
+HYPRE_Int hypre_ParVectorResize ( hypre_ParVector *vector, HYPRE_Int num_vectors );
 hypre_ParVector *hypre_ParVectorRead ( MPI_Comm comm, const char *file_name );
 HYPRE_Int hypre_ParVectorPrint ( hypre_ParVector *vector, const char *file_name );
 HYPRE_Int hypre_ParVectorSetConstantValues ( hypre_ParVector *v, HYPRE_Complex value );

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -237,8 +237,7 @@ HYPRE_Int hypre_SeqVectorInitialize_v2( hypre_Vector *vector,
 HYPRE_Int hypre_SeqVectorInitialize ( hypre_Vector *vector );
 HYPRE_Int hypre_SeqVectorSetDataOwner ( hypre_Vector *vector, HYPRE_Int owns_data );
 HYPRE_Int hypre_SeqVectorSetSize ( hypre_Vector *vector, HYPRE_Int size );
-HYPRE_Int hypre_SeqVectorResize ( hypre_Vector *vector, HYPRE_Int num_vectors_in,
-                                  HYPRE_Int size_in );
+HYPRE_Int hypre_SeqVectorResize ( hypre_Vector *vector, HYPRE_Int num_vectors_in );
 hypre_Vector *hypre_SeqVectorRead ( char *file_name );
 HYPRE_Int hypre_SeqVectorPrint ( hypre_Vector *vector, char *file_name );
 HYPRE_Int hypre_SeqVectorSetConstantValues ( hypre_Vector *v, HYPRE_Complex value );

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -237,6 +237,8 @@ HYPRE_Int hypre_SeqVectorInitialize_v2( hypre_Vector *vector,
 HYPRE_Int hypre_SeqVectorInitialize ( hypre_Vector *vector );
 HYPRE_Int hypre_SeqVectorSetDataOwner ( hypre_Vector *vector, HYPRE_Int owns_data );
 HYPRE_Int hypre_SeqVectorSetSize ( hypre_Vector *vector, HYPRE_Int size );
+HYPRE_Int hypre_SeqVectorResize ( hypre_Vector *vector, HYPRE_Int num_vectors_in,
+                                  HYPRE_Int size_in );
 hypre_Vector *hypre_SeqVectorRead ( char *file_name );
 HYPRE_Int hypre_SeqVectorPrint ( hypre_Vector *vector, char *file_name );
 HYPRE_Int hypre_SeqVectorSetConstantValues ( hypre_Vector *v, HYPRE_Complex value );

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -509,8 +509,7 @@ HYPRE_Int hypre_SeqVectorInitialize_v2( hypre_Vector *vector,
 HYPRE_Int hypre_SeqVectorInitialize ( hypre_Vector *vector );
 HYPRE_Int hypre_SeqVectorSetDataOwner ( hypre_Vector *vector, HYPRE_Int owns_data );
 HYPRE_Int hypre_SeqVectorSetSize ( hypre_Vector *vector, HYPRE_Int size );
-HYPRE_Int hypre_SeqVectorResize ( hypre_Vector *vector, HYPRE_Int num_vectors_in,
-                                  HYPRE_Int size_in );
+HYPRE_Int hypre_SeqVectorResize ( hypre_Vector *vector, HYPRE_Int num_vectors_in );
 hypre_Vector *hypre_SeqVectorRead ( char *file_name );
 HYPRE_Int hypre_SeqVectorPrint ( hypre_Vector *vector, char *file_name );
 HYPRE_Int hypre_SeqVectorSetConstantValues ( hypre_Vector *v, HYPRE_Complex value );

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -509,6 +509,8 @@ HYPRE_Int hypre_SeqVectorInitialize_v2( hypre_Vector *vector,
 HYPRE_Int hypre_SeqVectorInitialize ( hypre_Vector *vector );
 HYPRE_Int hypre_SeqVectorSetDataOwner ( hypre_Vector *vector, HYPRE_Int owns_data );
 HYPRE_Int hypre_SeqVectorSetSize ( hypre_Vector *vector, HYPRE_Int size );
+HYPRE_Int hypre_SeqVectorResize ( hypre_Vector *vector, HYPRE_Int num_vectors_in,
+                                  HYPRE_Int size_in );
 hypre_Vector *hypre_SeqVectorRead ( char *file_name );
 HYPRE_Int hypre_SeqVectorPrint ( hypre_Vector *vector, char *file_name );
 HYPRE_Int hypre_SeqVectorSetConstantValues ( hypre_Vector *v, HYPRE_Complex value );

--- a/src/seq_mv/vector.c
+++ b/src/seq_mv/vector.c
@@ -162,7 +162,7 @@ hypre_SeqVectorSetSize( hypre_Vector *vector,
  * hypre_SeqVectorResize
  *
  * Resize a sequential vector by either changing its number of components
- * or size.
+ * or size (per component).
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int

--- a/src/seq_mv/vector.c
+++ b/src/seq_mv/vector.c
@@ -161,20 +161,18 @@ hypre_SeqVectorSetSize( hypre_Vector *vector,
 /*--------------------------------------------------------------------------
  * hypre_SeqVectorResize
  *
- * Resize a sequential vector by either changing its number of components
- * or size (per component).
+ * Resize a sequential vector when changing its number of components.
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_SeqVectorResize( hypre_Vector *vector,
-                       HYPRE_Int     num_vectors_in,
-                       HYPRE_Int     size_in )
+                       HYPRE_Int     num_vectors_in )
 {
    HYPRE_Int  method        = hypre_VectorMultiVecStorageMethod(vector);
    HYPRE_Int  size          = hypre_VectorSize(vector);
    HYPRE_Int  num_vectors   = hypre_VectorNumVectors(vector);
    HYPRE_Int  total_size    = num_vectors * size;
-   HYPRE_Int  total_size_in = num_vectors_in * size_in;
+   HYPRE_Int  total_size_in = num_vectors_in * size;
 
    /* Reallocate data array */
    if (total_size_in > total_size)
@@ -188,7 +186,6 @@ hypre_SeqVectorResize( hypre_Vector *vector,
    }
 
    /* Update vector info */
-   hypre_VectorSize(vector) = size_in;
    hypre_VectorNumVectors(vector) = num_vectors_in;
    if (method == 0)
    {

--- a/src/seq_mv/vector.c
+++ b/src/seq_mv/vector.c
@@ -159,7 +159,48 @@ hypre_SeqVectorSetSize( hypre_Vector *vector,
 }
 
 /*--------------------------------------------------------------------------
- * ReadVector
+ * hypre_SeqVectorResize
+ *
+ * Resize a sequential vector by either changing its number of components
+ * or size.
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_SeqVectorResize( hypre_Vector *vector,
+                       HYPRE_Int     num_vectors_in,
+                       HYPRE_Int     size_in )
+{
+   HYPRE_Int  method      = hypre_VectorMultiVecStorageMethod(vector);
+   HYPRE_Int  size        = hypre_VectorSize(vector);
+   HYPRE_Int  num_vectors = hypre_VectorNumVectors(vector);
+
+   /* Reallocate data array */
+   hypre_VectorData(vector) = hypre_TReAlloc_v2(hypre_VectorData(vector),
+                                                HYPRE_Complex,
+                                                size * num_vectors,
+                                                HYPRE_Complex,
+                                                size_in * num_vectors_in,
+                                                hypre_VectorMemoryLocation(vector));
+
+   /* Update vector info */
+   hypre_VectorSize(vector) = size_in;
+   hypre_VectorNumVectors(vector) = num_vectors_in;
+   if (method == 0)
+   {
+      hypre_VectorVectorStride(vector) = size;
+      hypre_VectorIndexStride(vector)  = 1;
+   }
+   else if (method == 1)
+   {
+      hypre_VectorVectorStride(vector) = 1;
+      hypre_VectorIndexStride(vector)  = num_vectors;
+   }
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_SeqVectorRead
  *--------------------------------------------------------------------------*/
 
 hypre_Vector *

--- a/src/seq_mv/vector.c
+++ b/src/seq_mv/vector.c
@@ -170,17 +170,22 @@ hypre_SeqVectorResize( hypre_Vector *vector,
                        HYPRE_Int     num_vectors_in,
                        HYPRE_Int     size_in )
 {
-   HYPRE_Int  method      = hypre_VectorMultiVecStorageMethod(vector);
-   HYPRE_Int  size        = hypre_VectorSize(vector);
-   HYPRE_Int  num_vectors = hypre_VectorNumVectors(vector);
+   HYPRE_Int  method        = hypre_VectorMultiVecStorageMethod(vector);
+   HYPRE_Int  size          = hypre_VectorSize(vector);
+   HYPRE_Int  num_vectors   = hypre_VectorNumVectors(vector);
+   HYPRE_Int  total_size    = num_vectors * size;
+   HYPRE_Int  total_size_in = num_vectors_in * size_in;
 
    /* Reallocate data array */
-   hypre_VectorData(vector) = hypre_TReAlloc_v2(hypre_VectorData(vector),
-                                                HYPRE_Complex,
-                                                size * num_vectors,
-                                                HYPRE_Complex,
-                                                size_in * num_vectors_in,
-                                                hypre_VectorMemoryLocation(vector));
+   if (total_size_in > total_size)
+   {
+      hypre_VectorData(vector) = hypre_TReAlloc_v2(hypre_VectorData(vector),
+                                                   HYPRE_Complex,
+                                                   total_size,
+                                                   HYPRE_Complex,
+                                                   total_size_in,
+                                                   hypre_VectorMemoryLocation(vector));
+   }
 
    /* Update vector info */
    hypre_VectorSize(vector) = size_in;


### PR DESCRIPTION
This PR adds `hypre_SeqVectorResize` and `hypre_ParVectorResize` for resizing sequential and parallel vectors, respectively. Data reallocation takes place when the total size (`size * num_vectors`) passed as input is greater than the space currently allocated for the data member of a `hypre_Vector`.

This is useful for block-Krylov solvers/eigensolvers using BoomerAMG and multicomponent vectors.

cc @prj- 