### PR TITLE
AMD ILU Support (WIP)

### DIFF
--- a/src/parcsr_ls/Makefile
+++ b/src/parcsr_ls/Makefile
@@ -152,9 +152,11 @@ CUFILES =\
  ams.c\
  ame.c\
  par_amg_setup.c\
+ par_ilu_setup_device.c\
+ par_ilu_solve_device.c\
+ par_ilu_solve_schur_gmres_device.c\
  par_ilu.c\
  par_ilu_setup.c \
- par_ilu_solve_device.c\
  par_ilu_solve.c \
  par_cheby_device.c\
  par_relax_more_device.c\

--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -3371,6 +3371,11 @@ void *hypre_ParILURAPSchurGMRESMatvecCreateH(void *ilu_vdata, void *x);
 HYPRE_Int hypre_ParILURAPSchurGMRESMatvecH(void *matvec_data, HYPRE_Complex alpha, void *ilu_vdata,
                                            void *x, HYPRE_Complex beta, void *y);
 HYPRE_Int hypre_ParILURAPSchurGMRESMatvecDestroyH(void *matvec_data );
+HYPRE_Int hypre_ILULocalRCMBuildG(hypre_CSRMatrix *A, HYPRE_Int start, HYPRE_Int end,
+                                  HYPRE_Int **permp, HYPRE_Int **qpermp, hypre_CSRMatrix **G);
+HYPRE_Int hypre_ILULocalRCMBuildFinalPerm(HYPRE_Int start, HYPRE_Int end,
+                                          HYPRE_Int * G_perm, HYPRE_Int *perm, HYPRE_Int *qperm,
+                                          HYPRE_Int **permp, HYPRE_Int **qpermp);
 HYPRE_Int hypre_ILULocalRCM( hypre_CSRMatrix *A, HYPRE_Int start, HYPRE_Int end, HYPRE_Int **permp,
                              HYPRE_Int **qpermp, HYPRE_Int sym);
 HYPRE_Int hypre_ILULocalRCMNumbering(hypre_CSRMatrix *A, HYPRE_Int root, HYPRE_Int *marker,

--- a/src/parcsr_ls/par_ilu.h
+++ b/src/parcsr_ls/par_ilu.h
@@ -13,19 +13,7 @@
  *--------------------------------------------------------------------------*/
 typedef struct hypre_ParILUData_struct
 {
-#ifdef HYPRE_USING_CUDA
-   /* Data slots for cusparse-based ilu0 */
-   cusparseMatDescr_t      matL_des;//lower tri with ones on diagonal
-   cusparseMatDescr_t      matU_des;//upper tri
-   csrsv2Info_t            matAL_info;//ILU info for L of A block (used in A-smoothing)
-   csrsv2Info_t            matAU_info;//ILU info for U of A block
-   csrsv2Info_t            matBL_info;//ILU info for L of B block
-   csrsv2Info_t            matBU_info;//ILU info for U of B block
-   csrsv2Info_t            matSL_info;//ILU info for L of S block
-   csrsv2Info_t            matSU_info;//ILU info for U of S block
-   cusparseSolvePolicy_t   ilu_solve_policy;//Use/Don't use level
-   void                    *ilu_solve_buffer;//working array on device memory
-
+#ifdef HYPRE_USING_GPU
    /* on GPU, we have to form E and F explicitly, since we don't have much control to it
     *
     */
@@ -37,10 +25,33 @@ typedef struct hypre_ParILUData_struct
    hypre_ParCSRMatrix      *Aperm;
    hypre_ParCSRMatrix      *R;
    hypre_ParCSRMatrix      *P;
+   hypre_Vector            *SchurMatVec_diag;
+   hypre_Vector            *Adiag_diag;
+   hypre_Vector            *Sdiag_diag;
+   hypre_Vector            *ZTemp;
    hypre_Vector            *Ftemp_upper;
    hypre_Vector            *Utemp_lower;
    HYPRE_Int               *A_diag_fake;//fake diagonal, pretend the diagonal matrix is empty
-   hypre_Vector            *Adiag_diag;
+
+   hypre_GpuMatData        *matL_des;
+   hypre_GpuMatData        *matU_des;
+   hypre_CsrsvData         * matALU_csrsvdata;
+   hypre_CsrsvData         * matBLU_csrsvdata;
+   hypre_CsrsvData         * matSLU_csrsvdata;
+
+   /* Data slots for cusparse-based ilu0 */
+    //cusparseMatDescr_t      matL_des;//lower tri with ones on diagonal
+    //cusparseMatDescr_t      matU_des;//upper tri
+
+   //csrsv2Info_t            matAL_info;//ILU info for L of A block (used in A-smoothing)
+   //csrsv2Info_t            matAU_info;//ILU info for U of A block
+   //csrsv2Info_t            matBL_info;//ILU info for L of B block
+   //csrsv2Info_t            matBU_info;//ILU info for U of B block
+   //csrsv2Info_t            matSL_info;//ILU info for L of S block
+   //csrsv2Info_t            matSU_info;//ILU info for U of S block
+
+   // This is moved into csrsvData
+   //cusparseSolvePolicy_t   ilu_solve_policy;//Use/Don't use level
 #endif
    //general data
    HYPRE_Int            global_solver;
@@ -149,17 +160,22 @@ typedef struct hypre_ParILUData_struct
 
 #define hypre_ParILUDataTestOption(ilu_data)                   ((ilu_data) -> test_opt)
 
-#ifdef HYPRE_USING_CUDA
-#define hypre_ParILUDataMatLMatrixDescription(ilu_data)        ((ilu_data) -> matL_des)
-#define hypre_ParILUDataMatUMatrixDescription(ilu_data)        ((ilu_data) -> matU_des)
-#define hypre_ParILUDataMatALILUSolveInfo(ilu_data)            ((ilu_data) -> matAL_info)
-#define hypre_ParILUDataMatAUILUSolveInfo(ilu_data)            ((ilu_data) -> matAU_info)
-#define hypre_ParILUDataMatBLILUSolveInfo(ilu_data)            ((ilu_data) -> matBL_info)
-#define hypre_ParILUDataMatBUILUSolveInfo(ilu_data)            ((ilu_data) -> matBU_info)
-#define hypre_ParILUDataMatSLILUSolveInfo(ilu_data)            ((ilu_data) -> matSL_info)
-#define hypre_ParILUDataMatSUILUSolveInfo(ilu_data)            ((ilu_data) -> matSU_info)
-#define hypre_ParILUDataILUSolveBuffer(ilu_data)               ((ilu_data) -> ilu_solve_buffer)
-#define hypre_ParILUDataILUSolvePolicy(ilu_data)               ((ilu_data) -> ilu_solve_policy)
+#ifdef HYPRE_USING_GPU
+#define hypre_ParILUDataMatLMatData(ilu_data)                  ((ilu_data) -> matL_des)
+#define hypre_ParILUDataMatUMatData(ilu_data)                  ((ilu_data) -> matU_des)
+#define hypre_ParILUDataMatALUCsrsvData(ilu_data)              ((ilu_data) -> matALU_csrsvdata)
+#define hypre_ParILUDataMatBLUCsrsvData(ilu_data)              ((ilu_data) -> matBLU_csrsvdata)
+#define hypre_ParILUDataMatSLUCsrsvData(ilu_data)              ((ilu_data) -> matSLU_csrsvdata)
+//#define hypre_ParILUDataMatLMatrixDescription(ilu_data)        ((ilu_data) -> matL_des)
+//#define hypre_ParILUDataMatUMatrixDescription(ilu_data)        ((ilu_data) -> matU_des)
+//#define hypre_ParILUDataMatALILUSolveInfo(ilu_data)            ((ilu_data) -> matAL_info)
+//#define hypre_ParILUDataMatAUILUSolveInfo(ilu_data)            ((ilu_data) -> matAU_info)
+//#define hypre_ParILUDataMatBLILUSolveInfo(ilu_data)            ((ilu_data) -> matBL_info)
+//#define hypre_ParILUDataMatBUILUSolveInfo(ilu_data)            ((ilu_data) -> matBU_info)
+//#define hypre_ParILUDataMatSLILUSolveInfo(ilu_data)            ((ilu_data) -> matSL_info)
+//#define hypre_ParILUDataMatSUILUSolveInfo(ilu_data)            ((ilu_data) -> matSU_info)
+//#define hypre_ParILUDataILUSolvePolicy(ilu_data)               ((ilu_data) -> ilu_solve_policy)
+
 #define hypre_ParILUDataMatAILUDevice(ilu_data)                ((ilu_data) -> matALU_d)
 #define hypre_ParILUDataMatBILUDevice(ilu_data)                ((ilu_data) -> matBLU_d)
 #define hypre_ParILUDataMatSILUDevice(ilu_data)                ((ilu_data) -> matSLU_d)
@@ -170,6 +186,10 @@ typedef struct hypre_ParILUData_struct
 #define hypre_ParILUDataP(ilu_data)                            ((ilu_data) -> P)
 #define hypre_ParILUDataFTempUpper(ilu_data)                   ((ilu_data) -> Ftemp_upper)
 #define hypre_ParILUDataUTempLower(ilu_data)                   ((ilu_data) -> Utemp_lower)
+#define hypre_ParILUDataSchurMatVecDiag(ilu_data)              ((ilu_data) -> SchurMatVec_diag)
+#define hypre_ParILUDataADiagDiag(ilu_data)                    ((ilu_data) -> Adiag_diag)
+#define hypre_ParILUDataSDiagDiag(ilu_data)                    ((ilu_data) -> Sdiag_diag)
+#define hypre_ParILUDataZTemp(ilu_data)                        ((ilu_data) -> ZTemp)
 #define hypre_ParILUDataMatAFakeDiagonal(ilu_data)             ((ilu_data) -> A_diag_fake)
 #define hypre_ParILUDataADiagDiag(ilu_data)                    ((ilu_data) -> Adiag_diag)
 #endif
@@ -359,79 +379,131 @@ HYPRE_Int hypre_ILUSolveUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_loca
                                     hypre_Vector *output_local, hypre_Vector *diag_diag, HYPRE_Int upper_jacobi_iters);
 #endif
 
+#ifdef HYPRE_USING_GPU
+HYPRE_Int hypre_ILUSetupILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *qperm,
+                                   HYPRE_Int n, HYPRE_Int nLU, hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                                   hypre_CsrsvData **matBLU_csrsvdata_ptr, hypre_CsrsvData **matSLU_csrsvdata_ptr,
+                                   hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **Eptr,
+                                   hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve);
+HYPRE_Int hypre_ILUSetupILUKDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm,
+                                   HYPRE_Int *qperm, HYPRE_Int n, HYPRE_Int nLU, hypre_GpuMatData * matL_des,
+                                   hypre_GpuMatData * matU_des,
+                                   hypre_CsrsvData ** matBLU_csrsvdata, hypre_CsrsvData ** matSLU_csrsvdata,
+                                   hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr,
+                                   hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve);
+HYPRE_Int hypre_ILUSetupILUTDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Real *tol,
+                                   HYPRE_Int *perm, HYPRE_Int *qperm, HYPRE_Int n, HYPRE_Int nLU, hypre_GpuMatData * matL_des,
+                                   hypre_GpuMatData * matU_des,
+                                   hypre_CsrsvData ** matBLU_csrsvdata, hypre_CsrsvData ** matSLU_csrsvdata,
+                                   hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr,
+                                   hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve);
+HYPRE_Int hypre_ParILUDeviceILUExtractEBFC(hypre_CSRMatrix *A_diag, HYPRE_Int nLU,
+                                             hypre_CSRMatrix **Bp, hypre_CSRMatrix **Cp, hypre_CSRMatrix **Ep, hypre_CSRMatrix **Fp);
+HYPRE_Int HYPRE_ILUSetupDeviceCSRILU0(hypre_CSRMatrix *A);
+HYPRE_Int HYPRE_ILUSetupDeviceCSRILU0SetupSolve(hypre_CSRMatrix *A, hypre_GpuMatData * matL_des,
+                                                  hypre_GpuMatData * matU_des, hypre_CsrsvData ** matLU_csrsvdata_ptr);
+HYPRE_Int hypre_ILUSolveDeviceSchurGMRESIter(hypre_ParCSRMatrix *A, hypre_ParVector *f,
+                                             hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp,
+                                             hypre_ParVector *utemp, HYPRE_Solver schur_solver, HYPRE_Solver schur_precond, hypre_ParVector *rhs,
+                                             hypre_ParVector *x, HYPRE_Int *u_end,
+                                             hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d,
+                                             hypre_Vector *ztemp, hypre_Vector **Adiag_diag, hypre_Vector **Sdiag_diag,
+                                             HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters);
+HYPRE_Int hypre_ILUSolveDeviceLU(hypre_ParCSRMatrix *A, hypre_GpuMatData * matL_des,
+                                 hypre_GpuMatData * matU_des, hypre_CsrsvData * matLU_csrsvdata,
+                                 hypre_CSRMatrix *matLU_d,
+                                 hypre_ParVector *f,  hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp,
+                                 hypre_ParVector *utemp);
+
+HYPRE_Int hypre_ILUSolveDeviceSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f,
+                                         hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp,
+                                         hypre_ParVector *utemp, HYPRE_Solver schur_solver, HYPRE_Solver schur_precond, hypre_ParVector *rhs,
+                                         hypre_ParVector *x, HYPRE_Int *u_end, hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                                         hypre_CsrsvData *matBLU_csrsvdata, hypre_CsrsvData *matSLU_csrsvdata,
+                                         hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d);
+HYPRE_Int hypre_ParILUDeviceSchurGMRESDummySetup(void *a, void *b, void *c, void *d);
+HYPRE_Int hypre_ParILUDeviceSchurGMRESDummySolve(void *ilu_vdata, void *ilu_vdata2,
+                                                 hypre_ParVector *f, hypre_ParVector *u);
+HYPRE_Int hypre_ParILUDeviceSchurGMRESCommInfo(void *ilu_vdata, HYPRE_Int *my_id,
+                                               HYPRE_Int *num_procs);
+void *hypre_ParILUDeviceSchurGMRESMatvecCreate(void *ilu_vdata, void *x);
+HYPRE_Int hypre_ParILUDeviceSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha,
+                                             void *ilu_vdata, void *x, HYPRE_Complex beta, void *y);
+HYPRE_Int hypre_ParILUDeviceSchurGMRESMatvecJacobiIter(void *matvec_data, HYPRE_Complex alpha,
+                                                       void *ilu_vdata, void *x, HYPRE_Complex beta, void *y);
+HYPRE_Int hypre_ParILUDeviceSchurGMRESMatvecDestroy(void *matvec_data );
+#endif
+
+#ifdef HYPRE_USING_ROCSPARSE
+HYPRE_Int hypre_ParILURocsparseILUExtractEBFC(hypre_CSRMatrix *A_diag, HYPRE_Int nLU,
+                                             hypre_CSRMatrix **Bp, hypre_CSRMatrix **Cp, hypre_CSRMatrix **Ep, hypre_CSRMatrix **Fp);
+HYPRE_Int HYPRE_ILUSetupRocsparseCSRILU0(hypre_CSRMatrix *A, rocsparse_analysis_policy analysis_policy, rocsparse_solve_policy solve_policy);
+HYPRE_Int HYPRE_ILUSetupRocsparseCSRILU0SetupSolve(hypre_CSRMatrix *A, hypre_GpuMatData * matL_des,
+                                                  hypre_GpuMatData * matU_des, hypre_CsrsvData ** matLU_csrsvdata_ptr);
+HYPRE_Int hypre_ILUSolveRocsparseLU(hypre_ParCSRMatrix *A, hypre_GpuMatData * matL_des,
+                                    hypre_GpuMatData * matU_des, hypre_CsrsvData * matLU_csrsvdata,
+                                    hypre_CSRMatrix *matLU_d,
+                                    hypre_ParVector *f,  hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp,
+                                    hypre_ParVector *utemp);
+HYPRE_Int hypre_ILUSolveRocsparseSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f,
+                                            hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp,
+                                            hypre_ParVector *utemp, HYPRE_Solver schur_solver, HYPRE_Solver schur_precond, hypre_ParVector *rhs,
+                                            hypre_ParVector *x, HYPRE_Int *u_end, hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                                            hypre_CsrsvData *matBLU_csrsvdata, hypre_CsrsvData *matSLU_csrsvdata,
+                                            hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d);
+HYPRE_Int hypre_ParILURocsparseSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha,
+                                                void *ilu_vdata, void *x, HYPRE_Complex beta, void *y);
+#endif
+
+
 #ifdef HYPRE_USING_CUDA
-HYPRE_Int hypre_ILUSolveCusparseLU(hypre_ParCSRMatrix *A, cusparseMatDescr_t matL_des,
-                                   cusparseMatDescr_t matU_des, csrsv2Info_t matL_info, csrsv2Info_t matU_info,
-                                   hypre_CSRMatrix *matLU_d, cusparseSolvePolicy_t ilu_solve_policy, void *ilu_solve_buffer,
+HYPRE_Int hypre_ParILUCusparseSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha,
+                                               void *ilu_vdata, void *x, HYPRE_Complex beta, void *y);
+HYPRE_Int hypre_ILUSolveCusparseSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f,
+                                            hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp,
+                                            hypre_ParVector *utemp, HYPRE_Solver schur_solver, HYPRE_Solver schur_precond, hypre_ParVector *rhs,
+                                            hypre_ParVector *x, HYPRE_Int *u_end, hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                                            hypre_CsrsvData *matBLU_csrsvdata, hypre_CsrsvData *matSLU_csrsvdata,
+                                            hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d);
+
+HYPRE_Int hypre_ILUSolveCusparseLU(hypre_ParCSRMatrix *A, hypre_GpuMatData * matL_des,
+                                   hypre_GpuMatData * matU_des, hypre_CsrsvData * matLU_csrsvdata,
+                                   hypre_CSRMatrix *matLU_d,
                                    hypre_ParVector *f,  hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp,
                                    hypre_ParVector *utemp);
-HYPRE_Int hypre_ILUSolveCusparseSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f,
-                                           hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp,
-                                           hypre_ParVector *utemp, HYPRE_Solver schur_solver, HYPRE_Solver schur_precond, hypre_ParVector *rhs,
-                                           hypre_ParVector *x, HYPRE_Int *u_end, cusparseMatDescr_t matL_des, cusparseMatDescr_t matU_des,
-                                           csrsv2Info_t matBL_info, csrsv2Info_t matBU_info, csrsv2Info_t matSL_info, csrsv2Info_t matSU_info,
-                                           hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d,
-                                           cusparseSolvePolicy_t ilu_solve_policy, void *ilu_solve_buffer);
 HYPRE_Int hypre_ILUSolveRAPGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u,
                                  HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp,
                                  hypre_ParVector *utemp, hypre_ParVector *xtemp, hypre_ParVector *ytemp, HYPRE_Solver schur_solver,
                                  HYPRE_Solver schur_precond, hypre_ParVector *rhs, hypre_ParVector *x, HYPRE_Int *u_end,
-                                 cusparseMatDescr_t matL_des, cusparseMatDescr_t matU_des, csrsv2Info_t matAL_info,
-                                 csrsv2Info_t matAU_info, csrsv2Info_t matBL_info, csrsv2Info_t matBU_info, csrsv2Info_t matSL_info,
-                                 csrsv2Info_t matSU_info, hypre_ParCSRMatrix *Aperm, hypre_CSRMatrix *matALU_d,
+                                 hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                                 hypre_CsrsvData *matALU_csrsvdata, hypre_CsrsvData *matBLU_csrsvdata, hypre_CsrsvData *matSLU_csrsvdata,
+                                 hypre_ParCSRMatrix *Aperm, hypre_CSRMatrix *matALU_d,
                                  hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d,
-                                 cusparseSolvePolicy_t ilu_solve_policy, void *ilu_solve_buffer, HYPRE_Int test_opt);
+                                 HYPRE_Int test_opt);
 HYPRE_Int hypre_ParILUCusparseExtractDiagonalCSR(hypre_ParCSRMatrix *A, HYPRE_Int *perm,
                                                  HYPRE_Int *rqperm, hypre_CSRMatrix **A_diagp);
 HYPRE_Int hypre_ParILUCusparseILUExtractEBFC(hypre_CSRMatrix *A_diag, HYPRE_Int nLU,
                                              hypre_CSRMatrix **Bp, hypre_CSRMatrix **Cp, hypre_CSRMatrix **Ep, hypre_CSRMatrix **Fp);
 HYPRE_Int HYPRE_ILUSetupCusparseCSRILU0(hypre_CSRMatrix *A, cusparseSolvePolicy_t ilu_solve_policy);
-HYPRE_Int HYPRE_ILUSetupCusparseCSRILU0SetupSolve(hypre_CSRMatrix *A, cusparseMatDescr_t matL_des,
-                                                  cusparseMatDescr_t matU_des, cusparseSolvePolicy_t ilu_solve_policy, csrsv2Info_t *matL_infop,
-                                                  csrsv2Info_t *matU_infop, HYPRE_Int *buffer_sizep, void **bufferp);
-HYPRE_Int hypre_ILUSetupILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *qperm,
-                                   HYPRE_Int n, HYPRE_Int nLU, cusparseMatDescr_t matL_des, cusparseMatDescr_t matU_des,
-                                   cusparseSolvePolicy_t ilu_solve_policy, void **bufferp, csrsv2Info_t *matBL_infop,
-                                   csrsv2Info_t *matBU_infop, csrsv2Info_t *matSL_infop, csrsv2Info_t *matSU_infop,
-                                   hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **Eptr,
-                                   hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve);
-HYPRE_Int hypre_ILUSetupILUKDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm,
-                                   HYPRE_Int *qperm, HYPRE_Int n, HYPRE_Int nLU, cusparseMatDescr_t matL_des,
-                                   cusparseMatDescr_t matU_des, cusparseSolvePolicy_t ilu_solve_policy, void **bufferp,
-                                   csrsv2Info_t *matBL_infop, csrsv2Info_t *matBU_infop, csrsv2Info_t *matSL_infop,
-                                   csrsv2Info_t *matSU_infop, hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr,
-                                   hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve);
-HYPRE_Int hypre_ILUSetupILUTDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Real *tol,
-                                   HYPRE_Int *perm, HYPRE_Int *qperm, HYPRE_Int n, HYPRE_Int nLU, cusparseMatDescr_t matL_des,
-                                   cusparseMatDescr_t matU_des, cusparseSolvePolicy_t ilu_solve_policy, void **bufferp,
-                                   csrsv2Info_t *matBL_infop, csrsv2Info_t *matBU_infop, csrsv2Info_t *matSL_infop,
-                                   csrsv2Info_t *matSU_infop, hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr,
-                                   hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve);
+
+HYPRE_Int HYPRE_ILUSetupCusparseCSRILU0SetupSolve(hypre_CSRMatrix *A, hypre_GpuMatData * matL_des,
+                                                  hypre_GpuMatData * matU_des, hypre_CsrsvData ** matLU_csrsvdata_ptr);
+
 HYPRE_Int hypre_ParILURAPReorder(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *rqperm,
                                  hypre_ParCSRMatrix **A_pq);
 HYPRE_Int hypre_ILUSetupLDUtoCusparse(hypre_ParCSRMatrix *L, HYPRE_Real *D, hypre_ParCSRMatrix *U,
                                       hypre_ParCSRMatrix **LDUp);
 HYPRE_Int hypre_ParILURAPBuildRP(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *BLUm,
-                                 hypre_ParCSRMatrix* E, hypre_ParCSRMatrix *F, cusparseMatDescr_t matL_des,
-                                 cusparseMatDescr_t matU_des, hypre_ParCSRMatrix **Rp, hypre_ParCSRMatrix **Pp);
+                                 hypre_ParCSRMatrix* E, hypre_ParCSRMatrix *F, hypre_GpuMatData * matL_des,
+                                 hypre_GpuMatData * matU_des, hypre_ParCSRMatrix **Rp, hypre_ParCSRMatrix **Pp);
 HYPRE_Int hypre_ILUSetupRAPMILU0(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix **ALUp,
                                  HYPRE_Int modified);
 HYPRE_Int hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n,
-                                      HYPRE_Int nLU, cusparseMatDescr_t matL_des, cusparseMatDescr_t matU_des,
-                                      cusparseSolvePolicy_t ilu_solve_policy, void **bufferp, csrsv2Info_t *matAL_infop,
-                                      csrsv2Info_t *matAU_infop, csrsv2Info_t *matBL_infop, csrsv2Info_t *matBU_infop,
-                                      csrsv2Info_t *matSL_infop, csrsv2Info_t *matSU_infop, hypre_ParCSRMatrix **Apermptr,
+                                      HYPRE_Int nLU, hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                                      hypre_CsrsvData **matALU_csrsvdata, hypre_CsrsvData **matBLU_csrsvdata,
+                                      hypre_CsrsvData **matSLU_csrsvdata, hypre_ParCSRMatrix **Apermptr,
                                       hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **ALUptr, hypre_CSRMatrix **BLUptr,
                                       hypre_CSRMatrix **CLUptr, hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int test_opt);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESDummySetup(void *a, void *b, void *c, void *d);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESDummySolve(void *ilu_vdata, void *ilu_vdata2,
-                                                   hypre_ParVector *f, hypre_ParVector *u);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESCommInfo(void *ilu_vdata, HYPRE_Int *my_id,
-                                                 HYPRE_Int *num_procs);
-void *hypre_ParILUCusparseSchurGMRESMatvecCreate(void *ilu_vdata, void *x);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha,
-                                               void *ilu_vdata, void *x, HYPRE_Complex beta, void *y);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESMatvecDestroy(void *matvec_data );
 HYPRE_Int hypre_ParILURAPSchurGMRESDummySetup(void *a, void *b, void *c, void *d);
 HYPRE_Int hypre_ParILURAPSchurGMRESSolve(void *ilu_vdata, void *ilu_vdata2, hypre_ParVector *f,
                                          hypre_ParVector *u);

--- a/src/parcsr_ls/par_ilu_setup.c
+++ b/src/parcsr_ls/par_ilu_setup.c
@@ -39,12 +39,7 @@ hypre_ILUSetup( void               *ilu_vdata,
    HYPRE_Int            *qperm               = hypre_ParILUDataQPerm(ilu_data);
    HYPRE_Real           tol_ddPQ             = hypre_ParILUDataTolDDPQ(ilu_data);
 
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
-   /* pointers to cusparse data, note that they are not NULL only when needed */
-   cusparseMatDescr_t      matL_des          = hypre_ParILUDataMatLMatrixDescription(ilu_data);
-   cusparseMatDescr_t      matU_des          = hypre_ParILUDataMatUMatrixDescription(ilu_data);
-   void                    *ilu_solve_buffer = hypre_ParILUDataILUSolveBuffer(ilu_data);//device memory
-   cusparseSolvePolicy_t   ilu_solve_policy  = hypre_ParILUDataILUSolvePolicy(ilu_data);
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
    hypre_ParCSRMatrix      *Aperm            = hypre_ParILUDataAperm(ilu_data);
    hypre_ParCSRMatrix      *R                = hypre_ParILUDataR(ilu_data);
    hypre_ParCSRMatrix      *P                = hypre_ParILUDataP(ilu_data);
@@ -53,17 +48,19 @@ hypre_ILUSetup( void               *ilu_vdata,
    hypre_CSRMatrix         *matSLU_d         = hypre_ParILUDataMatSILUDevice(ilu_data);
    hypre_CSRMatrix         *matE_d           = hypre_ParILUDataMatEDevice(ilu_data);
    hypre_CSRMatrix         *matF_d           = hypre_ParILUDataMatFDevice(ilu_data);
-   csrsv2Info_t            matAL_info        = hypre_ParILUDataMatALILUSolveInfo(ilu_data);
-   csrsv2Info_t            matAU_info        = hypre_ParILUDataMatAUILUSolveInfo(ilu_data);
-   csrsv2Info_t            matBL_info        = hypre_ParILUDataMatBLILUSolveInfo(ilu_data);
-   csrsv2Info_t            matBU_info        = hypre_ParILUDataMatBUILUSolveInfo(ilu_data);
-   csrsv2Info_t            matSL_info        = hypre_ParILUDataMatSLILUSolveInfo(ilu_data);
-   csrsv2Info_t            matSU_info        = hypre_ParILUDataMatSUILUSolveInfo(ilu_data);
    HYPRE_Int               *A_diag_fake      = hypre_ParILUDataMatAFakeDiagonal(ilu_data);
    hypre_Vector            *Ftemp_upper      = NULL;
    hypre_Vector            *Utemp_lower      = NULL;
-   HYPRE_Int               test_opt;
+   hypre_Vector            *SchurMatVec_diag = NULL;
    hypre_Vector            *Adiag_diag       = NULL;
+   hypre_Vector            *Sdiag_diag       = NULL;
+
+   hypre_GpuMatData        *matL_des = hypre_ParILUDataMatLMatData(ilu_data);
+   hypre_GpuMatData        *matU_des = hypre_ParILUDataMatUMatData(ilu_data);
+   hypre_CsrsvData         * matALU_csrsvdata = hypre_ParILUDataMatALUCsrsvData(ilu_data);
+   hypre_CsrsvData         * matBLU_csrsvdata = hypre_ParILUDataMatBLUCsrsvData(ilu_data);
+   hypre_CsrsvData         * matSLU_csrsvdata = hypre_ParILUDataMatSLUCsrsvData(ilu_data);
+	HYPRE_Int test_opt = hypre_ParILUDataTestOption(ilu_data);
 #endif
 
    hypre_ParCSRMatrix   *matA                = hypre_ParILUDataMatA(ilu_data);
@@ -117,70 +114,55 @@ hypre_ILUSetup( void               *ilu_vdata,
 
    /* ----- begin -----*/
    HYPRE_ANNOTATE_FUNC_BEGIN;
-
    //num_threads = hypre_NumThreads();
 
    hypre_MPI_Comm_size(comm, &num_procs);
    hypre_MPI_Comm_rank(comm, &my_id);
 
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
    /* create cuda and cusparse information when needed */
    /* Use most of them from global information */
    /* set matrix L descripter, L is a lower triangular matrix with unit diagonal entries */
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
    if (!matL_des)
    {
-      HYPRE_CUSPARSE_CALL(cusparseCreateMatDescr(&(hypre_ParILUDataMatLMatrixDescription(ilu_data))));
-      matL_des = hypre_ParILUDataMatLMatrixDescription(ilu_data);
-      HYPRE_CUSPARSE_CALL(cusparseSetMatIndexBase(matL_des, CUSPARSE_INDEX_BASE_ZERO));
-      HYPRE_CUSPARSE_CALL(cusparseSetMatType(matL_des, CUSPARSE_MATRIX_TYPE_GENERAL));
-      HYPRE_CUSPARSE_CALL(cusparseSetMatFillMode(matL_des, CUSPARSE_FILL_MODE_LOWER));
-      HYPRE_CUSPARSE_CALL(cusparseSetMatDiagType(matL_des, CUSPARSE_DIAG_TYPE_UNIT));
+       matL_des = hypre_GpuMatDataCreate();
+#if defined(HYPRE_USING_CUSPARSE)
+       HYPRE_CUSPARSE_CALL(cusparseSetMatFillMode(hypre_GpuMatDataMatDescr(matL_des), CUSPARSE_FILL_MODE_LOWER));
+       HYPRE_CUSPARSE_CALL(cusparseSetMatDiagType(hypre_GpuMatDataMatDescr(matL_des), CUSPARSE_DIAG_TYPE_UNIT));
+#endif
+#if defined(HYPRE_USING_ROCSPARSE)
+       HYPRE_ROCSPARSE_CALL( rocsparse_set_mat_fill_mode(hypre_GpuMatDataMatDescr(matL_des), rocsparse_fill_mode_lower) );
+       HYPRE_ROCSPARSE_CALL( rocsparse_set_mat_diag_type(hypre_GpuMatDataMatDescr(matL_des), rocsparse_diag_type_unit) );
+#endif
+       hypre_ParILUDataMatLMatData(ilu_data) = matL_des;
    }
-   /* set matrix U descripter, U is a upper triangular matrix with non-unit diagonal entries */
    if (!matU_des)
    {
-      HYPRE_CUSPARSE_CALL(cusparseCreateMatDescr(&(hypre_ParILUDataMatUMatrixDescription(ilu_data))));
-      matU_des = hypre_ParILUDataMatUMatrixDescription(ilu_data);
-      HYPRE_CUSPARSE_CALL(cusparseSetMatIndexBase(matU_des, CUSPARSE_INDEX_BASE_ZERO));
-      HYPRE_CUSPARSE_CALL(cusparseSetMatType(matU_des, CUSPARSE_MATRIX_TYPE_GENERAL));
-      HYPRE_CUSPARSE_CALL(cusparseSetMatFillMode(matU_des, CUSPARSE_FILL_MODE_UPPER));
-      HYPRE_CUSPARSE_CALL(cusparseSetMatDiagType(matU_des, CUSPARSE_DIAG_TYPE_NON_UNIT));
+       matU_des = hypre_GpuMatDataCreate();
+#if defined(HYPRE_USING_CUSPARSE)
+       HYPRE_CUSPARSE_CALL(cusparseSetMatFillMode(hypre_GpuMatDataMatDescr(matU_des), CUSPARSE_FILL_MODE_UPPER));
+       HYPRE_CUSPARSE_CALL(cusparseSetMatDiagType(hypre_GpuMatDataMatDescr(matU_des), CUSPARSE_DIAG_TYPE_NON_UNIT));
+#endif
+#if defined(HYPRE_USING_ROCSPARSE)
+       HYPRE_ROCSPARSE_CALL( rocsparse_set_mat_fill_mode(hypre_GpuMatDataMatDescr(matU_des), rocsparse_fill_mode_upper) );
+       HYPRE_ROCSPARSE_CALL( rocsparse_set_mat_diag_type(hypre_GpuMatDataMatDescr(matU_des), rocsparse_diag_type_non_unit) );
+#endif
+       hypre_ParILUDataMatUMatData(ilu_data) = matU_des;
    }
-   if (!matAL_info)
-   {
-      HYPRE_CUSPARSE_CALL( (cusparseDestroyCsrsv2Info(hypre_ParILUDataMatALILUSolveInfo(ilu_data))) );
-      matAL_info = NULL;
+
+   /* Destroy these if they exist already */
+   if (matALU_csrsvdata) {
+       hypre_CsrsvDataDestroy(matALU_csrsvdata);
    }
-   if (!matAU_info)
-   {
-      HYPRE_CUSPARSE_CALL( (cusparseDestroyCsrsv2Info(hypre_ParILUDataMatAUILUSolveInfo(ilu_data))) );
-      matAU_info = NULL;
+
+   if (matBLU_csrsvdata) {
+       hypre_CsrsvDataDestroy(matBLU_csrsvdata);
    }
-   if (!matBL_info)
-   {
-      HYPRE_CUSPARSE_CALL( (cusparseDestroyCsrsv2Info(hypre_ParILUDataMatBLILUSolveInfo(ilu_data))) );
-      matBL_info = NULL;
+
+   if (matSLU_csrsvdata) {
+       hypre_CsrsvDataDestroy(matSLU_csrsvdata);
    }
-   if (!matBU_info)
-   {
-      HYPRE_CUSPARSE_CALL( (cusparseDestroyCsrsv2Info(hypre_ParILUDataMatBUILUSolveInfo(ilu_data))) );
-      matBU_info = NULL;
-   }
-   if (!matSL_info)
-   {
-      HYPRE_CUSPARSE_CALL( (cusparseDestroyCsrsv2Info(hypre_ParILUDataMatSLILUSolveInfo(ilu_data))) );
-      matSL_info = NULL;
-   }
-   if (!matSU_info)
-   {
-      HYPRE_CUSPARSE_CALL( (cusparseDestroyCsrsv2Info(hypre_ParILUDataMatSUILUSolveInfo(ilu_data))) );
-      matSU_info = NULL;
-   }
-   if (ilu_solve_buffer)
-   {
-      hypre_TFree(ilu_solve_buffer, HYPRE_MEMORY_DEVICE);
-      ilu_solve_buffer = NULL;
-   }
+
    if (matALU_d)
    {
       hypre_CSRMatrixDestroy( matALU_d );
@@ -241,6 +223,26 @@ hypre_ILUSetup( void               *ilu_vdata,
       hypre_SeqVectorDestroy(hypre_ParILUDataUTempLower(ilu_data));
       hypre_ParILUDataUTempLower(ilu_data) = NULL;
    }
+   if (hypre_ParILUDataZTemp(ilu_data))
+   {
+      hypre_SeqVectorDestroy(hypre_ParILUDataZTemp(ilu_data));
+      hypre_ParILUDataZTemp(ilu_data) = NULL;
+   }
+   if (hypre_ParILUDataSchurMatVecDiag(ilu_data))
+   {
+      hypre_SeqVectorDestroy(hypre_ParILUDataSchurMatVecDiag(ilu_data));
+      hypre_ParILUDataSchurMatVecDiag(ilu_data) = NULL;
+   }
+   if (hypre_ParILUDataADiagDiag(ilu_data))
+   {
+      hypre_SeqVectorDestroy(hypre_ParILUDataADiagDiag(ilu_data));
+      hypre_ParILUDataADiagDiag(ilu_data) = NULL;
+   }
+   if (hypre_ParILUDataSDiagDiag(ilu_data))
+   {
+      hypre_SeqVectorDestroy(hypre_ParILUDataSDiagDiag(ilu_data));
+      hypre_ParILUDataSDiagDiag(ilu_data) = NULL;
+   }
    if (hypre_ParILUDataMatAFakeDiagonal(ilu_data))
    {
       hypre_TFree(hypre_ParILUDataMatAFakeDiagonal(ilu_data), HYPRE_MEMORY_DEVICE);
@@ -289,7 +291,6 @@ hypre_ILUSetup( void               *ilu_vdata,
       hypre_TFree(CF_marker_array, HYPRE_MEMORY_HOST);
       CF_marker_array = NULL;
    }
-
 
    /* clear old l1_norm data, if created */
    if (hypre_ParILUDataL1Norms(ilu_data))
@@ -346,6 +347,7 @@ hypre_ILUSetup( void               *ilu_vdata,
       hypre_TFree(hypre_ParILUDataRelResNorms(ilu_data), HYPRE_MEMORY_HOST);
       hypre_ParILUDataRelResNorms(ilu_data) = NULL;
    }
+
    if (hypre_ParILUDataSchurSolver(ilu_data))
    {
       switch (ilu_type)
@@ -366,13 +368,12 @@ hypre_ILUSetup( void               *ilu_vdata,
       switch (ilu_type)
       {
          case 10: case 11: case 40: case 41:
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
-            if (hypre_ParILUDataIluType(ilu_data) != 10 &&
-                hypre_ParILUDataIluType(ilu_data) != 11)
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
+            if (hypre_ParILUDataIluType(ilu_data) != 10 && hypre_ParILUDataIluType(ilu_data) != 11)
             {
 #endif
                HYPRE_ILUDestroy(hypre_ParILUDataSchurPrecond(ilu_data)); //ILU as precond for Schur
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
             }
 #endif
             break;
@@ -381,6 +382,7 @@ hypre_ILUSetup( void               *ilu_vdata,
       }
       (hypre_ParILUDataSchurPrecond(ilu_data)) = NULL;
    }
+
    /* start to create working vectors */
    Utemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(A),
                                  hypre_ParCSRMatrixGlobalNumRows(A),
@@ -418,26 +420,29 @@ hypre_ILUSetup( void               *ilu_vdata,
             break;
       }
    }
+
    //   m = n - nLU;
    /* factorization */
    switch (ilu_type)
    {
       case 0:
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
-         /* only apply the setup of ILU0 with cusparse */
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
+         /* only apply the setup of ILU0 with cusparse/rocsparse */
          if (fill_level == 0)
          {
-            hypre_ILUSetupILU0Device(matA, perm, perm, n, n, matL_des, matU_des, ilu_solve_policy,
-                                     &ilu_solve_buffer,
-                                     &matBL_info, &matBU_info, &matSL_info, &matSU_info, &matBLU_d, &matS,
-                                     &matE_d, &matF_d, &A_diag_fake, tri_solve);//BJ + cusparse_ilu0()
+            hypre_ILUSetupILU0Device(matA, perm, perm, n, n, matL_des, matU_des,
+                                     &matBLU_csrsvdata, &matSLU_csrsvdata, &matBLU_d, &matS,
+                                     &matE_d, &matF_d, &A_diag_fake, tri_solve);//BJ + ilu0
          }
          else
          {
-            hypre_ILUSetupILUKDevice(matA, fill_level, perm, perm, n, n, matL_des, matU_des, ilu_solve_policy,
-                                     &ilu_solve_buffer,
-                                     &matBL_info, &matBU_info, &matSL_info, &matSU_info, &matBLU_d, &matS,
+#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_UNIFIED_MEMORY)
+            hypre_ILUSetupILUKDevice(matA, fill_level, perm, perm, n, n, matL_des, matU_des,
+                                     &matBLU_csrsvdata, &matSLU_csrsvdata, &matBLU_d, &matS,
                                      &matE_d, &matF_d, &A_diag_fake, tri_solve);//BJ + hypre_iluk(), setup the device solve
+#else
+            // Throw exception ???
+#endif
          }
 #else
          hypre_ILUSetupILUK(matA, fill_level, perm, perm, n, n, &matL, &matD, &matU, &matS,
@@ -445,10 +450,9 @@ hypre_ILUSetup( void               *ilu_vdata,
 #endif
          break;
       case 1:
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
+#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_UNIFIED_MEMORY)
          hypre_ILUSetupILUTDevice(matA, max_row_elmts, droptol, perm, perm, n, n, matL_des, matU_des,
-                                  ilu_solve_policy, &ilu_solve_buffer,
-                                  &matBL_info, &matBU_info, &matSL_info, &matSU_info, &matBLU_d, &matS,
+                                  &matBLU_csrsvdata, &matSLU_csrsvdata, &matBLU_d, &matS,
                                   &matE_d, &matF_d, &A_diag_fake, tri_solve);//BJ + hypre_ilut(), setup the device solve
 #else
          hypre_ILUSetupILUT(matA, max_row_elmts, droptol, perm, perm, n, n, &matL, &matD, &matU, &matS,
@@ -456,21 +460,23 @@ hypre_ILUSetup( void               *ilu_vdata,
 #endif
          break;
       case 10:
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
          if (fill_level == 0)
          {
             /* Only support ILU0 */
-            hypre_ILUSetupILU0Device(matA, perm, perm, n, nLU, matL_des, matU_des, ilu_solve_policy,
-                                     &ilu_solve_buffer,
-                                     &matBL_info, &matBU_info, &matSL_info, &matSU_info, &matBLU_d, &matS,
-                                     &matE_d, &matF_d, &A_diag_fake, 1);//BJ + cusparse_ilu0()
+            hypre_ILUSetupILU0Device(matA, perm, perm, n, nLU, matL_des, matU_des,
+                                     &matBLU_csrsvdata, &matSLU_csrsvdata, &matBLU_d, &matS,
+                                     &matE_d, &matF_d, &A_diag_fake, tri_solve);//BJ + ilu0()
          }
          else
          {
-            hypre_ILUSetupILUKDevice(matA, fill_level, perm, perm, n, nLU, matL_des, matU_des, ilu_solve_policy,
-                                     &ilu_solve_buffer,
-                                     &matBL_info, &matBU_info, &matSL_info, &matSU_info, &matBLU_d, &matS,
-                                     &matE_d, &matF_d, &A_diag_fake, 1);//BJ + cusparse_ilu0()
+#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_UNIFIED_MEMORY)
+            hypre_ILUSetupILUKDevice(matA, fill_level, perm, perm, n, nLU, matL_des, matU_des,
+                                     &matBLU_csrsvdata, &matSLU_csrsvdata, &matBLU_d, &matS,
+                                     &matE_d, &matF_d, &A_diag_fake, tri_solve);//BJ + hypre_iluk(), setup the device solve
+#else
+            // Throw exception ???
+#endif
          }
 #else
          hypre_ILUSetupILUK(matA, fill_level, perm, perm, nLU, nLU, &matL, &matD, &matU, &matS,
@@ -478,11 +484,10 @@ hypre_ILUSetup( void               *ilu_vdata,
 #endif
          break;
       case 11:
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
+#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_UNIFIED_MEMORY)
          hypre_ILUSetupILUTDevice(matA, max_row_elmts, droptol, perm, perm, n, nLU, matL_des, matU_des,
-                                  ilu_solve_policy, &ilu_solve_buffer,
-                                  &matBL_info, &matBU_info, &matSL_info, &matSU_info, &matBLU_d, &matS,
-                                  &matE_d, &matF_d, &A_diag_fake, 1);//BJ + cusparse_ilu0()
+                                  &matBLU_csrsvdata, &matSLU_csrsvdata, &matBLU_d, &matS,
+                                  &matE_d, &matF_d, &A_diag_fake, tri_solve);//BJ + hypre_ilut(), setup the device solve
 #else
          hypre_ILUSetupILUT(matA, max_row_elmts, droptol, perm, perm, nLU, nLU, &matL, &matD, &matU, &matS,
                             &u_end); //GMRES + hypre_ilut()
@@ -508,9 +513,8 @@ hypre_ILUSetup( void               *ilu_vdata,
          break;
       case 50:
 #if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
-         test_opt = hypre_ParILUDataTestOption(ilu_data);
-         hypre_ILUSetupRAPILU0Device(matA, perm, n, nLU, matL_des, matU_des, ilu_solve_policy,
-                                     &ilu_solve_buffer, &matAL_info, &matAU_info, &matBL_info, &matBU_info, &matSL_info, &matSU_info,
+         hypre_ILUSetupRAPILU0Device(matA, perm, n, nLU, matL_des, matU_des,
+                                     &matALU_csrsvdata, &matBLU_csrsvdata, &matSLU_csrsvdata,
                                      &Aperm, &matS, &matALU_d, &matBLU_d, &matSLU_d, &matE_d, &matF_d,
                                      test_opt); //RAP + hypre_modified_ilu0
 #else
@@ -519,11 +523,10 @@ hypre_ILUSetup( void               *ilu_vdata,
 #endif
          break;
       default:
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
-         hypre_ILUSetupILU0Device(matA, perm, perm, n, n, matL_des, matU_des, ilu_solve_policy,
-                                  &ilu_solve_buffer,
-                                  &matBL_info, &matBU_info, &matSL_info, &matSU_info, &matBLU_d, &matS,
-                                  &matE_d, &matF_d, &A_diag_fake, tri_solve);//BJ + cusparse_ilu0()
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
+         hypre_ILUSetupILU0Device(matA, perm, perm, n, n, matL_des, matU_des,
+                                  &matBLU_csrsvdata, &matSLU_csrsvdata, &matBLU_d, &matS,
+                                  &matE_d, &matF_d, &A_diag_fake, tri_solve);//BJ + ilu0()
 #else
          hypre_ILUSetupILU0(matA, perm, perm, n, n, &matL, &matD, &matU, &matS, &u_end);//BJ + hypre_ilu0()
 #endif
@@ -546,12 +549,14 @@ hypre_ILUSetup( void               *ilu_vdata,
    /* setup Schur solver */
    switch (ilu_type)
    {
-      case 10: case 11:
+      case 0: case 1: default:
+         break;
+
+      case 10:
          if (matS)
          {
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
             /* create working vectors */
-
             Xtemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(matS),
                                           hypre_ParCSRMatrixGlobalNumRows(matS),
                                           hypre_ParCSRMatrixRowStarts(matS));
@@ -579,15 +584,15 @@ hypre_ILUSetup( void               *ilu_vdata,
 
             gmres_functions =
                hypre_GMRESFunctionsCreate(
-                  hypre_ParKrylovCAlloc,
+                  hypre_CAlloc,
                   hypre_ParKrylovFree,
-                  hypre_ParILUCusparseSchurGMRESCommInfo, //parCSR A -> ilu_data
+                  hypre_ParILUDeviceSchurGMRESCommInfo, //parCSR A -> ilu_data
                   hypre_ParKrylovCreateVector,
                   hypre_ParKrylovCreateVectorArray,
                   hypre_ParKrylovDestroyVector,
-                  hypre_ParILUCusparseSchurGMRESMatvecCreate, //parCSR A -- inactive
-                  hypre_ParILUCusparseSchurGMRESMatvec, //parCSR A -> ilu_data
-                  hypre_ParILUCusparseSchurGMRESMatvecDestroy, //parCSR A -- inactive
+                  hypre_ParILUDeviceSchurGMRESMatvecCreate, //parCSR A -- inactive
+                  (tri_solve==1 ? hypre_ParILUDeviceSchurGMRESMatvec : hypre_ParILUDeviceSchurGMRESMatvecJacobiIter), //parCSR A -> ilu_data
+                  hypre_ParILUDeviceSchurGMRESMatvecDestroy, //parCSR A -- inactive
                   hypre_ParKrylovInnerProd,
                   hypre_ParKrylovCopyVector,
                   hypre_ParKrylovClearVector,
@@ -613,8 +618,8 @@ hypre_ILUSetup( void               *ilu_vdata,
             schur_precond = (HYPRE_Solver) ilu_vdata;
             /* add preconditioner to solver */
             HYPRE_GMRESSetPrecond(schur_solver,
-                                  (HYPRE_PtrToSolverFcn) hypre_ParILUCusparseSchurGMRESDummySolve,
-                                  (HYPRE_PtrToSolverFcn) hypre_ParILUCusparseSchurGMRESDummySetup,
+                                  (HYPRE_PtrToSolverFcn) hypre_ParILUDeviceSchurGMRESDummySolve,
+                                  (HYPRE_PtrToSolverFcn) hypre_ParILUDeviceSchurGMRESDummySetup,
                                   schur_precond);
             HYPRE_GMRESGetPrecond(schur_solver, &schur_precond_gotten);
             if (schur_precond_gotten != (schur_precond))
@@ -669,6 +674,173 @@ hypre_ILUSetup( void               *ilu_vdata,
             HYPRE_ILUSetDropThresholdArray(schur_precond, hypre_ParILUDataSchurPrecondIluDroptol(ilu_data));
             HYPRE_ILUSetPrintLevel        (schur_precond, hypre_ParILUDataSchurPrecondPrintLevel(ilu_data));
             HYPRE_ILUSetMaxIter           (schur_precond, hypre_ParILUDataSchurPrecondMaxIter(ilu_data));
+            HYPRE_ILUSetTriSolve          (schur_precond, hypre_ParILUDataSchurPrecondTriSolve(ilu_data));
+            HYPRE_ILUSetLowerJacobiIters  (schur_precond, hypre_ParILUDataSchurPrecondLowerJacobiIters(ilu_data));
+            HYPRE_ILUSetUpperJacobiIters  (schur_precond, hypre_ParILUDataSchurPrecondUpperJacobiIters(ilu_data));
+            HYPRE_ILUSetTol               (schur_precond, hypre_ParILUDataSchurPrecondTol(ilu_data));
+
+            /* add preconditioner to solver */
+            HYPRE_GMRESSetPrecond(schur_solver,
+                                  (HYPRE_PtrToSolverFcn) HYPRE_ILUSolve,
+                                  (HYPRE_PtrToSolverFcn) HYPRE_ILUSetup,
+                                  schur_precond);
+            HYPRE_GMRESGetPrecond(schur_solver, &schur_precond_gotten);
+            if (schur_precond_gotten != (schur_precond))
+            {
+               hypre_printf("Schur complement got bad precond\n");
+               HYPRE_ANNOTATE_FUNC_END;
+
+               return (-1);
+            }
+
+            /* need to create working vector rhs and x for Schur System */
+            rhs = hypre_ParVectorCreate(comm,
+                                        hypre_ParCSRMatrixGlobalNumRows(matS),
+                                        hypre_ParCSRMatrixRowStarts(matS));
+            hypre_ParVectorInitialize(rhs);
+            x = hypre_ParVectorCreate(comm,
+                                      hypre_ParCSRMatrixGlobalNumRows(matS),
+                                      hypre_ParCSRMatrixRowStarts(matS));
+            hypre_ParVectorInitialize(x);
+
+            /* setup solver */
+            HYPRE_GMRESSetup(schur_solver, (HYPRE_Matrix)matS, (HYPRE_Vector)rhs, (HYPRE_Vector)x);
+
+            /* update ilu_data */
+            hypre_ParILUDataSchurSolver   (ilu_data) = schur_solver;
+            hypre_ParILUDataSchurPrecond  (ilu_data) = schur_precond;
+            hypre_ParILUDataRhs           (ilu_data) = rhs;
+            hypre_ParILUDataX             (ilu_data) = x;
+#endif
+         }
+         break;
+      case 11:
+         if (matS)
+         {
+#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_UNIFIED_MEMORY)
+            /* create working vectors */
+            Xtemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(matS),
+                                          hypre_ParCSRMatrixGlobalNumRows(matS),
+                                          hypre_ParCSRMatrixRowStarts(matS));
+            hypre_ParVectorInitialize(Xtemp);
+
+            Ytemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(matS),
+                                          hypre_ParCSRMatrixGlobalNumRows(matS),
+                                          hypre_ParCSRMatrixRowStarts(matS));
+            hypre_ParVectorInitialize(Ytemp);
+            Ztemp = hypre_SeqVectorCreate(n>nLU ? n : nLU);
+            hypre_SeqVectorInitialize(Ztemp);
+
+            Ftemp_upper = hypre_SeqVectorCreate(nLU);
+            hypre_VectorOwnsData(Ftemp_upper)   = 0;
+            hypre_VectorData(Ftemp_upper)       = hypre_VectorData(hypre_ParVectorLocalVector(Ftemp));
+            hypre_SeqVectorInitialize(Ftemp_upper);
+
+            Utemp_lower = hypre_SeqVectorCreate(n - nLU);
+            hypre_VectorOwnsData(Utemp_lower)   = 0;
+            hypre_VectorData(Utemp_lower)       = hypre_VectorData(hypre_ParVectorLocalVector(Utemp)) + nLU;
+            hypre_SeqVectorInitialize(Utemp_lower);
+
+            /* create GMRES */
+            //            HYPRE_ParCSRGMRESCreate(comm, &schur_solver);
+
+            hypre_GMRESFunctions * gmres_functions;
+
+            gmres_functions =
+               hypre_GMRESFunctionsCreate(
+                  hypre_ParKrylovCAlloc,
+                  hypre_ParKrylovFree,
+                  hypre_ParILUDeviceSchurGMRESCommInfo, //parCSR A -> ilu_data
+                  hypre_ParKrylovCreateVector,
+                  hypre_ParKrylovCreateVectorArray,
+                  hypre_ParKrylovDestroyVector,
+                  hypre_ParILUDeviceSchurGMRESMatvecCreate, //parCSR A -- inactive
+                  (tri_solve==1 ? hypre_ParILUDeviceSchurGMRESMatvec : hypre_ParILUDeviceSchurGMRESMatvecJacobiIter), //parCSR A -> ilu_data
+                  hypre_ParILUDeviceSchurGMRESMatvecDestroy, //parCSR A -- inactive
+                  hypre_ParKrylovInnerProd,
+                  hypre_ParKrylovCopyVector,
+                  hypre_ParKrylovClearVector,
+                  hypre_ParKrylovScaleVector,
+                  hypre_ParKrylovAxpy,
+                  hypre_ParKrylovIdentitySetup, //parCSR A -- inactive
+                  hypre_ParKrylovIdentity ); //parCSR A -- inactive
+            schur_solver = ( (HYPRE_Solver) hypre_GMRESCreate( gmres_functions ) );
+
+            /* setup GMRES parameters */
+            HYPRE_GMRESSetKDim            (schur_solver, hypre_ParILUDataSchurGMRESKDim(ilu_data));
+            HYPRE_GMRESSetMaxIter         (schur_solver,
+                                           hypre_ParILUDataSchurGMRESMaxIter(ilu_data));/* we don't need that many solves */
+            HYPRE_GMRESSetTol             (schur_solver, hypre_ParILUDataSchurGMRESTol(ilu_data));
+            HYPRE_GMRESSetAbsoluteTol     (schur_solver, hypre_ParILUDataSchurGMRESAbsoluteTol(ilu_data));
+            HYPRE_GMRESSetLogging         (schur_solver, hypre_ParILUDataSchurSolverLogging(ilu_data));
+            HYPRE_GMRESSetPrintLevel      (schur_solver,
+                                           hypre_ParILUDataSchurSolverPrintLevel(ilu_data));/* set to zero now, don't print */
+            HYPRE_GMRESSetRelChange       (schur_solver, hypre_ParILUDataSchurGMRESRelChange(ilu_data));
+
+            /* setup preconditioner parameters */
+            /* create Unit precond */
+            schur_precond = (HYPRE_Solver) ilu_vdata;
+            /* add preconditioner to solver */
+            HYPRE_GMRESSetPrecond(schur_solver,
+                                  (HYPRE_PtrToSolverFcn) hypre_ParILUDeviceSchurGMRESDummySolve,
+                                  (HYPRE_PtrToSolverFcn) hypre_ParILUDeviceSchurGMRESDummySetup,
+                                  schur_precond);
+            HYPRE_GMRESGetPrecond(schur_solver, &schur_precond_gotten);
+            if (schur_precond_gotten != (schur_precond))
+            {
+               hypre_printf("Schur complement got bad precond\n");
+               return (-1);
+            }
+
+            /* need to create working vector rhs and x for Schur System */
+            rhs = hypre_ParVectorCreate(comm,
+                                        hypre_ParCSRMatrixGlobalNumRows(matS),
+                                        hypre_ParCSRMatrixRowStarts(matS));
+            hypre_ParVectorInitialize(rhs);
+            x = hypre_ParVectorCreate(comm,
+                                      hypre_ParCSRMatrixGlobalNumRows(matS),
+                                      hypre_ParCSRMatrixRowStarts(matS));
+            hypre_ParVectorInitialize(x);
+
+            /* setup solver */
+            HYPRE_GMRESSetup(schur_solver, (HYPRE_Matrix)ilu_vdata, (HYPRE_Vector)rhs, (HYPRE_Vector)x);
+
+            /* solve for right-hand-side consists of only 1 */
+            hypre_Vector      *rhs_local = hypre_ParVectorLocalVector(rhs);
+            //HYPRE_Real        *Xtemp_data  = hypre_VectorData(Xtemp_local);
+            hypre_SeqVectorSetConstantValues(rhs_local, 1.0);
+
+            /* update ilu_data */
+            hypre_ParILUDataSchurSolver   (ilu_data) = schur_solver;
+            hypre_ParILUDataSchurPrecond  (ilu_data) = schur_precond;
+            hypre_ParILUDataRhs           (ilu_data) = rhs;
+            hypre_ParILUDataX             (ilu_data) = x;
+#else
+            /* setup GMRES parameters */
+            HYPRE_ParCSRGMRESCreate(comm, &schur_solver);
+
+            HYPRE_GMRESSetKDim            (schur_solver, hypre_ParILUDataSchurGMRESKDim(ilu_data));
+            HYPRE_GMRESSetMaxIter         (schur_solver,
+                                           hypre_ParILUDataSchurGMRESMaxIter(ilu_data));/* we don't need that many solves */
+            HYPRE_GMRESSetTol             (schur_solver, hypre_ParILUDataSchurGMRESTol(ilu_data));
+            HYPRE_GMRESSetAbsoluteTol     (schur_solver, hypre_ParILUDataSchurGMRESAbsoluteTol(ilu_data));
+            HYPRE_GMRESSetLogging         (schur_solver, hypre_ParILUDataSchurSolverLogging(ilu_data));
+            HYPRE_GMRESSetPrintLevel      (schur_solver,
+                                           hypre_ParILUDataSchurSolverPrintLevel(ilu_data));/* set to zero now, don't print */
+            HYPRE_GMRESSetRelChange       (schur_solver, hypre_ParILUDataSchurGMRESRelChange(ilu_data));
+
+            /* setup preconditioner parameters */
+            /* create precond, the default is ILU0 */
+            HYPRE_ILUCreate               (&schur_precond);
+            HYPRE_ILUSetType              (schur_precond, hypre_ParILUDataSchurPrecondIluType(ilu_data));
+            HYPRE_ILUSetLevelOfFill       (schur_precond, hypre_ParILUDataSchurPrecondIluLfil(ilu_data));
+            HYPRE_ILUSetMaxNnzPerRow      (schur_precond, hypre_ParILUDataSchurPrecondIluMaxRowNnz(ilu_data));
+            HYPRE_ILUSetDropThresholdArray(schur_precond, hypre_ParILUDataSchurPrecondIluDroptol(ilu_data));
+            HYPRE_ILUSetPrintLevel        (schur_precond, hypre_ParILUDataSchurPrecondPrintLevel(ilu_data));
+            HYPRE_ILUSetMaxIter           (schur_precond, hypre_ParILUDataSchurPrecondMaxIter(ilu_data));
+            HYPRE_ILUSetTriSolve          (schur_precond, hypre_ParILUDataSchurPrecondTriSolve(ilu_data));
+            HYPRE_ILUSetLowerJacobiIters  (schur_precond, hypre_ParILUDataSchurPrecondLowerJacobiIters(ilu_data));
+            HYPRE_ILUSetUpperJacobiIters  (schur_precond, hypre_ParILUDataSchurPrecondUpperJacobiIters(ilu_data));
             HYPRE_ILUSetTol               (schur_precond, hypre_ParILUDataSchurPrecondTol(ilu_data));
 
             /* add preconditioner to solver */
@@ -788,6 +960,9 @@ hypre_ILUSetup( void               *ilu_vdata,
             HYPRE_ILUSetDropThresholdArray(schur_precond, hypre_ParILUDataSchurPrecondIluDroptol(ilu_data));
             HYPRE_ILUSetPrintLevel        (schur_precond, hypre_ParILUDataSchurPrecondPrintLevel(ilu_data));
             HYPRE_ILUSetMaxIter           (schur_precond, hypre_ParILUDataSchurPrecondMaxIter(ilu_data));
+            HYPRE_ILUSetTriSolve          (schur_precond, hypre_ParILUDataSchurPrecondTriSolve(ilu_data));
+            HYPRE_ILUSetLowerJacobiIters  (schur_precond, hypre_ParILUDataSchurPrecondLowerJacobiIters(ilu_data));
+            HYPRE_ILUSetUpperJacobiIters  (schur_precond, hypre_ParILUDataSchurPrecondUpperJacobiIters(ilu_data));
             HYPRE_ILUSetTol               (schur_precond, hypre_ParILUDataSchurPrecondTol(ilu_data));
 
             /* add preconditioner to solver */
@@ -857,7 +1032,7 @@ hypre_ILUSetup( void               *ilu_vdata,
                hypre_GMRESFunctionsCreate(
                   hypre_ParKrylovCAlloc,
                   hypre_ParKrylovFree,
-                  hypre_ParILUCusparseSchurGMRESCommInfo, //parCSR A -> ilu_data
+                  hypre_ParILUDeviceSchurGMRESCommInfo, //parCSR A -> ilu_data
                   hypre_ParKrylovCreateVector,
                   hypre_ParKrylovCreateVectorArray,
                   hypre_ParKrylovDestroyVector,
@@ -895,7 +1070,7 @@ hypre_ILUSetup( void               *ilu_vdata,
             /* add preconditioner to solver */
             HYPRE_GMRESSetPrecond(schur_solver,
                                   (HYPRE_PtrToSolverFcn) hypre_ParILURAPSchurGMRESSolve,
-                                  //(HYPRE_PtrToSolverFcn) hypre_ParILUCusparseSchurGMRESDummySolve,
+                                  //(HYPRE_PtrToSolverFcn) hypre_ParILUDeviceSchurGMRESDummySolve,
                                   (HYPRE_PtrToSolverFcn) hypre_ParILURAPSchurGMRESDummySetup,
                                   schur_precond);
             HYPRE_GMRESGetPrecond(schur_solver, &schur_precond_gotten);
@@ -1015,7 +1190,7 @@ hypre_ILUSetup( void               *ilu_vdata,
             /* add preconditioner to solver */
             HYPRE_GMRESSetPrecond(schur_solver,
                                   (HYPRE_PtrToSolverFcn) hypre_ParILURAPSchurGMRESSolveH,
-                                  //(HYPRE_PtrToSolverFcn) hypre_ParILUCusparseSchurGMRESDummySolve,
+                                  //(HYPRE_PtrToSolverFcn) hypre_ParILUDeviceSchurGMRESDummySolve,
                                   (HYPRE_PtrToSolverFcn) hypre_ParILURAPSchurGMRESDummySetupH,
                                   schur_precond);
             HYPRE_GMRESGetPrecond(schur_solver, &schur_precond_gotten);
@@ -1042,30 +1217,29 @@ hypre_ILUSetup( void               *ilu_vdata,
 #endif
          break;
       }
-      default:
-         break;
    }
+
    /* set pointers to ilu data */
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
    /* set cusparse pointers */
-   //hypre_ParILUDataILUSolveBuffer(ilu_data)  = ilu_solve_buffer;
    hypre_ParILUDataMatAILUDevice(ilu_data)      = matALU_d;
    hypre_ParILUDataMatBILUDevice(ilu_data)      = matBLU_d;
    hypre_ParILUDataMatSILUDevice(ilu_data)      = matSLU_d;
    hypre_ParILUDataMatEDevice(ilu_data)         = matE_d;
    hypre_ParILUDataMatFDevice(ilu_data)         = matF_d;
-   hypre_ParILUDataILUSolveBuffer(ilu_data)     = ilu_solve_buffer;
-   hypre_ParILUDataMatALILUSolveInfo(ilu_data)  = matAL_info;
-   hypre_ParILUDataMatAUILUSolveInfo(ilu_data)  = matAU_info;
-   hypre_ParILUDataMatBLILUSolveInfo(ilu_data)  = matBL_info;
-   hypre_ParILUDataMatBUILUSolveInfo(ilu_data)  = matBU_info;
-   hypre_ParILUDataMatSLILUSolveInfo(ilu_data)  = matSL_info;
-   hypre_ParILUDataMatSUILUSolveInfo(ilu_data)  = matSU_info;
+   hypre_ParILUDataMatALUCsrsvData(ilu_data) = matALU_csrsvdata;
+   hypre_ParILUDataMatBLUCsrsvData(ilu_data) = matBLU_csrsvdata;
+   hypre_ParILUDataMatSLUCsrsvData(ilu_data) = matSLU_csrsvdata;
+
    hypre_ParILUDataAperm(ilu_data)              = Aperm;
    hypre_ParILUDataR(ilu_data)                  = R;
    hypre_ParILUDataP(ilu_data)                  = P;
    hypre_ParILUDataFTempUpper(ilu_data)         = Ftemp_upper;
    hypre_ParILUDataUTempLower(ilu_data)         = Utemp_lower;
+   hypre_ParILUDataSchurMatVecDiag(ilu_data)    = SchurMatVec_diag;
+   hypre_ParILUDataADiagDiag(ilu_data)          = Adiag_diag;
+   hypre_ParILUDataSDiagDiag(ilu_data)          = Sdiag_diag;
+   hypre_ParILUDataZTemp(ilu_data)              = Ztemp;
    hypre_ParILUDataMatAFakeDiagonal(ilu_data)   = A_diag_fake;
    hypre_ParILUDataADiagDiag(ilu_data)          = Adiag_diag;
 #endif
@@ -1098,7 +1272,7 @@ hypre_ILUSetup( void               *ilu_vdata,
    size_C = hypre_ParCSRMatrixGlobalNumRows(matA);
    /* switch to compute complexity */
 
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
    HYPRE_Int nnzBEF = 0;
    HYPRE_Int nnzG;/* Global nnz */
    if (ilu_type == 0 && fill_level == 0)
@@ -1191,7 +1365,7 @@ hypre_ILUSetup( void               *ilu_vdata,
                                                        hypre_ParCSRMatrixDNumNonzeros(matL) +
                                                        hypre_ParCSRMatrixDNumNonzeros(matU)) /
                                                       hypre_ParCSRMatrixDNumNonzeros(matA);
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
    }
 #endif
    if ((my_id == 0) && (print_level > 0))
@@ -1273,720 +1447,10 @@ hypre_ParILUCusparseExtractDiagonalCSR( hypre_ParCSRMatrix *A,
    return hypre_error_flag;
 }
 
-/* Extract submatrix from diagonal part of A into a
- * | B F |
- * | E C |
- * Struct in order to do ILU with cusparse.
- * WARNING: Cusparse requires each row been sorted by column
- *          This function only works when rows are sorted!.
- * A = input matrix
- * perm = permutation array indicating ordering of rows. Perm could come from a
- *    CF_marker array or a reordering routine.
- * qperm = permutation array indicating ordering of columns
- * Bp = pointer to the output B matrix.
- * Cp = pointer to the output C matrix.
- * Ep = pointer to the output E matrix.
- * Fp = pointer to the output F matrix.
- */
-HYPRE_Int
-hypre_ParILUCusparseILUExtractEBFC(hypre_CSRMatrix *A_diag, HYPRE_Int nLU, hypre_CSRMatrix **Bp,
-                                   hypre_CSRMatrix **Cp, hypre_CSRMatrix **Ep, hypre_CSRMatrix **Fp)
-{
-   /* Get necessary slots */
-   HYPRE_Int           *A_diag_i       = hypre_CSRMatrixI(A_diag);
-   HYPRE_Int           *A_diag_j       = hypre_CSRMatrixJ(A_diag);
-   HYPRE_Real          *A_diag_data    = hypre_CSRMatrixData(A_diag);
-   HYPRE_Int            n              = hypre_CSRMatrixNumRows(A_diag);
-   HYPRE_Int            nnz_A_diag     = A_diag_i[n];
-
-   HYPRE_Int            i, j, row, col;
-
-   hypre_assert(nLU >= 0 && nLU <= n);
-
-   if (nLU == n)
-   {
-      /* No schur complement makes everything easy :) */
-      hypre_CSRMatrix  *B              = NULL;
-      hypre_CSRMatrix  *C              = NULL;
-      hypre_CSRMatrix  *E              = NULL;
-      hypre_CSRMatrix  *F              = NULL;
-      B                                = hypre_CSRMatrixCreate(n, n, nnz_A_diag);
-      hypre_CSRMatrixInitialize(B);
-      hypre_CSRMatrixCopy(A_diag, B, 1);
-      C                                = hypre_CSRMatrixCreate(0, 0, 0);
-      hypre_CSRMatrixInitialize(C);
-      E                                = hypre_CSRMatrixCreate(0, 0, 0);
-      hypre_CSRMatrixInitialize(E);
-      F                                = hypre_CSRMatrixCreate(0, 0, 0);
-      hypre_CSRMatrixInitialize(F);
-      *Bp = B;
-      *Cp = C;
-      *Ep = E;
-      *Fp = F;
-   }
-   else if (nLU == 0)
-   {
-      /* All schur complement also makes everything easy :) */
-      hypre_CSRMatrix  *B              = NULL;
-      hypre_CSRMatrix  *C              = NULL;
-      hypre_CSRMatrix  *E              = NULL;
-      hypre_CSRMatrix  *F              = NULL;
-      C                                = hypre_CSRMatrixCreate(n, n, nnz_A_diag);
-      hypre_CSRMatrixInitialize(C);
-      hypre_CSRMatrixCopy(A_diag, C, 1);
-      B                                = hypre_CSRMatrixCreate(0, 0, 0);
-      hypre_CSRMatrixInitialize(B);
-      E                                = hypre_CSRMatrixCreate(0, 0, 0);
-      hypre_CSRMatrixInitialize(E);
-      F                                = hypre_CSRMatrixCreate(0, 0, 0);
-      hypre_CSRMatrixInitialize(F);
-      *Bp = B;
-      *Cp = C;
-      *Ep = E;
-      *Fp = F;
-   }
-   else
-   {
-      /* Has schur complement :( */
-      HYPRE_Int         m              = n - nLU;
-      hypre_CSRMatrix  *B              = NULL;
-      hypre_CSRMatrix  *C              = NULL;
-      hypre_CSRMatrix  *E              = NULL;
-      hypre_CSRMatrix  *F              = NULL;
-      HYPRE_Int         capacity_B;
-      HYPRE_Int         capacity_E;
-      HYPRE_Int         capacity_F;
-      HYPRE_Int         capacity_C;
-      HYPRE_Int         ctrB;
-      HYPRE_Int         ctrC;
-      HYPRE_Int         ctrE;
-      HYPRE_Int         ctrF;
-
-      HYPRE_Int        *B_i            = NULL;
-      HYPRE_Int        *C_i            = NULL;
-      HYPRE_Int        *E_i            = NULL;
-      HYPRE_Int        *F_i            = NULL;
-      HYPRE_Int        *B_j            = NULL;
-      HYPRE_Int        *C_j            = NULL;
-      HYPRE_Int        *E_j            = NULL;
-      HYPRE_Int        *F_j            = NULL;
-      HYPRE_Real       *B_data         = NULL;
-      HYPRE_Real       *C_data         = NULL;
-      HYPRE_Real       *E_data         = NULL;
-      HYPRE_Real       *F_data         = NULL;
-
-      /* Create CSRMatrices */
-      B                                = hypre_CSRMatrixCreate(nLU, nLU, 0);
-      hypre_CSRMatrixInitialize(B);
-      C                                = hypre_CSRMatrixCreate(m, m, 0);
-      hypre_CSRMatrixInitialize(C);
-      E                                = hypre_CSRMatrixCreate(m, nLU, 0);
-      hypre_CSRMatrixInitialize(E);
-      F                                = hypre_CSRMatrixCreate(nLU, m, 0);
-      hypre_CSRMatrixInitialize(F);
-
-      /* Estimate # of nonzeros */
-      capacity_B                       = nLU + ceil(nnz_A_diag * 1.0 * nLU / n * nLU / n);
-      capacity_C                       = m + ceil(nnz_A_diag * 1.0 * m / n * m / n);
-      capacity_E                       = hypre_min(m, nLU) + ceil(nnz_A_diag * 1.0 * nLU / n * m / n);
-      capacity_F                       = capacity_E;
-
-      /* Allocate memory */
-      B_i                              = hypre_CSRMatrixI(B);
-      B_j                              = hypre_CTAlloc(HYPRE_Int, capacity_B, HYPRE_MEMORY_DEVICE);
-      B_data                           = hypre_CTAlloc(HYPRE_Real, capacity_B, HYPRE_MEMORY_DEVICE);
-      C_i                              = hypre_CSRMatrixI(C);
-      C_j                              = hypre_CTAlloc(HYPRE_Int, capacity_C, HYPRE_MEMORY_DEVICE);
-      C_data                           = hypre_CTAlloc(HYPRE_Real, capacity_C, HYPRE_MEMORY_DEVICE);
-      E_i                              = hypre_CSRMatrixI(E);
-      E_j                              = hypre_CTAlloc(HYPRE_Int, capacity_E, HYPRE_MEMORY_DEVICE);
-      E_data                           = hypre_CTAlloc(HYPRE_Real, capacity_E, HYPRE_MEMORY_DEVICE);
-      F_i                              = hypre_CSRMatrixI(F);
-      F_j                              = hypre_CTAlloc(HYPRE_Int, capacity_F, HYPRE_MEMORY_DEVICE);
-      F_data                           = hypre_CTAlloc(HYPRE_Real, capacity_F, HYPRE_MEMORY_DEVICE);
-      ctrB                             = 0;
-      ctrC                             = 0;
-      ctrE                             = 0;
-      ctrF                             = 0;
-
-      /* Loop to copy data */
-      /* B and F first */
-      for (i = 0; i < nLU; i++)
-      {
-         B_i[i]   = ctrB;
-         F_i[i]   = ctrF;
-         for (j = A_diag_i[i]; j < A_diag_i[i + 1]; j++)
-         {
-            col = A_diag_j[j];
-            if (col >= nLU)
-            {
-               break;
-            }
-            B_j[ctrB] = col;
-            B_data[ctrB++] = A_diag_data[j];
-            /* check capacity */
-            if (ctrB >= capacity_B)
-            {
-               HYPRE_Int tmp;
-               tmp = capacity_B;
-               capacity_B = capacity_B * EXPAND_FACT + 1;
-               B_j = hypre_TReAlloc_v2(B_j, HYPRE_Int, tmp, HYPRE_Int, capacity_B, HYPRE_MEMORY_DEVICE);
-               B_data = hypre_TReAlloc_v2(B_data, HYPRE_Real, tmp, HYPRE_Real, capacity_B, HYPRE_MEMORY_DEVICE);
-            }
-         }
-         for (; j < A_diag_i[i + 1]; j++)
-         {
-            col = A_diag_j[j];
-            col = col - nLU;
-            F_j[ctrF] = col;
-            F_data[ctrF++] = A_diag_data[j];
-            if (ctrF >= capacity_F)
-            {
-               HYPRE_Int tmp;
-               tmp = capacity_F;
-               capacity_F = capacity_F * EXPAND_FACT + 1;
-               F_j = hypre_TReAlloc_v2(F_j, HYPRE_Int, tmp, HYPRE_Int, capacity_F, HYPRE_MEMORY_DEVICE);
-               F_data = hypre_TReAlloc_v2(F_data, HYPRE_Real, tmp, HYPRE_Real, capacity_F, HYPRE_MEMORY_DEVICE);
-            }
-         }
-      }
-      B_i[nLU] = ctrB;
-      F_i[nLU] = ctrF;
-
-      /* E and C afterward */
-      for (i = nLU; i < n; i++)
-      {
-         row = i - nLU;
-         E_i[row] = ctrE;
-         C_i[row] = ctrC;
-         for (j = A_diag_i[i]; j < A_diag_i[i + 1]; j++)
-         {
-            col = A_diag_j[j];
-            if (col >= nLU)
-            {
-               break;
-            }
-            E_j[ctrE] = col;
-            E_data[ctrE++] = A_diag_data[j];
-            /* check capacity */
-            if (ctrE >= capacity_E)
-            {
-               HYPRE_Int tmp;
-               tmp = capacity_E;
-               capacity_E = capacity_E * EXPAND_FACT + 1;
-               E_j = hypre_TReAlloc_v2(E_j, HYPRE_Int, tmp, HYPRE_Int, capacity_E, HYPRE_MEMORY_DEVICE);
-               E_data = hypre_TReAlloc_v2(E_data, HYPRE_Real, tmp, HYPRE_Real, capacity_E, HYPRE_MEMORY_DEVICE);
-            }
-         }
-         for (; j < A_diag_i[i + 1]; j++)
-         {
-            col = A_diag_j[j];
-            col = col - nLU;
-            C_j[ctrC] = col;
-            C_data[ctrC++] = A_diag_data[j];
-            if (ctrC >= capacity_C)
-            {
-               HYPRE_Int tmp;
-               tmp = capacity_C;
-               capacity_C = capacity_C * EXPAND_FACT + 1;
-               C_j = hypre_TReAlloc_v2(C_j, HYPRE_Int, tmp, HYPRE_Int, capacity_C, HYPRE_MEMORY_DEVICE);
-               C_data = hypre_TReAlloc_v2(C_data, HYPRE_Real, tmp, HYPRE_Real, capacity_C, HYPRE_MEMORY_DEVICE);
-            }
-         }
-      }
-      E_i[m] = ctrE;
-      C_i[m] = ctrC;
-
-      hypre_assert((ctrB + ctrC + ctrE + ctrF) == nnz_A_diag);
-
-      /* Create CSRMatrices */
-      hypre_CSRMatrixJ(B)              = B_j;
-      hypre_CSRMatrixData(B)           = B_data;
-      hypre_CSRMatrixNumNonzeros(B)    = ctrB;
-      hypre_CSRMatrixSetDataOwner(B, 1);
-      *Bp                              = B;
-
-      hypre_CSRMatrixJ(C)              = C_j;
-      hypre_CSRMatrixData(C)           = C_data;
-      hypre_CSRMatrixNumNonzeros(C)    = ctrC;
-      hypre_CSRMatrixSetDataOwner(C, 1);
-      *Cp                              = C;
-
-      hypre_CSRMatrixJ(E)              = E_j;
-      hypre_CSRMatrixData(E)           = E_data;
-      hypre_CSRMatrixNumNonzeros(E)    = ctrE;
-      hypre_CSRMatrixSetDataOwner(E, 1);
-      *Ep                              = E;
-
-      hypre_CSRMatrixJ(F)              = F_j;
-      hypre_CSRMatrixData(F)           = F_data;
-      hypre_CSRMatrixNumNonzeros(F)    = ctrF;
-      hypre_CSRMatrixSetDataOwner(F, 1);
-      *Fp                              = F;
-   }
-
-   return hypre_error_flag;
-}
-
-/* Wrapper for ILU0 with cusparse on a matrix, csr sort was done in this function */
-HYPRE_Int
-HYPRE_ILUSetupCusparseCSRILU0(hypre_CSRMatrix *A, cusparseSolvePolicy_t ilu_solve_policy)
-{
-
-   /* data objects for A */
-   HYPRE_Int               n                    = hypre_CSRMatrixNumRows(A);
-   HYPRE_Int               m                    = hypre_CSRMatrixNumCols(A);
-
-   hypre_assert(n == m);
-
-   HYPRE_Real              *A_data              = hypre_CSRMatrixData(A);
-   HYPRE_Int               *A_i                 = hypre_CSRMatrixI(A);
-   HYPRE_Int               *A_j                 = hypre_CSRMatrixJ(A);
-   HYPRE_Int               nnz_A                = hypre_CSRMatrixNumNonzeros(A);
-
-   /* pointers to cusparse data */
-   csrilu02Info_t          matA_info            = NULL;
-
-   /* variables and working arrays used during the ilu */
-   HYPRE_Int               zero_pivot;
-   HYPRE_Int               matA_buffersize;
-   void                    *matA_buffer         = NULL;
-
-   cusparseHandle_t handle = hypre_HandleCusparseHandle(hypre_handle());
-   cusparseMatDescr_t descr = hypre_CSRMatrixGPUMatDescr(A);
-
-   /* 1. Sort columns inside each row first, we can't assume that's sorted */
-   hypre_SortCSRCusparse(n, m, nnz_A, descr, A_i, A_j, A_data);
-
-   /* 2. Create info for ilu setup and solve */
-   HYPRE_CUSPARSE_CALL(cusparseCreateCsrilu02Info(&matA_info));
-
-   /* 3. Get working array size */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrilu02_bufferSize(handle, n, nnz_A, descr,
-                                                          A_data, A_i, A_j,
-                                                          matA_info, &matA_buffersize));
-
-   /* 4. Create working array, since they won't be visited by host, allocate on device */
-   matA_buffer                                  = hypre_TAlloc(char, matA_buffersize,
-                                                               HYPRE_MEMORY_DEVICE);
-
-   /* 5. Now perform the analysis */
-   /* 5-1. Analysis */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrilu02_analysis(handle, n, nnz_A, descr,
-                                                        A_data, A_i, A_j,
-                                                        matA_info, ilu_solve_policy, matA_buffer));
-
-   /* 5-2. Check for zero pivot */
-   HYPRE_CUSPARSE_CALL(cusparseXcsrilu02_zeroPivot(handle, matA_info, &zero_pivot));
-
-   /* 6. Apply the factorization */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrilu02(handle, n, nnz_A, descr,
-                                               A_data, A_i, A_j,
-                                               matA_info, ilu_solve_policy, matA_buffer));
-
-   /* Check for zero pivot */
-   HYPRE_CUSPARSE_CALL(cusparseXcsrilu02_zeroPivot(handle, matA_info, &zero_pivot));
-
-   /* Done with factorization, finishing up */
-   hypre_TFree(matA_buffer, HYPRE_MEMORY_DEVICE);
-   HYPRE_CUSPARSE_CALL(cusparseDestroyCsrilu02Info(matA_info));
-
-   return hypre_error_flag;
-}
-
-/* Wrapper for ILU0 solve analysis phase with cusparse on a matrix */
-HYPRE_Int
-HYPRE_ILUSetupCusparseCSRILU0SetupSolve(hypre_CSRMatrix *A, cusparseMatDescr_t matL_des,
-                                        cusparseMatDescr_t matU_des,
-                                        cusparseSolvePolicy_t ilu_solve_policy, csrsv2Info_t *matL_infop, csrsv2Info_t *matU_infop,
-                                        HYPRE_Int *buffer_sizep, void **bufferp)
-{
-   if (!A)
-   {
-      /* return if A is NULL */
-      *matL_infop    = NULL;
-      *matU_infop    = NULL;
-      *buffer_sizep  = 0;
-      *bufferp       = NULL;
-      return hypre_error_flag;
-   }
-
-   /* data objects for A */
-   HYPRE_Int               n                    = hypre_CSRMatrixNumRows(A);
-   HYPRE_Int               m                    = hypre_CSRMatrixNumCols(A);
-
-   hypre_assert(n == m);
-
-   if (n == 0)
-   {
-      /* return if A is 0 by 0 */
-      *matL_infop    = NULL;
-      *matU_infop    = NULL;
-      *buffer_sizep  = 0;
-      *bufferp       = NULL;
-      return hypre_error_flag;
-   }
-
-   HYPRE_Real              *A_data              = hypre_CSRMatrixData(A);
-   HYPRE_Int               *A_i                 = hypre_CSRMatrixI(A);
-   HYPRE_Int               *A_j                 = hypre_CSRMatrixJ(A);
-   HYPRE_Int               nnz_A                = A_i[n];
-
-   /* pointers to cusparse data */
-   csrsv2Info_t            matL_info            = *matL_infop;
-   csrsv2Info_t            matU_info            = *matU_infop;
-
-   /* clear data if already exists */
-   if (matL_info)
-   {
-      HYPRE_CUSPARSE_CALL( cusparseDestroyCsrsv2Info(matL_info) );
-      matL_info = NULL;
-   }
-   if (matU_info)
-   {
-      HYPRE_CUSPARSE_CALL( cusparseDestroyCsrsv2Info(matU_info) );
-      matU_info = NULL;
-   }
-
-   /* variables and working arrays used during the ilu */
-   HYPRE_Int               matL_buffersize;
-   HYPRE_Int               matU_buffersize;
-   HYPRE_Int               solve_buffersize;
-   HYPRE_Int               solve_oldbuffersize  = *buffer_sizep;
-   void                    *solve_buffer        = *bufferp;
-
-   cusparseHandle_t handle = hypre_HandleCusparseHandle(hypre_handle());
-
-   /* 1. Create info for ilu setup and solve */
-   HYPRE_CUSPARSE_CALL(cusparseCreateCsrsv2Info(&(matL_info)));
-   HYPRE_CUSPARSE_CALL(cusparseCreateCsrsv2Info(&(matU_info)));
-
-   /* 2. Get working array size */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, n,
-                                                        nnz_A,
-                                                        matL_des, A_data, A_i, A_j,
-                                                        matL_info, &matL_buffersize));
-
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, n,
-                                                        nnz_A,
-                                                        matU_des, A_data, A_i, A_j,
-                                                        matU_info, &matU_buffersize));
-
-   solve_buffersize = hypre_max( matL_buffersize, matU_buffersize );
-   /* 3. Create working array, since they won't be visited by host, allocate on device */
-   if (solve_buffersize > solve_oldbuffersize)
-   {
-      if (solve_buffer)
-      {
-         solve_buffer                           = hypre_TReAlloc_v2(solve_buffer, char, solve_oldbuffersize,
-                                                                    char, solve_buffersize, HYPRE_MEMORY_DEVICE);
-      }
-      else
-      {
-         solve_buffer                           = hypre_TAlloc(char, solve_buffersize, HYPRE_MEMORY_DEVICE);
-      }
-   }
-
-   /* 4. Now perform the analysis */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_analysis(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                      n, nnz_A, matL_des,
-                                                      A_data, A_i, A_j,
-                                                      matL_info, ilu_solve_policy, solve_buffer));
-
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_analysis(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                      n, nnz_A, matU_des,
-                                                      A_data, A_i, A_j,
-                                                      matU_info, ilu_solve_policy, solve_buffer));
-
-   /* Done with analysis, finishing up */
-   /* Set return value */
-   *matL_infop    = matL_info;
-   *matU_infop    = matU_info;
-   *buffer_sizep  = solve_buffersize;
-   *bufferp       = solve_buffer;
-
-   return hypre_error_flag;
-}
-
-/* ILU(0) (GPU)
- * A = input matrix
- * perm = permutation array indicating ordering of rows. Perm could come from a
- *    CF_marker array or a reordering routine.
- * qperm = permutation array indicating ordering of columns
- * nI = number of interial unknowns
- * nLU = size of incomplete factorization, nLU should obey nLU <= nI.
- *    Schur complement is formed if nLU < n
- * Lptr, Dptr, Uptr, Sptr = L, D, U, S factors. Note that with CUDA, Dptr and Uptr are unused
- * xtempp, ytempp = helper vector used in 2-level solve.
- * A_fake_diagp = fake diagonal for matvec
- * will form global Schur Matrix if nLU < n
- */
-HYPRE_Int
-hypre_ILUSetupILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *qperm, HYPRE_Int n,
-                         HYPRE_Int nLU,
-                         cusparseMatDescr_t matL_des, cusparseMatDescr_t matU_des, cusparseSolvePolicy_t ilu_solve_policy,
-                         void **bufferp, csrsv2Info_t *matBL_infop, csrsv2Info_t *matBU_infop,
-                         csrsv2Info_t *matSL_infop, csrsv2Info_t *matSU_infop,
-                         hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **Eptr,
-                         hypre_CSRMatrix **Fptr,
-                         HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve)
-{
-   /* GPU-accelerated ILU0 with cusparse */
-   HYPRE_Int               i, j, k1, k2, k3, col;
-
-   /* communication stuffs for S */
-   MPI_Comm                comm                 = hypre_ParCSRMatrixComm(A);
-
-   HYPRE_Int               my_id, num_procs;
-   hypre_MPI_Comm_size(comm, &num_procs);
-   hypre_MPI_Comm_rank(comm, &my_id);
-
-   hypre_ParCSRCommPkg     *comm_pkg;
-   hypre_ParCSRCommHandle  *comm_handle;
-   HYPRE_Int               num_sends, begin, end;
-   HYPRE_BigInt            *send_buf            = NULL;
-   HYPRE_Int               *rperm               = NULL;
-   HYPRE_Int               *rqperm              = NULL;
-
-   hypre_ParCSRMatrix      *matS                = NULL;
-   hypre_CSRMatrix         *A_diag              = NULL;
-   HYPRE_Int               *A_fake_diag_i       = NULL;
-   hypre_CSRMatrix         *A_offd              = NULL;
-   HYPRE_Int               *A_offd_i            = NULL;
-   HYPRE_Int               *A_offd_j            = NULL;
-   HYPRE_Real              *A_offd_data         = NULL;
-   hypre_CSRMatrix         *SLU                 = NULL;
-   /* pointers to cusparse data */
-   csrsv2Info_t            matBL_info           = NULL;
-   csrsv2Info_t            matBU_info           = NULL;
-   csrsv2Info_t            matSL_info           = NULL;
-   csrsv2Info_t            matSU_info           = NULL;
-
-   HYPRE_Int               buffer_size          = 0;
-   void                    *buffer              = NULL;
-
-   /* variables for matS */
-   HYPRE_Int               m                    = n - nLU;
-   HYPRE_Int               nI                   = nLU;//use default
-   HYPRE_Int               e                    = 0;
-   HYPRE_Int               m_e                  = m;
-   HYPRE_BigInt            total_rows;
-   HYPRE_BigInt            col_starts[2];
-   HYPRE_Int               *S_diag_i            = NULL;
-   HYPRE_Int               S_diag_nnz;
-   hypre_CSRMatrix         *S_offd              = NULL;
-   HYPRE_Int               *S_offd_i            = NULL;
-   HYPRE_Int               *S_offd_j            = NULL;
-   HYPRE_Real              *S_offd_data         = NULL;
-   HYPRE_BigInt            *S_offd_colmap       = NULL;
-   HYPRE_Int               S_offd_nnz;
-   HYPRE_Int               S_offd_ncols;
-
-   /* set data slots */
-   A_offd                                       = hypre_ParCSRMatrixOffd(A);
-   A_offd_i                                     = hypre_CSRMatrixI(A_offd);
-   A_offd_j                                     = hypre_CSRMatrixJ(A_offd);
-   A_offd_data                                  = hypre_CSRMatrixData(A_offd);
-
-   /* unfortunately we need to build the reverse permutation array */
-   rperm                                        = hypre_CTAlloc(HYPRE_Int, n, HYPRE_MEMORY_HOST);
-   rqperm                                       = hypre_CTAlloc(HYPRE_Int, n, HYPRE_MEMORY_HOST);
-   for (i = 0; i < n; i++)
-   {
-      rperm[perm[i]] = i;
-      rqperm[qperm[i]] = i;
-   }
-
-   /* Only call ILU when we really have a matrix on this processor */
-   if (n > 0)
-   {
-      /* Copy diagonal matrix into a new place with permutation
-       * That is, A_diag = A_diag(perm,qperm);
-       */
-      hypre_ParILUCusparseExtractDiagonalCSR(A, perm, rqperm, &A_diag);
-
-      /* Apply ILU factorization to the entile A_diag */
-      HYPRE_ILUSetupCusparseCSRILU0(A_diag, ilu_solve_policy);
-
-      /* | L \ U (B) L^{-1}F  |
-       * | EU^{-1}   L \ U (S)|
-       * Extract submatrix L_B U_B, L_S U_S, EU_B^{-1}, L_B^{-1}F
-       * Note that in this function after ILU, all rows are sorted
-       * in a way different than HYPRE. Diagonal is not listed in the front
-       */
-      hypre_ParILUCusparseILUExtractEBFC(A_diag, nLU, BLUptr, &SLU, Eptr, Fptr);
-   }
-   else
-   {
-      *BLUptr = NULL;
-      *Eptr = NULL;
-      *Fptr = NULL;
-      SLU = NULL;
-   }
-
-   /* create B */
-   /* only analyse when nacessary */
-   if ( nLU > 0 )
-   {
-      if (tri_solve)
-      {
-         /* Analysis of BILU */
-         HYPRE_ILUSetupCusparseCSRILU0SetupSolve(*BLUptr, matL_des, matU_des,
-                                                 ilu_solve_policy, &matBL_info, &matBU_info,
-                                                 &buffer_size, &buffer);
-      }
-   }
-
-   HYPRE_BigInt big_m = (HYPRE_BigInt)m;
-   hypre_MPI_Allreduce(&big_m, &total_rows, 1, HYPRE_MPI_BIG_INT, hypre_MPI_SUM, comm);
-   /* only form when total_rows > 0 */
-   if ( total_rows > 0 )
-   {
-      /* now create S */
-      /* need to get new column start */
-      {
-         HYPRE_BigInt global_start;
-         hypre_MPI_Scan( &big_m, &global_start, 1, HYPRE_MPI_BIG_INT, hypre_MPI_SUM, comm);
-         col_starts[0] = global_start - m;
-         col_starts[1] = global_start;
-      }
-
-      A_fake_diag_i = hypre_CTAlloc(HYPRE_Int, m + 1, HYPRE_MEMORY_DEVICE);
-      if (SLU)
-      {
-         if (tri_solve)
-         {
-            /* Analysis of SILU */
-            HYPRE_ILUSetupCusparseCSRILU0SetupSolve(SLU, matL_des, matU_des,
-                                                    ilu_solve_policy, &matSL_info, &matSU_info,
-                                                    &buffer_size, &buffer);
-         }
-      }
-      else
-      {
-         SLU = hypre_CSRMatrixCreate(0, 0, 0);
-         hypre_CSRMatrixInitialize(SLU);
-      }
-      S_diag_i = hypre_CSRMatrixI(SLU);
-      S_diag_nnz = S_diag_i[m];
-      /* Build ParCSRMatrix matS
-       * For example when np == 3 the new matrix takes the following form
-       * |IS_1 E_12 E_13|
-       * |E_21 IS_2 E_22| = S
-       * |E_31 E_32 IS_3|
-       * In which IS_i is the cusparse ILU factorization of S_i in one matrix
-       * */
-
-      /* We did nothing to A_offd, so all the data kept, just reorder them
-       * The create function takes comm, global num rows/cols,
-       *    row/col start, num cols offd, nnz diag, nnz offd
-       */
-      S_offd_nnz = hypre_CSRMatrixNumNonzeros(A_offd);
-      S_offd_ncols = hypre_CSRMatrixNumCols(A_offd);
-
-      matS = hypre_ParCSRMatrixCreate( comm,
-                                       total_rows,
-                                       total_rows,
-                                       col_starts,
-                                       col_starts,
-                                       S_offd_ncols,
-                                       S_diag_nnz,
-                                       S_offd_nnz);
-
-      /* first put diagonal data in */
-      hypre_CSRMatrixDestroy(hypre_ParCSRMatrixDiag(matS));
-      hypre_ParCSRMatrixDiag(matS) = SLU;
-
-      /* now start to construct offdiag of S */
-      S_offd = hypre_ParCSRMatrixOffd(matS);
-      S_offd_i = hypre_TAlloc(HYPRE_Int, m + 1, HYPRE_MEMORY_DEVICE);
-      S_offd_j = hypre_TAlloc(HYPRE_Int, S_offd_nnz, HYPRE_MEMORY_DEVICE);
-      S_offd_data = hypre_TAlloc(HYPRE_Real, S_offd_nnz, HYPRE_MEMORY_DEVICE);
-      S_offd_colmap = hypre_CTAlloc(HYPRE_BigInt, S_offd_ncols, HYPRE_MEMORY_HOST);
-
-      /* simply use a loop to copy data from A_offd */
-      S_offd_i[0] = 0;
-      k3 = 0;
-      for (i = 1; i <= e; i++)
-      {
-         S_offd_i[i] = k3;
-      }
-      for (i = 0; i < m_e; i++)
-      {
-         col = perm[i + nI];
-         k1 = A_offd_i[col];
-         k2 = A_offd_i[col + 1];
-         for (j = k1; j < k2; j++)
-         {
-            S_offd_j[k3] = A_offd_j[j];
-            S_offd_data[k3++] = A_offd_data[j];
-         }
-         S_offd_i[i + 1 + e] = k3;
-      }
-
-      /* give I, J, DATA to S_offd */
-      hypre_CSRMatrixI(S_offd) = S_offd_i;
-      hypre_CSRMatrixJ(S_offd) = S_offd_j;
-      hypre_CSRMatrixData(S_offd) = S_offd_data;
-
-      /* now we need to update S_offd_colmap */
-      comm_pkg = hypre_ParCSRMatrixCommPkg(A);
-      /* setup comm_pkg if not yet built */
-      if (!comm_pkg)
-      {
-         hypre_MatvecCommPkgCreate(A);
-         comm_pkg = hypre_ParCSRMatrixCommPkg(A);
-      }
-      /* get total num of send */
-      num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
-      begin = hypre_ParCSRCommPkgSendMapStart(comm_pkg, 0);
-      end = hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends);
-      send_buf = hypre_TAlloc(HYPRE_BigInt, end - begin, HYPRE_MEMORY_HOST);
-      /* copy new index into send_buf */
-      for (i = begin; i < end; i++)
-      {
-         send_buf[i - begin] = rperm[hypre_ParCSRCommPkgSendMapElmt(comm_pkg, i)] - nLU + col_starts[0];
-      }
-
-      /* main communication */
-      comm_handle = hypre_ParCSRCommHandleCreate(21, comm_pkg, send_buf, S_offd_colmap);
-      hypre_ParCSRCommHandleDestroy(comm_handle);
-
-      /* setup index */
-      hypre_ParCSRMatrixColMapOffd(matS) = S_offd_colmap;
-
-      hypre_ILUSortOffdColmap(matS);
-
-      /* free */
-      hypre_TFree(send_buf, HYPRE_MEMORY_HOST);
-   } /* end of forming S */
-   else
-   {
-      hypre_CSRMatrixDestroy(SLU);
-   }
-
-   *matSptr       = matS;
-   *bufferp       = buffer;
-   *matBL_infop   = matBL_info;
-   *matBU_infop   = matBU_info;
-   *matSL_infop   = matSL_info;
-   *matSU_infop   = matSU_info;
-   *A_fake_diag_ip = A_fake_diag_i;
-
-   /* Destroy the bridge after acrossing the river */
-   hypre_CSRMatrixDestroy(A_diag);
-   hypre_TFree(rperm, HYPRE_MEMORY_HOST);
-   hypre_TFree(rqperm, HYPRE_MEMORY_HOST);
-
-   return hypre_error_flag;
-}
-
 HYPRE_Int
 hypre_ILUSetupILUKDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *qperm,
-                         HYPRE_Int n, HYPRE_Int nLU,
-                         cusparseMatDescr_t matL_des, cusparseMatDescr_t matU_des, cusparseSolvePolicy_t ilu_solve_policy,
-                         void **bufferp, csrsv2Info_t *matBL_infop, csrsv2Info_t *matBU_infop,
-                         csrsv2Info_t *matSL_infop, csrsv2Info_t *matSU_infop,
+                         HYPRE_Int n, HYPRE_Int nLU, hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                         hypre_CsrsvData ** matBLU_csrsvdata_ptr, hypre_CsrsvData ** matSLU_csrsvdata_ptr,
                          hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **Eptr,
                          hypre_CSRMatrix **Fptr,
                          HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve)
@@ -2019,14 +1483,9 @@ hypre_ILUSetupILUKDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm,
    HYPRE_Int               *A_offd_j            = NULL;
    HYPRE_Real              *A_offd_data         = NULL;
    hypre_CSRMatrix         *SLU                 = NULL;
-   /* pointers to cusparse data */
-   csrsv2Info_t            matBL_info           = NULL;
-   csrsv2Info_t            matBU_info           = NULL;
-   csrsv2Info_t            matSL_info           = NULL;
-   csrsv2Info_t            matSU_info           = NULL;
-
-   HYPRE_Int               buffer_size          = 0;
-   void                    *buffer              = NULL;
+   /* opaque pointers to vendor library data structs */
+   hypre_CsrsvData         *matBLU_csrsvdata    = NULL;
+   hypre_CsrsvData         *matSLU_csrsvdata    = NULL;
 
    /* variables for matS */
    HYPRE_Int               m                    = n - nLU;
@@ -2110,7 +1569,7 @@ hypre_ILUSetupILUKDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm,
 
       A_diag = hypre_ParCSRMatrixDiag(ALU);
 
-      hypre_ParILUCusparseILUExtractEBFC(A_diag, nLU, BLUptr, &SLU, Eptr, Fptr);
+      hypre_ParILUDeviceILUExtractEBFC(A_diag, nLU, BLUptr, &SLU, Eptr, Fptr);
 
       if (Apq)
       {
@@ -2132,10 +1591,8 @@ hypre_ILUSetupILUKDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm,
    {
       if (tri_solve)
       {
-         /* Analysis of BILU */
          HYPRE_ILUSetupCusparseCSRILU0SetupSolve(*BLUptr, matL_des, matU_des,
-                                                 ilu_solve_policy, &matBL_info, &matBU_info,
-                                                 &buffer_size, &buffer);
+                                                 &matBLU_csrsvdata);
       }
    }
 
@@ -2156,13 +1613,10 @@ hypre_ILUSetupILUKDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm,
       A_fake_diag_i = hypre_CTAlloc(HYPRE_Int, m + 1, HYPRE_MEMORY_DEVICE);
       if (SLU)
       {
+         /* Analysis of SILU */
          if (tri_solve)
-         {
-            /* Analysis of SILU */
             HYPRE_ILUSetupCusparseCSRILU0SetupSolve(SLU, matL_des, matU_des,
-                                                    ilu_solve_policy, &matSL_info, &matSU_info,
-                                                    &buffer_size, &buffer);
-         }
+                                                    &matSLU_csrsvdata);
       }
       else
       {
@@ -2268,11 +1722,8 @@ hypre_ILUSetupILUKDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm,
    }
 
    *matSptr       = matS;
-   *bufferp       = buffer;
-   *matBL_infop   = matBL_info;
-   *matBU_infop   = matBU_info;
-   *matSL_infop   = matSL_info;
-   *matSU_infop   = matSU_info;
+   *matBLU_csrsvdata_ptr    = matBLU_csrsvdata;
+   *matSLU_csrsvdata_ptr    = matSLU_csrsvdata;
    *A_fake_diag_ip = A_fake_diag_i;
 
    /* Destroy the bridge after acrossing the river */
@@ -2287,9 +1738,8 @@ hypre_ILUSetupILUKDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm,
 HYPRE_Int
 hypre_ILUSetupILUTDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Real *tol, HYPRE_Int *perm,
                          HYPRE_Int *qperm, HYPRE_Int n, HYPRE_Int nLU,
-                         cusparseMatDescr_t matL_des, cusparseMatDescr_t matU_des, cusparseSolvePolicy_t ilu_solve_policy,
-                         void **bufferp, csrsv2Info_t *matBL_infop, csrsv2Info_t *matBU_infop,
-                         csrsv2Info_t *matSL_infop, csrsv2Info_t *matSU_infop,
+                         hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                         hypre_CsrsvData ** matBLU_csrsvdata_ptr, hypre_CsrsvData ** matSLU_csrsvdata_ptr,
                          hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **Eptr,
                          hypre_CSRMatrix **Fptr,
                          HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve)
@@ -2322,14 +1772,10 @@ hypre_ILUSetupILUTDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Real *tol,
    HYPRE_Int               *A_offd_j            = NULL;
    HYPRE_Real              *A_offd_data         = NULL;
    hypre_CSRMatrix         *SLU                 = NULL;
-   /* pointers to cusparse data */
-   csrsv2Info_t            matBL_info           = NULL;
-   csrsv2Info_t            matBU_info           = NULL;
-   csrsv2Info_t            matSL_info           = NULL;
-   csrsv2Info_t            matSU_info           = NULL;
 
-   HYPRE_Int               buffer_size          = 0;
-   void                    *buffer              = NULL;
+   /* opaque pointers to vendor library data structs */
+   hypre_CsrsvData         *matBLU_csrsvdata    = NULL;
+   hypre_CsrsvData         *matSLU_csrsvdata    = NULL;
 
    /* variables for matS */
    HYPRE_Int               m                    = n - nLU;
@@ -2413,7 +1859,7 @@ hypre_ILUSetupILUTDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Real *tol,
 
       A_diag = hypre_ParCSRMatrixDiag(ALU);
 
-      hypre_ParILUCusparseILUExtractEBFC(A_diag, nLU, BLUptr, &SLU, Eptr, Fptr);
+      hypre_ParILUDeviceILUExtractEBFC(A_diag, nLU, BLUptr, &SLU, Eptr, Fptr);
 
       if (Apq)
       {
@@ -2433,12 +1879,11 @@ hypre_ILUSetupILUTDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Real *tol,
    /* only analyse when nacessary */
    if ( nLU > 0 )
    {
+      /* Analysis of BILU */
       if (tri_solve)
       {
-         /* Analysis of BILU */
          HYPRE_ILUSetupCusparseCSRILU0SetupSolve(*BLUptr, matL_des, matU_des,
-                                                 ilu_solve_policy, &matBL_info, &matBU_info,
-                                                 &buffer_size, &buffer);
+                                                 &matBLU_csrsvdata);
       }
    }
 
@@ -2459,13 +1904,10 @@ hypre_ILUSetupILUTDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Real *tol,
       A_fake_diag_i = hypre_CTAlloc(HYPRE_Int, m + 1, HYPRE_MEMORY_DEVICE);
       if (SLU)
       {
+         /* Analysis of SILU */
          if (tri_solve)
-         {
-            /* Analysis of SILU */
             HYPRE_ILUSetupCusparseCSRILU0SetupSolve(SLU, matL_des, matU_des,
-                                                    ilu_solve_policy, &matSL_info, &matSU_info,
-                                                    &buffer_size, &buffer);
-         }
+                                                    &matSLU_csrsvdata);
       }
       else
       {
@@ -2571,11 +2013,8 @@ hypre_ILUSetupILUTDevice(hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Real *tol,
    }
 
    *matSptr       = matS;
-   *bufferp       = buffer;
-   *matBL_infop   = matBL_info;
-   *matBU_infop   = matBU_info;
-   *matSL_infop   = matSL_info;
-   *matSU_infop   = matSU_info;
+   *matBLU_csrsvdata_ptr    = matBLU_csrsvdata;
+   *matSLU_csrsvdata_ptr    = matSLU_csrsvdata;
    *A_fake_diag_ip = A_fake_diag_i;
 
    /* Destroy the bridge after acrossing the river */
@@ -2708,7 +2147,7 @@ hypre_ParILURAPReorder(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *rqperm
 HYPRE_Int
 hypre_ParILURAPBuildRP(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *BLUm, hypre_ParCSRMatrix* E,
                        hypre_ParCSRMatrix *F,
-                       cusparseMatDescr_t matL_des, cusparseMatDescr_t matU_des, hypre_ParCSRMatrix **Rp,
+                       hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des, hypre_ParCSRMatrix **Rp,
                        hypre_ParCSRMatrix **Pp)
 {
    /* declare variables */
@@ -2775,25 +2214,23 @@ hypre_ParILURAPBuildRP(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *BLUm, hypre_Pa
    }
 
    /* check buffer size and create buffer */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt(handle, algo,
-                                                           CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                           CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                           n, m, nnz_BLUm, &alpha, matL_des, BLUm_diag_data, BLUm_diag_i,
-                                                           BLUm_diag_j, rhs, n, malL_info, policy, &buffer_size));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt( handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
+															CUSPARSE_OPERATION_NON_TRANSPOSE,
+															n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matL_des), BLUm_diag_data, BLUm_diag_i,
+															BLUm_diag_j, rhs, n, malL_info, policy, &buffer_size));
 
    buffer = hypre_TAlloc(char, buffer_size, HYPRE_MEMORY_DEVICE);
 
-   /* analysis */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_analysis(handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                      CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                      n, m, nnz_BLUm, &alpha, matL_des, BLUm_diag_data, BLUm_diag_i,
-                                                      BLUm_diag_j, rhs, n, malL_info, policy, buffer));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_analysis( handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													   CUSPARSE_OPERATION_NON_TRANSPOSE,
+													   n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matL_des), BLUm_diag_data, BLUm_diag_i,
+													   BLUm_diag_j, rhs, n, malL_info, policy, buffer));
 
    /* solve phase */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_solve(handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                   CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                   n, m, nnz_BLUm, &alpha, matL_des, BLUm_diag_data, BLUm_diag_i,
-                                                   BLUm_diag_j, rhs, n, malL_info, policy, buffer));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_solve( handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													CUSPARSE_OPERATION_NON_TRANSPOSE,
+													n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matL_des), BLUm_diag_data, BLUm_diag_i,
+													BLUm_diag_j, rhs, n, malL_info, policy, buffer));
 
    /* now P = -UB\(LB\F) -> UB*P = -(LB\F)
     */
@@ -2804,12 +2241,10 @@ hypre_ParILURAPBuildRP(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *BLUm, hypre_Pa
    buffer_size_old = buffer_size;
 
    /* check buffer size and create buffer */
-
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt(handle, algo,
-                                                           CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                           CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                           n, m, nnz_BLUm, &alpha, matU_des, BLUm_diag_data, BLUm_diag_i,
-                                                           BLUm_diag_j, rhs, n, malU_info, policy, &buffer_size));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt( handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
+															CUSPARSE_OPERATION_NON_TRANSPOSE,
+															n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matU_des), BLUm_diag_data, BLUm_diag_i,
+															BLUm_diag_j, rhs, n, malU_info, policy, &buffer_size));
 
    if (buffer_size > buffer_size_old)
    {
@@ -2818,17 +2253,16 @@ hypre_ParILURAPBuildRP(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *BLUm, hypre_Pa
    }
 
    /* analysis */
-
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_analysis(handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                      CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                      n, m, nnz_BLUm, &alpha, matU_des, BLUm_diag_data, BLUm_diag_i,
-                                                      BLUm_diag_j, rhs, n, malU_info, policy, buffer));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_analysis( handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													   CUSPARSE_OPERATION_NON_TRANSPOSE,
+													   n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matU_des), BLUm_diag_data, BLUm_diag_i,
+													   BLUm_diag_j, rhs, n, malU_info, policy, buffer));
 
    /* solve phase */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_solve(handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                   CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                   n, m, nnz_BLUm, &alpha, matU_des, BLUm_diag_data, BLUm_diag_i,
-                                                   BLUm_diag_j, rhs, n, malU_info, policy, buffer));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_solve( handle, algo, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													CUSPARSE_OPERATION_NON_TRANSPOSE,
+													n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matU_des), BLUm_diag_data, BLUm_diag_i,
+													BLUm_diag_j, rhs, n, malU_info, policy, buffer));
 
    /* wait till GPU done to copy data */
    cudaDeviceSynchronize();
@@ -2915,11 +2349,10 @@ hypre_ParILURAPBuildRP(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *BLUm, hypre_Pa
    }
 
    /* check buffer size and create buffer */
-
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt(handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
-                                                           CUSPARSE_OPERATION_TRANSPOSE,
-                                                           n, m, nnz_BLUm, &alpha, matU_des, BLUm_diag_data, BLUm_diag_i,
-                                                           BLUm_diag_j, rhs, m, malU_info2, policy, &buffer_size));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt( handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
+															CUSPARSE_OPERATION_TRANSPOSE,
+															n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matU_des), BLUm_diag_data, BLUm_diag_i,
+															BLUm_diag_j, rhs, m, malU_info2, policy, &buffer_size));
 
    if (buffer_size > buffer_size_old)
    {
@@ -2928,17 +2361,16 @@ hypre_ParILURAPBuildRP(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *BLUm, hypre_Pa
    }
 
    /* analysis */
-
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_analysis(handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
-                                                      CUSPARSE_OPERATION_TRANSPOSE,
-                                                      n, m, nnz_BLUm, &alpha, matU_des, BLUm_diag_data, BLUm_diag_i,
-                                                      BLUm_diag_j, rhs, m, malU_info2, policy, buffer));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_analysis( handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
+													   CUSPARSE_OPERATION_TRANSPOSE,
+													   n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matU_des), BLUm_diag_data, BLUm_diag_i,
+													   BLUm_diag_j, rhs, m, malU_info2, policy, buffer));
 
    /* solve phase */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_solve(handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
-                                                   CUSPARSE_OPERATION_TRANSPOSE,
-                                                   n, m, nnz_BLUm, &alpha, matU_des, BLUm_diag_data, BLUm_diag_i,
-                                                   BLUm_diag_j, rhs, m, malU_info2, policy, buffer));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_solve( handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
+													CUSPARSE_OPERATION_TRANSPOSE,
+													n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matU_des), BLUm_diag_data, BLUm_diag_i,
+													BLUm_diag_j, rhs, m, malU_info2, policy, buffer));
 
    /* R = - (EiUB ) / LB -> LB'R' = -EiUB'
     */
@@ -2947,11 +2379,10 @@ hypre_ParILURAPBuildRP(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *BLUm, hypre_Pa
    HYPRE_CUSPARSE_CALL(cusparseCreateCsrsm2Info(&malL_info2));
 
    /* check buffer size and create buffer */
-
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt(handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
-                                                           CUSPARSE_OPERATION_TRANSPOSE,
-                                                           n, m, nnz_BLUm, &alpha, matL_des, BLUm_diag_data, BLUm_diag_i,
-                                                           BLUm_diag_j, rhs, m, malL_info2, policy, &buffer_size));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_bufferSizeExt( handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
+															CUSPARSE_OPERATION_TRANSPOSE,
+															n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matL_des), BLUm_diag_data, BLUm_diag_i,
+															BLUm_diag_j, rhs, m, malL_info2, policy, &buffer_size));
 
    if (buffer_size > buffer_size_old)
    {
@@ -2960,17 +2391,16 @@ hypre_ParILURAPBuildRP(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *BLUm, hypre_Pa
    }
 
    /* analysis */
-
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_analysis(handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
-                                                      CUSPARSE_OPERATION_TRANSPOSE,
-                                                      n, m, nnz_BLUm, &alpha, matL_des, BLUm_diag_data, BLUm_diag_i,
-                                                      BLUm_diag_j, rhs, m, malL_info2, policy, buffer));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_analysis( handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
+													   CUSPARSE_OPERATION_TRANSPOSE,
+													   n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matL_des), BLUm_diag_data, BLUm_diag_i,
+													   BLUm_diag_j, rhs, m, malL_info2, policy, buffer));
 
    /* solve phase */
-   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_solve(handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
-                                                   CUSPARSE_OPERATION_TRANSPOSE,
-                                                   n, m, nnz_BLUm, &alpha, matL_des, BLUm_diag_data, BLUm_diag_i,
-                                                   BLUm_diag_j, rhs, m, malL_info2, policy, buffer));
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsm2_solve( handle, algo, CUSPARSE_OPERATION_TRANSPOSE,
+													CUSPARSE_OPERATION_TRANSPOSE,
+													n, m, nnz_BLUm, &alpha, hypre_GpuMatDataMatDescr(matL_des), BLUm_diag_data, BLUm_diag_i,
+													BLUm_diag_j, rhs, m, malL_info2, policy, buffer));
 
    cudaDeviceSynchronize();
    /* now form R, m * (n + m) */
@@ -3210,10 +2640,8 @@ hypre_ILUSetupRAPMILU0(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix **ALUp, HYPRE_I
  */
 HYPRE_Int
 hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n, HYPRE_Int nLU,
-                            cusparseMatDescr_t matL_des, cusparseMatDescr_t matU_des, cusparseSolvePolicy_t ilu_solve_policy,
-                            void **bufferp, csrsv2Info_t *matAL_infop, csrsv2Info_t *matAU_infop,
-                            csrsv2Info_t *matBL_infop, csrsv2Info_t *matBU_infop,
-                            csrsv2Info_t *matSL_infop, csrsv2Info_t *matSU_infop,
+                            hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                            hypre_CsrsvData ** matALU_csrsvdata_ptr, hypre_CsrsvData ** matBLU_csrsvdata_ptr, hypre_CsrsvData ** matSLU_csrsvdata_ptr,
                             hypre_ParCSRMatrix **Apermptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **ALUptr,
                             hypre_CSRMatrix **BLUptr, hypre_CSRMatrix **CLUptr,
                             hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int test_opt)
@@ -3223,15 +2651,10 @@ hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n,
    MPI_Comm             comm           = hypre_ParCSRMatrixComm(A);
    HYPRE_Int            *rperm         = NULL;
 
-   csrsv2Info_t         matAL_info     = NULL;
-   csrsv2Info_t         matAU_info     = NULL;
-   csrsv2Info_t         matBL_info     = NULL;
-   csrsv2Info_t         matBU_info     = NULL;
-   csrsv2Info_t         matSL_info     = NULL;
-   csrsv2Info_t         matSU_info     = NULL;
-
-   HYPRE_Int            buffer_size    = 0;
-   void                 *buffer        = NULL;
+   /* opaque pointers to vendor library data structs */
+   hypre_CsrsvData         *matALU_csrsvdata    = NULL;
+   hypre_CsrsvData         *matBLU_csrsvdata    = NULL;
+   hypre_CsrsvData         *matSLU_csrsvdata    = NULL;
 
    //hypre_CSRMatrix      *A_diag        = hypre_ParCSRMatrixDiag(A);
    HYPRE_Int            m              = n - nLU;
@@ -3279,9 +2702,9 @@ hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n,
          /* RAP where we save E and F */
          Apq_diag = hypre_ParCSRMatrixDiag(Apq);
          hypre_CSRMatrixSortRow(Apq_diag);
-         hypre_ParILUCusparseILUExtractEBFC(Apq_diag, nLU, &dB, &dS, Eptr, Fptr);
+         hypre_ParILUDeviceILUExtractEBFC(Apq_diag, nLU, &dB, &dS, Eptr, Fptr);
          /* get modified ILU of B */
-         hypre_ParILUCusparseILUExtractEBFC(Amd, nLU, BLUptr, &SLU, &dE, &dF);
+         hypre_ParILUDeviceILUExtractEBFC(Amd, nLU, BLUptr, &SLU, &dE, &dF);
          hypre_CSRMatrixDestroy(dB);
          hypre_CSRMatrixDestroy(dS);
          hypre_CSRMatrixDestroy(dE);
@@ -3293,9 +2716,9 @@ hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n,
          /* C-EB^{-1}F where we save EU^{-1}, L^{-1}F as sparse matrices */
          Apq_diag = hypre_ParCSRMatrixDiag(Apq);
          hypre_CSRMatrixSortRow(Apq_diag);
-         hypre_ParILUCusparseILUExtractEBFC(Apq_diag, nLU, &dB, CLUptr, &dE, &dF);
+         hypre_ParILUDeviceILUExtractEBFC(Apq_diag, nLU, &dB, CLUptr, &dE, &dF);
          /* get modified ILU of B */
-         hypre_ParILUCusparseILUExtractEBFC(Amd, nLU, BLUptr, &SLU, Eptr, Fptr);
+         hypre_ParILUDeviceILUExtractEBFC(Amd, nLU, BLUptr, &SLU, Eptr, Fptr);
          hypre_CSRMatrixDestroy(dB);
          hypre_CSRMatrixDestroy(dE);
          hypre_CSRMatrixDestroy(dF);
@@ -3306,9 +2729,9 @@ hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n,
          /* C-EB^{-1}F where we save E and F */
          Apq_diag = hypre_ParCSRMatrixDiag(Apq);
          hypre_CSRMatrixSortRow(Apq_diag);
-         hypre_ParILUCusparseILUExtractEBFC(Apq_diag, nLU, &dB, CLUptr, Eptr, Fptr);
+         hypre_ParILUDeviceILUExtractEBFC(Apq_diag, nLU, &dB, CLUptr, Eptr, Fptr);
          /* get modified ILU of B */
-         hypre_ParILUCusparseILUExtractEBFC(Amd, nLU, BLUptr, &SLU, &dE, &dF);
+         hypre_ParILUDeviceILUExtractEBFC(Amd, nLU, BLUptr, &SLU, &dE, &dF);
          hypre_CSRMatrixDestroy(dB);
          hypre_CSRMatrixDestroy(dE);
          hypre_CSRMatrixDestroy(dF);
@@ -3317,13 +2740,13 @@ hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n,
       case 4:
       {
          /* RAP where we save EU^{-1}, L^{-1}F as sparse matrices */
-         hypre_ParILUCusparseILUExtractEBFC(Ad, nLU, BLUptr, &SLU, Eptr, Fptr);
+         hypre_ParILUDeviceILUExtractEBFC(Ad, nLU, BLUptr, &SLU, Eptr, Fptr);
       }
       break;
    case 0: default:
       {
          /* RAP where we save EU^{-1}, L^{-1}F as sparse matrices */
-         hypre_ParILUCusparseILUExtractEBFC(Amd, nLU, BLUptr, &SLU, Eptr, Fptr);
+         hypre_ParILUDeviceILUExtractEBFC(Amd, nLU, BLUptr, &SLU, Eptr, Fptr);
       }
       break;
    }
@@ -3336,18 +2759,15 @@ hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n,
 
    /* Analysis of BILU */
    HYPRE_ILUSetupCusparseCSRILU0SetupSolve(*ALUptr, matL_des, matU_des,
-                                           ilu_solve_policy, &matAL_info, &matAU_info,
-                                           &buffer_size, &buffer);
+                                           &matALU_csrsvdata);
 
    /* Analysis of BILU */
    HYPRE_ILUSetupCusparseCSRILU0SetupSolve(*BLUptr, matL_des, matU_des,
-                                           ilu_solve_policy, &matBL_info, &matBU_info,
-                                           &buffer_size, &buffer);
+                                           &matBLU_csrsvdata);
 
    /* Analysis of SILU */
    HYPRE_ILUSetupCusparseCSRILU0SetupSolve(SLU, matL_des, matU_des,
-                                           ilu_solve_policy, &matSL_info, &matSU_info,
-                                           &buffer_size, &buffer);
+                                           &matSLU_csrsvdata);
 
    /* start forming parCSR matrix S */
 
@@ -3382,16 +2802,9 @@ hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n,
 
    *matSptr       = S;
    *Apermptr      = Apq;
-   *bufferp       = buffer;
-   *matAL_infop   = matAL_info;
-   *matAU_infop   = matAU_info;
-   *matBL_infop   = matBL_info;
-   *matBU_infop   = matBU_info;
-   *matSL_infop   = matSL_info;
-   *matSU_infop   = matSU_info;
-
-   hypre_TFree(rperm, HYPRE_MEMORY_HOST);
-
+   *matALU_csrsvdata_ptr = matALU_csrsvdata;
+   *matBLU_csrsvdata_ptr = matBLU_csrsvdata;
+   *matSLU_csrsvdata_ptr = matSLU_csrsvdata;
    return hypre_error_flag;
 }
 

--- a/src/parcsr_ls/par_ilu_setup_device.c
+++ b/src/parcsr_ls/par_ilu_setup_device.c
@@ -1,0 +1,1023 @@
+/******************************************************************************
+ * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+#include "_hypre_parcsr_ls.h"
+#include "_hypre_utilities.hpp"
+#include "par_ilu.h"
+#include "seq_mv.hpp"
+
+
+/*********************************************************************************/
+/*                       hypre_ILUSetupILU0Device                                */
+/*********************************************************************************/
+
+/* ILU(0) (GPU)
+ * A = input matrix
+ * perm = permutation array indicating ordering of rows. Perm could come from a
+ *    CF_marker array or a reordering routine.
+ * qperm = permutation array indicating ordering of columns
+ * nI = number of interial unknowns
+ * nLU = size of incomplete factorization, nLU should obey nLU <= nI.
+ *    Schur complement is formed if nLU < n
+ * Lptr, Dptr, Uptr, Sptr = L, D, U, S factors. Note that with CUDA, Dptr and Uptr are unused
+ * xtempp, ytempp = helper vector used in 2-level solve.
+ * A_fake_diagp = fake diagonal for matvec
+ * will form global Schur Matrix if nLU < n
+ */
+
+#if defined(HYPRE_USING_GPU)
+
+HYPRE_Int
+hypre_ILUSetupILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *qperm,
+                         HYPRE_Int n, HYPRE_Int nLU, hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                         hypre_CsrsvData **matBLU_csrsvdata_ptr, hypre_CsrsvData **matSLU_csrsvdata_ptr,
+                         hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **Eptr,
+                         hypre_CSRMatrix **Fptr, HYPRE_Int **A_fake_diag_ip, HYPRE_Int tri_solve)
+{
+   HYPRE_Int               i, j, k1, k2, k3, col;
+
+   /* communication stuffs for S */
+   MPI_Comm                comm                 = hypre_ParCSRMatrixComm(A);
+
+   HYPRE_Int               my_id, num_procs;
+   hypre_MPI_Comm_size(comm, &num_procs);
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+   hypre_ParCSRCommPkg     *comm_pkg;
+   hypre_ParCSRCommHandle  *comm_handle;
+   HYPRE_Int               num_sends, begin, end;
+   HYPRE_BigInt            *send_buf            = NULL;
+   HYPRE_Int               *rperm               = NULL;
+   HYPRE_Int               *rqperm              = NULL;
+   hypre_ParCSRMatrix      *matS                = NULL;
+   hypre_CSRMatrix         *A_diag              = NULL;
+   HYPRE_Int               *A_fake_diag_i       = NULL;
+   hypre_CSRMatrix         *A_offd              = NULL;
+   HYPRE_Int               *A_offd_i            = NULL;
+   HYPRE_Int               *A_offd_j            = NULL;
+   HYPRE_Real              *A_offd_data         = NULL;
+   hypre_CSRMatrix         *SLU                 = NULL;
+   /* opaque pointers to vendor library data structs */
+   hypre_CsrsvData         *matBLU_csrsvdata    = NULL;
+   hypre_CsrsvData         *matSLU_csrsvdata    = NULL;
+
+   /* variables for matS */
+   HYPRE_Int               m                    = n - nLU;
+   HYPRE_Int               nI                   = nLU;//use default
+   HYPRE_Int               e                    = 0;
+   HYPRE_Int               m_e                  = m;
+   HYPRE_BigInt            total_rows;
+   HYPRE_BigInt            col_starts[2];
+   HYPRE_Int               S_diag_nnz;
+   hypre_CSRMatrix         *S_offd              = NULL;
+   HYPRE_Int               *S_offd_i            = NULL;
+   HYPRE_Int               *S_offd_j            = NULL;
+   HYPRE_Real              *S_offd_data         = NULL;
+   HYPRE_BigInt            *S_offd_colmap       = NULL;
+   HYPRE_Int               S_offd_nnz;
+   HYPRE_Int               S_offd_ncols;
+
+#ifdef HYPRE_USING_CUDA
+   cudaEvent_t start, stop;
+   float time;
+   cudaEventCreate(&start);
+   cudaEventCreate(&stop);
+   cudaEventRecord(start, 0);
+#endif
+
+   /* set data slots */
+   A_offd                                       = hypre_ParCSRMatrixOffd(A);
+   A_offd_i                                     = hypre_CSRMatrixI(A_offd);
+   A_offd_j                                     = hypre_CSRMatrixJ(A_offd);
+   A_offd_data                                  = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int A_offd_nnz                         = hypre_CSRMatrixNumNonzeros(A_offd);
+   HYPRE_Int A_offd_n                           = hypre_CSRMatrixNumRows(A_offd);
+
+   /* unfortunately we need to build the reverse permutation array */
+   rperm                                        = hypre_CTAlloc(HYPRE_Int, n, HYPRE_MEMORY_DEVICE);
+   rqperm                                       = hypre_CTAlloc(HYPRE_Int, n, HYPRE_MEMORY_DEVICE);
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+   if (n > 0)
+   {
+      HYPRE_THRUST_CALL( sequence,
+                         thrust::make_permutation_iterator(rperm, perm),
+                         thrust::make_permutation_iterator(rperm+n, perm+n),
+                         0 );
+      HYPRE_THRUST_CALL( sequence,
+                         thrust::make_permutation_iterator(rqperm, qperm),
+                         thrust::make_permutation_iterator(rqperm+n, qperm+n),
+                         0 );
+   }
+#else
+   // not sure if this works
+   for (i = 0; i < n; i++)
+   {
+      rperm[perm[i]] = i;
+      rqperm[qperm[i]] = i;
+   }
+#endif
+
+   /* Only call ILU when we really have a matrix on this processor */
+   if (n > 0)
+   {
+      /* Copy diagonal matrix into a new place with permutation
+       * That is, A_diag = A_diag(perm,qperm);
+       */
+      hypre_CSRMatrixApplyRowColPermutation(hypre_ParCSRMatrixDiag(A), perm, rqperm, &A_diag);
+
+      /* Apply ILU factorization to the entile A_diag */
+      HYPRE_ILUSetupDeviceCSRILU0(A_diag);
+
+      /* | L \ U (B) L^{-1}F  |
+       * | EU^{-1}   L \ U (S)|
+       * Extract submatrix L_B U_B, L_S U_S, EU_B^{-1}, L_B^{-1}F
+       * Note that in this function after ILU, all rows are sorted
+       * in a way different than HYPRE. Diagonal is not listed in the front
+       */
+      hypre_ParILUDeviceILUExtractEBFC(A_diag, nLU, BLUptr, &SLU, Eptr, Fptr);
+   }
+   else
+   {
+      *BLUptr = NULL;
+      *Eptr = NULL;
+      *Fptr = NULL;
+      SLU = NULL;
+   }
+
+   /* create B */
+   /* only analyse when nacessary */
+   if ( nLU > 0 )
+   {
+      /* Solve Analysis of BILU */
+      if (tri_solve)
+      {
+         HYPRE_ILUSetupDeviceCSRILU0SetupSolve(*BLUptr, matL_des, matU_des, &matBLU_csrsvdata);
+      }
+   }
+
+   HYPRE_BigInt big_m = (HYPRE_BigInt)m;
+   hypre_MPI_Allreduce(&big_m, &total_rows, 1, HYPRE_MPI_BIG_INT, hypre_MPI_SUM, comm);
+
+    /* only form when total_rows > 0 */
+   if ( total_rows > 0 )
+   {
+      /* now create S */
+      /* need to get new column start */
+      {
+         HYPRE_BigInt global_start;
+         hypre_MPI_Scan( &big_m, &global_start, 1, HYPRE_MPI_BIG_INT, hypre_MPI_SUM, comm);
+         col_starts[0] = global_start - m;
+         col_starts[1] = global_start;
+      }
+      A_fake_diag_i = hypre_CTAlloc(HYPRE_Int, m + 1, HYPRE_MEMORY_DEVICE);
+      if (SLU)
+      {
+         /* Solve Analysis of SILU */
+         if (tri_solve)
+         {
+            HYPRE_ILUSetupDeviceCSRILU0SetupSolve(SLU, matL_des, matU_des, &matSLU_csrsvdata);
+         }
+      }
+      else
+      {
+         SLU = hypre_CSRMatrixCreate(0, 0, 0);
+         hypre_CSRMatrixInitialize(SLU);
+      }
+      S_diag_nnz = hypre_CSRMatrixNumNonzeros(SLU);
+      /* Build ParCSRMatrix matS
+       * For example when np == 3 the new matrix takes the following form
+       * |IS_1 E_12 E_13|
+       * |E_21 IS_2 E_22| = S
+       * |E_31 E_32 IS_3|
+       * In which IS_i is the ILU factorization of S_i in one matrix
+       * */
+
+      /* We did nothing to A_offd, so all the data kept, just reorder them
+       * The create function takes comm, global num rows/cols,
+       *    row/col start, num cols offd, nnz diag, nnz offd
+       */
+      S_offd_nnz = hypre_CSRMatrixNumNonzeros(A_offd);
+      S_offd_ncols = hypre_CSRMatrixNumCols(A_offd);
+
+      matS = hypre_ParCSRMatrixCreate( comm,
+                                       total_rows,
+                                       total_rows,
+                                       col_starts,
+                                       col_starts,
+                                       S_offd_ncols,
+                                       S_diag_nnz,
+                                       S_offd_nnz);
+
+      /* first put diagonal data in */
+      hypre_CSRMatrixDestroy(hypre_ParCSRMatrixDiag(matS));
+      hypre_ParCSRMatrixDiag(matS) = SLU;
+
+      /* now start to construct offdiag of S */
+      S_offd = hypre_ParCSRMatrixOffd(matS);
+
+      S_offd_i = hypre_TAlloc(HYPRE_Int, m + 1, HYPRE_MEMORY_DEVICE);
+      S_offd_j = hypre_TAlloc(HYPRE_Int, S_offd_nnz, HYPRE_MEMORY_DEVICE);
+      S_offd_data = hypre_TAlloc(HYPRE_Real, S_offd_nnz, HYPRE_MEMORY_DEVICE);
+
+      HYPRE_Int * S_offd_i_host = hypre_TAlloc(HYPRE_Int, m + 1, HYPRE_MEMORY_HOST);
+      HYPRE_Int * S_offd_j_host = hypre_TAlloc(HYPRE_Int, S_offd_nnz, HYPRE_MEMORY_HOST);
+      HYPRE_Real * S_offd_data_host = hypre_TAlloc(HYPRE_Real, S_offd_nnz, HYPRE_MEMORY_HOST);
+
+      S_offd_colmap = hypre_CTAlloc(HYPRE_BigInt, S_offd_ncols, HYPRE_MEMORY_HOST);
+
+      HYPRE_Int * A_offd_i_host = hypre_TAlloc(HYPRE_Int, A_offd_n+1, HYPRE_MEMORY_HOST);
+      HYPRE_Int * A_offd_j_host = hypre_TAlloc(HYPRE_Int, A_offd_nnz, HYPRE_MEMORY_HOST);
+      HYPRE_Real * A_offd_data_host = hypre_TAlloc(HYPRE_Real, A_offd_nnz, HYPRE_MEMORY_HOST);
+
+      hypre_TMemcpy(A_offd_i_host, A_offd_i, HYPRE_Int, A_offd_n+1, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(A_offd_j_host, A_offd_j, HYPRE_Int, A_offd_nnz, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(A_offd_data_host, A_offd_data, HYPRE_Real, A_offd_nnz, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+
+      HYPRE_Int * perm_host = hypre_CTAlloc(HYPRE_Int, n, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(perm_host, perm, HYPRE_Int, n, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+
+      /* simply use a loop to copy data from A_offd */
+      S_offd_i_host[0] = 0;
+      k3 = 0;
+      for (i = 1; i <= e; i++)
+      {
+         S_offd_i_host[i] = k3;
+      }
+      for (i = 0; i < m_e; i++)
+      {
+         col = perm_host[i + nI];
+         k1 = A_offd_i_host[col];
+         k2 = A_offd_i_host[col + 1];
+         for (j = k1; j < k2; j++)
+         {
+            S_offd_j_host[k3] = A_offd_j_host[j];
+            S_offd_data_host[k3++] = A_offd_data_host[j];
+         }
+         S_offd_i_host[i + 1 + e] = k3;
+      }
+      hypre_TFree(perm_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(A_offd_i_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(A_offd_j_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(A_offd_data_host, HYPRE_MEMORY_HOST);
+
+      /* give I, J, DATA to S_offd */
+      hypre_TMemcpy(S_offd_i,     S_offd_i_host, HYPRE_Int, m+1, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(S_offd_j,     S_offd_j_host, HYPRE_Int, S_offd_nnz, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(S_offd_data,  S_offd_data_host, HYPRE_Real, S_offd_nnz, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TFree(S_offd_i_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(S_offd_j_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(S_offd_data_host, HYPRE_MEMORY_HOST);
+      hypre_CSRMatrixI(S_offd) = S_offd_i;
+      hypre_CSRMatrixJ(S_offd) = S_offd_j;
+      hypre_CSRMatrixData(S_offd) = S_offd_data;
+
+      /* now we need to update S_offd_colmap */
+      comm_pkg = hypre_ParCSRMatrixCommPkg(A);
+      /* setup comm_pkg if not yet built */
+      if (!comm_pkg)
+      {
+         hypre_MatvecCommPkgCreate(A);
+         comm_pkg = hypre_ParCSRMatrixCommPkg(A);
+      }
+      /* get total num of send */
+      num_sends = hypre_ParCSRCommPkgNumSends(comm_pkg);
+      begin = hypre_ParCSRCommPkgSendMapStart(comm_pkg, 0);
+      end = hypre_ParCSRCommPkgSendMapStart(comm_pkg, num_sends);
+      send_buf = hypre_TAlloc(HYPRE_BigInt, end - begin, HYPRE_MEMORY_HOST);
+
+      /* copy new index into send_buf */
+      HYPRE_Int * rperm_host = hypre_CTAlloc(HYPRE_Int, n, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(rperm_host, rperm, HYPRE_Int, n, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+      for (i = begin; i < end; i++)
+      {
+         send_buf[i - begin] = rperm_host[hypre_ParCSRCommPkgSendMapElmt(comm_pkg, i)] - nLU + col_starts[0];
+      }
+      hypre_TFree(rperm_host, HYPRE_MEMORY_HOST);
+
+      /* main communication */
+      comm_handle = hypre_ParCSRCommHandleCreate(21, comm_pkg, send_buf, S_offd_colmap);
+      hypre_ParCSRCommHandleDestroy(comm_handle);
+
+      /* setup index */
+      hypre_ParCSRMatrixColMapOffd(matS) = S_offd_colmap;
+
+      hypre_ILUSortOffdColmap(matS);
+
+      /* free */
+      hypre_TFree(send_buf, HYPRE_MEMORY_HOST);
+   }
+   else {
+       /** need to clean this up here potentially if its empty */
+       if (hypre_CSRMatrixNumRows(SLU)==0 && hypre_CSRMatrixNumNonzeros(SLU)==0) {
+           hypre_CSRMatrixDestroy( SLU );
+           SLU = NULL;
+       }
+   }
+
+   /* end of forming S */
+   *matSptr       = matS;
+   *matBLU_csrsvdata_ptr = matBLU_csrsvdata;
+   *matSLU_csrsvdata_ptr = matSLU_csrsvdata;
+   *A_fake_diag_ip = A_fake_diag_i;
+
+   /* Destroy the bridge after acrossing the river */
+   hypre_CSRMatrixDestroy(A_diag);
+   hypre_TFree(rperm, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(rqperm, HYPRE_MEMORY_DEVICE);
+
+
+#ifdef HYPRE_USING_CUDA
+   cudaEventRecord( stop, 0 );
+   cudaEventSynchronize( stop );
+   cudaEventElapsedTime( &time, start, stop );
+   printf("%s %s %d : time=%1.5g\n",__FILE__,__FUNCTION__,__LINE__,time/1000.);
+   cudaEventDestroy( start );
+   cudaEventDestroy( stop );
+#endif
+   return hypre_error_flag;
+}
+
+
+/*********************************************************************************/
+/*                   HYPRE_ILUSetupCusparseCSRILU0                               */
+/*********************************************************************************/
+
+HYPRE_Int HYPRE_ILUSetupDeviceCSRILU0(hypre_CSRMatrix *A)
+{
+#if defined(HYPRE_USING_CUSPARSE)
+    HYPRE_ILUSetupCusparseCSRILU0(A, CUSPARSE_SOLVE_POLICY_USE_LEVEL);
+#endif
+
+#if defined(HYPRE_USING_ROCSPARSE)
+    HYPRE_ILUSetupRocsparseCSRILU0(A, rocsparse_analysis_policy_reuse, rocsparse_solve_policy_auto);
+#endif
+   return hypre_error_flag;
+}
+
+#if defined(HYPRE_USING_CUSPARSE)
+
+/* Wrapper for ILU0 with cusparse on a matrix, csr sort was done in this function */
+HYPRE_Int
+HYPRE_ILUSetupCusparseCSRILU0(hypre_CSRMatrix *A,
+                              cusparseSolvePolicy_t ilu_solve_policy)
+{
+
+   /* data objects for A */
+   HYPRE_Int               n                    = hypre_CSRMatrixNumRows(A);
+   HYPRE_Int               m                    = hypre_CSRMatrixNumCols(A);
+
+   hypre_assert(n == m);
+
+   HYPRE_Real              *A_data              = hypre_CSRMatrixData(A);
+   HYPRE_Int               *A_i                 = hypre_CSRMatrixI(A);
+   HYPRE_Int               *A_j                 = hypre_CSRMatrixJ(A);
+   HYPRE_Int               nnz_A                = hypre_CSRMatrixNumNonzeros(A);
+
+   /* pointers to cusparse data */
+   csrilu02Info_t          matA_info            = NULL;
+
+   /* variables and working arrays used during the ilu */
+   HYPRE_Int               zero_pivot;
+   HYPRE_Int               matA_buffersize;
+   void                    *matA_buffer         = NULL;
+
+   cusparseHandle_t handle = hypre_HandleCusparseHandle(hypre_handle());
+   cusparseMatDescr_t descr = hypre_CSRMatrixGPUMatDescr(A);
+
+   /* 1. Sort columns inside each row first, we can't assume that's sorted */
+   hypre_SortCSRCusparse(n, m, nnz_A, descr, A_i, A_j, A_data);
+
+   /* 2. Create info for ilu setup and solve */
+   HYPRE_CUSPARSE_CALL(cusparseCreateCsrilu02Info(&matA_info));
+
+   /* 3. Get working array size */
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrilu02_bufferSize(handle, n, nnz_A, descr,
+														  A_data, A_i, A_j,
+														  matA_info, &matA_buffersize));
+
+   /* 4. Create working array, since they won't be visited by host, allocate on device */
+   matA_buffer                                  = hypre_MAlloc(matA_buffersize, HYPRE_MEMORY_DEVICE);
+
+   /* 5. Now perform the analysis */
+   /* 5-1. Analysis */
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrilu02_analysis(handle, n, nnz_A, descr,
+														A_data, A_i, A_j,
+														matA_info, ilu_solve_policy, matA_buffer));
+
+   /* 5-2. Check for zero pivot */
+   HYPRE_CUSPARSE_CALL(cusparseXcsrilu02_zeroPivot(handle, matA_info, &zero_pivot));
+
+   /* 6. Apply the factorization */
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrilu02(handle, n, nnz_A, descr,
+											   A_data, A_i, A_j,
+											   matA_info, ilu_solve_policy, matA_buffer));
+
+   /* Check for zero pivot */
+   HYPRE_CUSPARSE_CALL(cusparseXcsrilu02_zeroPivot(handle, matA_info, &zero_pivot));
+
+   /* Done with factorization, finishing up */
+   hypre_TFree(matA_buffer, HYPRE_MEMORY_DEVICE);
+   HYPRE_CUSPARSE_CALL(cusparseDestroyCsrilu02Info(matA_info));
+
+   return hypre_error_flag;
+}
+
+#endif
+
+#if defined(HYPRE_USING_ROCSPARSE)
+
+HYPRE_Int
+HYPRE_ILUSetupRocsparseCSRILU0(hypre_CSRMatrix *A, rocsparse_analysis_policy analysis_policy, rocsparse_solve_policy solve_policy)
+{
+   /* data objects for A */
+   HYPRE_Int               n                    = hypre_CSRMatrixNumRows(A);
+   HYPRE_Int               m                    = hypre_CSRMatrixNumCols(A);
+
+   hypre_assert(n == m);
+
+   HYPRE_Real              *A_data              = hypre_CSRMatrixData(A);
+   HYPRE_Int               *A_i                 = hypre_CSRMatrixI(A);
+   HYPRE_Int               *A_j                 = hypre_CSRMatrixJ(A);
+   HYPRE_Int               nnz_A                = hypre_CSRMatrixNumNonzeros(A);
+
+   /* pointers to cusparse data */
+   rocsparse_mat_info info;
+
+   /* variables and working arrays used during the ilu */
+   HYPRE_Int               zero_pivot;
+   size_t                  buffer_size;
+   void                    *buffer         = NULL;
+
+   rocsparse_handle handle = hypre_HandleCusparseHandle(hypre_handle());
+   rocsparse_mat_descr descr = hypre_CSRMatrixGPUMatDescr(A);
+
+   /* 1. Sort columns inside each row first, we can't assume that's sorted */
+   hypre_SortCSRRocsparse(n, m, nnz_A, descr, A_i, A_j, A_data);
+
+   /* 2. Create info for ilu setup and solve */
+   HYPRE_ROCSPARSE_CALL(rocsparse_create_mat_info(&info));
+
+   /* 3. Get working array size */
+   HYPRE_ROCSPARSE_CALL(hypre_rocsparse_csrilu0_buffer_size(handle, n, nnz_A, descr, A_data, A_i, A_j,
+															info, &buffer_size));
+
+   /* 4. Create working array, since they won't be visited by host, allocate on device */
+   buffer = hypre_MAlloc(buffer_size, HYPRE_MEMORY_DEVICE);
+
+   /* 5. Now perform the analysis */
+   /* 5-1. Analysis */
+   HYPRE_ROCSPARSE_CALL(hypre_rocsparse_csrilu0_analysis(handle,  n, nnz_A, descr, A_data, A_i, A_j,
+														 info, analysis_policy, solve_policy, buffer));
+
+   /* 5-2. Check for zero pivot */
+   HYPRE_ROCSPARSE_CALL(rocsparse_csrsv_zero_pivot(handle, descr, info, &zero_pivot));
+
+   /* 6. Apply the factorization */
+   HYPRE_ROCSPARSE_CALL(hypre_rocsparse_csrilu0(handle, n, nnz_A, descr, A_data, A_i, A_j,
+												info, solve_policy, buffer));
+
+   /* Check for zero pivot */
+   HYPRE_ROCSPARSE_CALL(rocsparse_csrsv_zero_pivot(handle, descr, info, &zero_pivot));
+
+   /* Done with factorization, finishing up */
+   hypre_TFree(buffer, HYPRE_MEMORY_DEVICE);
+   HYPRE_ROCSPARSE_CALL(rocsparse_destroy_mat_info(info));
+
+   return hypre_error_flag;
+
+}
+
+#endif
+
+
+
+
+/*********************************************************************************/
+/*                   HYPRE_ILUSetupCusparseCSRILU0SetupSolve                     */
+/*********************************************************************************/
+
+HYPRE_Int HYPRE_ILUSetupDeviceCSRILU0SetupSolve(hypre_CSRMatrix *A, hypre_GpuMatData * matL_des,
+                                                hypre_GpuMatData * matU_des, hypre_CsrsvData ** matLU_csrsvdata_ptr)
+{
+#if defined(HYPRE_USING_CUSPARSE)
+   HYPRE_ILUSetupCusparseCSRILU0SetupSolve(A, matL_des, matU_des, matLU_csrsvdata_ptr);
+#endif
+
+#if defined(HYPRE_USING_ROCSPARSE)
+   HYPRE_ILUSetupRocsparseCSRILU0SetupSolve(A, matL_des, matU_des, matLU_csrsvdata_ptr);
+#endif
+   return hypre_error_flag;
+}
+
+#endif
+
+#if defined(HYPRE_USING_CUSPARSE)
+
+/* Wrapper for ILU0 solve analysis phase with cusparse on a matrix */
+HYPRE_Int
+HYPRE_ILUSetupCusparseCSRILU0SetupSolve(hypre_CSRMatrix *A, hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                                        hypre_CsrsvData ** matLU_csrsvdata_ptr)
+{
+
+    if (!A)
+   {
+      /* return if A is NULL */
+      *matLU_csrsvdata_ptr    = NULL;
+      return hypre_error_flag;
+   }
+
+   /* data objects for A */
+   HYPRE_Int               n                    = hypre_CSRMatrixNumRows(A);
+   HYPRE_Int               m                    = hypre_CSRMatrixNumCols(A);
+
+   hypre_assert(n == m);
+
+   if (n == 0)
+   {
+      /* return if A is 0 by 0 */
+      *matLU_csrsvdata_ptr    = NULL;
+      return hypre_error_flag;
+   }
+
+   HYPRE_Real              *A_data              = hypre_CSRMatrixData(A);
+   HYPRE_Int               *A_i                 = hypre_CSRMatrixI(A);
+   HYPRE_Int               *A_j                 = hypre_CSRMatrixJ(A);
+   HYPRE_Int               nnz_A                = hypre_CSRMatrixNumNonzeros(A);
+
+   /* variables and working arrays used during the ilu */
+   HYPRE_Int               matL_buffersize;
+   HYPRE_Int               matU_buffersize;
+
+   cusparseHandle_t handle = hypre_HandleCusparseHandle(hypre_handle());
+
+   /************************************/
+   /* Create these data structures now */
+   if (*matLU_csrsvdata_ptr) {
+       hypre_CsrsvDataDestroy(*matLU_csrsvdata_ptr);
+   }
+   hypre_CsrsvData * matLU_csrsvdata           = hypre_CsrsvDataCreate();
+   cusparseSolvePolicy_t ilu_solve_policy      = hypre_CsrsvDataSolvePolicy(matLU_csrsvdata);
+   csrsv2Info_t matL_info = hypre_CsrsvDataInfoL(matLU_csrsvdata);
+   csrsv2Info_t matU_info = hypre_CsrsvDataInfoU(matLU_csrsvdata);
+   HYPRE_CUSPARSE_CALL(cusparseCreateCsrsv2Info(&matL_info));
+   HYPRE_CUSPARSE_CALL(cusparseCreateCsrsv2Info(&matU_info));
+   size_t solve_buffersize;
+   char * solve_buffer;
+
+   /* 2. Get working array size */
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, n, nnz_A,
+														hypre_GpuMatDataMatDescr(matL_des), A_data, A_i, A_j,
+														matL_info, &matL_buffersize));
+
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, n, nnz_A,
+														hypre_GpuMatDataMatDescr(matU_des), A_data, A_i, A_j,
+														matU_info, &matU_buffersize));
+
+   /* 3. Create working array, since they won't be visited by host, allocate on device */
+   solve_buffersize = hypre_max( matL_buffersize, matU_buffersize );
+   solve_buffer     = (char *)hypre_MAlloc(solve_buffersize, HYPRE_MEMORY_DEVICE);
+
+   /* 4. Now perform the analysis */
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_analysis(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													  n, nnz_A, hypre_GpuMatDataMatDescr(matL_des),
+													  A_data, A_i, A_j,
+													  matL_info, ilu_solve_policy, solve_buffer));
+
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_analysis(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													  n, nnz_A, hypre_GpuMatDataMatDescr(matU_des),
+													  A_data, A_i, A_j,
+													  matU_info, ilu_solve_policy, solve_buffer));
+
+   /* Done with analysis, finishing up */
+   /* Set return value */
+   hypre_CsrsvDataInfoL(matLU_csrsvdata) =  matL_info;
+   hypre_CsrsvDataInfoU(matLU_csrsvdata) =  matU_info;
+   hypre_CsrsvDataBufferSize(matLU_csrsvdata) = solve_buffersize;
+   hypre_CsrsvDataBuffer(matLU_csrsvdata) = solve_buffer;
+   *matLU_csrsvdata_ptr    = matLU_csrsvdata;
+   return hypre_error_flag;
+}
+
+#endif
+
+
+#if defined(HYPRE_USING_ROCSPARSE)
+
+HYPRE_Int
+HYPRE_ILUSetupRocsparseCSRILU0SetupSolve(hypre_CSRMatrix *A, hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                                         hypre_CsrsvData ** matLU_csrsvdata_ptr)
+{
+   if (!A)
+   {
+      /* return if A is NULL */
+      *matLU_csrsvdata_ptr    = NULL;
+      return hypre_error_flag;
+   }
+
+   /* data objects for A */
+   HYPRE_Int               n                    = hypre_CSRMatrixNumRows(A);
+   HYPRE_Int               m                    = hypre_CSRMatrixNumCols(A);
+
+   hypre_assert(n == m);
+
+   if (n == 0)
+   {
+      /* return if A is 0 by 0 */
+      *matLU_csrsvdata_ptr    = NULL;
+      return hypre_error_flag;
+   }
+
+   HYPRE_Real              *A_data              = hypre_CSRMatrixData(A);
+   HYPRE_Int               *A_i                 = hypre_CSRMatrixI(A);
+   HYPRE_Int               *A_j                 = hypre_CSRMatrixJ(A);
+   HYPRE_Int               nnz_A                = hypre_CSRMatrixNumNonzeros(A);
+
+   /* variables and working arrays used during the ilu */
+   size_t               matL_buffersize;
+   size_t               matU_buffersize;
+
+   rocsparse_handle handle = hypre_HandleCusparseHandle(hypre_handle());
+   /************************************/
+   /* Create these data structures now */
+   if (*matLU_csrsvdata_ptr) {
+       hypre_CsrsvDataDestroy(*matLU_csrsvdata_ptr);
+   }
+   hypre_CsrsvData * matLU_csrsvdata             = hypre_CsrsvDataCreate();
+   rocsparse_analysis_policy ilu_analysis_policy = hypre_CsrsvDataAnalysisPolicy(matLU_csrsvdata);
+   rocsparse_solve_policy ilu_solve_policy       = hypre_CsrsvDataSolvePolicy(matLU_csrsvdata);
+   rocsparse_mat_info matL_info = hypre_CsrsvDataInfoL(matLU_csrsvdata);
+   rocsparse_mat_info matU_info = hypre_CsrsvDataInfoU(matLU_csrsvdata);
+   HYPRE_ROCSPARSE_CALL( rocsparse_create_mat_info(&matL_info) );
+   HYPRE_ROCSPARSE_CALL( rocsparse_create_mat_info(&matU_info) );
+   size_t solve_buffersize;
+   char * solve_buffer;
+
+   /* 2. Get working array size */
+   HYPRE_ROCSPARSE_CALL(hypre_rocsparse_csrsv_buffer_size(handle, rocsparse_operation_none, n, nnz_A,
+														  hypre_GpuMatDataMatDescr(matL_des), A_data, A_i, A_j,
+														  matL_info, &matL_buffersize));
+
+   HYPRE_ROCSPARSE_CALL(hypre_rocsparse_csrsv_buffer_size(handle, rocsparse_operation_none, n, nnz_A,
+														  hypre_GpuMatDataMatDescr(matU_des), A_data, A_i, A_j,
+														  matU_info, &matU_buffersize));
+
+   /* 3. Create working array, since they won't be visited by host, allocate on device */
+   solve_buffersize = hypre_max( matL_buffersize, matU_buffersize );
+   solve_buffer     = (char *)hypre_MAlloc(solve_buffersize, HYPRE_MEMORY_DEVICE);
+
+   /* 4. Now perform the analysis */
+   HYPRE_ROCSPARSE_CALL( hypre_rocsparse_csrsv_analysis(handle, rocsparse_operation_none,
+														n, nnz_A, hypre_GpuMatDataMatDescr(matL_des),
+														A_data, A_i, A_j, matL_info,
+														ilu_analysis_policy, ilu_solve_policy, solve_buffer));
+
+   HYPRE_ROCSPARSE_CALL( hypre_rocsparse_csrsv_analysis(handle, rocsparse_operation_none,
+														n, nnz_A, hypre_GpuMatDataMatDescr(matU_des),
+														A_data, A_i, A_j, matU_info,
+														ilu_analysis_policy, ilu_solve_policy, solve_buffer));
+
+   /* Done with analysis, finishing up */
+   /* Set return value */
+   hypre_CsrsvDataInfoL(matLU_csrsvdata) =  matL_info;
+   hypre_CsrsvDataInfoU(matLU_csrsvdata) =  matU_info;
+   hypre_CsrsvDataBufferSize(matLU_csrsvdata) = solve_buffersize;
+   hypre_CsrsvDataBuffer(matLU_csrsvdata) = solve_buffer;
+   *matLU_csrsvdata_ptr    = matLU_csrsvdata;
+
+   return hypre_error_flag;
+}
+
+#endif
+
+
+
+
+
+
+/* Extract submatrix from diagonal part of A into a
+ * | B F |
+ * | E C |
+ * Struct in order to do ILU with cusparse.
+ * WARNING: Cusparse requires each row been sorted by column
+ *          This function only works when rows are sorted!.
+ * A = input matrix
+ * perm = permutation array indicating ordering of rows. Perm could come from a
+ *    CF_marker array or a reordering routine.
+ * qperm = permutation array indicating ordering of columns
+ * Bp = pointer to the output B matrix.
+ * Cp = pointer to the output C matrix.
+ * Ep = pointer to the output E matrix.
+ * Fp = pointer to the output F matrix.
+ */
+/*********************************************************************************/
+/*                   hypre_ParILUCusparseILUExtractEBFC                          */
+/*********************************************************************************/
+
+HYPRE_Int hypre_ParILUDeviceILUExtractEBFC(hypre_CSRMatrix *A_diag, HYPRE_Int nLU,
+                                           hypre_CSRMatrix **Bp, hypre_CSRMatrix **Cp, hypre_CSRMatrix **Ep, hypre_CSRMatrix **Fp)
+{
+   /* Get necessary slots */
+   HYPRE_Int            n              = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Int            nnz_A_diag     = hypre_CSRMatrixNumNonzeros(A_diag);
+
+#if (defined(HYPRE_USING_GPU) && defined(HYPRE_USING_UNIFIED_MEMORY)) || !defined(HYPRE_USING_GPU)
+   HYPRE_Int           *A_diag_i       = hypre_CSRMatrixI(A_diag);
+   HYPRE_Int           *A_diag_j       = hypre_CSRMatrixJ(A_diag);
+   HYPRE_Real          *A_diag_data    = hypre_CSRMatrixData(A_diag);
+#elif defined(HYPRE_USING_GPU)
+   /* move the data back to the host */
+   HYPRE_Int            *A_diag_i = hypre_CTAlloc(HYPRE_Int, n+1, HYPRE_MEMORY_HOST);
+   HYPRE_Int            *A_diag_j = hypre_CTAlloc(HYPRE_Int, nnz_A_diag, HYPRE_MEMORY_HOST);
+   HYPRE_Real            *A_diag_data = hypre_CTAlloc(HYPRE_Real, nnz_A_diag, HYPRE_MEMORY_HOST);
+   hypre_TMemcpy(A_diag_i,     hypre_CSRMatrixI(A_diag), HYPRE_Int, n+1, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+   hypre_TMemcpy(A_diag_j,     hypre_CSRMatrixJ(A_diag), HYPRE_Int, nnz_A_diag, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+   hypre_TMemcpy(A_diag_data,  hypre_CSRMatrixData(A_diag), HYPRE_Real, nnz_A_diag, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+#else
+#error "This can't happen!"
+#endif
+
+   HYPRE_Int            i, j, row, col;
+
+   hypre_assert(nLU >= 0 && nLU <= n);
+   if (nLU == n)
+   {
+      /* No schur complement makes everything easy :) */
+      hypre_CSRMatrix  *B              = NULL;
+      hypre_CSRMatrix  *C              = NULL;
+      hypre_CSRMatrix  *E              = NULL;
+      hypre_CSRMatrix  *F              = NULL;
+      B                                = hypre_CSRMatrixCreate(n, n, nnz_A_diag);
+      hypre_CSRMatrixInitialize(B);
+      hypre_CSRMatrixCopy(A_diag, B, 1);
+
+      /* What is the point of this ? PJM 4/8/2022 
+       Commenting out to avoid memory leaks. */
+      C                                = hypre_CSRMatrixCreate(0, 0, 0);
+      hypre_CSRMatrixInitialize(C);
+      E                                = hypre_CSRMatrixCreate(0, 0, 0);
+      hypre_CSRMatrixInitialize(E);
+      F                                = hypre_CSRMatrixCreate(0, 0, 0);
+      hypre_CSRMatrixInitialize(F);
+      *Bp = B;
+      *Cp = C;
+      *Ep = E;
+      *Fp = F;
+   }
+   else if (nLU == 0)
+   {
+      /* All schur complement also makes everything easy :) */
+      hypre_CSRMatrix  *B              = NULL;
+      hypre_CSRMatrix  *C              = NULL;
+      hypre_CSRMatrix  *E              = NULL;
+      hypre_CSRMatrix  *F              = NULL;
+      C                                = hypre_CSRMatrixCreate(n, n, nnz_A_diag);
+      hypre_CSRMatrixInitialize(C);
+      hypre_CSRMatrixCopy(A_diag, C, 1);
+      /* What is the point of this ? PJM 4/8/2022 
+       Commenting out to avoid memory leaks. */
+      B                                = hypre_CSRMatrixCreate(0, 0, 0);
+      hypre_CSRMatrixInitialize(B);
+      E                                = hypre_CSRMatrixCreate(0, 0, 0);
+      hypre_CSRMatrixInitialize(E);
+      F                                = hypre_CSRMatrixCreate(0, 0, 0);
+      hypre_CSRMatrixInitialize(F);
+      *Bp = B;
+      *Cp = C;
+      *Ep = E;
+      *Fp = F;
+   }
+   else
+   {
+      /* Has schur complement :( */
+      HYPRE_Int         m              = n - nLU;
+      hypre_CSRMatrix  *B              = NULL;
+      hypre_CSRMatrix  *C              = NULL;
+      hypre_CSRMatrix  *E              = NULL;
+      hypre_CSRMatrix  *F              = NULL;
+      HYPRE_Int         capacity_B;
+      HYPRE_Int         capacity_E;
+      HYPRE_Int         capacity_F;
+      HYPRE_Int         capacity_C;
+      HYPRE_Int         ctrB;
+      HYPRE_Int         ctrC;
+      HYPRE_Int         ctrE;
+      HYPRE_Int         ctrF;
+
+      HYPRE_Int        *B_i            = NULL;
+      HYPRE_Int        *C_i            = NULL;
+      HYPRE_Int        *E_i            = NULL;
+      HYPRE_Int        *F_i            = NULL;
+      HYPRE_Int        *B_j            = NULL;
+      HYPRE_Int        *C_j            = NULL;
+      HYPRE_Int        *E_j            = NULL;
+      HYPRE_Int        *F_j            = NULL;
+      HYPRE_Real       *B_data         = NULL;
+      HYPRE_Real       *C_data         = NULL;
+      HYPRE_Real       *E_data         = NULL;
+      HYPRE_Real       *F_data         = NULL;
+
+      /* Create CSRMatrices */
+      B                                = hypre_CSRMatrixCreate(nLU, nLU, 0);
+      hypre_CSRMatrixInitialize(B);
+      C                                = hypre_CSRMatrixCreate(m, m, 0);
+      hypre_CSRMatrixInitialize(C);
+      E                                = hypre_CSRMatrixCreate(m, nLU, 0);
+      hypre_CSRMatrixInitialize(E);
+      F                                = hypre_CSRMatrixCreate(nLU, m, 0);
+      hypre_CSRMatrixInitialize(F);
+
+      /* Estimate # of nonzeros */
+      capacity_B                       = nLU + ceil(nnz_A_diag * 1.0 * nLU / n * nLU / n);
+      capacity_C                       = m + ceil(nnz_A_diag * 1.0 * m / n * m / n);
+      capacity_E                       = hypre_min(m, nLU) + ceil(nnz_A_diag * 1.0 * nLU / n * m / n);
+      capacity_F                       = capacity_E;
+
+      /* Allocate memory */
+      ctrB                             = 0;
+      ctrC                             = 0;
+      ctrE                             = 0;
+      ctrF                             = 0;
+
+      /* Host arrays */
+      HYPRE_Int * B_i_host                         = hypre_CTAlloc(HYPRE_Int, hypre_CSRMatrixNumRows(B)+1, HYPRE_MEMORY_HOST);
+      HYPRE_Int * B_j_host                         = hypre_CTAlloc(HYPRE_Int, capacity_B, HYPRE_MEMORY_HOST);
+      HYPRE_Real *B_data_host                      = hypre_CTAlloc(HYPRE_Real, capacity_B, HYPRE_MEMORY_HOST);
+      HYPRE_Int * C_i_host                         = hypre_CTAlloc(HYPRE_Int, hypre_CSRMatrixNumRows(C)+1, HYPRE_MEMORY_HOST);
+      HYPRE_Int * C_j_host                         = hypre_CTAlloc(HYPRE_Int, capacity_C, HYPRE_MEMORY_HOST);
+      HYPRE_Real *C_data_host                      = hypre_CTAlloc(HYPRE_Real, capacity_C, HYPRE_MEMORY_HOST);
+      HYPRE_Int * E_i_host                         = hypre_CTAlloc(HYPRE_Int, hypre_CSRMatrixNumRows(E)+1, HYPRE_MEMORY_HOST);
+      HYPRE_Int * E_j_host                         = hypre_CTAlloc(HYPRE_Int, capacity_E, HYPRE_MEMORY_HOST);
+      HYPRE_Real *E_data_host                      = hypre_CTAlloc(HYPRE_Real, capacity_E, HYPRE_MEMORY_HOST);
+      HYPRE_Int * F_i_host                         = hypre_CTAlloc(HYPRE_Int, hypre_CSRMatrixNumRows(F)+1, HYPRE_MEMORY_HOST);
+      HYPRE_Int * F_j_host                         = hypre_CTAlloc(HYPRE_Int, capacity_F, HYPRE_MEMORY_HOST);
+      HYPRE_Real * F_data_host                     = hypre_CTAlloc(HYPRE_Real, capacity_F, HYPRE_MEMORY_HOST);
+
+      /* Loop to copy data */
+      /* B and F first */
+      for (i = 0; i < nLU; i++)
+      {
+         B_i_host[i]   = ctrB;
+         F_i_host[i]   = ctrF;
+         for (j = A_diag_i[i]; j < A_diag_i[i + 1]; j++)
+         {
+            col = A_diag_j[j];
+            if (col >= nLU)
+            {
+               break;
+            }
+            B_j_host[ctrB] = col;
+            B_data_host[ctrB++] = A_diag_data[j];
+            /* check capacity */
+            if (ctrB >= capacity_B)
+            {
+               HYPRE_Int tmp;
+               tmp = capacity_B;
+               capacity_B = capacity_B * EXPAND_FACT + 1;
+               B_j_host = hypre_TReAlloc_v2(B_j_host, HYPRE_Int, tmp, HYPRE_Int, capacity_B, HYPRE_MEMORY_HOST);
+               B_data_host = hypre_TReAlloc_v2(B_data_host, HYPRE_Real, tmp, HYPRE_Real, capacity_B, HYPRE_MEMORY_HOST);
+            }
+         }
+         for (; j < A_diag_i[i + 1]; j++)
+         {
+            col = A_diag_j[j];
+            col = col - nLU;
+            F_j_host[ctrF] = col;
+            F_data_host[ctrF++] = A_diag_data[j];
+            if (ctrF >= capacity_F)
+            {
+               HYPRE_Int tmp;
+               tmp = capacity_F;
+               capacity_F = capacity_F * EXPAND_FACT + 1;
+               F_j_host = hypre_TReAlloc_v2(F_j_host, HYPRE_Int, tmp, HYPRE_Int, capacity_F, HYPRE_MEMORY_HOST);
+               F_data_host = hypre_TReAlloc_v2(F_data_host, HYPRE_Real, tmp, HYPRE_Real, capacity_F, HYPRE_MEMORY_HOST);
+            }
+         }
+      }
+      B_i_host[nLU] = ctrB;
+      F_i_host[nLU] = ctrF;
+
+      /* E and C afterward */
+      for (i = nLU; i < n; i++)
+      {
+         row = i - nLU;
+         E_i_host[row] = ctrE;
+         C_i_host[row] = ctrC;
+         for (j = A_diag_i[i]; j < A_diag_i[i + 1]; j++)
+         {
+            col = A_diag_j[j];
+            if (col >= nLU)
+            {
+               break;
+            }
+            E_j_host[ctrE] = col;
+            E_data_host[ctrE++] = A_diag_data[j];
+            /* check capacity */
+            if (ctrE >= capacity_E)
+            {
+               HYPRE_Int tmp;
+               tmp = capacity_E;
+               capacity_E = capacity_E * EXPAND_FACT + 1;
+               E_j_host = hypre_TReAlloc_v2(E_j_host, HYPRE_Int, tmp, HYPRE_Int, capacity_E, HYPRE_MEMORY_HOST);
+               E_data_host = hypre_TReAlloc_v2(E_data_host, HYPRE_Real, tmp, HYPRE_Real, capacity_E, HYPRE_MEMORY_HOST);
+            }
+         }
+         for (; j < A_diag_i[i + 1]; j++)
+         {
+            col = A_diag_j[j];
+            col = col - nLU;
+            C_j_host[ctrC] = col;
+            C_data_host[ctrC++] = A_diag_data[j];
+            if (ctrC >= capacity_C)
+            {
+               HYPRE_Int tmp;
+               tmp = capacity_C;
+               capacity_C = capacity_C * EXPAND_FACT + 1;
+               C_j_host = hypre_TReAlloc_v2(C_j_host, HYPRE_Int, tmp, HYPRE_Int, capacity_C, HYPRE_MEMORY_HOST);
+               C_data_host = hypre_TReAlloc_v2(C_data_host, HYPRE_Real, tmp, HYPRE_Real, capacity_C, HYPRE_MEMORY_HOST);
+            }
+         }
+      }
+      E_i_host[m] = ctrE;
+      C_i_host[m] = ctrC;
+
+      hypre_assert((ctrB + ctrC + ctrE + ctrF) == nnz_A_diag);
+
+      B_i                              = hypre_CSRMatrixI(B);
+      B_j                              = hypre_CTAlloc(HYPRE_Int, ctrB, HYPRE_MEMORY_DEVICE);
+      B_data                           = hypre_CTAlloc(HYPRE_Real, ctrB, HYPRE_MEMORY_DEVICE);
+      C_i                              = hypre_CSRMatrixI(C);
+      C_j                              = hypre_CTAlloc(HYPRE_Int, ctrC, HYPRE_MEMORY_DEVICE);
+      C_data                           = hypre_CTAlloc(HYPRE_Real, ctrC, HYPRE_MEMORY_DEVICE);
+      E_i                              = hypre_CSRMatrixI(E);
+      E_j                              = hypre_CTAlloc(HYPRE_Int, ctrE, HYPRE_MEMORY_DEVICE);
+      E_data                           = hypre_CTAlloc(HYPRE_Real, ctrE, HYPRE_MEMORY_DEVICE);
+      F_i                              = hypre_CSRMatrixI(F);
+      F_j                              = hypre_CTAlloc(HYPRE_Int, ctrF, HYPRE_MEMORY_DEVICE);
+      F_data                           = hypre_CTAlloc(HYPRE_Real, ctrF, HYPRE_MEMORY_DEVICE);
+
+      hypre_TMemcpy(B_i, B_i_host, HYPRE_Int, hypre_CSRMatrixNumRows(B)+1, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(B_j, B_j_host, HYPRE_Int, ctrB, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(B_data, B_data_host, HYPRE_Real, ctrB, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+
+      hypre_TMemcpy(C_i, C_i_host, HYPRE_Int, hypre_CSRMatrixNumRows(C)+1, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(C_j, C_j_host, HYPRE_Int, ctrC, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(C_data, C_data_host, HYPRE_Real, ctrC, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+
+      hypre_TMemcpy(E_i, E_i_host, HYPRE_Int, hypre_CSRMatrixNumRows(E)+1, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(E_j, E_j_host, HYPRE_Int, ctrE, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(E_data, E_data_host, HYPRE_Real, ctrE, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+
+      hypre_TMemcpy(F_i, F_i_host, HYPRE_Int, hypre_CSRMatrixNumRows(F)+1, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(F_j, F_j_host, HYPRE_Int, ctrF, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(F_data, F_data_host, HYPRE_Real, ctrF, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+
+      /* Create CSRMatrices */
+      hypre_CSRMatrixJ(B)              = B_j;
+      hypre_CSRMatrixData(B)           = B_data;
+      hypre_CSRMatrixNumNonzeros(B)    = ctrB;
+      hypre_CSRMatrixSetDataOwner(B, 1);
+      *Bp                              = B;
+
+      hypre_CSRMatrixJ(C)              = C_j;
+      hypre_CSRMatrixData(C)           = C_data;
+      hypre_CSRMatrixNumNonzeros(C)    = ctrC;
+      hypre_CSRMatrixSetDataOwner(C, 1);
+      *Cp                              = C;
+
+      hypre_CSRMatrixJ(E)              = E_j;
+      hypre_CSRMatrixData(E)           = E_data;
+      hypre_CSRMatrixNumNonzeros(E)    = ctrE;
+      hypre_CSRMatrixSetDataOwner(E, 1);
+      *Ep                              = E;
+
+      hypre_CSRMatrixJ(F)              = F_j;
+      hypre_CSRMatrixData(F)           = F_data;
+      hypre_CSRMatrixNumNonzeros(F)    = ctrF;
+      hypre_CSRMatrixSetDataOwner(F, 1);
+      *Fp                              = F;
+
+      hypre_TFree(B_i_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(B_j_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(B_data_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(C_i_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(C_j_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(C_data_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(E_i_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(E_j_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(E_data_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(F_i_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(F_j_host, HYPRE_MEMORY_HOST);
+      hypre_TFree(F_data_host, HYPRE_MEMORY_HOST);
+   }
+
+#if defined(HYPRE_USING_GPU) && !defined(HYPRE_USING_UNIFIED_MEMORY)
+   hypre_TFree(A_diag_i, HYPRE_MEMORY_HOST);
+   hypre_TFree(A_diag_j, HYPRE_MEMORY_HOST);
+   hypre_TFree(A_diag_data, HYPRE_MEMORY_HOST);
+#endif
+   return hypre_error_flag;
+}

--- a/src/parcsr_ls/par_ilu_solve_device.c
+++ b/src/parcsr_ls/par_ilu_solve_device.c
@@ -10,6 +10,198 @@
 #include "seq_mv.hpp"
 
 /*********************************************************************************/
+/*                   hypre_ILUSolveDeviceLU                                      */
+/*********************************************************************************/
+/* Incomplete LU solve (GPU)
+ * L, D and U factors only have local scope (no off-diagonal processor terms)
+ * so apart from the residual calculation (which uses A), the solves with the
+ * L and U factors are local.
+*/
+
+HYPRE_Int
+hypre_ILUSolveDeviceLU(hypre_ParCSRMatrix *A, hypre_GpuMatData * matL_des,
+                       hypre_GpuMatData * matU_des, hypre_CsrsvData * matLU_csrsvdata,
+                       hypre_CSRMatrix *matLU_d, hypre_ParVector *f,  hypre_ParVector *u, HYPRE_Int *perm,
+                       HYPRE_Int n, hypre_ParVector *ftemp, hypre_ParVector *utemp)
+{
+#if defined(HYPRE_USING_CUSPARSE)
+   hypre_ILUSolveCusparseLU(A, matL_des, matU_des, matLU_csrsvdata,
+                            matLU_d, f,  u, perm, n, ftemp, utemp);
+#endif
+
+#if defined(HYPRE_USING_ROCSPARSE)
+   hypre_ILUSolveRocsparseLU(A, matL_des, matU_des, matLU_csrsvdata,
+                             matLU_d, f,  u, perm, n, ftemp, utemp);
+#endif
+   return hypre_error_flag;
+}
+
+#if defined(HYPRE_USING_CUSPARSE)
+
+/* Incomplete LU solve (GPU)
+ * L, D and U factors only have local scope (no off-diagonal processor terms)
+ * so apart from the residual calculation (which uses A), the solves with the
+ * L and U factors are local.
+*/
+
+HYPRE_Int
+hypre_ILUSolveCusparseLU(hypre_ParCSRMatrix *A, hypre_GpuMatData * matL_des,
+                         hypre_GpuMatData * matU_des, hypre_CsrsvData * matLU_csrsvdata,
+                         hypre_CSRMatrix *matLU_d,
+                         hypre_ParVector *f,  hypre_ParVector *u, HYPRE_Int *perm,
+                         HYPRE_Int n, hypre_ParVector *ftemp, hypre_ParVector *utemp)
+{
+   /* Only solve when we have stuffs to be solved */
+   if (n == 0)
+   {
+      return hypre_error_flag;
+   }
+
+   MPI_Comm             comm = hypre_ParCSRMatrixComm(A);
+   HYPRE_Int my_id;
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+   /* ILU data */
+   HYPRE_Real              *LU_data             = hypre_CSRMatrixData(matLU_d);
+   HYPRE_Int               *LU_i                = hypre_CSRMatrixI(matLU_d);
+   HYPRE_Int               *LU_j                = hypre_CSRMatrixJ(matLU_d);
+   HYPRE_Int               nnz                  = hypre_CSRMatrixNumNonzeros(matLU_d);
+
+   hypre_Vector            *utemp_local         = hypre_ParVectorLocalVector(utemp);
+   HYPRE_Real              *utemp_data          = hypre_VectorData(utemp_local);
+
+   hypre_Vector            *ftemp_local         = hypre_ParVectorLocalVector(ftemp);
+   HYPRE_Real              *ftemp_data          = hypre_VectorData(ftemp_local);
+
+   HYPRE_Real              alpha;
+   HYPRE_Real              beta;
+   //HYPRE_Int               i, j, k1, k2;
+
+   /* begin */
+   alpha = -1.0;
+   beta = 1.0;
+
+   cusparseHandle_t handle = hypre_HandleCusparseHandle(hypre_handle());
+
+   /* Initialize Utemp to zero.
+    * This is necessary for correctness, when we use optimized
+    * vector operations in the case where sizeof(L, D or U) < sizeof(A)
+   */
+   //hypre_ParVectorSetConstantValues( utemp, 0.);
+   /* compute residual */
+   hypre_ParCSRMatrixMatvecOutOfPlace(alpha, A, u, beta, f, ftemp);
+
+   /* apply permutation */
+   HYPRE_THRUST_CALL(gather, perm, perm + n, ftemp_data, utemp_data);
+
+   /* L solve - Forward solve */
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_solve(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+												   n, nnz, &beta, hypre_GpuMatDataMatDescr(matL_des),
+												   LU_data, LU_i, LU_j, hypre_CsrsvDataInfoL(matLU_csrsvdata),
+												   utemp_data, ftemp_data,
+												   hypre_CsrsvDataSolvePolicy(matLU_csrsvdata),
+												   hypre_CsrsvDataBuffer(matLU_csrsvdata) ));
+
+   /* U solve - Backward substitution */
+   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_solve(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+												   n, nnz, &beta, hypre_GpuMatDataMatDescr(matU_des),
+												   LU_data, LU_i, LU_j, hypre_CsrsvDataInfoU(matLU_csrsvdata),
+												   ftemp_data, utemp_data,
+												   hypre_CsrsvDataSolvePolicy(matLU_csrsvdata),
+												   hypre_CsrsvDataBuffer(matLU_csrsvdata) ));
+
+   /* apply reverse permutation */
+   HYPRE_THRUST_CALL(scatter, utemp_data, utemp_data + n, perm, ftemp_data);
+   /* Update solution */
+   hypre_ParVectorAxpy(beta, ftemp, u);
+
+
+   return hypre_error_flag;
+}
+
+#endif
+
+#if defined(HYPRE_USING_ROCSPARSE)
+
+HYPRE_Int
+hypre_ILUSolveRocsparseLU(hypre_ParCSRMatrix *A, hypre_GpuMatData * matL_des,
+                          hypre_GpuMatData * matU_des, hypre_CsrsvData * matLU_csrsvdata,
+                          hypre_CSRMatrix *matLU_d,
+                          hypre_ParVector *f,  hypre_ParVector *u, HYPRE_Int *perm,
+                          HYPRE_Int n, hypre_ParVector *ftemp, hypre_ParVector *utemp)
+{
+   /* Only solve when we have stuffs to be solved */
+   if (n == 0)
+   {
+      return hypre_error_flag;
+   }
+
+   MPI_Comm             comm = hypre_ParCSRMatrixComm(A);
+   HYPRE_Int my_id;
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+   /* ILU data */
+   HYPRE_Real              *LU_data             = hypre_CSRMatrixData(matLU_d);
+   HYPRE_Int               *LU_i                = hypre_CSRMatrixI(matLU_d);
+   HYPRE_Int               *LU_j                = hypre_CSRMatrixJ(matLU_d);
+   HYPRE_Int               nnz                  = hypre_CSRMatrixNumNonzeros(matLU_d);
+
+   hypre_Vector            *utemp_local         = hypre_ParVectorLocalVector(utemp);
+   HYPRE_Real              *utemp_data          = hypre_VectorData(utemp_local);
+
+   hypre_Vector            *ftemp_local         = hypre_ParVectorLocalVector(ftemp);
+   HYPRE_Real              *ftemp_data          = hypre_VectorData(ftemp_local);
+
+   HYPRE_Real              alpha;
+   HYPRE_Real              beta;
+   //HYPRE_Int               i, j, k1, k2;
+
+   /* begin */
+   alpha = -1.0;
+   beta = 1.0;
+
+   rocsparse_handle handle = hypre_HandleCusparseHandle(hypre_handle());
+
+   /* Initialize Utemp to zero.
+    * This is necessary for correctness, when we use optimized
+    * vector operations in the case where sizeof(L, D or U) < sizeof(A)
+   */
+   //hypre_ParVectorSetConstantValues( utemp, 0.);
+   /* compute residual */
+   hypre_ParCSRMatrixMatvecOutOfPlace(alpha, A, u, beta, f, ftemp);
+
+   /* apply permutation */
+   HYPRE_THRUST_CALL(gather, perm, perm + n, ftemp_data, utemp_data);
+
+   /* L solve - Forward solve */
+   HYPRE_ROCSPARSE_CALL( hypre_rocsparse_csrsv_solve(handle, rocsparse_operation_none, n, nnz,
+													 &beta, hypre_GpuMatDataMatDescr(matL_des),
+													 LU_data, LU_i, LU_j, hypre_CsrsvDataInfoL(matLU_csrsvdata),
+													 utemp_data, ftemp_data,
+													 hypre_CsrsvDataSolvePolicy(matLU_csrsvdata),
+													 hypre_CsrsvDataBuffer(matLU_csrsvdata) ));
+
+   /* U solve - Backward substitution */
+   HYPRE_ROCSPARSE_CALL( hypre_rocsparse_csrsv_solve(handle, rocsparse_operation_none, n, nnz,
+													 &beta, hypre_GpuMatDataMatDescr(matU_des),
+													 LU_data, LU_i, LU_j, hypre_CsrsvDataInfoU(matLU_csrsvdata),
+													 ftemp_data, utemp_data,
+													 hypre_CsrsvDataSolvePolicy(matLU_csrsvdata),
+													 hypre_CsrsvDataBuffer(matLU_csrsvdata) ));
+
+   /* apply reverse permutation */
+   HYPRE_THRUST_CALL(scatter, utemp_data, utemp_data + n, perm, ftemp_data);
+   /* Update solution */
+   hypre_ParVectorAxpy(beta, ftemp, u);
+
+
+   return hypre_error_flag;
+}
+
+#endif
+
+
+/*********************************************************************************/
 /*                   hypre_ILUSolveDeviceLUIter                                  */
 /*********************************************************************************/
 /* Incomplete LU solve (GPU) using Jacobi iterative approach
@@ -18,7 +210,7 @@
  * L and U factors are local.
 */
 
-#if defined(HYPRE_USING_CUDA) && defined(HYPRE_USING_CUSPARSE)
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
 
 HYPRE_Int
 hypre_ILUSolveLJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_Vector *work_local,
@@ -50,6 +242,7 @@ hypre_ILUSolveLJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_V
 
    return hypre_error_flag;
 }
+
 HYPRE_Int
 hypre_ILUSolveUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_Vector *work_local,
                           hypre_Vector *output_local, hypre_Vector *diag_diag, HYPRE_Int upper_jacobi_iters)
@@ -69,14 +262,13 @@ hypre_ILUSolveUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_V
    hypreDevice_zeqxmydd(num_rows, input_data, 0.0, work_data, output_data, diag_diag_data);
 
    /* Do the remaining iterations */
-   for ( kk = 1; kk < upper_jacobi_iters; ++kk )
-   {
+   for( kk = 1; kk < upper_jacobi_iters; ++kk ) {
 
-      /* apply SpMV */
-      hypre_CSRMatrixSpMVDevice(0, 1.0, A, output_local, 0.0, work_local, 2);
+       /* apply SpMV */
+       hypre_CSRMatrixSpMVDevice(0, 1.0, A, output_local, 0.0, work_local, 2);
 
-      /* transform */
-      hypreDevice_zeqxmydd(num_rows, input_data, -1.0, work_data, output_data, diag_diag_data);
+       /* transform */
+       hypreDevice_zeqxmydd(num_rows, input_data, -1.0, work_data, output_data, diag_diag_data);
    }
 
    return hypre_error_flag;
@@ -167,5 +359,4 @@ hypre_ILUSolveDeviceLUIter(hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d,
 
    return hypre_error_flag;
 }
-
 #endif

--- a/src/parcsr_ls/par_ilu_solve_schur_gmres_device.c
+++ b/src/parcsr_ls/par_ilu_solve_schur_gmres_device.c
@@ -1,0 +1,973 @@
+/******************************************************************************
+ * Copyright 1998-2019 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+#include "_hypre_parcsr_ls.h"
+#include "_hypre_utilities.hpp"
+#include "par_ilu.h"
+#include "seq_mv.hpp"
+
+/*--------------------------------------------------------------------------
+ * hypre_ParILUDeviceSchurGMRESMatvec
+ *--------------------------------------------------------------------------*/
+
+   /* Slightly different, for this new matvec, the diagonal of the original matrix
+    * is the LU factorization. Thus, the matvec is done in an different way
+    * |IS_1 E_12 E_13|
+    * |E_21 IS_2 E_23| = S
+    * |E_31 E_32 IS_3|
+    *
+    * |IS_1          |
+    * |     IS_2     | = M
+    * |          IS_3|
+    *
+    * Solve Sy = g is just M^{-1}S = M^{-1}g
+    *
+    * |      I       IS_1^{-1}E_12 IS_1^{-1}E_13|
+    * |IS_2^{-1}E_21       I       IS_2^{-1}E_23| = M^{-1}S
+    * |IS_3^{-1}E_31 IS_3^{-1}E_32       I      |
+    *
+    * */
+
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
+
+HYPRE_Int
+hypre_ParILUDeviceSchurGMRESMatvec( void   *matvec_data,
+                                      HYPRE_Complex  alpha,
+                                      void   *ilu_vdata,
+                                      void   *x,
+                                      HYPRE_Complex  beta,
+                                      void   *y           )
+{
+#if defined(HYPRE_USING_CUSPARSE)
+   hypre_ParILUCusparseSchurGMRESMatvec(matvec_data, alpha, ilu_vdata, x, beta, y);
+#endif
+
+#if defined(HYPRE_USING_ROCSPARSE)
+   hypre_ParILURocsparseSchurGMRESMatvec(matvec_data, alpha, ilu_vdata, x, beta, y);
+#endif
+
+   return hypre_error_flag;
+}
+
+#endif
+
+
+#if defined(HYPRE_USING_CUSPARSE)
+
+HYPRE_Int
+hypre_ParILUCusparseSchurGMRESMatvec( void   *matvec_data,
+                                      HYPRE_Complex  alpha,
+                                      void   *ilu_vdata,
+                                      void   *x,
+                                      HYPRE_Complex  beta,
+                                      void   *y           )
+{
+   /* get matrix information first */
+   hypre_ParILUData *ilu_data                   = (hypre_ParILUData*) ilu_vdata;
+   hypre_ParCSRMatrix *A                        = hypre_ParILUDataMatS(ilu_data);
+
+   /* fist step, apply matvec on empty diagonal slot */
+   hypre_CSRMatrix   *A_diag                    = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Int         *A_diag_i                  = hypre_CSRMatrixI(A_diag);
+   HYPRE_Int         *A_diag_j                  = hypre_CSRMatrixJ(A_diag);
+   HYPRE_Real        *A_diag_data               = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int         A_diag_n                   = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Int         A_diag_nnz                 = hypre_CSRMatrixNumNonzeros(A_diag);
+   HYPRE_Int         *A_diag_fake_i             = hypre_ParILUDataMatAFakeDiagonal(ilu_data);
+
+   hypre_ParVector         *xtemp               = hypre_ParILUDataXTemp(ilu_data);
+   hypre_Vector            *xtemp_local         = hypre_ParVectorLocalVector(xtemp);
+   HYPRE_Real              *xtemp_data          = hypre_VectorData(xtemp_local);
+   hypre_ParVector         *ytemp               = hypre_ParILUDataYTemp(ilu_data);
+   hypre_Vector            *ytemp_local         = hypre_ParVectorLocalVector(ytemp);
+   HYPRE_Real              *ytemp_data          = hypre_VectorData(ytemp_local);
+   HYPRE_Real              zero                 = 0.0;
+   HYPRE_Real              one                  = 1.0;
+
+   cusparseHandle_t handle = hypre_HandleCusparseHandle(hypre_handle());
+
+   /* Matvec with
+    *         |  O  E_12 E_13|
+    * alpha * |E_21   O  E_23|
+    *         |E_31 E_32   O |
+    * store in xtemp
+    */
+   /* more recent versions of cusparse require zeroing of the matrix meta data nrow/nnz, in order to fake a zero diagonal
+      PJM 4/8/2022 */
+   hypre_CSRMatrixI(A_diag)                     = A_diag_fake_i;
+   HYPRE_Int t1 = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Int t2 = hypre_CSRMatrixNumNonzeros(A_diag);
+   hypre_CSRMatrixNumRows(A_diag) = 0;
+   hypre_CSRMatrixNumNonzeros(A_diag) = 0;
+
+   hypre_ParCSRMatrixMatvec( alpha, (hypre_ParCSRMatrix *) A, (hypre_ParVector *) x, zero, xtemp );
+
+   hypre_CSRMatrixNumRows(A_diag) = t1;
+   hypre_CSRMatrixNumNonzeros(A_diag) = t2;
+   hypre_CSRMatrixI(A_diag)                     = A_diag_i;
+
+   /* Compute U^{-1}*L^{-1}*(A_offd * x)
+    * Or in another word, matvec with
+    *         |      O       IS_1^{-1}E_12 IS_1^{-1}E_13|
+    * alpha * |IS_2^{-1}E_21       O       IS_2^{-1}E_23|
+    *         |IS_3^{-1}E_31 IS_3^{-1}E_32       O      |
+    * store in xtemp
+    */
+   if ( A_diag_n > 0 )
+   {
+	   /* L solve - Forward solve */
+	   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_solve(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													   A_diag_n, A_diag_nnz, &one,
+													   hypre_GpuMatDataMatDescr(hypre_ParILUDataMatLMatData(ilu_data)),
+													   A_diag_data, A_diag_i, A_diag_j,
+													   hypre_CsrsvDataInfoL(hypre_ParILUDataMatSLUCsrsvData(ilu_data)),
+													   xtemp_data, ytemp_data,
+													   hypre_CsrsvDataSolvePolicy(hypre_ParILUDataMatSLUCsrsvData(ilu_data)),
+													   hypre_CsrsvDataBuffer(hypre_ParILUDataMatSLUCsrsvData(ilu_data))));
+
+	   /* U solve - Backward substitution */
+	   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_solve(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													   A_diag_n, A_diag_nnz, &one,
+													   hypre_GpuMatDataMatDescr(hypre_ParILUDataMatUMatData(ilu_data)),
+													   A_diag_data, A_diag_i, A_diag_j,
+													   hypre_CsrsvDataInfoU(hypre_ParILUDataMatSLUCsrsvData(ilu_data)),
+													   ytemp_data, xtemp_data,
+													   hypre_CsrsvDataSolvePolicy(hypre_ParILUDataMatSLUCsrsvData(ilu_data)),
+													   hypre_CsrsvDataBuffer(hypre_ParILUDataMatSLUCsrsvData(ilu_data))));
+   }
+
+   /* now add the original x onto it */
+   hypre_ParVectorAxpy( alpha, (hypre_ParVector *) x, (hypre_ParVector *) xtemp);
+
+   /* finall, add that into y and get final result */
+   hypre_ParVectorScale( beta, (hypre_ParVector *) y );
+   hypre_ParVectorAxpy( one, xtemp, (hypre_ParVector *) y);
+
+   return hypre_error_flag;
+}
+
+#endif
+
+#if defined(HYPRE_USING_ROCSPARSE)
+
+HYPRE_Int
+hypre_ParILURocsparseSchurGMRESMatvec( void   *matvec_data,
+                                      HYPRE_Complex  alpha,
+                                      void   *ilu_vdata,
+                                      void   *x,
+                                      HYPRE_Complex  beta,
+                                      void   *y           )
+{
+   /* get matrix information first */
+   hypre_ParILUData *ilu_data                   = (hypre_ParILUData*) ilu_vdata;
+   hypre_ParCSRMatrix *A                        = hypre_ParILUDataMatS(ilu_data);
+
+   /* fist step, apply matvec on empty diagonal slot */
+   hypre_CSRMatrix   *A_diag                    = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Int         *A_diag_i                  = hypre_CSRMatrixI(A_diag);
+   HYPRE_Int         *A_diag_j                  = hypre_CSRMatrixJ(A_diag);
+   HYPRE_Real        *A_diag_data               = hypre_CSRMatrixData(A_diag);
+   HYPRE_Int         A_diag_n                   = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Int         A_diag_nnz                 = hypre_CSRMatrixNumNonzeros(A_diag);
+   HYPRE_Int         *A_diag_fake_i             = hypre_ParILUDataMatAFakeDiagonal(ilu_data);
+
+   hypre_ParVector         *xtemp               = hypre_ParILUDataXTemp(ilu_data);
+   hypre_Vector            *xtemp_local         = hypre_ParVectorLocalVector(xtemp);
+   HYPRE_Real              *xtemp_data          = hypre_VectorData(xtemp_local);
+   hypre_ParVector         *ytemp               = hypre_ParILUDataYTemp(ilu_data);
+   hypre_Vector            *ytemp_local         = hypre_ParVectorLocalVector(ytemp);
+   HYPRE_Real              *ytemp_data          = hypre_VectorData(ytemp_local);
+   HYPRE_Real              zero                 = 0.0;
+   HYPRE_Real              one                  = 1.0;
+
+   rocsparse_handle handle = hypre_HandleCusparseHandle(hypre_handle());
+
+   /* Matvec with
+    *         |  O  E_12 E_13|
+    * alpha * |E_21   O  E_23|
+    *         |E_31 E_32   O |
+    * store in xtemp
+    */
+   /* more recent versions of cusparse require zeroing of the matrix meta data nrow/nnz, in order to fake a zero diagonal
+      PJM 4/8/2022 */
+   hypre_CSRMatrixI(A_diag)                     = A_diag_fake_i;
+   HYPRE_Int t1 = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Int t2 = hypre_CSRMatrixNumNonzeros(A_diag);
+   hypre_CSRMatrixNumRows(A_diag) = 0;
+   hypre_CSRMatrixNumNonzeros(A_diag) = 0;
+
+   hypre_ParCSRMatrixMatvec( alpha, (hypre_ParCSRMatrix *) A, (hypre_ParVector *) x, zero, xtemp );
+
+   hypre_CSRMatrixNumRows(A_diag) = t1;
+   hypre_CSRMatrixNumNonzeros(A_diag) = t2;
+   hypre_CSRMatrixI(A_diag)                     = A_diag_i;
+
+   /* Compute U^{-1}*L^{-1}*(A_offd * x)
+    * Or in another word, matvec with
+    *         |      O       IS_1^{-1}E_12 IS_1^{-1}E_13|
+    * alpha * |IS_2^{-1}E_21       O       IS_2^{-1}E_23|
+    *         |IS_3^{-1}E_31 IS_3^{-1}E_32       O      |
+    * store in xtemp
+    */
+   if ( A_diag_n > 0 )
+   {
+	   /* L solve - Forward solve */
+	   HYPRE_ROCSPARSE_CALL( hypre_rocsparse_csrsv_solve(handle, rocsparse_operation_none,
+														 A_diag_n, A_diag_nnz, &one,
+														 hypre_GpuMatDataMatDescr(hypre_ParILUDataMatLMatData(ilu_data)),
+														 A_diag_data, A_diag_i, A_diag_j,
+														 hypre_CsrsvDataInfoL(hypre_ParILUDataMatSLUCsrsvData(ilu_data)),
+														 xtemp_data, ytemp_data,
+														 hypre_CsrsvDataSolvePolicy(hypre_ParILUDataMatSLUCsrsvData(ilu_data)),
+														 hypre_CsrsvDataBuffer(hypre_ParILUDataMatSLUCsrsvData(ilu_data))));
+
+	   /* U solve - Backward substitution */
+	   HYPRE_ROCSPARSE_CALL( hypre_rocsparse_csrsv_solve(handle, rocsparse_operation_none,
+														 A_diag_n, A_diag_nnz, &one,
+														 hypre_GpuMatDataMatDescr(hypre_ParILUDataMatUMatData(ilu_data)),
+														 A_diag_data, A_diag_i, A_diag_j,
+														 hypre_CsrsvDataInfoU(hypre_ParILUDataMatSLUCsrsvData(ilu_data)),
+														 ytemp_data, xtemp_data,
+														 hypre_CsrsvDataSolvePolicy(hypre_ParILUDataMatSLUCsrsvData(ilu_data)),
+														 hypre_CsrsvDataBuffer(hypre_ParILUDataMatSLUCsrsvData(ilu_data))));
+   }
+
+   /* now add the original x onto it */
+   hypre_ParVectorAxpy( alpha, (hypre_ParVector *) x, (hypre_ParVector *) xtemp);
+
+   /* finall, add that into y and get final result */
+   hypre_ParVectorScale( beta, (hypre_ParVector *) y );
+   hypre_ParVectorAxpy( one, xtemp, (hypre_ParVector *) y);
+
+   return hypre_error_flag;
+}
+
+#endif
+
+
+/*********************************************************************************/
+/*                   hypre_ILUSolveDeviceSchurGMRES                              */
+/*********************************************************************************/
+
+/* Schur Complement solve with GMRES on schur complement
+ * ParCSRMatrix S is already built in ilu data sturcture, here directly use S
+ * L, D and U factors only have local scope (no off-diagonal processor terms)
+ * so apart from the residual calculation (which uses A), the solves with the
+ * L and U factors are local.
+ * S is the global Schur complement
+ * schur_solver is a GMRES solver
+ * schur_precond is the ILU preconditioner for GMRES
+ * rhs and x are helper vector for solving Schur system
+*/
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
+
+HYPRE_Int
+hypre_ILUSolveDeviceSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f,
+                               hypre_ParVector *u, HYPRE_Int *perm,
+                               HYPRE_Int nLU, hypre_ParCSRMatrix *S,
+                               hypre_ParVector *ftemp, hypre_ParVector *utemp,
+                               HYPRE_Solver schur_solver, HYPRE_Solver schur_precond,
+                               hypre_ParVector *rhs, hypre_ParVector *x, HYPRE_Int *u_end,
+                               hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                               hypre_CsrsvData *matBLU_csrsvdata, hypre_CsrsvData *matSLU_csrsvdata,
+                               hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d)
+{
+#if defined(HYPRE_USING_CUSPARSE)
+   hypre_ILUSolveCusparseSchurGMRES(A, f, u, perm, nLU, S, ftemp, utemp,
+                                    schur_solver, schur_precond, rhs, x, u_end,
+                                    matL_des, matU_des, matBLU_csrsvdata, matSLU_csrsvdata,
+                                    matBLU_d, matE_d, matF_d);
+#endif
+
+#if defined(HYPRE_USING_ROCSPARSE)
+   hypre_ILUSolveRocsparseSchurGMRES(A, f, u, perm, nLU, S, ftemp, utemp,
+                                    schur_solver, schur_precond, rhs, x, u_end,
+                                    matL_des, matU_des, matBLU_csrsvdata, matSLU_csrsvdata,
+                                    matBLU_d, matE_d, matF_d);
+#endif
+   return hypre_error_flag;
+}
+
+#endif
+
+#if defined(HYPRE_USING_CUSPARSE)
+
+HYPRE_Int
+hypre_ILUSolveCusparseSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f,
+                               hypre_ParVector *u, HYPRE_Int *perm,
+                               HYPRE_Int nLU, hypre_ParCSRMatrix *S,
+                               hypre_ParVector *ftemp, hypre_ParVector *utemp,
+                               HYPRE_Solver schur_solver, HYPRE_Solver schur_precond,
+                               hypre_ParVector *rhs, hypre_ParVector *x, HYPRE_Int *u_end,
+                               hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                               hypre_CsrsvData *matBLU_csrsvdata, hypre_CsrsvData *matSLU_csrsvdata,
+                               hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d)
+{
+   /* If we don't have S block, just do one L solve and one U solve */
+   if (!S)
+   {
+      /* Just call BJ cusparse and return */
+      return hypre_ILUSolveCusparseLU(A, matL_des, matU_des, matBLU_csrsvdata, matBLU_d,
+                                      f, u, perm, nLU, ftemp, utemp);
+   }
+
+   /* data objects for communication */
+   MPI_Comm             comm = hypre_ParCSRMatrixComm(A);
+   HYPRE_Int my_id;
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+   /* data objects for temp vector */
+   hypre_Vector      *utemp_local = hypre_ParVectorLocalVector(utemp);
+   HYPRE_Real        *utemp_data  = hypre_VectorData(utemp_local);
+   hypre_Vector      *ftemp_local = hypre_ParVectorLocalVector(ftemp);
+   HYPRE_Real        *ftemp_data  = hypre_VectorData(ftemp_local);
+   hypre_Vector      *rhs_local   = hypre_ParVectorLocalVector(rhs);
+   HYPRE_Real        *rhs_data    = hypre_VectorData(rhs_local);
+   hypre_Vector      *x_local     = hypre_ParVectorLocalVector(x);
+   HYPRE_Real        *x_data      = hypre_VectorData(x_local);
+
+   HYPRE_Real        alpha;
+   HYPRE_Real        beta;
+   //HYPRE_Real        gamma;
+   //HYPRE_Int         i, j, k1, k2, col;
+
+   /* problem size */
+   HYPRE_Int         *BLU_i      = NULL;
+   HYPRE_Int         *BLU_j      = NULL;
+   HYPRE_Real        *BLU_data   = NULL;
+   HYPRE_Int         BLU_nnz     = 0;
+   hypre_CSRMatrix   *matSLU_d   = hypre_ParCSRMatrixDiag(S);
+   HYPRE_Int         *SLU_i      = hypre_CSRMatrixI(matSLU_d);
+   HYPRE_Int         *SLU_j      = hypre_CSRMatrixJ(matSLU_d);
+   HYPRE_Real        *SLU_data   = hypre_CSRMatrixData(matSLU_d);
+   HYPRE_Int         m           = hypre_CSRMatrixNumRows(matSLU_d);
+   HYPRE_Int         n           = nLU + m;
+   HYPRE_Int         SLU_nnz     = hypre_CSRMatrixNumNonzeros(matSLU_d);
+
+   hypre_Vector *ftemp_upper           = hypre_SeqVectorCreate(nLU);
+   hypre_Vector *utemp_lower           = hypre_SeqVectorCreate(m);
+   hypre_VectorOwnsData(ftemp_upper)   = 0;
+   hypre_VectorOwnsData(utemp_lower)   = 0;
+   hypre_VectorData(ftemp_upper)       = ftemp_data;
+   hypre_VectorData(utemp_lower)       = utemp_data + nLU;
+   hypre_SeqVectorInitialize(ftemp_upper);
+   hypre_SeqVectorInitialize(utemp_lower);
+
+   //printf("%s %s %d : nLU=%d,  m=%d,  ftemp size-(nLU+m)=%d\n",__FILE__,__FUNCTION__,__LINE__,nLU,m,hypre_VectorSize(ftemp_local)-nLU-m);
+
+   if ( nLU > 0)
+   {
+      BLU_i                      = hypre_CSRMatrixI(matBLU_d);
+      BLU_j                      = hypre_CSRMatrixJ(matBLU_d);
+      BLU_data                   = hypre_CSRMatrixData(matBLU_d);
+      BLU_nnz                    = hypre_CSRMatrixNumNonzeros(matBLU_d);
+   }
+
+   /* begin */
+   beta = 1.0;
+   alpha = -1.0;
+   //gamma = 0.0;
+
+   cusparseHandle_t handle = hypre_HandleCusparseHandle(hypre_handle());
+
+   /* compute residual */
+   hypre_ParCSRMatrixMatvecOutOfPlace(alpha, A, u, beta, f, ftemp);
+
+   /* 1st need to solve LBi*xi = fi
+    * L solve, solve xi put in u_temp upper
+    */
+
+   /* apply permutation before we can start our solve */
+   HYPRE_THRUST_CALL(gather, perm, perm + n, ftemp_data, utemp_data);
+
+   if (nLU > 0)
+   {
+      /* This solve won't touch data in utemp, thus, gi is still in utemp_lower */
+	   /* L solve - Forward solve */
+	   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_solve(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													   nLU, BLU_nnz, &beta, hypre_GpuMatDataMatDescr(matL_des),
+													   BLU_data, BLU_i, BLU_j, hypre_CsrsvDataInfoL(matBLU_csrsvdata),
+													   utemp_data, ftemp_data,
+													   hypre_CsrsvDataSolvePolicy(matBLU_csrsvdata),
+													   hypre_CsrsvDataBuffer(matBLU_csrsvdata) ));
+      /* 2nd need to compute g'i = gi - Ei*UBi^{-1}*xi
+       * Ei*UBi^{-1} is exactly the matE_d here
+       * Now:  LBi^{-1}f_i is in ftemp_upper
+       *       gi' is in utemp_lower
+       */
+
+      hypre_CSRMatrixMatvec(alpha, matE_d, ftemp_upper, beta, utemp_lower);
+
+   }
+
+   /* 3rd need to solve global Schur Complement M^{-1}Sy = M^{-1}g'
+    * for now only solve the local system
+    * solve y put in u_temp lower
+    * only solve whe S is not NULL
+    */
+
+   /* setup vectors for solve
+    * rhs = M^{-1}g'
+    */
+
+   if (m > 0)
+   {
+         /* L solve */
+	   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_solve(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													   m, SLU_nnz, &beta, hypre_GpuMatDataMatDescr(matL_des),
+													   SLU_data, SLU_i, SLU_j, hypre_CsrsvDataInfoL(matSLU_csrsvdata),
+													   utemp_data + nLU, ftemp_data + nLU,
+													   hypre_CsrsvDataSolvePolicy(matSLU_csrsvdata),
+													   hypre_CsrsvDataBuffer(matSLU_csrsvdata) ));
+
+	   /* U solve */
+	   HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_solve(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													   m, SLU_nnz, &beta, hypre_GpuMatDataMatDescr(matU_des),
+													   SLU_data, SLU_i, SLU_j, hypre_CsrsvDataInfoU(matSLU_csrsvdata),
+													   ftemp_data + nLU, rhs_data,
+													   hypre_CsrsvDataSolvePolicy(matSLU_csrsvdata),
+													   hypre_CsrsvDataBuffer(matSLU_csrsvdata) ));
+   }
+
+
+   /* solve */
+   /* with tricky initial guess */
+   //hypre_Vector *tv = hypre_ParVectorLocalVector(x);
+   //HYPRE_Real *tz = hypre_VectorData(tv);
+   HYPRE_GMRESSolve(schur_solver, (HYPRE_Matrix)schur_precond, (HYPRE_Vector)rhs, (HYPRE_Vector)x);
+   /* 4th need to compute zi = xi - LBi^-1*yi
+    * put zi in f_temp upper
+    * only do this computation when nLU < n
+    * U is unsorted, search is expensive when unnecessary
+    */
+
+   if (nLU > 0)
+   {
+      hypre_CSRMatrixMatvec(alpha, matF_d, x_local, beta, ftemp_upper);
+
+      /* 5th need to solve UBi*ui = zi */
+      /* put result in u_temp upper */
+
+	  /* U solve - Forward solve */
+	  HYPRE_CUSPARSE_CALL(hypre_cusparse_csrsv2_solve(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+													  nLU, BLU_nnz, &beta, hypre_GpuMatDataMatDescr(matU_des),
+													  BLU_data, BLU_i, BLU_j, hypre_CsrsvDataInfoU(matBLU_csrsvdata),
+													  ftemp_data, utemp_data,
+													  hypre_CsrsvDataSolvePolicy(matBLU_csrsvdata),
+													  hypre_CsrsvDataBuffer(matBLU_csrsvdata) ));
+   }
+
+   /* copy lower part solution into u_temp as well */
+   hypre_TMemcpy(utemp_data + nLU, x_data, HYPRE_Real, m, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+
+   /* perm back */
+   HYPRE_THRUST_CALL(scatter, utemp_data, utemp_data + n, perm, ftemp_data);
+
+   /* done, now everything are in u_temp, update solution */
+   hypre_ParVectorAxpy(beta, ftemp, u);
+
+   hypre_SeqVectorDestroy(ftemp_upper);
+   hypre_SeqVectorDestroy(utemp_lower);
+
+   return hypre_error_flag;
+}
+
+#endif
+
+
+#if defined(HYPRE_USING_ROCSPARSE)
+
+HYPRE_Int
+hypre_ILUSolveRocsparseSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f,
+                                  hypre_ParVector *u, HYPRE_Int *perm,
+                                  HYPRE_Int nLU, hypre_ParCSRMatrix *S,
+                                  hypre_ParVector *ftemp, hypre_ParVector *utemp,
+                                  HYPRE_Solver schur_solver, HYPRE_Solver schur_precond,
+                                  hypre_ParVector *rhs, hypre_ParVector *x, HYPRE_Int *u_end,
+                                  hypre_GpuMatData * matL_des, hypre_GpuMatData * matU_des,
+                                  hypre_CsrsvData *matBLU_csrsvdata, hypre_CsrsvData *matSLU_csrsvdata,
+                                  hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d)
+{
+   /* If we don't have S block, just do one L solve and one U solve */
+   if (!S)
+   {
+      /* Just call BJ cusparse and return */
+      return hypre_ILUSolveRocsparseLU(A, matL_des, matU_des, matBLU_csrsvdata, matBLU_d,
+                                       f, u, perm, nLU, ftemp, utemp);
+   }
+
+   /* data objects for communication */
+   MPI_Comm             comm = hypre_ParCSRMatrixComm(A);
+   HYPRE_Int my_id;
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+   /* data objects for temp vector */
+   hypre_Vector      *utemp_local = hypre_ParVectorLocalVector(utemp);
+   HYPRE_Real        *utemp_data  = hypre_VectorData(utemp_local);
+   hypre_Vector      *ftemp_local = hypre_ParVectorLocalVector(ftemp);
+   HYPRE_Real        *ftemp_data  = hypre_VectorData(ftemp_local);
+   hypre_Vector      *rhs_local   = hypre_ParVectorLocalVector(rhs);
+   HYPRE_Real        *rhs_data    = hypre_VectorData(rhs_local);
+   hypre_Vector      *x_local     = hypre_ParVectorLocalVector(x);
+   HYPRE_Real        *x_data      = hypre_VectorData(x_local);
+
+   HYPRE_Real        alpha;
+   HYPRE_Real        beta;
+   //HYPRE_Real        gamma;
+   //HYPRE_Int         i, j, k1, k2, col;
+
+   /* problem size */
+   HYPRE_Int         *BLU_i      = NULL;
+   HYPRE_Int         *BLU_j      = NULL;
+   HYPRE_Real        *BLU_data   = NULL;
+   HYPRE_Int         BLU_nnz     = 0;
+   hypre_CSRMatrix   *matSLU_d   = hypre_ParCSRMatrixDiag(S);
+   HYPRE_Int         *SLU_i      = hypre_CSRMatrixI(matSLU_d);
+   HYPRE_Int         *SLU_j      = hypre_CSRMatrixJ(matSLU_d);
+   HYPRE_Real        *SLU_data   = hypre_CSRMatrixData(matSLU_d);
+   HYPRE_Int         m           = hypre_CSRMatrixNumRows(matSLU_d);
+   HYPRE_Int         n           = nLU + m;
+   HYPRE_Int         SLU_nnz     = hypre_CSRMatrixNumNonzeros(matSLU_d);
+
+   hypre_Vector *ftemp_upper           = hypre_SeqVectorCreate(nLU);
+   hypre_Vector *utemp_lower           = hypre_SeqVectorCreate(m);
+   hypre_VectorOwnsData(ftemp_upper)   = 0;
+   hypre_VectorOwnsData(utemp_lower)   = 0;
+   hypre_VectorData(ftemp_upper)       = ftemp_data;
+   hypre_VectorData(utemp_lower)       = utemp_data + nLU;
+   hypre_SeqVectorInitialize(ftemp_upper);
+   hypre_SeqVectorInitialize(utemp_lower);
+
+   //printf("%s %s %d : nLU=%d,  m=%d,  ftemp size-(nLU+m)=%d\n",__FILE__,__FUNCTION__,__LINE__,nLU,m,hypre_VectorSize(ftemp_local)-nLU-m);
+
+   if ( nLU > 0)
+   {
+      BLU_i                      = hypre_CSRMatrixI(matBLU_d);
+      BLU_j                      = hypre_CSRMatrixJ(matBLU_d);
+      BLU_data                   = hypre_CSRMatrixData(matBLU_d);
+      BLU_nnz                    = hypre_CSRMatrixNumNonzeros(matBLU_d);
+   }
+
+   /* begin */
+   beta = 1.0;
+   alpha = -1.0;
+   //gamma = 0.0;
+
+   rocsparse_handle handle = hypre_HandleCusparseHandle(hypre_handle());
+
+   /* compute residual */
+   hypre_ParCSRMatrixMatvecOutOfPlace(alpha, A, u, beta, f, ftemp);
+
+   /* 1st need to solve LBi*xi = fi
+    * L solve, solve xi put in u_temp upper
+    */
+
+   /* apply permutation before we can start our solve */
+   HYPRE_THRUST_CALL(gather, perm, perm + n, ftemp_data, utemp_data);
+
+   if (nLU > 0)
+   {
+      /* This solve won't touch data in utemp, thus, gi is still in utemp_lower */
+	   /* L solve - Forward solve */
+	   HYPRE_ROCSPARSE_CALL( hypre_rocsparse_csrsv_solve(handle, rocsparse_operation_none,
+														 nLU, BLU_nnz, &beta, hypre_GpuMatDataMatDescr(matL_des),
+														 BLU_data, BLU_i, BLU_j, hypre_CsrsvDataInfoL(matBLU_csrsvdata),
+														 utemp_data, ftemp_data,
+														 hypre_CsrsvDataSolvePolicy(matBLU_csrsvdata),
+														 hypre_CsrsvDataBuffer(matBLU_csrsvdata) ));
+      /* 2nd need to compute g'i = gi - Ei*UBi^{-1}*xi
+       * Ei*UBi^{-1} is exactly the matE_d here
+       * Now:  LBi^{-1}f_i is in ftemp_upper
+       *       gi' is in utemp_lower
+       */
+
+      hypre_CSRMatrixMatvec(alpha, matE_d, ftemp_upper, beta, utemp_lower);
+
+   }
+
+   /* 3rd need to solve global Schur Complement M^{-1}Sy = M^{-1}g'
+    * for now only solve the local system
+    * solve y put in u_temp lower
+    * only solve whe S is not NULL
+    */
+
+   /* setup vectors for solve
+    * rhs = M^{-1}g'
+    */
+
+   if (m > 0)
+   {
+	   /* L solve */
+	   HYPRE_ROCSPARSE_CALL( hypre_rocsparse_csrsv_solve(handle, rocsparse_operation_none,
+														 m, SLU_nnz, &beta, hypre_GpuMatDataMatDescr(matL_des),
+														 SLU_data, SLU_i, SLU_j, hypre_CsrsvDataInfoL(matSLU_csrsvdata),
+														 utemp_data + nLU, ftemp_data + nLU,
+														 hypre_CsrsvDataSolvePolicy(matSLU_csrsvdata),
+														 hypre_CsrsvDataBuffer(matSLU_csrsvdata) ));
+
+	   /* U solve */
+	   HYPRE_ROCSPARSE_CALL( hypre_rocsparse_csrsv_solve(handle, rocsparse_operation_none,
+														 m, SLU_nnz, &beta, hypre_GpuMatDataMatDescr(matU_des),
+														 SLU_data, SLU_i, SLU_j, hypre_CsrsvDataInfoU(matSLU_csrsvdata),
+														 ftemp_data + nLU, rhs_data,
+														 hypre_CsrsvDataSolvePolicy(matSLU_csrsvdata),
+														 hypre_CsrsvDataBuffer(matSLU_csrsvdata) ));
+   }
+
+
+   /* solve */
+   /* with tricky initial guess */
+   //hypre_Vector *tv = hypre_ParVectorLocalVector(x);
+   //HYPRE_Real *tz = hypre_VectorData(tv);
+   HYPRE_GMRESSolve(schur_solver, (HYPRE_Matrix)schur_precond, (HYPRE_Vector)rhs, (HYPRE_Vector)x);
+   /* 4th need to compute zi = xi - LBi^-1*yi
+    * put zi in f_temp upper
+    * only do this computation when nLU < n
+    * U is unsorted, search is expensive when unnecessary
+    */
+
+   if (nLU > 0)
+   {
+      hypre_CSRMatrixMatvec(alpha, matF_d, x_local, beta, ftemp_upper);
+
+      /* 5th need to solve UBi*ui = zi */
+      /* put result in u_temp upper */
+	  /* U solve - Forward solve */
+	  HYPRE_ROCSPARSE_CALL( hypre_rocsparse_csrsv_solve(handle, rocsparse_operation_none,
+														nLU, BLU_nnz, &beta, hypre_GpuMatDataMatDescr(matU_des),
+														BLU_data, BLU_i, BLU_j, hypre_CsrsvDataInfoU(matBLU_csrsvdata),
+														ftemp_data, utemp_data,
+														hypre_CsrsvDataSolvePolicy(matBLU_csrsvdata),
+														hypre_CsrsvDataBuffer(matBLU_csrsvdata) ));
+   }
+
+   /* copy lower part solution into u_temp as well */
+   hypre_TMemcpy(utemp_data + nLU, x_data, HYPRE_Real, m, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+
+   /* perm back */
+   HYPRE_THRUST_CALL(scatter, utemp_data, utemp_data + n, perm, ftemp_data);
+
+   /* done, now everything are in u_temp, update solution */
+   hypre_ParVectorAxpy(beta, ftemp, u);
+
+   hypre_SeqVectorDestroy(ftemp_upper);
+   hypre_SeqVectorDestroy(utemp_lower);
+
+   return hypre_error_flag;
+}
+
+#endif
+
+
+
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+
+/*********************************************************************************/
+/*                   hypre_ILUSolveDeviceSchurGMRESIter                          */
+/*********************************************************************************/
+
+/* Schur Complement solve with GMRES on schur complement
+ * ParCSRMatrix S is already built in ilu data sturcture, here directly use S
+ * L, D and U factors only have local scope (no off-diagonal processor terms)
+ * so apart from the residual calculation (which uses A), the solves with the
+ * L and U factors are local.
+ * S is the global Schur complement
+ * schur_solver is a GMRES solver
+ * schur_precond is the ILU preconditioner for GMRES
+ * rhs and x are helper vector for solving Schur system
+*/
+
+HYPRE_Int
+hypre_ILUSolveDeviceSchurGMRESIter(hypre_ParCSRMatrix *A, hypre_ParVector *f,
+                                   hypre_ParVector *u, HYPRE_Int *perm,
+                                   HYPRE_Int nLU, hypre_ParCSRMatrix *S,
+                                   hypre_ParVector *ftemp, hypre_ParVector *utemp,
+                                   HYPRE_Solver schur_solver, HYPRE_Solver schur_precond,
+                                   hypre_ParVector *rhs, hypre_ParVector *x, HYPRE_Int *u_end,
+                                   hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d,
+                                   hypre_Vector *ztemp_local, hypre_Vector **Adiag_diag, hypre_Vector **Sdiag_diag,
+                                   HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters)
+{
+   /* If we don't have S block, just do one L solve and one U solve */
+   if (!S)
+   {
+      /* Just call BJ cusparse and return */
+      return hypre_ILUSolveDeviceLUIter(A, matBLU_d,
+                                        f, u, perm, nLU, ftemp, utemp, ztemp_local, Adiag_diag,
+                                        lower_jacobi_iters, upper_jacobi_iters);
+   }
+
+   MPI_Comm             comm = hypre_ParCSRMatrixComm(A);
+   HYPRE_Int my_id;
+   hypre_MPI_Comm_rank(comm, &my_id);
+
+   /* data objects for communication */
+   //   MPI_Comm          comm = hypre_ParCSRMatrixComm(A);
+
+   /* data objects for temp vector */
+   hypre_Vector      *utemp_local = hypre_ParVectorLocalVector(utemp);
+   HYPRE_Real        *utemp_data  = hypre_VectorData(utemp_local);
+   hypre_Vector      *ftemp_local = hypre_ParVectorLocalVector(ftemp);
+   HYPRE_Real        *ftemp_data  = hypre_VectorData(ftemp_local);
+   hypre_Vector      *rhs_local   = hypre_ParVectorLocalVector(rhs);
+   hypre_Vector      *x_local     = hypre_ParVectorLocalVector(x);
+   HYPRE_Real        *x_data      = hypre_VectorData(x_local);
+
+   HYPRE_Real        alpha;
+   HYPRE_Real        beta;
+   //HYPRE_Real        gamma;
+   //HYPRE_Int         i, j, k1, k2, col;
+
+   /* problem size */
+   hypre_CSRMatrix   *matSLU_d   = hypre_ParCSRMatrixDiag(S);
+   HYPRE_Int         m           = hypre_CSRMatrixNumRows(matSLU_d);
+   HYPRE_Int         n           = nLU + m;
+
+   hypre_Vector *ftemp_upper           = hypre_SeqVectorCreate(nLU);
+   hypre_Vector *utemp_lower           = hypre_SeqVectorCreate(m);
+   hypre_VectorOwnsData(ftemp_upper)   = 0;
+   hypre_VectorOwnsData(utemp_lower)   = 0;
+   hypre_VectorData(ftemp_upper)       = ftemp_data;
+   hypre_VectorData(utemp_lower)       = utemp_data + nLU;
+   hypre_SeqVectorInitialize(ftemp_upper);
+   hypre_SeqVectorInitialize(utemp_lower);
+
+
+   hypre_Vector *ftemp_shift           = hypre_SeqVectorCreate(m);
+   hypre_VectorOwnsData(ftemp_shift)   = 0;
+   hypre_VectorData(ftemp_shift)       = ftemp_data+nLU;
+   hypre_SeqVectorInitialize(ftemp_shift);
+
+   hypre_Vector *utemp_shift           = hypre_SeqVectorCreate(m);
+   hypre_VectorOwnsData(utemp_shift)   = 0;
+   hypre_VectorData(utemp_shift)       = utemp_data+nLU;
+   hypre_SeqVectorInitialize(utemp_shift);
+
+   //printf("%s %s %d : nLU=%d,  m=%d,  ftemp size-(nLU+m)=%d\n",__FILE__,__FUNCTION__,__LINE__,nLU,m,hypre_VectorSize(ftemp_local)-nLU-m);
+
+   /* begin */
+   beta = 1.0;
+   alpha = -1.0;
+   //gamma = 0.0;
+
+   /* Grab the main diagonal from the diagonal block. Only do this once */
+   if (!(*Adiag_diag)) {
+      /* storage for the diagonal */
+      *Adiag_diag = hypre_SeqVectorCreate(n);
+      hypre_SeqVectorInitialize(*Adiag_diag);
+      /* extract with device kernel */
+      hypre_CSRMatrixExtractDiagonalDevice(matBLU_d, hypre_VectorData(*Adiag_diag), 2);
+      //hypre_CSRMatrixGetMainDiag(matLU_d, *Adiag);
+   }
+
+   /* compute residual */
+   hypre_ParCSRMatrixMatvecOutOfPlace(alpha, A, u, beta, f, ftemp);
+
+   /* 1st need to solve LBi*xi = fi
+    * L solve, solve xi put in u_temp upper
+    */
+
+   /* apply permutation before we can start our solve */
+   HYPRE_THRUST_CALL(gather, perm, perm + n, ftemp_data, utemp_data);
+
+   if (nLU > 0)
+   {
+
+      /* apply the iterative solve to L */
+      hypre_ILUSolveLJacobiIter(matBLU_d, utemp_local, ztemp_local, ftemp_local, lower_jacobi_iters);
+
+      /* 2nd need to compute g'i = gi - Ei*UBi^{-1}*xi
+       * Ei*UBi^{-1} is exactly the matE_d here
+       * Now:  LBi^{-1}f_i is in ftemp_upper
+       *       gi' is in utemp_lower
+       */
+
+      hypre_CSRMatrixMatvec(alpha, matE_d, ftemp_upper, beta, utemp_lower);
+
+   }
+
+   /* 3rd need to solve global Schur Complement M^{-1}Sy = M^{-1}g'
+    * for now only solve the local system
+    * solve y put in u_temp lower
+    * only solve whe S is not NULL
+    */
+
+   /* setup vectors for solve
+    * rhs = M^{-1}g'
+    */
+
+
+   if (m > 0)
+   {
+      /* Grab the main diagonal from the diagonal block. Only do this once */
+      if (!(*Sdiag_diag)) {
+         /* storage for the diagonal */
+         *Sdiag_diag = hypre_SeqVectorCreate(m);
+         hypre_SeqVectorInitialize(*Sdiag_diag);
+         /* extract with device kernel */
+         hypre_CSRMatrixExtractDiagonalDevice(matSLU_d, hypre_VectorData(*Sdiag_diag), 2);
+         //hypre_CSRMatrixGetMainDiag(matLU_d, *Adiag);
+      }
+
+      /* apply the iterative solve to L */
+      hypre_ILUSolveLJacobiIter(matSLU_d, utemp_shift, rhs_local, ftemp_shift, lower_jacobi_iters);
+
+      hypre_ILUSolveUJacobiIter(matSLU_d, ftemp_shift, utemp_shift, rhs_local, *Sdiag_diag, upper_jacobi_iters);
+
+      /* apply the iterative solve to L and U */
+      //hypre_ILUSolveLUJacobiIter(matSLU_d, utemp_shift, ftemp_shift, rhs_local, *Sdiag_diag,
+      //				 lower_jacobi_iters, upper_jacobi_iters, my_id);
+
+   }
+
+   /* solve */
+   /* with tricky initial guess */
+   //hypre_Vector *tv = hypre_ParVectorLocalVector(x);
+   //HYPRE_Real *tz = hypre_VectorData(tv);
+   HYPRE_GMRESSolve(schur_solver, (HYPRE_Matrix)schur_precond, (HYPRE_Vector)rhs, (HYPRE_Vector)x);
+   /* 4th need to compute zi = xi - LBi^-1*yi
+    * put zi in f_temp upper
+    * only do this computation when nLU < n
+    * U is unsorted, search is expensive when unnecessary
+    */
+   if (nLU > 0)
+   {
+      hypre_CSRMatrixMatvec(alpha, matF_d, x_local, beta, ftemp_upper);
+
+      /* 5th need to solve UBi*ui = zi */
+      /* put result in u_temp upper */
+
+      /* apply the iterative solve to U */
+      hypre_ILUSolveUJacobiIter(matBLU_d, ftemp_local, ztemp_local, utemp_local, *Adiag_diag, upper_jacobi_iters);
+
+   }
+
+   /* copy lower part solution into u_temp as well */
+   hypre_TMemcpy(utemp_data + nLU, x_data, HYPRE_Real, m, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+
+   /* perm back */
+   HYPRE_THRUST_CALL(scatter, utemp_data, utemp_data + n, perm, ftemp_data);
+
+   /* done, now everything are in u_temp, update solution */
+   hypre_ParVectorAxpy(beta, ftemp, u);
+
+   hypre_SeqVectorDestroy(ftemp_shift);
+   hypre_SeqVectorDestroy(utemp_shift);
+   hypre_SeqVectorDestroy(ftemp_upper);
+   hypre_SeqVectorDestroy(utemp_lower);
+   return hypre_error_flag;
+}
+
+
+/*--------------------------------------------------------------------------
+ * hypre_ParILUDeviceSchurGMRESMatvecJacobiIter
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_ParILUDeviceSchurGMRESMatvecJacobiIter( void   *matvec_data,
+                                                HYPRE_Complex  alpha,
+                                                void   *ilu_vdata,
+                                                void   *x,
+                                                HYPRE_Complex  beta,
+                                                void   *y           )
+{
+   /* Slightly different, for this new matvec, the diagonal of the original matrix
+    * is the LU factorization. Thus, the matvec is done in an different way
+    * |IS_1 E_12 E_13|
+    * |E_21 IS_2 E_23| = S
+    * |E_31 E_32 IS_3|
+    *
+    * |IS_1          |
+    * |     IS_2     | = M
+    * |          IS_3|
+    *
+    * Solve Sy = g is just M^{-1}S = M^{-1}g
+    *
+    * |      I       IS_1^{-1}E_12 IS_1^{-1}E_13|
+    * |IS_2^{-1}E_21       I       IS_2^{-1}E_23| = M^{-1}S
+    * |IS_3^{-1}E_31 IS_3^{-1}E_32       I      |
+    *
+    * */
+
+   /* get matrix information first */
+   hypre_ParILUData *ilu_data                   = (hypre_ParILUData*) ilu_vdata;
+   hypre_ParCSRMatrix *A                        = hypre_ParILUDataMatS(ilu_data);
+
+   /* fist step, apply matvec on empty diagonal slot */
+   hypre_CSRMatrix   *A_diag                    = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Int         *A_diag_i                  = hypre_CSRMatrixI(A_diag);
+   HYPRE_Int         A_diag_n                   = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Int         *A_diag_fake_i             = hypre_ParILUDataMatAFakeDiagonal(ilu_data);
+
+   hypre_ParVector         *xtemp               = hypre_ParILUDataXTemp(ilu_data);
+   hypre_Vector            *xtemp_local         = hypre_ParVectorLocalVector(xtemp);
+   hypre_ParVector         *ytemp               = hypre_ParILUDataYTemp(ilu_data);
+   hypre_Vector            *ytemp_local         = hypre_ParVectorLocalVector(ytemp);
+   HYPRE_Real              zero                 = 0.0;
+   HYPRE_Real              one                  = 1.0;
+
+   hypre_Vector            *ztemp_local         = hypre_ParILUDataZTemp(ilu_data);
+   hypre_Vector            *SchurMatVec_diag    = hypre_ParILUDataSchurMatVecDiag(ilu_data);
+
+   /* Matvec with
+    *         |  O  E_12 E_13|
+    * alpha * |E_21   O  E_23|
+    *         |E_31 E_32   O |
+    * store in xtemp
+    */
+
+   /* more recent versions of cusparse require zeroing of the matrix meta data nrow/nnz, in order to fake a zero diagonal
+      PJM 4/8/2022 */
+   hypre_CSRMatrixI(A_diag)                     = A_diag_fake_i;
+   HYPRE_Int t1 = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Int t2 = hypre_CSRMatrixNumNonzeros(A_diag);
+   hypre_CSRMatrixNumRows(A_diag) = 0;
+   hypre_CSRMatrixNumNonzeros(A_diag) = 0;
+
+   hypre_ParCSRMatrixMatvec( alpha, (hypre_ParCSRMatrix *) A, (hypre_ParVector *) x, zero, xtemp );
+
+   hypre_CSRMatrixNumRows(A_diag) = t1;
+   hypre_CSRMatrixNumNonzeros(A_diag) = t2;
+   hypre_CSRMatrixI(A_diag)                     = A_diag_i;
+
+
+   /* Compute U^{-1}*L^{-1}*(A_offd * x)
+    * Or in another word, matvec with
+    *         |      O       IS_1^{-1}E_12 IS_1^{-1}E_13|
+    * alpha * |IS_2^{-1}E_21       O       IS_2^{-1}E_23|
+    *         |IS_3^{-1}E_31 IS_3^{-1}E_32       O      |
+    * store in xtemp
+    */
+   if ( A_diag_n > 0 )
+   {
+      /* Grab the main diagonal from the diagonal block. Only do this once */
+      if (!SchurMatVec_diag) {
+         /* storage for the diagonal */
+         SchurMatVec_diag = hypre_SeqVectorCreate(A_diag_n);
+         hypre_SeqVectorInitialize(SchurMatVec_diag);
+         hypre_ParILUDataSchurMatVecDiag(ilu_data) = SchurMatVec_diag;
+         /* extract with device kernel */
+         hypre_CSRMatrixExtractDiagonalDevice(A_diag, hypre_VectorData(SchurMatVec_diag), 2);
+      }
+
+      /* apply the iterative solve to L and U */
+      hypre_ILUSolveLUJacobiIter(A_diag, ytemp_local, ztemp_local, xtemp_local, SchurMatVec_diag,
+                                 hypre_ParILUDataLowerJacobiIters(ilu_data), hypre_ParILUDataUpperJacobiIters(ilu_data), 0);
+   }
+
+   /* now add the original x onto it */
+   hypre_ParVectorAxpy( alpha, (hypre_ParVector *) x, (hypre_ParVector *) xtemp);
+
+   /* finall, add that into y and get final result */
+   hypre_ParVectorScale( beta, (hypre_ParVector *) y );
+   hypre_ParVectorAxpy( one, xtemp, (hypre_ParVector *) y);
+
+   return hypre_error_flag;
+}
+
+
+#endif

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -2295,6 +2295,11 @@ void *hypre_ParILURAPSchurGMRESMatvecCreateH(void *ilu_vdata, void *x);
 HYPRE_Int hypre_ParILURAPSchurGMRESMatvecH(void *matvec_data, HYPRE_Complex alpha, void *ilu_vdata,
                                            void *x, HYPRE_Complex beta, void *y);
 HYPRE_Int hypre_ParILURAPSchurGMRESMatvecDestroyH(void *matvec_data );
+HYPRE_Int hypre_ILULocalRCMBuildG( hypre_CSRMatrix *A, HYPRE_Int start, HYPRE_Int end,
+				   HYPRE_Int **permp, HYPRE_Int **qpermp, hypre_CSRMatrix **G);
+HYPRE_Int hypre_ILULocalRCMBuildFinalPerm( HYPRE_Int start, HYPRE_Int end,
+					   HYPRE_Int * G_perm, HYPRE_Int *perm, HYPRE_Int *qperm,
+					   HYPRE_Int **permp, HYPRE_Int **qpermp);
 HYPRE_Int hypre_ILULocalRCM( hypre_CSRMatrix *A, HYPRE_Int start, HYPRE_Int end, HYPRE_Int **permp,
                              HYPRE_Int **qpermp, HYPRE_Int sym);
 HYPRE_Int hypre_ILULocalRCMNumbering(hypre_CSRMatrix *A, HYPRE_Int root, HYPRE_Int *marker,

--- a/src/seq_mv/csr_matop_device.c
+++ b/src/seq_mv/csr_matop_device.c
@@ -21,7 +21,12 @@ hypre_CsrsvData*
 hypre_CsrsvDataCreate()
 {
    hypre_CsrsvData *data = hypre_CTAlloc(hypre_CsrsvData, 1, HYPRE_MEMORY_HOST);
-
+#if defined(HYPRE_USING_CUSPARSE)
+   hypre_CsrsvDataSolvePolicy(data) = CUSPARSE_SOLVE_POLICY_USE_LEVEL;
+#elif defined(HYPRE_USING_ROCSPARSE)
+   hypre_CsrsvDataSolvePolicy(data) = rocsparse_solve_policy_auto;
+   hypre_CsrsvDataAnalysisPolicy(data) = rocsparse_analysis_policy_reuse;
+#endif
    return data;
 }
 
@@ -69,7 +74,7 @@ hypre_GpuMatDataCreate()
    HYPRE_CUSPARSE_CALL( cusparseCreateMatDescr(&mat_descr) );
    HYPRE_CUSPARSE_CALL( cusparseSetMatType(mat_descr, CUSPARSE_MATRIX_TYPE_GENERAL) );
    HYPRE_CUSPARSE_CALL( cusparseSetMatIndexBase(mat_descr, CUSPARSE_INDEX_BASE_ZERO) );
-   hypre_GpuMatDataMatDecsr(data) = mat_descr;
+   hypre_GpuMatDataMatDescr(data) = mat_descr;
 #endif
 
 #if defined(HYPRE_USING_ROCSPARSE)
@@ -78,7 +83,7 @@ hypre_GpuMatDataCreate()
    HYPRE_ROCSPARSE_CALL( rocsparse_create_mat_descr(&mat_descr) );
    HYPRE_ROCSPARSE_CALL( rocsparse_set_mat_type(mat_descr, rocsparse_matrix_type_general) );
    HYPRE_ROCSPARSE_CALL( rocsparse_set_mat_index_base(mat_descr, rocsparse_index_base_zero) );
-   hypre_GpuMatDataMatDecsr(data) = mat_descr;
+   hypre_GpuMatDataMatDescr(data) = mat_descr;
    HYPRE_ROCSPARSE_CALL( rocsparse_create_mat_info(&info) );
    hypre_GpuMatDataMatInfo(data) = info;
 #endif
@@ -119,12 +124,12 @@ hypre_GpuMatDataDestroy(hypre_GpuMatData *data)
    }
 
 #if defined(HYPRE_USING_CUSPARSE)
-   HYPRE_CUSPARSE_CALL( cusparseDestroyMatDescr(hypre_GpuMatDataMatDecsr(data)) );
+   HYPRE_CUSPARSE_CALL( cusparseDestroyMatDescr(hypre_GpuMatDataMatDescr(data)) );
    hypre_TFree(hypre_GpuMatDataSpMVBuffer(data), HYPRE_MEMORY_DEVICE);
 #endif
 
 #if defined(HYPRE_USING_ROCSPARSE)
-   HYPRE_ROCSPARSE_CALL( rocsparse_destroy_mat_descr(hypre_GpuMatDataMatDecsr(data)) );
+   HYPRE_ROCSPARSE_CALL( rocsparse_destroy_mat_descr(hypre_GpuMatDataMatDescr(data)) );
    HYPRE_ROCSPARSE_CALL( rocsparse_destroy_mat_info(hypre_GpuMatDataMatInfo(data)) );
 #endif
 
@@ -1899,6 +1904,166 @@ hypre_CSRMatrixDiagScaleDevice( hypre_CSRMatrix *A,
 
    hypre_SyncComputeStream(hypre_handle());
 
+   return hypre_error_flag;
+}
+
+#endif /* HYPRE_USING_CUDA || defined(HYPRE_USING_HIP) */
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+
+__global__ void
+hypreGPUKernel_CSRMatrixComputePermutedRowPtrs( hypre_DeviceItem    &item,
+												HYPRE_Int n,
+                                                HYPRE_Int *perm,
+                                                HYPRE_Int *row_ptrs_in,
+                                                HYPRE_Int *row_ptrs_out)
+{
+   HYPRE_Int i = hypre_gpu_get_grid_thread_id<1, 1>(item);
+   if (i < n)
+   {
+      HYPRE_Int p = perm[i];
+      HYPRE_Int r0 = row_ptrs_in[p];
+      HYPRE_Int r1 = row_ptrs_in[p+1];
+      row_ptrs_out[i] = r1 - r0;
+   }
+}
+
+HYPRE_Int
+hypreDevice_CSRMatrixComputePermutedRowPtrs(HYPRE_Int n,
+                                            HYPRE_Int *perm,
+                                            HYPRE_Int *row_ptrs_in,
+                                            HYPRE_Int *row_ptrs_out)
+{
+   /* trivial case */
+   if (n <= 0)
+   {
+      return hypre_error_flag;
+   }
+
+   dim3 bDim = hypre_GetDefaultDeviceBlockDimension();
+   dim3 gDim = hypre_GetDefaultDeviceGridDimension(n, "thread", bDim);
+
+   HYPRE_GPU_LAUNCH( hypreGPUKernel_CSRMatrixComputePermutedRowPtrs, gDim, bDim, n,
+                      perm, row_ptrs_in, row_ptrs_out);
+
+   return hypre_error_flag;
+}
+
+
+
+__global__ void
+hypreGPUKernel_CSRMatrixPermuteColsVals( hypre_DeviceItem    &item,
+										 HYPRE_Int num_rows, HYPRE_Int nnz, HYPRE_Int threads_per_row,
+                                         HYPRE_Int * perm, HYPRE_Int * rqperm,
+                                         HYPRE_Int * src_i, HYPRE_Int * src_j, HYPRE_Complex * src_data,
+                                         HYPRE_Int * dst_i, HYPRE_Int * dst_j, HYPRE_Complex * dst_data)
+{
+   HYPRE_Int tidx = hypre_gpu_get_thread_id<1>(item);
+   HYPRE_Int tid = tidx%threads_per_row;
+   HYPRE_Int rowSmall = tidx/threads_per_row;
+   HYPRE_Int row = (blockDim.x/threads_per_row)*blockIdx.x + rowSmall;
+
+   HYPRE_Int src_r0=0, src_r1=0, dst_r0=0, dst_r1=0;
+   if (row<num_rows) {
+      /* read the row pointers by the first thread in the warp */
+      if (tid==0) {
+         HYPRE_Int p = perm[row];
+         src_r0 = src_i[p];
+         src_r1 = src_i[p+1];
+         dst_r0 = dst_i[row];
+         dst_r1 = dst_i[row+1];
+      }
+   }
+   /* broadcast across the (sub) warp */
+   src_r0 = __shfl_sync(0xffffffff, src_r0, 0, threads_per_row);
+   src_r1 = __shfl_sync(0xffffffff, src_r1, 0, threads_per_row);
+   dst_r0 = __shfl_sync(0xffffffff, dst_r0, 0, threads_per_row);
+   dst_r1 = __shfl_sync(0xffffffff, dst_r1, 0, threads_per_row);
+
+   if (row<num_rows) {
+      for (HYPRE_Int t=tid; t<src_r1-src_r0; t+=threads_per_row) {
+         //if (src_r0+t<nnz && dst_r0+t<nnz) {
+         dst_j[dst_r0+t]    = rqperm[src_j[src_r0+t]]; //]
+         dst_data[dst_r0+t] = src_data[src_r0+t];
+         //}
+      }
+   }
+}
+
+HYPRE_Int nextPowerOfTwo(HYPRE_Int v) {
+  v--;
+  v |= v >> 1;
+  v |= v >> 2;
+  v |= v >> 4;
+  v |= v >> 8;
+  v |= v >> 16;
+  v++;
+  return v;
+}
+
+HYPRE_Int
+hypreDevice_CSRMatrixPermuteColsVals(HYPRE_Int nrows, HYPRE_Int nnz,
+                                     HYPRE_Int * perm, HYPRE_Int * rqperm,
+                                     HYPRE_Int * src_i, HYPRE_Int * src_j, HYPRE_Complex * src_data,
+                                     HYPRE_Int * dst_i, HYPRE_Int * dst_j, HYPRE_Complex * dst_data)
+{
+   HYPRE_Int num_threads=128;
+   HYPRE_Int threads_per_row = (nnz + nrows - 1)/nrows;
+   threads_per_row = std::min(nextPowerOfTwo(threads_per_row), HYPRE_WARP_SIZE);
+   HYPRE_Int num_rows_per_block = num_threads/threads_per_row;
+   HYPRE_Int num_blocks = (nrows + num_rows_per_block - 1)/num_rows_per_block;
+
+   /* compute the location of the diagonal in each row */
+   const dim3 bDim(num_threads,1,1);
+   const dim3 gDim(num_blocks,1,1);
+
+   HYPRE_GPU_LAUNCH( hypreGPUKernel_CSRMatrixPermuteColsVals, gDim, bDim, nrows, nnz, threads_per_row,
+                      perm, rqperm, src_i, src_j, src_data, dst_i, dst_j, dst_data);
+   return hypre_error_flag;
+}
+
+HYPRE_Int
+hypre_CSRMatrixApplyRowColPermutation( hypre_CSRMatrix    *A,
+                                       HYPRE_Int          *perm,
+                                       HYPRE_Int          *rqperm,
+                                       hypre_CSRMatrix   **B )
+{
+   HYPRE_Int           *A_i       = hypre_CSRMatrixI(A);
+   HYPRE_Int           *A_j       = hypre_CSRMatrixJ(A);
+   HYPRE_Complex       *A_data    = hypre_CSRMatrixData(A);
+   HYPRE_Int            n         = hypre_CSRMatrixNumRows(A);
+   HYPRE_Int            nnz       = hypre_CSRMatrixNumNonzeros(A);
+
+#if defined(HYPRE_USING_CUDA)
+   cudaEvent_t start, stop;
+   float time;
+   cudaEventCreate(&start);
+   cudaEventCreate(&stop);
+   cudaEventRecord(start, 0);
+#endif
+
+   /* No schur complement makes everything easy :) */
+   *B                               = hypre_CSRMatrixCreate(n, n, nnz);
+   hypre_CSRMatrixInitialize(*B);
+   HYPRE_Int        *B_i            = hypre_CSRMatrixI(*B);
+   HYPRE_Int        *B_j            = hypre_CSRMatrixJ(*B);
+   HYPRE_Complex    *B_data         = hypre_CSRMatrixData(*B);
+
+   /* compute permuted row ptrs */
+   hypreDevice_CSRMatrixComputePermutedRowPtrs(n, perm, A_i, B_i);
+   hypreDevice_IntegerExclusiveScan(n+1, B_i);
+
+   /* permute the cols/values */
+   hypreDevice_CSRMatrixPermuteColsVals(n, nnz, perm, rqperm, A_i, A_j, A_data, B_i, B_j, B_data);
+
+#if defined(HYPRE_USING_CUDA)
+   cudaEventRecord( stop, 0 );
+   cudaEventSynchronize( stop );
+   cudaEventElapsedTime( &time, start, stop );
+   //printf("%s %s %d : time=%1.5g\n",__FILE__,__FUNCTION__,__LINE__,time/1000.);
+   cudaEventDestroy( start );
+   cudaEventDestroy( stop );
+#endif
    return hypre_error_flag;
 }
 

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -325,6 +325,7 @@ HYPRE_Int hypre_CSRMatrixIntSpMVDevice( HYPRE_Int num_rows, HYPRE_Int num_nonzer
                                         HYPRE_Int alpha, HYPRE_Int *d_ia, HYPRE_Int *d_ja,
                                         HYPRE_Int *d_a, HYPRE_Int *d_x, HYPRE_Int beta,
                                         HYPRE_Int *d_y );
+HYPRE_Int hypre_CSRMatrixGetMainDiag(hypre_CSRMatrix *A, hypre_Vector *diag);
 
 #if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE) || defined(HYPRE_USING_ONEMKLSPARSE)
 hypre_CsrsvData* hypre_CsrsvDataCreate();
@@ -333,9 +334,14 @@ hypre_GpuMatData* hypre_GpuMatDataCreate();
 void hypre_GPUMatDataSetCSRData(hypre_GpuMatData *data, hypre_CSRMatrix *matrix);
 void hypre_GpuMatDataDestroy(hypre_GpuMatData *data);
 hypre_GpuMatData* hypre_CSRMatrixGetGPUMatData(hypre_CSRMatrix *matrix);
-#define hypre_CSRMatrixGPUMatDescr(matrix)       ( hypre_GpuMatDataMatDecsr(hypre_CSRMatrixGetGPUMatData(matrix)) )
+#define hypre_CSRMatrixGPUMatDescr(matrix)       ( hypre_GpuMatDataMatDescr(hypre_CSRMatrixGetGPUMatData(matrix)) )
 #define hypre_CSRMatrixGPUMatInfo(matrix)        ( hypre_GpuMatDataMatInfo (hypre_CSRMatrixGetGPUMatData(matrix)) )
 #define hypre_CSRMatrixGPUMatHandle(matrix)      ( hypre_GpuMatDataMatHandle (hypre_CSRMatrixGetGPUMatData(matrix)) )
 #define hypre_CSRMatrixGPUMatSpMVBuffer(matrix)  ( hypre_GpuMatDataSpMVBuffer (hypre_CSRMatrixGetGPUMatData(matrix)) )
 #endif
 void hypre_CSRMatrixGpuSpMVAnalysis(hypre_CSRMatrix *matrix);
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+HYPRE_Int
+hypre_CSRMatrixApplyRowColPermutation( hypre_CSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *rqperm, hypre_CSRMatrix **B );
+#endif

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -597,6 +597,7 @@ HYPRE_Int hypre_CSRMatrixIntSpMVDevice( HYPRE_Int num_rows, HYPRE_Int num_nonzer
                                         HYPRE_Int alpha, HYPRE_Int *d_ia, HYPRE_Int *d_ja,
                                         HYPRE_Int *d_a, HYPRE_Int *d_x, HYPRE_Int beta,
                                         HYPRE_Int *d_y );
+HYPRE_Int hypre_CSRMatrixGetMainDiag(hypre_CSRMatrix *A, hypre_Vector *diag);
 
 #if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE) || defined(HYPRE_USING_ONEMKLSPARSE)
 hypre_CsrsvData* hypre_CsrsvDataCreate();
@@ -605,12 +606,17 @@ hypre_GpuMatData* hypre_GpuMatDataCreate();
 void hypre_GPUMatDataSetCSRData(hypre_GpuMatData *data, hypre_CSRMatrix *matrix);
 void hypre_GpuMatDataDestroy(hypre_GpuMatData *data);
 hypre_GpuMatData* hypre_CSRMatrixGetGPUMatData(hypre_CSRMatrix *matrix);
-#define hypre_CSRMatrixGPUMatDescr(matrix)       ( hypre_GpuMatDataMatDecsr(hypre_CSRMatrixGetGPUMatData(matrix)) )
+#define hypre_CSRMatrixGPUMatDescr(matrix)       ( hypre_GpuMatDataMatDescr(hypre_CSRMatrixGetGPUMatData(matrix)) )
 #define hypre_CSRMatrixGPUMatInfo(matrix)        ( hypre_GpuMatDataMatInfo (hypre_CSRMatrixGetGPUMatData(matrix)) )
 #define hypre_CSRMatrixGPUMatHandle(matrix)      ( hypre_GpuMatDataMatHandle (hypre_CSRMatrixGetGPUMatData(matrix)) )
 #define hypre_CSRMatrixGPUMatSpMVBuffer(matrix)  ( hypre_GpuMatDataSpMVBuffer (hypre_CSRMatrixGetGPUMatData(matrix)) )
 #endif
 void hypre_CSRMatrixGpuSpMVAnalysis(hypre_CSRMatrix *matrix);
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+HYPRE_Int
+hypre_CSRMatrixApplyRowColPermutation( hypre_CSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *rqperm, hypre_CSRMatrix **B );
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1405,6 +1405,7 @@ typedef struct
 #define hypre_HandleCurandGenerator(hypre_handle)                hypre_DeviceDataCurandGenerator(hypre_HandleDeviceData(hypre_handle))
 #define hypre_HandleCublasHandle(hypre_handle)                   hypre_DeviceDataCublasHandle(hypre_HandleDeviceData(hypre_handle))
 #define hypre_HandleCusparseHandle(hypre_handle)                 hypre_DeviceDataCusparseHandle(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleCusolverSpHandle(hypre_handle)               hypre_DeviceDataCusolverSpHandle(hypre_HandleDeviceData(hypre_handle))
 #define hypre_HandleComputeStream(hypre_handle)                  hypre_DeviceDataComputeStream(hypre_HandleDeviceData(hypre_handle))
 #define hypre_HandleCubBinGrowth(hypre_handle)                   hypre_DeviceDataCubBinGrowth(hypre_HandleDeviceData(hypre_handle))
 #define hypre_HandleCubMinBin(hypre_handle)                      hypre_DeviceDataCubMinBin(hypre_HandleDeviceData(hypre_handle))
@@ -1893,6 +1894,7 @@ HYPRE_Int hypre_CudaCompileFlagCheck();
 
 HYPRE_Int hypreDevice_zeqxmydd(HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex alpha, HYPRE_Complex *y,
                                HYPRE_Complex *z, HYPRE_Complex *d);
+HYPRE_Int hypreDevice_fused_vecop(HYPRE_Int n, HYPRE_Complex alpha, HYPRE_Complex *x, HYPRE_Complex beta, HYPRE_Complex *y, HYPRE_Complex *z, HYPRE_Complex *d);
 
 #endif
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -74,6 +74,7 @@ using hypre_DeviceItem = void*;
 #include <curand.h>
 #include <cublas_v2.h>
 #include <cusparse.h>
+#include <cusolverSp.h>
 
 #ifndef CUDART_VERSION
 #error CUDART_VERSION Undefined!
@@ -361,6 +362,9 @@ using hypre_DeviceItem = sycl::nd_item<1>;
 #define hypre_rocsparse_csrgemm_buffer_size    rocsparse_scsrgemm_buffer_size
 #define hypre_rocsparse_csrgemm                rocsparse_scsrgemm
 #define hypre_rocsparse_csr2csc                rocsparse_scsr2csc
+#define hypre_rocsparse_csrilu0_buffer_size    rocsparse_scsrilu0_buffer_size
+#define hypre_rocsparse_csrilu0_analysis       rocsparse_scsrilu0_analysis
+#define hypre_rocsparse_csrilu0                rocsparse_scsrilu0
 #elif defined(HYPRE_LONG_DOUBLE) /* Long Double */
 /* ... */
 #else /* Double */
@@ -393,6 +397,9 @@ using hypre_DeviceItem = sycl::nd_item<1>;
 #define hypre_rocsparse_csrgemm_buffer_size    rocsparse_dcsrgemm_buffer_size
 #define hypre_rocsparse_csrgemm                rocsparse_dcsrgemm
 #define hypre_rocsparse_csr2csc                rocsparse_dcsr2csc
+#define hypre_rocsparse_csrilu0_buffer_size    rocsparse_dcsrilu0_buffer_size
+#define hypre_rocsparse_csrilu0_analysis       rocsparse_dcsrilu0_analysis
+#define hypre_rocsparse_csrilu0                rocsparse_dcsrilu0
 #endif
 
 
@@ -409,6 +416,14 @@ using hypre_DeviceItem = sycl::nd_item<1>;
    if (CUSPARSE_STATUS_SUCCESS != err) {                                                     \
       printf("CUSPARSE ERROR (code = %d, %s) at %s:%d\n",                                    \
             err, cusparseGetErrorString(err), __FILE__, __LINE__);                           \
+      hypre_assert(0); exit(1);                                                              \
+   } } while(0)
+
+#define HYPRE_CUSOLVER_CALL(call) do {                                                       \
+   cusolverStatus_t err = call;                                                              \
+   if (CUSOLVER_STATUS_SUCCESS != err) {                                                     \
+      printf("CUSOLVER ERROR (code = %d) at %s:%d\n",                                        \
+            err, __FILE__, __LINE__);                                                        \
       hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
@@ -488,6 +503,10 @@ struct hypre_DeviceData
 
 #if defined(HYPRE_USING_CUSPARSE)
    cusparseHandle_t                  cusparse_handle;
+#endif
+
+#if defined(HYPRE_USING_CUSOLVER)
+   cusolverSpHandle_t                cusolverSp_handle;
 #endif
 
 #if defined(HYPRE_USING_ROCSPARSE)
@@ -602,6 +621,10 @@ cublasHandle_t      hypre_DeviceDataCublasHandle(hypre_DeviceData *data);
 cusparseHandle_t    hypre_DeviceDataCusparseHandle(hypre_DeviceData *data);
 #endif
 
+#if defined(HYPRE_USING_CUSOLVER)
+cusolverSpHandle_t  hypre_DeviceDataCusolverSpHandle(hypre_DeviceData *data);
+#endif
+
 #if defined(HYPRE_USING_ROCSPARSE)
 rocsparse_handle    hypre_DeviceDataCusparseHandle(hypre_DeviceData *data);
 #endif
@@ -623,22 +646,31 @@ struct hypre_CsrsvData
 #if defined(HYPRE_USING_CUSPARSE)
    csrsv2Info_t info_L;
    csrsv2Info_t info_U;
+   cusparseSolvePolicy_t solve_policy;
+   /* place holder */
+   char analysis_policy;
 #elif defined(HYPRE_USING_ROCSPARSE)
    rocsparse_mat_info info_L;
    rocsparse_mat_info info_U;
+   rocsparse_solve_policy solve_policy;
+   rocsparse_analysis_policy analysis_policy;
 #elif defined(HYPRE_USING_ONEMKLSPARSE)
    /* WM: todo - placeholders */
    char info_L;
    char info_U;
+   char analysis_policy;
+   char solve_policy;
 #endif
    hypre_int    BufferSize;
    char        *Buffer;
 };
 
-#define hypre_CsrsvDataInfoL(data)      ((data) -> info_L)
-#define hypre_CsrsvDataInfoU(data)      ((data) -> info_U)
-#define hypre_CsrsvDataBufferSize(data) ((data) -> BufferSize)
-#define hypre_CsrsvDataBuffer(data)     ((data) -> Buffer)
+#define hypre_CsrsvDataInfoL(data)          ((data) -> info_L)
+#define hypre_CsrsvDataInfoU(data)          ((data) -> info_U)
+#define hypre_CsrsvDataBufferSize(data)     ((data) -> BufferSize)
+#define hypre_CsrsvDataBuffer(data)         ((data) -> Buffer)
+#define hypre_CsrsvDataSolvePolicy(data)    ((data) -> solve_policy)
+#define hypre_CsrsvDataAnalysisPolicy(data) ((data) -> analysis_policy)
 
 struct hypre_GpuMatData
 {
@@ -657,7 +689,7 @@ struct hypre_GpuMatData
 #endif
 };
 
-#define hypre_GpuMatDataMatDecsr(data)    ((data) -> mat_descr)
+#define hypre_GpuMatDataMatDescr(data)    ((data) -> mat_descr)
 #define hypre_GpuMatDataMatInfo(data)     ((data) -> mat_info)
 #define hypre_GpuMatDataMatHandle(data)   ((data) -> mat_handle)
 #define hypre_GpuMatDataSpMVBuffer(data)  ((data) -> spmv_buffer)

--- a/src/utilities/device_utils.c
+++ b/src/utilities/device_utils.c
@@ -130,6 +130,14 @@ hypre_DeviceDataDestroy(hypre_DeviceData *data)
    }
 #endif // #if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
 
+#if defined(HYPRE_USING_CUSOLVER)
+   if (data->cusolverSp_handle)
+   {
+      HYPRE_CUSOLVER_CALL( cusolverSpDestroy(data->cusolverSp_handle) );
+   }
+#endif // #if defined(HYPRE_USING_CUSOLVER)
+
+
 #if defined(HYPRE_USING_CUDA_STREAMS)
    for (HYPRE_Int i = 0; i < HYPRE_MAX_NUM_STREAMS; i++)
    {
@@ -2581,6 +2589,49 @@ hypreDevice_zeqxmydd(HYPRE_Int      n,
    return hypre_error_flag;
 }
 
+/*****************************************************************
+           Pauls Changes for IterTriSolve Branch
+ ******************************************************************/
+
+__global__ void
+hypreGPUKernel_fused_vecop(hypre_DeviceItem &item, HYPRE_Int n, HYPRE_Complex alpha, HYPRE_Complex *x, HYPRE_Complex beta, HYPRE_Complex *y, HYPRE_Complex *z, HYPRE_Complex *d)
+{
+   HYPRE_Int i = hypre_gpu_get_grid_thread_id<1, 1>(item);
+
+   if (i < n)
+   {
+     HYPRE_Complex yy = y[i];
+     HYPRE_Complex xx = z[i] + alpha*yy;
+     x[i] = xx;
+     z[i] = (xx + beta * yy)*d[i];
+   }
+}
+
+/*
+ */
+HYPRE_Int
+hypreDevice_fused_vecop(HYPRE_Int n, HYPRE_Complex alpha, HYPRE_Complex *x, HYPRE_Complex beta, HYPRE_Complex *y, HYPRE_Complex *z, HYPRE_Complex *d)
+{
+   /* trivial case */
+   if (n <= 0)
+   {
+      return hypre_error_flag;
+   }
+
+   dim3 bDim = hypre_GetDefaultDeviceBlockDimension();
+   dim3 gDim = hypre_GetDefaultDeviceGridDimension(n, "thread", bDim);
+
+   HYPRE_GPU_LAUNCH( hypreGPUKernel_fused_vecop, gDim, bDim, n, alpha, x, beta, y, z, d);
+
+   return hypre_error_flag;
+}
+
+
+/*****************************************************************
+           End Pauls Changes for IterTriSolve Branch
+ ******************************************************************/
+
+
 /*--------------------------------------------------------------------
  * hypreGPUKernel_BigToSmallCopy
  *--------------------------------------------------------------------*/
@@ -2731,6 +2782,27 @@ hypre_DeviceDataCusparseHandle(hypre_DeviceData *data)
    return handle;
 }
 #endif // defined(HYPRE_USING_CUSPARSE)
+
+
+#if defined(HYPRE_USING_CUSOLVER)
+cusolverSpHandle_t
+hypre_DeviceDataCusolverSpHandle(hypre_DeviceData *data)
+{
+   if (data->cusolverSp_handle)
+   {
+      return data->cusolverSp_handle;
+   }
+
+   cusolverSpHandle_t handle;
+   HYPRE_CUSOLVER_CALL( cusolverSpCreate(&handle) );
+
+   HYPRE_CUSOLVER_CALL( cusolverSpSetStream(handle, hypre_DeviceDataComputeStream(data)) );
+
+   data->cusolverSp_handle = handle;
+
+   return handle;
+}
+#endif // defined(HYPRE_USING_CUSOLVER)
 
 
 #if defined(HYPRE_USING_ROCSPARSE)

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -22,6 +22,7 @@ using hypre_DeviceItem = void*;
 #include <curand.h>
 #include <cublas_v2.h>
 #include <cusparse.h>
+#include <cusolverSp.h>
 
 #ifndef CUDART_VERSION
 #error CUDART_VERSION Undefined!
@@ -309,6 +310,9 @@ using hypre_DeviceItem = sycl::nd_item<1>;
 #define hypre_rocsparse_csrgemm_buffer_size    rocsparse_scsrgemm_buffer_size
 #define hypre_rocsparse_csrgemm                rocsparse_scsrgemm
 #define hypre_rocsparse_csr2csc                rocsparse_scsr2csc
+#define hypre_rocsparse_csrilu0_buffer_size    rocsparse_scsrilu0_buffer_size
+#define hypre_rocsparse_csrilu0_analysis       rocsparse_scsrilu0_analysis
+#define hypre_rocsparse_csrilu0                rocsparse_scsrilu0
 #elif defined(HYPRE_LONG_DOUBLE) /* Long Double */
 /* ... */
 #else /* Double */
@@ -341,6 +345,9 @@ using hypre_DeviceItem = sycl::nd_item<1>;
 #define hypre_rocsparse_csrgemm_buffer_size    rocsparse_dcsrgemm_buffer_size
 #define hypre_rocsparse_csrgemm                rocsparse_dcsrgemm
 #define hypre_rocsparse_csr2csc                rocsparse_dcsr2csc
+#define hypre_rocsparse_csrilu0_buffer_size    rocsparse_dcsrilu0_buffer_size
+#define hypre_rocsparse_csrilu0_analysis       rocsparse_dcsrilu0_analysis
+#define hypre_rocsparse_csrilu0                rocsparse_dcsrilu0
 #endif
 
 
@@ -357,6 +364,14 @@ using hypre_DeviceItem = sycl::nd_item<1>;
    if (CUSPARSE_STATUS_SUCCESS != err) {                                                     \
       printf("CUSPARSE ERROR (code = %d, %s) at %s:%d\n",                                    \
             err, cusparseGetErrorString(err), __FILE__, __LINE__);                           \
+      hypre_assert(0); exit(1);                                                              \
+   } } while(0)
+
+#define HYPRE_CUSOLVER_CALL(call) do {                                                       \
+   cusolverStatus_t err = call;                                                              \
+   if (CUSOLVER_STATUS_SUCCESS != err) {                                                     \
+      printf("CUSOLVER ERROR (code = %d) at %s:%d\n",                                        \
+            err, __FILE__, __LINE__);                                                        \
       hypre_assert(0); exit(1);                                                              \
    } } while(0)
 
@@ -436,6 +451,10 @@ struct hypre_DeviceData
 
 #if defined(HYPRE_USING_CUSPARSE)
    cusparseHandle_t                  cusparse_handle;
+#endif
+
+#if defined(HYPRE_USING_CUSOLVER)
+   cusolverSpHandle_t                cusolverSp_handle;
 #endif
 
 #if defined(HYPRE_USING_ROCSPARSE)
@@ -550,6 +569,10 @@ cublasHandle_t      hypre_DeviceDataCublasHandle(hypre_DeviceData *data);
 cusparseHandle_t    hypre_DeviceDataCusparseHandle(hypre_DeviceData *data);
 #endif
 
+#if defined(HYPRE_USING_CUSOLVER)
+cusolverSpHandle_t  hypre_DeviceDataCusolverSpHandle(hypre_DeviceData *data);
+#endif
+
 #if defined(HYPRE_USING_ROCSPARSE)
 rocsparse_handle    hypre_DeviceDataCusparseHandle(hypre_DeviceData *data);
 #endif
@@ -571,22 +594,31 @@ struct hypre_CsrsvData
 #if defined(HYPRE_USING_CUSPARSE)
    csrsv2Info_t info_L;
    csrsv2Info_t info_U;
+   cusparseSolvePolicy_t solve_policy;
+   /* place holder */
+   char analysis_policy;
 #elif defined(HYPRE_USING_ROCSPARSE)
    rocsparse_mat_info info_L;
    rocsparse_mat_info info_U;
+   rocsparse_solve_policy solve_policy;
+   rocsparse_analysis_policy analysis_policy;
 #elif defined(HYPRE_USING_ONEMKLSPARSE)
    /* WM: todo - placeholders */
    char info_L;
    char info_U;
+   char analysis_policy;
+   char solve_policy;
 #endif
    hypre_int    BufferSize;
    char        *Buffer;
 };
 
-#define hypre_CsrsvDataInfoL(data)      ((data) -> info_L)
-#define hypre_CsrsvDataInfoU(data)      ((data) -> info_U)
-#define hypre_CsrsvDataBufferSize(data) ((data) -> BufferSize)
-#define hypre_CsrsvDataBuffer(data)     ((data) -> Buffer)
+#define hypre_CsrsvDataInfoL(data)          ((data) -> info_L)
+#define hypre_CsrsvDataInfoU(data)          ((data) -> info_U)
+#define hypre_CsrsvDataBufferSize(data)     ((data) -> BufferSize)
+#define hypre_CsrsvDataBuffer(data)         ((data) -> Buffer)
+#define hypre_CsrsvDataSolvePolicy(data)    ((data) -> solve_policy)
+#define hypre_CsrsvDataAnalysisPolicy(data) ((data) -> analysis_policy)
 
 struct hypre_GpuMatData
 {
@@ -605,7 +637,7 @@ struct hypre_GpuMatData
 #endif
 };
 
-#define hypre_GpuMatDataMatDecsr(data)    ((data) -> mat_descr)
+#define hypre_GpuMatDataMatDescr(data)    ((data) -> mat_descr)
 #define hypre_GpuMatDataMatInfo(data)     ((data) -> mat_info)
 #define hypre_GpuMatDataMatHandle(data)   ((data) -> mat_handle)
 #define hypre_GpuMatDataSpMVBuffer(data)  ((data) -> spmv_buffer)

--- a/src/utilities/protos.h
+++ b/src/utilities/protos.h
@@ -329,6 +329,7 @@ HYPRE_Int hypre_CudaCompileFlagCheck();
 
 HYPRE_Int hypreDevice_zeqxmydd(HYPRE_Int n, HYPRE_Complex *x, HYPRE_Complex alpha, HYPRE_Complex *y,
                                HYPRE_Complex *z, HYPRE_Complex *d);
+HYPRE_Int hypreDevice_fused_vecop(HYPRE_Int n, HYPRE_Complex alpha, HYPRE_Complex *x, HYPRE_Complex beta, HYPRE_Complex *y, HYPRE_Complex *z, HYPRE_Complex *d);
 
 #endif
 


### PR DESCRIPTION
Jacobi iterations with API for CPU ILU solver. GPU jacobi iterative solve now works with any ilu factorization choices.

Added GPU implementation of Matrix Row/Column permutation (should work for CUDA and HIP).

Added in hooks for cusolver (used for RCM reordering)

When iterative tri solve is chosen, one doesn't need to call solve analysis for the L and U factors.

Added Lower/Upper Jacobi iteration parameters for more flexibility.

Schur compliment iterative triangular solver works

AMD and Nvidia architectures work for block ILU0

Block Jacobi ILU0 and Block Jacobi ILU0 with Schur Compliment solvers work on summit and crusher without uvm.