### PR TITLE
Update Tioga Regressions

### DIFF
--- a/AUTOTEST/machine-tioga.sh
+++ b/AUTOTEST/machine-tioga.sh
@@ -53,7 +53,7 @@ module -q load rocm/5.1.1
 
 # HIP without UM [benchmark, struct]
 co="--with-hip --with-MPI-include=${MPICH_DIR}/include --with-MPI-lib-dirs=${MPICH_DIR}/lib --with-MPI-libs=mpi --with-gpu-arch='gfx90a' CC=cc CXX=CC"
-ro="-bench -struct -rt -mpibind -save ${save}"
+ro="-bench -struct -rt -save ${save}"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ro
 ./renametest.sh basic $output_dir/basic-hip-nonum
 
@@ -64,7 +64,7 @@ co="--with-hip --enable-unified-memory --enable-single --enable-debug --with-MPI
 
 # run on CPU
 co="--with-hip --with-test-using-host --with-memory-tracker --enable-debug --with-MPI-include=${MPICH_DIR}/include --with-MPI-lib-dirs=${MPICH_DIR}/lib --with-MPI-libs=mpi --with-gpu-arch='gfx90a' CC=cc CXX=CC"
-ro="-ij-noilu -ams -struct -sstruct -rt -mpibind -D HYPRE_NO_SAVED"
+ro="-ij-noilu -ams -struct -sstruct -rt -D HYPRE_NO_SAVED"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ro
 ./renametest.sh basic $output_dir/basic-hip-cpu
 

--- a/src/test/TEST_bench/benchmark_ij.perf.saved.tioga
+++ b/src/test/TEST_bench/benchmark_ij.perf.saved.tioga
@@ -1,81 +1,81 @@
 # Output file: benchmark_ij.out.1
-PCG Setup wall clock time = 0.188726 seconds
-PCG Solve wall clock time = 0.386892 seconds
+PCG Setup wall clock time = 0.170772 seconds
+PCG Solve wall clock time = 0.335337 seconds
 # Output file: benchmark_ij.out.2
-PCG Setup wall clock time = 0.180939 seconds
-PCG Solve wall clock time = 0.317590 seconds
+PCG Setup wall clock time = 0.163119 seconds
+PCG Solve wall clock time = 0.271529 seconds
 # Output file: benchmark_ij.out.3
-PCG Setup wall clock time = 0.222097 seconds
-PCG Solve wall clock time = 0.783766 seconds
+PCG Setup wall clock time = 0.201941 seconds
+PCG Solve wall clock time = 0.672232 seconds
 # Output file: benchmark_ij.out.4
-PCG Setup wall clock time = 0.255440 seconds
-PCG Solve wall clock time = 0.165860 seconds
+PCG Setup wall clock time = 0.226705 seconds
+PCG Solve wall clock time = 0.152017 seconds
 # Output file: benchmark_ij.out.5
-PCG Setup wall clock time = 0.273521 seconds
-PCG Solve wall clock time = 0.149416 seconds
+PCG Setup wall clock time = 0.254766 seconds
+PCG Solve wall clock time = 0.137966 seconds
 # Output file: benchmark_ij.out.6
-PCG Setup wall clock time = 0.217261 seconds
-PCG Solve wall clock time = 0.694767 seconds
+PCG Setup wall clock time = 0.204024 seconds
+PCG Solve wall clock time = 0.613917 seconds
 # Output file: benchmark_ij.out.7
-PCG Setup wall clock time = 0.310995 seconds
-PCG Solve wall clock time = 0.171850 seconds
+PCG Setup wall clock time = 0.282569 seconds
+PCG Solve wall clock time = 0.158339 seconds
 # Output file: benchmark_ij.out.8
-PCG Setup wall clock time = 0.175203 seconds
-PCG Solve wall clock time = 0.387443 seconds
+PCG Setup wall clock time = 0.159975 seconds
+PCG Solve wall clock time = 0.334356 seconds
 # Output file: benchmark_ij.out.9
-PCG Setup wall clock time = 0.166534 seconds
-PCG Solve wall clock time = 0.316284 seconds
+PCG Setup wall clock time = 0.151504 seconds
+PCG Solve wall clock time = 0.272460 seconds
 # Output file: benchmark_ij.out.10
-PCG Setup wall clock time = 0.207859 seconds
-PCG Solve wall clock time = 0.741136 seconds
+PCG Setup wall clock time = 0.190785 seconds
+PCG Solve wall clock time = 0.639297 seconds
 # Output file: benchmark_ij.out.11
-PCG Setup wall clock time = 0.242683 seconds
-PCG Solve wall clock time = 0.164636 seconds
+PCG Setup wall clock time = 0.217895 seconds
+PCG Solve wall clock time = 0.145796 seconds
 # Output file: benchmark_ij.out.12
-PCG Setup wall clock time = 0.260674 seconds
-PCG Solve wall clock time = 0.143710 seconds
+PCG Setup wall clock time = 0.245100 seconds
+PCG Solve wall clock time = 0.132285 seconds
 # Output file: benchmark_ij.out.13
-PCG Setup wall clock time = 0.204073 seconds
-PCG Solve wall clock time = 0.693755 seconds
+PCG Setup wall clock time = 0.188967 seconds
+PCG Solve wall clock time = 0.596166 seconds
 # Output file: benchmark_ij.out.14
-PCG Setup wall clock time = 0.953338 seconds
-PCG Solve wall clock time = 0.684894 seconds
+PCG Setup wall clock time = 0.953187 seconds
+PCG Solve wall clock time = 0.680926 seconds
 # Output file: benchmark_ij.out.15
-PCG Setup wall clock time = 0.864777 seconds
-PCG Solve wall clock time = 0.737157 seconds
+PCG Setup wall clock time = 0.868636 seconds
+PCG Solve wall clock time = 0.733326 seconds
 # Output file: benchmark_ij.out.16
-PCG Setup wall clock time = 0.882788 seconds
-PCG Solve wall clock time = 0.654301 seconds
+PCG Setup wall clock time = 0.882904 seconds
+PCG Solve wall clock time = 0.647630 seconds
 # Output file: benchmark_ij.out.17
-PCG Setup wall clock time = 0.259058 seconds
-PCG Solve wall clock time = 0.153848 seconds
+PCG Setup wall clock time = 0.243402 seconds
+PCG Solve wall clock time = 0.143477 seconds
 # Output file: benchmark_ij.out.18
-PCG Setup wall clock time = 0.260442 seconds
-PCG Solve wall clock time = 0.127049 seconds
+PCG Setup wall clock time = 0.231762 seconds
+PCG Solve wall clock time = 0.111623 seconds
 # Output file: benchmark_ij.out.19
-PCG Setup wall clock time = 0.304233 seconds
-PCG Solve wall clock time = 0.357143 seconds
+PCG Setup wall clock time = 0.276950 seconds
+PCG Solve wall clock time = 0.324065 seconds
 # Output file: benchmark_ij.out.20
-PCG Setup wall clock time = 0.207102 seconds
-PCG Solve wall clock time = 0.204482 seconds
+PCG Setup wall clock time = 0.185776 seconds
+PCG Solve wall clock time = 0.177456 seconds
 # Output file: benchmark_ij.out.21
-PCG Setup wall clock time = 0.269332 seconds
-PCG Solve wall clock time = 0.215327 seconds
+PCG Setup wall clock time = 0.240707 seconds
+PCG Solve wall clock time = 0.189251 seconds
 # Output file: benchmark_ij.out.22
-PCG Setup wall clock time = 0.276635 seconds
-PCG Solve wall clock time = 0.183314 seconds
+PCG Setup wall clock time = 0.239942 seconds
+PCG Solve wall clock time = 0.168473 seconds
 # Output file: benchmark_ij.out.23
-PCG Setup wall clock time = 0.268271 seconds
-PCG Solve wall clock time = 0.180593 seconds
+PCG Setup wall clock time = 0.235985 seconds
+PCG Solve wall clock time = 0.168673 seconds
 # Output file: benchmark_ij.out.24
-PCG Setup wall clock time = 0.239714 seconds
-PCG Solve wall clock time = 0.202786 seconds
+PCG Setup wall clock time = 0.217153 seconds
+PCG Solve wall clock time = 0.185827 seconds
 # Output file: benchmark_ij.out.25
-PCG Setup wall clock time = 0.237256 seconds
-PCG Solve wall clock time = 0.211505 seconds
+PCG Setup wall clock time = 0.205445 seconds
+PCG Solve wall clock time = 0.198855 seconds
 # Output file: benchmark_ij.out.26
-PCG Setup wall clock time = 0.279965 seconds
-PCG Solve wall clock time = 0.473005 seconds
+PCG Setup wall clock time = 0.265667 seconds
+PCG Solve wall clock time = 0.438971 seconds
 # Output file: benchmark_ij.out.27
-PCG Setup wall clock time = 0.298462 seconds
-PCG Solve wall clock time = 0.334035 seconds
+PCG Setup wall clock time = 0.287397 seconds
+PCG Solve wall clock time = 0.319967 seconds

--- a/src/test/TEST_bench/benchmark_spgemm.perf.saved.tioga
+++ b/src/test/TEST_bench/benchmark_spgemm.perf.saved.tioga
@@ -1,72 +1,72 @@
 # Output file: benchmark_spgemm.out.1
-Device Parcsr Matrix-by-Matrix wall clock time = 0.019889 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.019578 seconds
 # Output file: benchmark_spgemm.out.2
-Device Parcsr Matrix-by-Matrix wall clock time = 0.076819 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.076419 seconds
 # Output file: benchmark_spgemm.out.3
-Device Parcsr Matrix-by-Matrix wall clock time = 0.008884 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.008474 seconds
 # Output file: benchmark_spgemm.out.4
-Device Parcsr Matrix-by-Matrix wall clock time = 0.010011 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.009719 seconds
 # Output file: benchmark_spgemm.out.5
-Device Parcsr Matrix-by-Matrix wall clock time = 0.008854 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.007846 seconds
 # Output file: benchmark_spgemm.out.6
-Device Parcsr Matrix-by-Matrix wall clock time = 0.081874 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.080421 seconds
 # Output file: benchmark_spgemm.out.7
-Device Parcsr Matrix-by-Matrix wall clock time = 0.004065 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.003545 seconds
 # Output file: benchmark_spgemm.out.8
-Device Parcsr Matrix-by-Matrix wall clock time = 0.006895 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.006074 seconds
 # Output file: benchmark_spgemm.out.9
-Device Parcsr Matrix-by-Matrix wall clock time = 0.039068 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.038709 seconds
 # Output file: benchmark_spgemm.out.10
-Device Parcsr Matrix-by-Matrix wall clock time = 0.116622 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.115453 seconds
 # Output file: benchmark_spgemm.out.11
-Device Parcsr Matrix-by-Matrix wall clock time = 0.016892 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.016367 seconds
 # Output file: benchmark_spgemm.out.12
-Device Parcsr Matrix-by-Matrix wall clock time = 0.019927 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.019611 seconds
 # Output file: benchmark_spgemm.out.13
-Device Parcsr Matrix-by-Matrix wall clock time = 0.009113 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.008411 seconds
 # Output file: benchmark_spgemm.out.14
-Device Parcsr Matrix-by-Matrix wall clock time = 0.132173 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.130224 seconds
 # Output file: benchmark_spgemm.out.15
-Device Parcsr Matrix-by-Matrix wall clock time = 0.002346 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.001776 seconds
 # Output file: benchmark_spgemm.out.16
-Device Parcsr Matrix-by-Matrix wall clock time = 0.008833 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.007971 seconds
 # Output file: benchmark_spgemm.out.17
-Device Parcsr Matrix-by-Matrix wall clock time = 0.002913 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.002087 seconds
 # Output file: benchmark_spgemm.out.18
-Device Parcsr Matrix-by-Matrix wall clock time = 0.005856 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.005301 seconds
 # Output file: benchmark_spgemm.out.19
-Device Parcsr Matrix-by-Matrix wall clock time = 0.002930 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.002224 seconds
 # Output file: benchmark_spgemm.out.20
-Device Parcsr Matrix-by-Matrix wall clock time = 0.003172 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.002487 seconds
 # Output file: benchmark_spgemm.out.21
-Device Parcsr Matrix-by-Matrix wall clock time = 0.034395 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.031799 seconds
 # Output file: benchmark_spgemm.out.22
-Device Parcsr Matrix-by-Matrix wall clock time = 0.116523 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.112757 seconds
 # Output file: benchmark_spgemm.out.23
-Device Parcsr Matrix-by-Matrix wall clock time = 0.014950 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.013535 seconds
 # Output file: benchmark_spgemm.out.24
-Device Parcsr Matrix-by-Matrix wall clock time = 0.017896 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.016090 seconds
 # Output file: benchmark_spgemm.out.25
-Device Parcsr Matrix-by-Matrix wall clock time = 0.060106 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.057450 seconds
 # Output file: benchmark_spgemm.out.26
-Device Parcsr Matrix-by-Matrix wall clock time = 0.588868 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.587366 seconds
 # Output file: benchmark_spgemm.out.27
-Device Parcsr Matrix-by-Matrix wall clock time = 0.024888 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.022603 seconds
 # Output file: benchmark_spgemm.out.28
-Device Parcsr Matrix-by-Matrix wall clock time = 0.030994 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.028229 seconds
 # Output file: benchmark_spgemm.out.29
-Device Parcsr Matrix-by-Matrix wall clock time = 0.060870 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.057857 seconds
 # Output file: benchmark_spgemm.out.30
-Device Parcsr Matrix-by-Matrix wall clock time = 0.062836 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.060432 seconds
 # Output file: benchmark_spgemm.out.31
-Device Parcsr Matrix-by-Matrix wall clock time = 0.022955 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.020985 seconds
 # Output file: benchmark_spgemm.out.32
-Device Parcsr Matrix-by-Matrix wall clock time = 0.021522 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.019986 seconds
 # Output file: benchmark_spgemm.out.33
-Device Parcsr Matrix-by-Matrix wall clock time = 0.069183 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.063040 seconds
 # Output file: benchmark_spgemm.out.34
-Device Parcsr Matrix-by-Matrix wall clock time = 0.071740 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.067800 seconds
 # Output file: benchmark_spgemm.out.35
-Device Parcsr Matrix-by-Matrix wall clock time = 0.026649 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.023271 seconds
 # Output file: benchmark_spgemm.out.36
-Device Parcsr Matrix-by-Matrix wall clock time = 0.024854 seconds
+Device Parcsr Matrix-by-Matrix wall clock time = 0.022089 seconds

--- a/src/test/TEST_bench/benchmark_struct.perf.saved.tioga
+++ b/src/test/TEST_bench/benchmark_struct.perf.saved.tioga
@@ -1,24 +1,24 @@
 # Output file: benchmark_struct.out.1
-PCG Setup wall clock time = 0.120527 seconds
-PCG Solve wall clock time = 0.524466 seconds
+PCG Setup wall clock time = 0.091983 seconds
+PCG Solve wall clock time = 0.421361 seconds
 # Output file: benchmark_struct.out.2
-PCG Setup wall clock time = 0.153928 seconds
-PCG Solve wall clock time = 0.703765 seconds
+PCG Setup wall clock time = 0.114076 seconds
+PCG Solve wall clock time = 0.568872 seconds
 # Output file: benchmark_struct.out.3
-PCG Setup wall clock time = 1.099122 seconds
-PCG Solve wall clock time = 5.576967 seconds
+PCG Setup wall clock time = 0.862025 seconds
+PCG Solve wall clock time = 4.294343 seconds
 # Output file: benchmark_struct.out.4
-PCG Setup wall clock time = 1.768987 seconds
-PCG Solve wall clock time = 9.280957 seconds
+PCG Setup wall clock time = 1.412173 seconds
+PCG Solve wall clock time = 7.285773 seconds
 # Output file: benchmark_struct.out.5
-PCG Setup wall clock time = 0.013666 seconds
-PCG Solve wall clock time = 0.106329 seconds
+PCG Setup wall clock time = 0.012046 seconds
+PCG Solve wall clock time = 0.095558 seconds
 # Output file: benchmark_struct.out.6
-PCG Setup wall clock time = 0.020694 seconds
-PCG Solve wall clock time = 0.259598 seconds
+PCG Setup wall clock time = 0.019933 seconds
+PCG Solve wall clock time = 0.241860 seconds
 # Output file: benchmark_struct.out.7
-PCG Setup wall clock time = 0.056668 seconds
-PCG Solve wall clock time = 0.355209 seconds
+PCG Setup wall clock time = 0.053942 seconds
+PCG Solve wall clock time = 0.333274 seconds
 # Output file: benchmark_struct.out.8
-PCG Setup wall clock time = 0.074631 seconds
-PCG Solve wall clock time = 0.548870 seconds
+PCG Setup wall clock time = 0.071390 seconds
+PCG Solve wall clock time = 0.519030 seconds

--- a/src/test/runtest.sh
+++ b/src/test/runtest.sh
@@ -129,9 +129,6 @@ function MpirunString
       tioga*)
          shift
          RunString="srun -n$1"
-         if [ "$mpibind" = "mpibind" ] ; then
-            mpibind="--mpibind=on"
-         fi
          ;;
       node*)
          shift


### PR DESCRIPTION
The way we are passing the mpibind option to slurm for the tioga regressions is no longer correct and causing issues. Slurm is now functioning as a wrapper for flux on Tioga, and plain srun commands (without any mpibind arguments) produces the correct behavior. In addition, I found that some of the benchmark runs are now going consistently faster than the recorded .saved files for tioga, so these have been updated as well.