### PR TITLE
Fix device build

### DIFF
--- a/src/sstruct_ls/node_relax.c
+++ b/src/sstruct_ls/node_relax.c
@@ -765,6 +765,7 @@ hypre_NodeRelax(  void                 *relax_vdata,
                    *----------------------------------------------*/
                   hypre_gselim(A_loc, x_loc, nvars, err);
                   (void) err;
+                  /* TODO (VPM): need a way to check error codes on device */
 
                   /*------------------------------------------------
                    * Copy solution from local storage.

--- a/src/sstruct_ls/node_relax.c
+++ b/src/sstruct_ls/node_relax.c
@@ -764,10 +764,8 @@ hypre_NodeRelax(  void                 *relax_vdata,
                    * Invert intra-nodal coupling
                    *----------------------------------------------*/
                   hypre_gselim(A_loc, x_loc, nvars, err);
-                  if (err)
-                  {
-                     hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Error in gselim!\n");
-                  }
+                  (void) err;
+
                   /*------------------------------------------------
                    * Copy solution from local storage.
                    *----------------------------------------------*/
@@ -971,10 +969,8 @@ hypre_NodeRelax(  void                 *relax_vdata,
                    * Invert intra-nodal coupling
                    *----------------------------------------------*/
                   hypre_gselim(A_loc, x_loc, nvars, err);
-                  if (err)
-                  {
-                     hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Error in gselim!\n");
-                  }
+                  (void) err;
+
                   /*------------------------------------------------
                    * Copy solution from local storage.
                    *----------------------------------------------*/
@@ -1170,4 +1166,3 @@ hypre_NodeRelaxSetTempVec( void                 *relax_vdata,
 
    return hypre_error_flag;
 }
-


### PR DESCRIPTION
A change from PR #923 broke our device build, see the compilation error below. Essentially, we cannot use `hypre_error_w_msg` inside GPU kernels or lambdas. Speaking more broadly, I think we should decide on how to capture errors from situations like this. In the meantime, I'm providing a fix with this PR :)

```
hipcc  -O2 -x hip -std=c++14   -DHAVE_CONFIG_H -I.. -I. -I./.. -I./../multivector -I./../utilities -I./../krylov -I./../struct_mv -I./../seq_mv -I./../parcsr_mv -I./../IJ_mv -I./../parcsr_block_mv -I./../sstruct_mv -I./../struct_ls -I./../parcsr_ls     -I/opt/rocm-5.4.3/include       -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -c node_relax.c -o node_relax.obj
node_relax.c:769:22: error: reference to __host__ function 'hypre_error_handler' in __host__ __device__ function
                     hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Error in gselim!\n");
                     ^
./../utilities/_hypre_utilities.h:295:39: note: expanded from macro 'hypre_error_w_msg'
#define hypre_error_w_msg(IERR, msg)  hypre_error_handler(__FILE__, __LINE__, IERR, msg)
                                      ^
./../struct_mv/_hypre_struct_mv.hpp:788:10: note: called by 'forall_kernel<(lambda at node_relax.c:738:16)>'
         loop_body(idx);
         ^
./../utilities/_hypre_utilities.h:292:6: note: 'hypre_error_handler' declared here
void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, const char *msg);
     ^
```