### PR TITLE
Add hypre_assert_exit

### DIFF
--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -231,27 +231,37 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
 #if defined(HYPRE_DEBUG)
 /* host assert */
 #define hypre_assert(EX) do { if (!(EX)) { fprintf(stderr, "[%s, %d] hypre_assert failed: %s\n", __FILE__, __LINE__, #EX); hypre_error(1); assert(0); } } while (0)
+
+/* host assert and exit */
+#define hypre_assert_exit(comm, EX) do { if (!(EX)) { hypre_assert(EX); hypre_MPI_Abort(comm, 1); } } while (0)
+
 /* device assert */
 #if defined(HYPRE_USING_CUDA)
 #define hypre_device_assert(EX) assert(EX)
-#elif defined(HYPRE_USING_HIP)
+
 /* FIXME: Currently, asserts in device kernels in HIP do not behave well */
+#elif defined(HYPRE_USING_HIP)
 #define hypre_device_assert(EX) do { if (0) { static_cast<void> (EX); } } while (0)
+
 #elif defined(HYPRE_USING_SYCL)
 #define hypre_device_assert(EX) assert(EX)
 #endif
+
 #else /* #ifdef HYPRE_DEBUG */
+
 /* this is to silence compiler's unused variable warnings */
 #ifdef __cplusplus
 #define hypre_assert(EX) do { if (0) { static_cast<void> (EX); } } while (0)
+#define hypre_assert_exit(comm, EX) do { if (0) { static_cast<void> (EX); static_cast<void> (comm); } } while (0)
 #else
 #define hypre_assert(EX) do { if (0) { (void) (EX); } } while (0)
+#define hypre_assert_exit(comm, EX) do { if (0) { (void) (EX); (void) (comm); } } while (0)
 #endif
+
 #define hypre_device_assert(EX)
 #endif
 
 #endif /* hypre_ERROR_HEADER */
-
 /******************************************************************************
  * Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -334,7 +334,7 @@ using hypre_DeviceItem = sycl::nd_item<3>;
    if (cudaSuccess != err) {                                                                 \
       printf("CUDA ERROR (code = %d, %s) at %s:%d\n", err, cudaGetErrorString(err),          \
                    __FILE__, __LINE__);                                                      \
-      hypre_assert(0); exit(1);                                                              \
+      hypre_assert_exit(hypre_MPI_COMM_WORLD, 0);                                            \
    } } while(0)
 
 #elif defined(HYPRE_USING_HIP)
@@ -343,7 +343,7 @@ using hypre_DeviceItem = sycl::nd_item<3>;
    if (hipSuccess != err) {                                                                  \
       printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),            \
                    __FILE__, __LINE__);                                                      \
-      hypre_assert(0); exit(1);                                                              \
+      hypre_assert_exit(hypre_MPI_COMM_WORLD, 0);                                            \
    } } while(0)
 
 #elif defined(HYPRE_USING_SYCL)
@@ -356,13 +356,13 @@ using hypre_DeviceItem = sycl::nd_item<3>;
    {                                                                                         \
       hypre_printf("SYCL ERROR (code = %s) at %s:%d\n", ex.what(),                           \
                      __FILE__, __LINE__);                                                    \
-      assert(0); exit(1);                                                                    \
+      hypre_assert_exit(hypre_MPI_COMM_WORLD, 0);                                            \
    }                                                                                         \
    catch(std::runtime_error const& ex)                                                       \
    {                                                                                         \
       hypre_printf("STD ERROR (code = %s) at %s:%d\n", ex.what(),                            \
                    __FILE__, __LINE__);                                                      \
-      assert(0); exit(1);                                                                    \
+      hypre_assert_exit(hypre_MPI_COMM_WORLD, 0);                                            \
    }
 #endif
 

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -282,7 +282,7 @@ using hypre_DeviceItem = sycl::nd_item<3>;
    if (cudaSuccess != err) {                                                                 \
       printf("CUDA ERROR (code = %d, %s) at %s:%d\n", err, cudaGetErrorString(err),          \
                    __FILE__, __LINE__);                                                      \
-      hypre_assert(0); exit(1);                                                              \
+      hypre_assert_exit(hypre_MPI_COMM_WORLD, 0);                                            \
    } } while(0)
 
 #elif defined(HYPRE_USING_HIP)
@@ -291,7 +291,7 @@ using hypre_DeviceItem = sycl::nd_item<3>;
    if (hipSuccess != err) {                                                                  \
       printf("HIP ERROR (code = %d, %s) at %s:%d\n", err, hipGetErrorString(err),            \
                    __FILE__, __LINE__);                                                      \
-      hypre_assert(0); exit(1);                                                              \
+      hypre_assert_exit(hypre_MPI_COMM_WORLD, 0);                                            \
    } } while(0)
 
 #elif defined(HYPRE_USING_SYCL)
@@ -304,13 +304,13 @@ using hypre_DeviceItem = sycl::nd_item<3>;
    {                                                                                         \
       hypre_printf("SYCL ERROR (code = %s) at %s:%d\n", ex.what(),                           \
                      __FILE__, __LINE__);                                                    \
-      assert(0); exit(1);                                                                    \
+      hypre_assert_exit(hypre_MPI_COMM_WORLD, 0);                                            \
    }                                                                                         \
    catch(std::runtime_error const& ex)                                                       \
    {                                                                                         \
       hypre_printf("STD ERROR (code = %s) at %s:%d\n", ex.what(),                            \
                    __FILE__, __LINE__);                                                      \
-      assert(0); exit(1);                                                                    \
+      hypre_assert_exit(hypre_MPI_COMM_WORLD, 0);                                            \
    }
 #endif
 

--- a/src/utilities/error.h
+++ b/src/utilities/error.h
@@ -30,24 +30,34 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
 #if defined(HYPRE_DEBUG)
 /* host assert */
 #define hypre_assert(EX) do { if (!(EX)) { fprintf(stderr, "[%s, %d] hypre_assert failed: %s\n", __FILE__, __LINE__, #EX); hypre_error(1); assert(0); } } while (0)
+
+/* host assert and exit */
+#define hypre_assert_exit(comm, EX) do { if (!(EX)) { hypre_assert(EX); hypre_MPI_Abort(comm, 1); } } while (0)
+
 /* device assert */
 #if defined(HYPRE_USING_CUDA)
 #define hypre_device_assert(EX) assert(EX)
-#elif defined(HYPRE_USING_HIP)
+
 /* FIXME: Currently, asserts in device kernels in HIP do not behave well */
+#elif defined(HYPRE_USING_HIP)
 #define hypre_device_assert(EX) do { if (0) { static_cast<void> (EX); } } while (0)
+
 #elif defined(HYPRE_USING_SYCL)
 #define hypre_device_assert(EX) assert(EX)
 #endif
+
 #else /* #ifdef HYPRE_DEBUG */
+
 /* this is to silence compiler's unused variable warnings */
 #ifdef __cplusplus
 #define hypre_assert(EX) do { if (0) { static_cast<void> (EX); } } while (0)
+#define hypre_assert_exit(comm, EX) do { if (0) { static_cast<void> (EX); static_cast<void> (comm); } } while (0)
 #else
 #define hypre_assert(EX) do { if (0) { (void) (EX); } } while (0)
+#define hypre_assert_exit(comm, EX) do { if (0) { (void) (EX); (void) (comm); } } while (0)
 #endif
+
 #define hypre_device_assert(EX)
 #endif
 
 #endif /* hypre_ERROR_HEADER */
-


### PR DESCRIPTION
This PR proposes an implementation for `hypre_assert_exit` as discussed [here](https://github.com/hypre-space/hypre/pull/840#discussion_r1113709360). If hypre hits an error, e.g., when doing a CUDA call, it will exit from the application only when `HYPRE_DEBUG` is defined instead of doing so always as we have now. 