### PR TITLE
Fix warning messages about set-but-not-used variables

### DIFF
--- a/src/IJ_mv/IJMatrix_parcsr.c
+++ b/src/IJ_mv/IJMatrix_parcsr.c
@@ -2984,7 +2984,7 @@ hypre_IJMatrixSetValuesOMPParCSR( hypre_IJMatrix       *matrix,
 
    HYPRE_Int print_level = hypre_IJMatrixPrintLevel(matrix);
    //HYPRE_Int max_num_threads;
-   HYPRE_Int error_flag = 0;
+   //HYPRE_Int error_flag = 0;
 
    /*HYPRE_Complex *off_proc_data;*/
    hypre_MPI_Comm_size(comm, &num_procs);
@@ -3094,7 +3094,7 @@ hypre_IJMatrixSetValuesOMPParCSR( hypre_IJMatrix       *matrix,
 #ifdef HYPRE_USING_OPENMP
                   #pragma omp atomic
 #endif
-                  error_flag++;
+                  //error_flag++;
                   if (print_level)
                   {
                      hypre_printf (" row %b too long! \n", row);
@@ -3122,7 +3122,7 @@ hypre_IJMatrixSetValuesOMPParCSR( hypre_IJMatrix       *matrix,
 #ifdef HYPRE_USING_OPENMP
                         #pragma omp atomic
 #endif
-                        error_flag++;
+                        //error_flag++;
                         if (print_level)
                         {
                            hypre_printf (" Error, element %b %b does not exist\n",
@@ -3146,7 +3146,7 @@ hypre_IJMatrixSetValuesOMPParCSR( hypre_IJMatrix       *matrix,
 #ifdef HYPRE_USING_OPENMP
                         #pragma omp atomic
 #endif
-                        error_flag++;
+                        //error_flag++;
                         if (print_level)
                         {
                            hypre_printf (" Error, element %b %b does not exist\n",
@@ -3166,7 +3166,7 @@ hypre_IJMatrixSetValuesOMPParCSR( hypre_IJMatrix       *matrix,
 #ifdef HYPRE_USING_OPENMP
                         #pragma omp atomic
 #endif
-                        error_flag++;
+                        //error_flag++;
                         if (print_level)
                         {
                            hypre_printf (" Error, element %b %b does not exist\n",
@@ -3194,7 +3194,7 @@ hypre_IJMatrixSetValuesOMPParCSR( hypre_IJMatrix       *matrix,
 #ifdef HYPRE_USING_OPENMP
                         #pragma omp atomic
 #endif
-                        error_flag++;
+                        //error_flag++;
                         if (print_level)
                         {
                            hypre_printf (" Error, element %b %b does not exist\n",
@@ -3453,7 +3453,7 @@ hypre_IJMatrixSetValuesOMPParCSR( hypre_IJMatrix       *matrix,
 #ifdef HYPRE_USING_OPENMP
                               #pragma omp atomic
 #endif
-                              error_flag++;
+                              //error_flag++;
                               if (print_level)
                               {
                                  hypre_printf("Error in row %b ! Too many elements!\n",
@@ -3489,7 +3489,7 @@ hypre_IJMatrixSetValuesOMPParCSR( hypre_IJMatrix       *matrix,
 #ifdef HYPRE_USING_OPENMP
                               #pragma omp atomic
 #endif
-                              error_flag++;
+                              //error_flag++;
                               if (print_level)
                               {
                                  hypre_printf("Error in row %b ! Too many elements !\n",

--- a/src/distributed_ls/Euclid/ilu_seq.c
+++ b/src/distributed_ls/Euclid/ilu_seq.c
@@ -246,7 +246,7 @@ void iluk_seq_block(Euclid_dh ctx)
   Factor_dh F = ctx->F;
   SubdomainGraph_dh sg = ctx->sg;
   bool bj = false, constrained = false;
-  HYPRE_Int discard = 0;
+  //HYPRE_Int discard = 0;
   HYPRE_Int gr = -1;  /* globalRow */
   bool debug = false;
 
@@ -359,7 +359,7 @@ void iluk_seq_block(Euclid_dh ctx)
             fill[idx] = tmpFill[col];
             ++idx;
           } else {
-            ++discard; 
+             //++discard; 
           }
         }
         col = list[col];
@@ -372,7 +372,7 @@ void iluk_seq_block(Euclid_dh ctx)
           fill[idx] = tmpFill[col];
           ++idx;
         } else { 
-          ++discard; 
+           //++discard; 
         }
         col = list[col];
       }

--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -1117,8 +1117,8 @@ typedef struct hypre_ParILUData_struct
    HYPRE_Real           *matmD;
    hypre_ParCSRMatrix   *matmU;
    hypre_ParCSRMatrix   *matS;
-   HYPRE_Real
-   *droptol;/* should be an array of 3 element, for B, (E and F), S respectively */
+   /* should be an array of 3 element, for B, (E and F), S respectively */
+   HYPRE_Real           *droptol;
    HYPRE_Int             lfil;
    HYPRE_Int             maxRowNnz;
    HYPRE_Int            *CF_marker_array;
@@ -1134,22 +1134,17 @@ typedef struct hypre_ParILUData_struct
    HYPRE_Real            final_rel_residual_norm;
    HYPRE_Real            tol;
    HYPRE_Real            operator_complexity;
-
    HYPRE_Int             logging;
    HYPRE_Int             print_level;
    HYPRE_Int             max_iter;
-
    HYPRE_Int             tri_solve;
    HYPRE_Int             lower_jacobi_iters;
    HYPRE_Int             upper_jacobi_iters;
-
    HYPRE_Int             ilu_type;
    HYPRE_Int             nLU;
    HYPRE_Int             nI;
-
    /* used when schur block is formed */
    HYPRE_Int            *u_end;
-
    /* temp vectors for solve phase */
    hypre_ParVector      *Utemp;
    hypre_ParVector      *Ftemp;
@@ -1158,53 +1153,46 @@ typedef struct hypre_ParILUData_struct
    hypre_Vector         *Ztemp;
    HYPRE_Real           *uext;
    HYPRE_Real           *fext;
-
    /* data structure sor solving Schur System */
    HYPRE_Solver          schur_solver;
    HYPRE_Solver          schur_precond;
    hypre_ParVector      *rhs;
    hypre_ParVector      *x;
-
-   /* schur solver data */
-   /* -> GENERAL-SLOTS */
+   /* Schur solver data */
    HYPRE_Int             ss_logging;
    HYPRE_Int             ss_print_level;
-
-   /* -> SCHUR-GMRES */
-   HYPRE_Int             ss_kDim;/* max number of iterations for GMRES */
-   HYPRE_Int             ss_max_iter;/* max number of iterations for GMRES solve */
-   HYPRE_Real            ss_tol;/* stop iteration tol for GMRES */
-   HYPRE_Real            ss_absolute_tol;/* absolute tol for GMRES or tol for NSH solve */
+   /* Schur-GMRES */
+   HYPRE_Int             ss_kDim;               /* max number of iterations for GMRES */
+   HYPRE_Int             ss_max_iter;           /* max number of iterations for GMRES solve */
+   HYPRE_Real            ss_tol;                /* stop iteration tol for GMRES */
+   HYPRE_Real            ss_absolute_tol;       /* absolute tol for GMRES or tol for NSH solve */
    HYPRE_Int             ss_rel_change;
-
-   /* -> SCHUR-NSH */
-   HYPRE_Int             ss_nsh_setup_max_iter;/* number of iterations for NSH inverse */
-   HYPRE_Int             ss_nsh_solve_max_iter;/* max number of iterations for NSH solve */
-   HYPRE_Real            ss_nsh_setup_tol;/* stop iteration tol for NSH inverse */
-   HYPRE_Real            ss_nsh_solve_tol;/* absolute tol for NSH solve */
-   HYPRE_Int             ss_nsh_max_row_nnz;/* max rows of nonzeros for NSH */
-   HYPRE_Int             ss_nsh_mr_col_version;/* MR column version setting in NSH */
-   HYPRE_Int             ss_nsh_mr_max_row_nnz;/* max rows for MR  */
-   HYPRE_Real           *ss_nsh_droptol;/* droptol array for NSH */
-   HYPRE_Int             ss_nsh_mr_max_iter;/* max MR iteration */
+   /* Schur-NSH */
+   HYPRE_Int             ss_nsh_setup_max_iter; /* number of iterations for NSH inverse */
+   HYPRE_Int             ss_nsh_solve_max_iter; /* max number of iterations for NSH solve */
+   HYPRE_Real            ss_nsh_setup_tol;      /* stop iteration tol for NSH inverse */
+   HYPRE_Real            ss_nsh_solve_tol;      /* absolute tol for NSH solve */
+   HYPRE_Int             ss_nsh_max_row_nnz;    /* max rows of nonzeros for NSH */
+   HYPRE_Int             ss_nsh_mr_col_version; /* MR column version setting in NSH */
+   HYPRE_Int             ss_nsh_mr_max_row_nnz; /* max rows for MR  */
+   HYPRE_Real           *ss_nsh_droptol;        /* droptol array for NSH */
+   HYPRE_Int             ss_nsh_mr_max_iter;    /* max MR iteration */
    HYPRE_Real            ss_nsh_mr_tol;
-
-   /* schur precond data */
-   HYPRE_Int             sp_ilu_type;/* ilu type is use ILU */
-   HYPRE_Int             sp_ilu_lfil;/* level of fill in for ILUK */
-   HYPRE_Int             sp_ilu_max_row_nnz;/* max rows for ILUT  */
+   /* Schur precond data */
+   HYPRE_Int             sp_ilu_type;           /* ilu type is use ILU */
+   HYPRE_Int             sp_ilu_lfil;           /* level of fill in for ILUK */
+   HYPRE_Int             sp_ilu_max_row_nnz;    /* max rows for ILUT  */
    /* droptol for ILUT or MR
     * ILUT: [0], [1], [2] B, E&F, S respectively
     * NSH: [0] for MR, [1] for NSH
     */
-   HYPRE_Real           *sp_ilu_droptol;/* droptol array for ILUT */
+   HYPRE_Real           *sp_ilu_droptol;        /* droptol array for ILUT */
    HYPRE_Int             sp_print_level;
-   HYPRE_Int             sp_max_iter;/* max precond iter or max MR iteration */
+   HYPRE_Int             sp_max_iter;           /* max precond iter or max MR iteration */
    HYPRE_Int             sp_tri_solve;
    HYPRE_Int             sp_lower_jacobi_iters;
    HYPRE_Int             sp_upper_jacobi_iters;
    HYPRE_Real            sp_tol;
-
    HYPRE_Int             test_opt;
    /* local reordering */
    HYPRE_Int             reordering_type;
@@ -1322,44 +1310,39 @@ typedef struct hypre_ParILUData_struct
 typedef struct hypre_ParNSHData_struct
 {
    /* solver information */
-   HYPRE_Int             global_solver;
+   HYPRE_Int              global_solver;
    hypre_ParCSRMatrix    *matA;
    hypre_ParCSRMatrix    *matM;
    hypre_ParVector       *F;
    hypre_ParVector       *U;
    hypre_ParVector       *residual;
    HYPRE_Real            *rel_res_norms;
-   HYPRE_Int             num_iterations;
+   HYPRE_Int              num_iterations;
    HYPRE_Real            *l1_norms;
-   HYPRE_Real            final_rel_residual_norm;
-   HYPRE_Real            tol;
-   HYPRE_Real            operator_complexity;
-
-   HYPRE_Int             logging;
-   HYPRE_Int             print_level;
-   HYPRE_Int             max_iter;
-
+   HYPRE_Real             final_rel_residual_norm;
+   HYPRE_Real             tol;
+   HYPRE_Real             operator_complexity;
+   HYPRE_Int              logging;
+   HYPRE_Int              print_level;
+   HYPRE_Int              max_iter;
    /* common data slots */
    /* droptol[0]: droptol for MR
     * droptol[1]: droptol for NSH
     */
    HYPRE_Real            *droptol;
-   HYPRE_Int             own_droptol_data;
-
+   HYPRE_Int              own_droptol_data;
    /* temp vectors for solve phase */
    hypre_ParVector       *Utemp;
    hypre_ParVector       *Ftemp;
-
    /* data slots for local MR */
-   HYPRE_Int             mr_max_iter;
-   HYPRE_Real            mr_tol;
-   HYPRE_Int             mr_max_row_nnz;
-   HYPRE_Int             mr_col_version;/* global version or column version MR */
-
+   HYPRE_Int              mr_max_iter;
+   HYPRE_Real             mr_tol;
+   HYPRE_Int              mr_max_row_nnz;
+   HYPRE_Int              mr_col_version; /* global version or column version MR */
    /* data slots for global NSH */
-   HYPRE_Int             nsh_max_iter;
-   HYPRE_Real            nsh_tol;
-   HYPRE_Int             nsh_max_row_nnz;
+   HYPRE_Int              nsh_max_iter;
+   HYPRE_Real             nsh_tol;
+   HYPRE_Int              nsh_max_row_nnz;
 } hypre_ParNSHData;
 
 #define hypre_ParNSHDataGlobalSolver(nsh_data)           ((nsh_data) -> global_solver)
@@ -4044,28 +4027,63 @@ HYPRE_Int hypre_FSAISolve ( void *fsai_vdata, hypre_ParCSRMatrix *A, hypre_ParVe
                             hypre_ParVector *x );
 
 /* par_ilu.c */
-HYPRE_Int hypre_ILUSolveCusparseLU(hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d, hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp, hypre_ParVector *utemp);
-HYPRE_Int hypre_ILUSolveCusparseSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp, hypre_ParVector *utemp, HYPRE_Solver schur_solver, HYPRE_Solver schur_precond, hypre_ParVector *rhs, hypre_ParVector *x, HYPRE_Int *u_end, hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d);
-HYPRE_Int hypre_ILUSolveRAPGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp, hypre_ParVector *utemp, hypre_ParVector *xtemp, hypre_ParVector *ytemp, HYPRE_Solver schur_solver, HYPRE_Solver schur_precond, hypre_ParVector *rhs, hypre_ParVector *x, HYPRE_Int *u_end, hypre_ParCSRMatrix *Aperm, hypre_CSRMatrix *matALU_d, hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d, HYPRE_Int test_opt);
-HYPRE_Int hypre_ParILUCusparseILUExtractEBFC(hypre_CSRMatrix *A_diag, HYPRE_Int nLU, hypre_CSRMatrix **Bp, hypre_CSRMatrix **Cp, hypre_CSRMatrix **Ep, hypre_CSRMatrix **Fp);
-HYPRE_Int hypre_ParILURAPReorder(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *rqperm, hypre_ParCSRMatrix **A_pq);
-HYPRE_Int hypre_ILUSetupLDUtoCusparse(hypre_ParCSRMatrix *L, HYPRE_Real *D, hypre_ParCSRMatrix *U, hypre_ParCSRMatrix **LDUp);
-HYPRE_Int hypre_ILUSetupRAPMILU0(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix **ALUp, HYPRE_Int modified);
+HYPRE_Int hypre_ILUSolveCusparseLU(hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d,
+                                   hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp,
+                                   hypre_ParVector *utemp);
+HYPRE_Int hypre_ILUSolveCusparseSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f,
+                                           hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp,
+                                           hypre_ParVector *utemp, HYPRE_Solver schur_solver, HYPRE_Solver schur_precond, hypre_ParVector *rhs,
+                                           hypre_ParVector *x, HYPRE_Int *u_end, hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d,
+                                           hypre_CSRMatrix *matF_d);
+HYPRE_Int hypre_ILUSolveRAPGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u,
+                                 HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp,
+                                 hypre_ParVector *utemp, hypre_ParVector *xtemp, hypre_ParVector *ytemp, HYPRE_Solver schur_solver,
+                                 HYPRE_Solver schur_precond, hypre_ParVector *rhs, hypre_ParVector *x, HYPRE_Int *u_end,
+                                 hypre_ParCSRMatrix *Aperm, hypre_CSRMatrix *matALU_d, hypre_CSRMatrix *matBLU_d,
+                                 hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d, HYPRE_Int test_opt);
+HYPRE_Int hypre_ParILUCusparseILUExtractEBFC(hypre_CSRMatrix *A_diag, HYPRE_Int nLU,
+                                             hypre_CSRMatrix **Bp, hypre_CSRMatrix **Cp, hypre_CSRMatrix **Ep, hypre_CSRMatrix **Fp);
+HYPRE_Int hypre_ParILURAPReorder(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *rqperm,
+                                 hypre_ParCSRMatrix **A_pq);
+HYPRE_Int hypre_ILUSetupLDUtoCusparse(hypre_ParCSRMatrix *L, HYPRE_Real *D, hypre_ParCSRMatrix *U,
+                                      hypre_ParCSRMatrix **LDUp);
+HYPRE_Int hypre_ILUSetupRAPMILU0(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix **ALUp,
+                                 HYPRE_Int modified);
 HYPRE_Int hypre_ParILUCusparseSchurGMRESDummySetup(void *a, void *b, void *c, void *d);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESDummySolve(void *ilu_vdata, void *ilu_vdata2, hypre_ParVector *f, hypre_ParVector *u);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESCommInfo(void *ilu_vdata, HYPRE_Int *my_id, HYPRE_Int *num_procs);
+HYPRE_Int hypre_ParILUCusparseSchurGMRESDummySolve(void *ilu_vdata, void *ilu_vdata2,
+                                                   hypre_ParVector *f, hypre_ParVector *u);
+HYPRE_Int hypre_ParILUCusparseSchurGMRESCommInfo(void *ilu_vdata, HYPRE_Int *my_id,
+                                                 HYPRE_Int *num_procs);
 void *hypre_ParILUCusparseSchurGMRESMatvecCreate(void *ilu_vdata, void *x);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha, void *ilu_vdata, void *x, HYPRE_Complex beta, void *y);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESMatvecDestroy(void *matvec_data ); HYPRE_Int hypre_ParILURAPSchurGMRESDummySetup(void *a, void *b, void *c, void *d);
-HYPRE_Int hypre_ParILURAPSchurGMRESSolve(void *ilu_vdata, void *ilu_vdata2, hypre_ParVector *f, hypre_ParVector *u); void *hypre_ParILURAPSchurGMRESMatvecCreate(void *ilu_vdata, void *x);
-HYPRE_Int hypre_ParILURAPSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha, void *ilu_vdata, void *x, HYPRE_Complex beta, void *y);
+HYPRE_Int hypre_ParILUCusparseSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha,
+                                               void *ilu_vdata, void *x, HYPRE_Complex beta, void *y);
+HYPRE_Int hypre_ParILUCusparseSchurGMRESMatvecDestroy(void *matvec_data );
+HYPRE_Int hypre_ParILURAPSchurGMRESDummySetup(void *a, void *b, void *c, void *d);
+HYPRE_Int hypre_ParILURAPSchurGMRESSolve(void *ilu_vdata, void *ilu_vdata2, hypre_ParVector *f,
+                                         hypre_ParVector *u); void *hypre_ParILURAPSchurGMRESMatvecCreate(void *ilu_vdata, void *x);
+HYPRE_Int hypre_ParILURAPSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha, void *ilu_vdata,
+                                          void *x, HYPRE_Complex beta, void *y);
 HYPRE_Int hypre_ParILURAPSchurGMRESMatvecDestroy(void *matvec_data );
-HYPRE_Int hypre_ILUSetupILUDevice(HYPRE_Int ilu_type, hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Real *tol, HYPRE_Int *perm_data, HYPRE_Int *qperm_data, HYPRE_Int n, HYPRE_Int nLU, hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int tri_solve);
-HYPRE_Int hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n, HYPRE_Int nLU, hypre_ParCSRMatrix **Apermptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **ALUptr, hypre_CSRMatrix **BLUptr, hypre_CSRMatrix **CLUptr, hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int test_opt);
-HYPRE_Int hypre_ILUSolveDeviceLUIter(hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d, hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp, hypre_ParVector *utemp, hypre_Vector *xtemp_local, hypre_Vector **Adiag_diag, HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters);
-HYPRE_Int hypre_ILUSolveLUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *work1_local, hypre_Vector *work2_local, hypre_Vector *inout_local, hypre_Vector *diag_diag, HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters, HYPRE_Int my_id);
-HYPRE_Int hypre_ILUSolveLJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_Vector *work_local, hypre_Vector *output_local, HYPRE_Int lower_jacobi_iters);
-HYPRE_Int hypre_ILUSolveUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_Vector *work_local, hypre_Vector *output_local, hypre_Vector *diag_diag, HYPRE_Int upper_jacobi_iters);
+HYPRE_Int hypre_ILUSetupILUDevice(HYPRE_Int ilu_type, hypre_ParCSRMatrix *A, HYPRE_Int lfil,
+                                  HYPRE_Real *tol, HYPRE_Int *perm_data, HYPRE_Int *qperm_data, HYPRE_Int n, HYPRE_Int nLU,
+                                  hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **Eptr,
+                                  hypre_CSRMatrix **Fptr, HYPRE_Int tri_solve);
+HYPRE_Int hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n,
+                                      HYPRE_Int nLU, hypre_ParCSRMatrix **Apermptr, hypre_ParCSRMatrix **matSptr,
+                                      hypre_CSRMatrix **ALUptr, hypre_CSRMatrix **BLUptr, hypre_CSRMatrix **CLUptr,
+                                      hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int test_opt);
+HYPRE_Int hypre_ILUSolveDeviceLUIter(hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d,
+                                     hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp,
+                                     hypre_ParVector *utemp, hypre_Vector *xtemp_local, hypre_Vector **Adiag_diag,
+                                     HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters);
+HYPRE_Int hypre_ILUSolveLUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *work1_local,
+                                     hypre_Vector *work2_local, hypre_Vector *inout_local, hypre_Vector *diag_diag,
+                                     HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters, HYPRE_Int my_id);
+HYPRE_Int hypre_ILUSolveLJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local,
+                                    hypre_Vector *work_local, hypre_Vector *output_local, HYPRE_Int lower_jacobi_iters);
+HYPRE_Int hypre_ILUSolveUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local,
+                                    hypre_Vector *work_local, hypre_Vector *output_local, hypre_Vector *diag_diag,
+                                    HYPRE_Int upper_jacobi_iters);
 
 #ifdef __cplusplus
 }

--- a/src/parcsr_ls/par_cgc_coarsen.c
+++ b/src/parcsr_ls/par_cgc_coarsen.c
@@ -1392,7 +1392,7 @@ HYPRE_Int hypre_AmgCGCBoundaryFix (hypre_ParCSRMatrix *S, HYPRE_Int *CF_marker,
    HYPRE_Int *S_offd_j = NULL;
    HYPRE_Int num_variables = hypre_CSRMatrixNumRows (S_diag);
    HYPRE_Int num_cols_offd = hypre_CSRMatrixNumCols (S_offd);
-   HYPRE_Int added_cpts = 0;
+   //HYPRE_Int added_cpts = 0;
    MPI_Comm comm = hypre_ParCSRMatrixComm(S);
 
    hypre_MPI_Comm_rank (comm, &mpirank);
@@ -1419,8 +1419,8 @@ HYPRE_Int hypre_AmgCGCBoundaryFix (hypre_ParCSRMatrix *S, HYPRE_Int *CF_marker,
       CF_marker[i] = C_PT;
 #if 0
       hypre_printf ("Processor %d: added point %d in hypre_AmgCGCBoundaryFix\n", mpirank, i);
-#endif
       added_cpts++;
+#endif
    }
 #if 0
    if (added_cpts) { hypre_printf ("Processor %d: added %d points in hypre_AmgCGCBoundaryFix\n", mpirank, added_cpts); }

--- a/src/parcsr_ls/par_cr.c
+++ b/src/parcsr_ls/par_cr.c
@@ -2075,7 +2075,9 @@ hypre_BoomerAMGIndepPMIS( hypre_ParCSRMatrix    *S,
          }
       }
 
-      //iter++;
+#if 0 /* debugging */
+      iter++;
+#endif
       /*------------------------------------------------
        * Set C-pts and F-pts.
        *------------------------------------------------*/
@@ -2685,7 +2687,9 @@ hypre_BoomerAMGIndepPMISa( hypre_ParCSRMatrix    *S,
          }
       }
 
-      //iter++;
+#if 0 /* debugging */
+      iter++;
+#endif
       /*------------------------------------------------
        * Set C-pts and F-pts.
        *------------------------------------------------*/

--- a/src/parcsr_ls/par_cr.c
+++ b/src/parcsr_ls/par_cr.c
@@ -1650,7 +1650,6 @@ hypre_BoomerAMGIndepPMIS( hypre_ParCSRMatrix    *S,
 
 
    HYPRE_Real       wall_time;
-   HYPRE_Int   iter = 0;
 
 
 
@@ -2076,7 +2075,7 @@ hypre_BoomerAMGIndepPMIS( hypre_ParCSRMatrix    *S,
          }
       }
 
-      iter++;
+      //iter++;
       /*------------------------------------------------
        * Set C-pts and F-pts.
        *------------------------------------------------*/
@@ -2267,7 +2266,6 @@ hypre_BoomerAMGIndepPMISa( hypre_ParCSRMatrix    *S,
 
 
    HYPRE_Real       wall_time;
-   HYPRE_Int   iter = 0;
 
 
 
@@ -2687,7 +2685,7 @@ hypre_BoomerAMGIndepPMISa( hypre_ParCSRMatrix    *S,
          }
       }
 
-      iter++;
+      //iter++;
       /*------------------------------------------------
        * Set C-pts and F-pts.
        *------------------------------------------------*/

--- a/src/parcsr_ls/par_ilu_setup.c
+++ b/src/parcsr_ls/par_ilu_setup.c
@@ -95,7 +95,8 @@ hypre_ILUSetup( void               *ilu_vdata,
    HYPRE_Int             num_procs, my_id;
 
 #if defined (HYPRE_USING_GPU)
-   HYPRE_ExecutionPolicy exec                 = hypre_GetExecPolicy1(hypre_ParCSRMatrixMemoryLocation(A));
+   HYPRE_ExecutionPolicy exec                 = hypre_GetExecPolicy1(hypre_ParCSRMatrixMemoryLocation(
+                                                                        A));
 
    /* VPM: Placeholder check to avoid -Wunused-variable warning. TODO: remove this */
    if (exec != HYPRE_EXEC_DEVICE && exec != HYPRE_EXEC_HOST)
@@ -407,7 +408,7 @@ hypre_ILUSetup( void               *ilu_vdata,
 
                /* GMRES + hypre_iluk() */
                hypre_ILUSetupILUDevice(1, matA, fill_level, NULL, perm, perm,
-                                        n, nLU, &matBLU_d, &matS, &matE_d, &matF_d, 1);
+                                       n, nLU, &matBLU_d, &matS, &matE_d, &matF_d, 1);
             }
          }
          else

--- a/src/parcsr_ls/par_ilu_solve.c
+++ b/src/parcsr_ls/par_ilu_solve.c
@@ -1420,9 +1420,11 @@ hypre_ILUSolveCusparseSchurGMRES(hypre_ParCSRMatrix   *A,
    if (m > 0)
    {
       /* L solve */
-      hypre_CSRMatrixTriLowerUpperSolveDevice_core('L', 1, matSLU_d, NULL, utemp_local, nLU, ftemp_local, nLU);
+      hypre_CSRMatrixTriLowerUpperSolveDevice_core('L', 1, matSLU_d, NULL, utemp_local, nLU, ftemp_local,
+                                                   nLU);
       /* U solve */
-      hypre_CSRMatrixTriLowerUpperSolveDevice_core('U', 0, matSLU_d, NULL, ftemp_local, nLU, rhs_local, 0);
+      hypre_CSRMatrixTriLowerUpperSolveDevice_core('U', 0, matSLU_d, NULL, ftemp_local, nLU, rhs_local,
+                                                   0);
    }
 
 

--- a/src/parcsr_ls/par_jacobi_interp.c
+++ b/src/parcsr_ls/par_jacobi_interp.c
@@ -90,9 +90,12 @@ void hypre_BoomerAMGJacobiInterp_1( hypre_ParCSRMatrix * A,
    HYPRE_Int   num_rows_diag_P = hypre_CSRMatrixNumRows(P_diag);
    HYPRE_Int i;
    /*HYPRE_Int Jnochanges=0, Jchanges, Pnew_num_nonzeros*/;
+#ifdef HYPRE_JACINT_PRINT_DIAGNOSTICS
    HYPRE_Int CF_coarse = 0;
+   HYPRE_Int nc1;
+#endif
    HYPRE_Int * J_marker = hypre_CTAlloc( HYPRE_Int,  num_rows_diag_P, HYPRE_MEMORY_HOST);
-   HYPRE_Int nc, ncmax, ncmin, nc1;
+   HYPRE_Int nc, ncmax, ncmin;
    HYPRE_Int num_procs, my_id;
    MPI_Comm comm = hypre_ParCSRMatrixComm( A );
 #ifdef HYPRE_JACINT_PRINT_ROW_SUMS
@@ -117,7 +120,9 @@ void hypre_BoomerAMGJacobiInterp_1( hypre_ParCSRMatrix * A,
    for ( i = 0; i < num_rows_diag_P; ++i )
    {
       J_marker[i] = CF_marker[i];
+#ifdef HYPRE_JACINT_PRINT_DIAGNOSTICS
       if (CF_marker[i] >= 0) { ++CF_coarse; }
+#endif
    }
 #ifdef HYPRE_JACINT_PRINT_DIAGNOSTICS
    hypre_printf("%i %i Jacobi_Interp_1, P has %i+%i=%i nonzeros, local sum %e\n", my_id, level,
@@ -154,15 +159,20 @@ void hypre_BoomerAMGJacobiInterp_1( hypre_ParCSRMatrix * A,
    hypre_printf("%i %i P in max,min row sums %e %e\n", my_id, level, PIimax, PIimin );
 #endif
 
-   ncmax = 0; ncmin = num_rows_diag_P; nc1 = 0;
+   ncmax = 0; ncmin = num_rows_diag_P;
+#ifdef HYPRE_JACINT_PRINT_DIAGNOSTICS
+   nc1 = 0;
+#endif
    for ( i = 0; i < num_rows_diag_P; ++i )
       if (CF_marker[i] < 0)
       {
          nc = P_diag_i[i + 1] - P_diag_i[i];
+#ifdef HYPRE_JACINT_PRINT_DIAGNOSTICS
          if (nc <= 1)
          {
             ++nc1;
          }
+#endif
          ncmax = hypre_max( nc, ncmax );
          ncmin = hypre_min( nc, ncmin );
       }
@@ -344,12 +354,17 @@ void hypre_BoomerAMGJacobiInterp_1( hypre_ParCSRMatrix * A,
    }
    hypre_printf("\n");
 #endif
-   ncmax = 0; ncmin = num_rows_diag_P; nc1 = 0;
+   ncmax = 0; ncmin = num_rows_diag_P;
+#ifdef HYPRE_JACINT_PRINT_DIAGNOSTICS
+   nc1 = 0;
+#endif
    for ( i = 0; i < num_rows_diag_P; ++i )
       if (CF_marker[i] < 0)
       {
          nc = P_diag_i[i + 1] - P_diag_i[i];
+#ifdef HYPRE_JACINT_PRINT_DIAGNOSTICS
          if (nc <= 1) { ++nc1; }
+#endif
          ncmax = hypre_max( nc, ncmax );
          ncmin = hypre_min( nc, ncmin );
       }

--- a/src/parcsr_ls/par_multi_interp.c
+++ b/src/parcsr_ls/par_multi_interp.c
@@ -130,7 +130,9 @@ hypre_BoomerAMGBuildMultipassHost( hypre_ParCSRMatrix  *A,
    HYPRE_Int        n_coarse = 0;
    HYPRE_Int        n_coarse_offd = 0;
    HYPRE_Int        n_SF = 0;
+#ifdef HYPRE_USING_OPENMP
    HYPRE_Int        n_SF_offd = 0;
+#endif
 
    HYPRE_Int       *fine_to_coarse = NULL;
    HYPRE_BigInt    *fine_to_coarse_offd = NULL;
@@ -320,13 +322,15 @@ hypre_BoomerAMGBuildMultipassHost( hypre_ParCSRMatrix  *A,
    }
 
    n_coarse_offd = 0;
-   n_SF_offd = 0;
 #ifdef HYPRE_USING_OPENMP
+   n_SF_offd = 0;
    #pragma omp parallel for private(i) reduction(+:n_coarse_offd,n_SF_offd) HYPRE_SMP_SCHEDULE
 #endif
    for (i = 0; i < num_cols_offd; i++)
       if (CF_marker_offd[i] == 1) { n_coarse_offd++; }
+#ifdef HYPRE_USING_OPENMP
       else if (CF_marker_offd[i] == -3) { n_SF_offd++; }
+#endif
 
    if (num_cols_offd)
    {

--- a/src/parcsr_ls/par_multi_interp.c
+++ b/src/parcsr_ls/par_multi_interp.c
@@ -130,9 +130,6 @@ hypre_BoomerAMGBuildMultipassHost( hypre_ParCSRMatrix  *A,
    HYPRE_Int        n_coarse = 0;
    HYPRE_Int        n_coarse_offd = 0;
    HYPRE_Int        n_SF = 0;
-#ifdef HYPRE_USING_OPENMP
-   HYPRE_Int        n_SF_offd = 0;
-#endif
 
    HYPRE_Int       *fine_to_coarse = NULL;
    HYPRE_BigInt    *fine_to_coarse_offd = NULL;
@@ -323,14 +320,10 @@ hypre_BoomerAMGBuildMultipassHost( hypre_ParCSRMatrix  *A,
 
    n_coarse_offd = 0;
 #ifdef HYPRE_USING_OPENMP
-   n_SF_offd = 0;
-   #pragma omp parallel for private(i) reduction(+:n_coarse_offd,n_SF_offd) HYPRE_SMP_SCHEDULE
+   #pragma omp parallel for private(i) reduction(+:n_coarse_offd) HYPRE_SMP_SCHEDULE
 #endif
    for (i = 0; i < num_cols_offd; i++)
       if (CF_marker_offd[i] == 1) { n_coarse_offd++; }
-#ifdef HYPRE_USING_OPENMP
-      else if (CF_marker_offd[i] == -3) { n_SF_offd++; }
-#endif
 
    if (num_cols_offd)
    {

--- a/src/parcsr_ls/par_sv_interp_ln.c
+++ b/src/parcsr_ls/par_sv_interp_ln.c
@@ -2153,7 +2153,8 @@ HYPRE_Int hypre_BoomerAMG_LNExpandInterp( hypre_ParCSRMatrix *A,
          HYPRE_Real value, lost_value, q_dist_value;
          HYPRE_Int q_count_k, num_lost, p_count_tot;
          HYPRE_Int lost_counter_diag, lost_counter_offd, j_counter;
-         HYPRE_Int new_num_q, new_j_counter, new_diag_pos, new_offd_pos;
+         HYPRE_Int new_j_counter, new_diag_pos, new_offd_pos;
+         //HYPRE_Int new_num_q;
          HYPRE_Int i_qmax, lost_counter_q;
          /* loop through the smooth vectors - we have to do the q
             with each smooth vec separately
@@ -2348,7 +2349,7 @@ HYPRE_Int hypre_BoomerAMG_LNExpandInterp( hypre_ParCSRMatrix *A,
 
                }
 
-               new_num_q = q_count_k;
+               //new_num_q = q_count_k;
                num_lost = q_count_k - loop_q_max;
 
                if (num_lost > 0)
@@ -2391,7 +2392,7 @@ HYPRE_Int hypre_BoomerAMG_LNExpandInterp( hypre_ParCSRMatrix *A,
                         {
                            lost_counter_offd++;
                         }
-                        new_num_q--;
+                        //new_num_q--;
 
                         /* technically only need to do this the last time */
                         q_dist_value = lost_value / loop_q_max;

--- a/src/parcsr_ls/partial.c
+++ b/src/parcsr_ls/partial.c
@@ -956,7 +956,7 @@ hypre_BoomerAMGBuildPartialStdInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker
    HYPRE_Int        jj_begin_row, jj_end_row;
    HYPRE_Int        jj_begin_row_offd = 0;
    HYPRE_Int        jj_end_row_offd = 0;
-   HYPRE_Int        coarse_counter;
+   //HYPRE_Int        coarse_counter;
    HYPRE_Int        n_coarse_old;
    HYPRE_BigInt     total_old_global_cpts;
 
@@ -1071,7 +1071,7 @@ hypre_BoomerAMGBuildPartialStdInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker
 
    jj_counter = start_indexing;
    jj_counter_offd = start_indexing;
-   coarse_counter = 0;
+   //coarse_counter = 0;
 
    cnt = 0;
    old_cnt = 0;
@@ -1104,7 +1104,7 @@ hypre_BoomerAMGBuildPartialStdInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker
       if (CF_marker[i] > 0)
       {
          jj_counter++;
-         coarse_counter++;
+         //coarse_counter++;
       }
 
       /*--------------------------------------------------------------------
@@ -1973,7 +1973,7 @@ hypre_BoomerAMGBuildPartialExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker
    HYPRE_Int        jj_begin_row, jj_end_row;
    HYPRE_Int        jj_begin_row_offd = 0;
    HYPRE_Int        jj_end_row_offd = 0;
-   HYPRE_Int        coarse_counter;
+   //HYPRE_Int        coarse_counter;
    HYPRE_Int        n_coarse_old;
    HYPRE_BigInt     total_old_global_cpts;
 
@@ -2074,7 +2074,7 @@ hypre_BoomerAMGBuildPartialExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker
 
    jj_counter = start_indexing;
    jj_counter_offd = start_indexing;
-   coarse_counter = 0;
+   //coarse_counter = 0;
 
    cnt = 0;
    old_cnt = 0;
@@ -2107,7 +2107,7 @@ hypre_BoomerAMGBuildPartialExtInterp(hypre_ParCSRMatrix *A, HYPRE_Int *CF_marker
       if (CF_marker[i] > 0)
       {
          jj_counter++;
-         coarse_counter++;
+         //coarse_counter++;
       }
 
       /*--------------------------------------------------------------------

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -2651,25 +2651,60 @@ HYPRE_Int hypre_FSAISolve ( void *fsai_vdata, hypre_ParCSRMatrix *A, hypre_ParVe
                             hypre_ParVector *x );
 
 /* par_ilu.c */
-HYPRE_Int hypre_ILUSolveCusparseLU(hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d, hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp, hypre_ParVector *utemp);
-HYPRE_Int hypre_ILUSolveCusparseSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp, hypre_ParVector *utemp, HYPRE_Solver schur_solver, HYPRE_Solver schur_precond, hypre_ParVector *rhs, hypre_ParVector *x, HYPRE_Int *u_end, hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d);
-HYPRE_Int hypre_ILUSolveRAPGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp, hypre_ParVector *utemp, hypre_ParVector *xtemp, hypre_ParVector *ytemp, HYPRE_Solver schur_solver, HYPRE_Solver schur_precond, hypre_ParVector *rhs, hypre_ParVector *x, HYPRE_Int *u_end, hypre_ParCSRMatrix *Aperm, hypre_CSRMatrix *matALU_d, hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d, HYPRE_Int test_opt);
-HYPRE_Int hypre_ParILUCusparseILUExtractEBFC(hypre_CSRMatrix *A_diag, HYPRE_Int nLU, hypre_CSRMatrix **Bp, hypre_CSRMatrix **Cp, hypre_CSRMatrix **Ep, hypre_CSRMatrix **Fp);
-HYPRE_Int hypre_ParILURAPReorder(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *rqperm, hypre_ParCSRMatrix **A_pq);
-HYPRE_Int hypre_ILUSetupLDUtoCusparse(hypre_ParCSRMatrix *L, HYPRE_Real *D, hypre_ParCSRMatrix *U, hypre_ParCSRMatrix **LDUp);
-HYPRE_Int hypre_ILUSetupRAPMILU0(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix **ALUp, HYPRE_Int modified);
+HYPRE_Int hypre_ILUSolveCusparseLU(hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d,
+                                   hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp,
+                                   hypre_ParVector *utemp);
+HYPRE_Int hypre_ILUSolveCusparseSchurGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f,
+                                           hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp,
+                                           hypre_ParVector *utemp, HYPRE_Solver schur_solver, HYPRE_Solver schur_precond, hypre_ParVector *rhs,
+                                           hypre_ParVector *x, HYPRE_Int *u_end, hypre_CSRMatrix *matBLU_d, hypre_CSRMatrix *matE_d,
+                                           hypre_CSRMatrix *matF_d);
+HYPRE_Int hypre_ILUSolveRAPGMRES(hypre_ParCSRMatrix *A, hypre_ParVector *f, hypre_ParVector *u,
+                                 HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix *S, hypre_ParVector *ftemp,
+                                 hypre_ParVector *utemp, hypre_ParVector *xtemp, hypre_ParVector *ytemp, HYPRE_Solver schur_solver,
+                                 HYPRE_Solver schur_precond, hypre_ParVector *rhs, hypre_ParVector *x, HYPRE_Int *u_end,
+                                 hypre_ParCSRMatrix *Aperm, hypre_CSRMatrix *matALU_d, hypre_CSRMatrix *matBLU_d,
+                                 hypre_CSRMatrix *matE_d, hypre_CSRMatrix *matF_d, HYPRE_Int test_opt);
+HYPRE_Int hypre_ParILUCusparseILUExtractEBFC(hypre_CSRMatrix *A_diag, HYPRE_Int nLU,
+                                             hypre_CSRMatrix **Bp, hypre_CSRMatrix **Cp, hypre_CSRMatrix **Ep, hypre_CSRMatrix **Fp);
+HYPRE_Int hypre_ParILURAPReorder(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int *rqperm,
+                                 hypre_ParCSRMatrix **A_pq);
+HYPRE_Int hypre_ILUSetupLDUtoCusparse(hypre_ParCSRMatrix *L, HYPRE_Real *D, hypre_ParCSRMatrix *U,
+                                      hypre_ParCSRMatrix **LDUp);
+HYPRE_Int hypre_ILUSetupRAPMILU0(hypre_ParCSRMatrix *A, hypre_ParCSRMatrix **ALUp,
+                                 HYPRE_Int modified);
 HYPRE_Int hypre_ParILUCusparseSchurGMRESDummySetup(void *a, void *b, void *c, void *d);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESDummySolve(void *ilu_vdata, void *ilu_vdata2, hypre_ParVector *f, hypre_ParVector *u);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESCommInfo(void *ilu_vdata, HYPRE_Int *my_id, HYPRE_Int *num_procs);
+HYPRE_Int hypre_ParILUCusparseSchurGMRESDummySolve(void *ilu_vdata, void *ilu_vdata2,
+                                                   hypre_ParVector *f, hypre_ParVector *u);
+HYPRE_Int hypre_ParILUCusparseSchurGMRESCommInfo(void *ilu_vdata, HYPRE_Int *my_id,
+                                                 HYPRE_Int *num_procs);
 void *hypre_ParILUCusparseSchurGMRESMatvecCreate(void *ilu_vdata, void *x);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha, void *ilu_vdata, void *x, HYPRE_Complex beta, void *y);
-HYPRE_Int hypre_ParILUCusparseSchurGMRESMatvecDestroy(void *matvec_data ); HYPRE_Int hypre_ParILURAPSchurGMRESDummySetup(void *a, void *b, void *c, void *d);
-HYPRE_Int hypre_ParILURAPSchurGMRESSolve(void *ilu_vdata, void *ilu_vdata2, hypre_ParVector *f, hypre_ParVector *u); void *hypre_ParILURAPSchurGMRESMatvecCreate(void *ilu_vdata, void *x);
-HYPRE_Int hypre_ParILURAPSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha, void *ilu_vdata, void *x, HYPRE_Complex beta, void *y);
+HYPRE_Int hypre_ParILUCusparseSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha,
+                                               void *ilu_vdata, void *x, HYPRE_Complex beta, void *y);
+HYPRE_Int hypre_ParILUCusparseSchurGMRESMatvecDestroy(void *matvec_data );
+HYPRE_Int hypre_ParILURAPSchurGMRESDummySetup(void *a, void *b, void *c, void *d);
+HYPRE_Int hypre_ParILURAPSchurGMRESSolve(void *ilu_vdata, void *ilu_vdata2, hypre_ParVector *f,
+                                         hypre_ParVector *u); void *hypre_ParILURAPSchurGMRESMatvecCreate(void *ilu_vdata, void *x);
+HYPRE_Int hypre_ParILURAPSchurGMRESMatvec(void *matvec_data, HYPRE_Complex alpha, void *ilu_vdata,
+                                          void *x, HYPRE_Complex beta, void *y);
 HYPRE_Int hypre_ParILURAPSchurGMRESMatvecDestroy(void *matvec_data );
-HYPRE_Int hypre_ILUSetupILUDevice(HYPRE_Int ilu_type, hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Real *tol, HYPRE_Int *perm_data, HYPRE_Int *qperm_data, HYPRE_Int n, HYPRE_Int nLU, hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int tri_solve);
-HYPRE_Int hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n, HYPRE_Int nLU, hypre_ParCSRMatrix **Apermptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **ALUptr, hypre_CSRMatrix **BLUptr, hypre_CSRMatrix **CLUptr, hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int test_opt);
-HYPRE_Int hypre_ILUSolveDeviceLUIter(hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d, hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp, hypre_ParVector *utemp, hypre_Vector *xtemp_local, hypre_Vector **Adiag_diag, HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters);
-HYPRE_Int hypre_ILUSolveLUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *work1_local, hypre_Vector *work2_local, hypre_Vector *inout_local, hypre_Vector *diag_diag, HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters, HYPRE_Int my_id);
-HYPRE_Int hypre_ILUSolveLJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_Vector *work_local, hypre_Vector *output_local, HYPRE_Int lower_jacobi_iters);
-HYPRE_Int hypre_ILUSolveUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local, hypre_Vector *work_local, hypre_Vector *output_local, hypre_Vector *diag_diag, HYPRE_Int upper_jacobi_iters);
+HYPRE_Int hypre_ILUSetupILUDevice(HYPRE_Int ilu_type, hypre_ParCSRMatrix *A, HYPRE_Int lfil,
+                                  HYPRE_Real *tol, HYPRE_Int *perm_data, HYPRE_Int *qperm_data, HYPRE_Int n, HYPRE_Int nLU,
+                                  hypre_CSRMatrix **BLUptr, hypre_ParCSRMatrix **matSptr, hypre_CSRMatrix **Eptr,
+                                  hypre_CSRMatrix **Fptr, HYPRE_Int tri_solve);
+HYPRE_Int hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix *A, HYPRE_Int *perm, HYPRE_Int n,
+                                      HYPRE_Int nLU, hypre_ParCSRMatrix **Apermptr, hypre_ParCSRMatrix **matSptr,
+                                      hypre_CSRMatrix **ALUptr, hypre_CSRMatrix **BLUptr, hypre_CSRMatrix **CLUptr,
+                                      hypre_CSRMatrix **Eptr, hypre_CSRMatrix **Fptr, HYPRE_Int test_opt);
+HYPRE_Int hypre_ILUSolveDeviceLUIter(hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d,
+                                     hypre_ParVector *f, hypre_ParVector *u, HYPRE_Int *perm, HYPRE_Int n, hypre_ParVector *ftemp,
+                                     hypre_ParVector *utemp, hypre_Vector *xtemp_local, hypre_Vector **Adiag_diag,
+                                     HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters);
+HYPRE_Int hypre_ILUSolveLUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *work1_local,
+                                     hypre_Vector *work2_local, hypre_Vector *inout_local, hypre_Vector *diag_diag,
+                                     HYPRE_Int lower_jacobi_iters, HYPRE_Int upper_jacobi_iters, HYPRE_Int my_id);
+HYPRE_Int hypre_ILUSolveLJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local,
+                                    hypre_Vector *work_local, hypre_Vector *output_local, HYPRE_Int lower_jacobi_iters);
+HYPRE_Int hypre_ILUSolveUJacobiIter(hypre_CSRMatrix *A, hypre_Vector *input_local,
+                                    hypre_Vector *work_local, hypre_Vector *output_local, hypre_Vector *diag_diag,
+                                    HYPRE_Int upper_jacobi_iters);

--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -1259,3 +1259,4 @@ HYPRE_Int hypre_ParVectorGetValuesDevice(hypre_ParVector *vector, HYPRE_Int num_
 #endif
 
 #endif
+

--- a/src/sstruct_ls/node_relax.c
+++ b/src/sstruct_ls/node_relax.c
@@ -764,6 +764,10 @@ hypre_NodeRelax(  void                 *relax_vdata,
                    * Invert intra-nodal coupling
                    *----------------------------------------------*/
                   hypre_gselim(A_loc, x_loc, nvars, err);
+                  if (err)
+                  {
+                     hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Error in gselim!\n");
+                  }
                   /*------------------------------------------------
                    * Copy solution from local storage.
                    *----------------------------------------------*/
@@ -967,6 +971,10 @@ hypre_NodeRelax(  void                 *relax_vdata,
                    * Invert intra-nodal coupling
                    *----------------------------------------------*/
                   hypre_gselim(A_loc, x_loc, nvars, err);
+                  if (err)
+                  {
+                     hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Error in gselim!\n");
+                  }
                   /*------------------------------------------------
                    * Copy solution from local storage.
                    *----------------------------------------------*/


### PR DESCRIPTION
I updated my Mac this weekend, and the compiler version must have changed, because a number of warning messages are now being generated about variables that are set but not used.  This PR fixes the warnings.  In most cases, I just commented lines out.  I am not against deleting some of these variables either, but I wasn't sure if any of you would prefer to keep this code around for debugging reasons.

Thanks!
