### PR TITLE
Change auxiliary matrix variables to HYPRE_BigInt

### DIFF
--- a/src/IJ_mv/IJMatrix_parcsr_device.c
+++ b/src/IJ_mv/IJMatrix_parcsr_device.c
@@ -101,9 +101,9 @@ hypre_IJMatrixSetAddValuesParCSRDevice( hypre_IJMatrix       *matrix,
       hypre_IJMatrixTranslator(matrix) = aux_matrix;
    }
 
-   HYPRE_Int      stack_elmts_max      = hypre_AuxParCSRMatrixMaxStackElmts(aux_matrix);
-   HYPRE_Int      stack_elmts_current  = hypre_AuxParCSRMatrixCurrentStackElmts(aux_matrix);
-   HYPRE_Int      stack_elmts_required = stack_elmts_current + nelms;
+   HYPRE_BigInt   stack_elmts_max      = hypre_AuxParCSRMatrixMaxStackElmts(aux_matrix);
+   HYPRE_BigInt   stack_elmts_current  = hypre_AuxParCSRMatrixCurrentStackElmts(aux_matrix);
+   HYPRE_BigInt   stack_elmts_required = stack_elmts_current + (HYPRE_BigInt) nelms;
    HYPRE_BigInt  *stack_i              = hypre_AuxParCSRMatrixStackI(aux_matrix);
    HYPRE_BigInt  *stack_j              = hypre_AuxParCSRMatrixStackJ(aux_matrix);
    HYPRE_Complex *stack_data           = hypre_AuxParCSRMatrixStackData(aux_matrix);
@@ -111,8 +111,10 @@ hypre_IJMatrixSetAddValuesParCSRDevice( hypre_IJMatrix       *matrix,
 
    if ( stack_elmts_max < stack_elmts_required )
    {
-      HYPRE_Int stack_elmts_max_new = hypre_max(hypre_AuxParCSRMatrixUsrOnProcElmts (aux_matrix), 0) +
-                                      hypre_max(hypre_AuxParCSRMatrixUsrOffProcElmts(aux_matrix), 0);
+      HYPRE_BigInt stack_elmts_max_new =
+         hypre_max(hypre_AuxParCSRMatrixUsrOnProcElmts (aux_matrix), 0) +
+         hypre_max(hypre_AuxParCSRMatrixUsrOffProcElmts(aux_matrix), 0);
+
       if ( hypre_AuxParCSRMatrixUsrOnProcElmts (aux_matrix) < 0 ||
            hypre_AuxParCSRMatrixUsrOffProcElmts(aux_matrix) < 0 )
       {
@@ -205,7 +207,7 @@ hypre_IJMatrixSetAddValuesParCSRDevice( hypre_IJMatrix       *matrix,
                     HYPRE_MEMORY_DEVICE);
    }
 
-   hypre_AuxParCSRMatrixCurrentStackElmts(aux_matrix) += nelms;
+   hypre_AuxParCSRMatrixCurrentStackElmts(aux_matrix) += (HYPRE_BigInt) nelms;
 
    hypre_TFree(row_ptr, HYPRE_MEMORY_DEVICE);
 

--- a/src/IJ_mv/_hypre_IJ_mv.h
+++ b/src/IJ_mv/_hypre_IJ_mv.h
@@ -81,16 +81,16 @@ typedef struct
    HYPRE_MemoryLocation memory_location;
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) || defined(HYPRE_USING_SYCL)
-   HYPRE_Int            max_stack_elmts;
-   HYPRE_Int            current_stack_elmts;
+   HYPRE_BigInt         max_stack_elmts;
+   HYPRE_BigInt         current_stack_elmts;
    HYPRE_BigInt        *stack_i;
    HYPRE_BigInt        *stack_j;
    HYPRE_Complex       *stack_data;
    char                *stack_sora;              /* Set (1) or Add (0) */
    HYPRE_Int            usr_on_proc_elmts;       /* user given num elmt on-proc */
    HYPRE_Int            usr_off_proc_elmts;      /* user given num elmt off-proc */
-   HYPRE_Real           init_alloc_factor;
-   HYPRE_Real           grow_factor;
+   HYPRE_BigInt         init_alloc_factor;
+   HYPRE_BigInt         grow_factor;
 #endif
 } hypre_AuxParCSRMatrix;
 

--- a/src/IJ_mv/aux_parcsr_matrix.c
+++ b/src/IJ_mv/aux_parcsr_matrix.c
@@ -61,8 +61,8 @@ hypre_AuxParCSRMatrixCreate( hypre_AuxParCSRMatrix **aux_matrix,
    hypre_AuxParCSRMatrixStackSorA(matrix) = NULL;
    hypre_AuxParCSRMatrixUsrOnProcElmts(matrix) = -1;
    hypre_AuxParCSRMatrixUsrOffProcElmts(matrix) = -1;
-   hypre_AuxParCSRMatrixInitAllocFactor(matrix) = 5.0;
-   hypre_AuxParCSRMatrixGrowFactor(matrix) = 2.0;
+   hypre_AuxParCSRMatrixInitAllocFactor(matrix) = 5;
+   hypre_AuxParCSRMatrixGrowFactor(matrix) = 2;
 #endif
 
    *aux_matrix = matrix;

--- a/src/IJ_mv/aux_parcsr_matrix.h
+++ b/src/IJ_mv/aux_parcsr_matrix.h
@@ -66,16 +66,16 @@ typedef struct
    HYPRE_MemoryLocation memory_location;
 
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) || defined(HYPRE_USING_SYCL)
-   HYPRE_Int            max_stack_elmts;
-   HYPRE_Int            current_stack_elmts;
+   HYPRE_BigInt         max_stack_elmts;
+   HYPRE_BigInt         current_stack_elmts;
    HYPRE_BigInt        *stack_i;
    HYPRE_BigInt        *stack_j;
    HYPRE_Complex       *stack_data;
    char                *stack_sora;              /* Set (1) or Add (0) */
    HYPRE_Int            usr_on_proc_elmts;       /* user given num elmt on-proc */
    HYPRE_Int            usr_off_proc_elmts;      /* user given num elmt off-proc */
-   HYPRE_Real           init_alloc_factor;
-   HYPRE_Real           grow_factor;
+   HYPRE_BigInt         init_alloc_factor;
+   HYPRE_BigInt         grow_factor;
 #endif
 } hypre_AuxParCSRMatrix;
 


### PR DESCRIPTION
This PR changes a few variables in the auxiliary matrix data structure to `HYPRE_BigInt`. This fix solves a floating-point exception error that may happen in AMD CPUs.