### PR TITLE
Fix compilation error

### DIFF
--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -3710,7 +3710,7 @@ HYPRE_Int hypre_ILUMinHeapRemoveIIIi( HYPRE_Int *heap, HYPRE_Int *I1,
 HYPRE_Int hypre_ILUMinHeapRemoveIRIi( HYPRE_Int *heap, HYPRE_Real *I1,
                                       HYPRE_Int *Ii1, HYPRE_Int len );
 HYPRE_Int hypre_ILUMaxrHeapRemoveRabsI( HYPRE_Real *heap, HYPRE_Int *I1, HYPRE_Int len );
-HYPRE_Int hypre_ILUMaxQSplitRabsI( HYPRE_Real *array, HYPRE_Int *I, HYPRE_Int left,
+HYPRE_Int hypre_ILUMaxQSplitRabsI( HYPRE_Real *arrayR, HYPRE_Int *arrayI, HYPRE_Int left,
                                    HYPRE_Int bound, HYPRE_Int right );
 HYPRE_Int hypre_ILUMaxRabs( HYPRE_Real *array_data, HYPRE_Int *array_j, HYPRE_Int start,
                             HYPRE_Int end, HYPRE_Int nLU, HYPRE_Int *rperm, HYPRE_Real *value,

--- a/src/parcsr_ls/par_ilu.c
+++ b/src/parcsr_ls/par_ilu.c
@@ -1452,15 +1452,16 @@ hypre_ILUMaxrHeapRemoveRabsI(HYPRE_Real *heap, HYPRE_Int *I1, HYPRE_Int len)
  *
  * Split based on quick sort algorithm (avoid sorting the entire array)
  * find the largest k elements out of original array
- * array: input array for compare
- * I: integer array bind with array
+ *
+ * arrayR: input array for compare
+ * arrayI: integer array bind with array
  * k: largest k elements
  * len: length of the array
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_ILUMaxQSplitRabsI(HYPRE_Real *array,
-                        HYPRE_Int  *I,
+hypre_ILUMaxQSplitRabsI(HYPRE_Real *arrayR,
+                        HYPRE_Int  *arrayI,
                         HYPRE_Int   left,
                         HYPRE_Int   bound,
                         HYPRE_Int   right)
@@ -1472,21 +1473,21 @@ hypre_ILUMaxQSplitRabsI(HYPRE_Real *array,
       return hypre_error_flag;
    }
 
-   hypre_swap2(I, array, left, (left + right) / 2);
+   hypre_swap2(arrayI, arrayR, left, (left + right) / 2);
    last = left;
    for (i = left + 1 ; i <= right ; i ++)
    {
-      if (hypre_abs(array[i]) > hypre_abs(array[left]))
+      if (hypre_abs(arrayR[i]) > hypre_abs(arrayR[left]))
       {
-         hypre_swap2(I, array, ++last, i);
+         hypre_swap2(arrayI, arrayR, ++last, i);
       }
    }
 
-   hypre_swap2(I, array, left, last);
-   hypre_ILUMaxQSplitRabsI(array, I, left, bound, last - 1);
+   hypre_swap2(arrayI, arrayR, left, last);
+   hypre_ILUMaxQSplitRabsI(arrayR, arrayI, left, bound, last - 1);
    if (bound > last)
    {
-      hypre_ILUMaxQSplitRabsI(array, I, last + 1, bound, right);
+      hypre_ILUMaxQSplitRabsI(arrayR, arrayI, last + 1, bound, right);
    }
 
    return hypre_error_flag;

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -2325,7 +2325,7 @@ HYPRE_Int hypre_ILUMinHeapRemoveIIIi( HYPRE_Int *heap, HYPRE_Int *I1,
 HYPRE_Int hypre_ILUMinHeapRemoveIRIi( HYPRE_Int *heap, HYPRE_Real *I1,
                                       HYPRE_Int *Ii1, HYPRE_Int len );
 HYPRE_Int hypre_ILUMaxrHeapRemoveRabsI( HYPRE_Real *heap, HYPRE_Int *I1, HYPRE_Int len );
-HYPRE_Int hypre_ILUMaxQSplitRabsI( HYPRE_Real *array, HYPRE_Int *I, HYPRE_Int left,
+HYPRE_Int hypre_ILUMaxQSplitRabsI( HYPRE_Real *arrayR, HYPRE_Int *arrayI, HYPRE_Int left,
                                    HYPRE_Int bound, HYPRE_Int right );
 HYPRE_Int hypre_ILUMaxRabs( HYPRE_Real *array_data, HYPRE_Int *array_j, HYPRE_Int start,
                             HYPRE_Int end, HYPRE_Int nLU, HYPRE_Int *rperm, HYPRE_Real *value,


### PR DESCRIPTION
This PR fixes a compilation error that arises in PETSc when hypre is used, see below:

```
In file included from ${PETSC_DIR}/src/mat/impls/hypre/mhypre.c:16:
${PETSC_DIR}/include/_hypre_parcsr_ls.h:3713:66: error: expected ')'
HYPRE_Int hypre_ILUMaxQSplitRabsI( HYPRE_Real *array, HYPRE_Int *I, HYPRE_Int left,
                                                                 ^
/usr/include/complex.h:53:11: note: expanded from macro 'I'
#define I _Complex_I
          ^
/usr/include/complex.h:48:21: note: expanded from macro '_Complex_I'
#define _Complex_I      (__extension__ 1.0iF)
                         ^
${HYPRE_DIR}/include/_hypre_parcsr_ls.h:3713:66: note: to match this '('
/usr/include/complex.h:53:11: note: expanded from macro 'I'
#define I _Complex_I
          ^
/usr/include/complex.h:48:20: note: expanded from macro '_Complex_I'
#define _Complex_I      (__extension__ 1.0iF)
                        ^
1 error generated.

```