### PR TITLE
Improve ILU documentation

### DIFF
--- a/src/docs/usr-manual/ch-solvers.rst
+++ b/src/docs/usr-manual/ch-solvers.rst
@@ -32,7 +32,7 @@ interfaces:
    MGR                                        X
    FSAI                                       X
    ParaSails                X        X        X
-   hypre-ILU                                  X
+   ILU                                        X
    Euclid                   X        X        X
    PILUT                    X        X        X
    PCG             X        X        X        X
@@ -155,7 +155,7 @@ be found in Chapter :ref:`ch-API`.
    solvers-mgr
    solvers-fsai
    solvers-parasails
-   solvers-hypre-ilu
+   solvers-ilu
    solvers-euclid
    solvers-pilut
    solvers-lobpcg

--- a/src/docs/usr-manual/solvers-boomeramg.rst
+++ b/src/docs/usr-manual/solvers-boomeramg.rst
@@ -118,7 +118,8 @@ A good overview of parallel smoothers and their properties can be found in
 * l1-Gauss-Seidel or Jacobi,
 * Chebyshev smoothers,
 * hybrid block and Schwarz smoothers [Yang2004]_,
-* ILU and approximate inverse smoothers.
+* Incomplete LU factorization, see :ref:`ilu-amg-smoother`.
+* Factorized Sparse Approximate Inverse (FSAI), see :ref:`fsai-amg-smoother`.
 
 Point relaxation schemes can be set using ``HYPRE_BoomerAMGSetRelaxType`` or, if
 one wants to specifically set the up cycle, down cycle or the coarsest grid,

--- a/src/docs/usr-manual/solvers-euclid.rst
+++ b/src/docs/usr-manual/solvers-euclid.rst
@@ -11,7 +11,8 @@ Euclid
    Euclid is not actively supported by the hypre development team. We recommend using
    :ref:`hypre-ilu` for parallel ILU algorithms. This new ILU implementation includes
    64-bit integers support (for linear systems with more than 2,147,483,647 global
-   unknowns) and NVIDIA/AMD GPUs support through the CUDA/HIP backends.
+   unknowns) through both *mixedint* and *bigint* builds of hypre and NVIDIA/AMD GPUs
+   support through the CUDA/HIP backends.
 
 The Euclid library is a scalable implementation of the Parallel ILU algorithm
 that was presented at SC99 [HyPo1999]_, and published in expanded form in the

--- a/src/docs/usr-manual/solvers-euclid.rst
+++ b/src/docs/usr-manual/solvers-euclid.rst
@@ -10,8 +10,8 @@ Euclid
 .. warning::
    Euclid is not actively supported by the hypre development team. We recommend using
    :ref:`hypre-ilu` for parallel ILU algorithms. This new ILU implementation includes
-   64-bit integers support (for linear systems larger than 2,147,483,647 global unknowns)
-   and NVIDIA/AMD GPUs support through the CUDA/HIP backends.
+   64-bit integers support (for linear systems with more than 2,147,483,647 global
+   unknowns) and NVIDIA/AMD GPUs support through the CUDA/HIP backends.
 
 The Euclid library is a scalable implementation of the Parallel ILU algorithm
 that was presented at SC99 [HyPo1999]_, and published in expanded form in the

--- a/src/docs/usr-manual/solvers-euclid.rst
+++ b/src/docs/usr-manual/solvers-euclid.rst
@@ -7,6 +7,12 @@
 Euclid
 ==============================================================================
 
+.. warning::
+   Euclid is not actively supported by the hypre development team. We recommend using
+   :ref:`hypre-ilu` for parallel ILU algorithms. This new ILU implementation includes
+   64-bit integers support (for linear systems larger than 2,147,483,647 global unknowns)
+   and NVIDIA/AMD GPUs support through the CUDA/HIP backends.
+
 The Euclid library is a scalable implementation of the Parallel ILU algorithm
 that was presented at SC99 [HyPo1999]_, and published in expanded form in the
 SIAM Journal on Scientific Computing [HyPo2001]_.  By *scalable* we mean that
@@ -45,28 +51,28 @@ subsection lists the options, and provides guidance as to the settings that (in
 our experience) will likely prove effective for minimizing execution time.
 
 .. code-block:: c
-   
+
    #include "HYPRE_parcsr_ls.h"
-   
+
    HYPRE_Solver eu;
    HYPRE_Solver pcg_solver;
    HYPRE_ParVector b, x;
    HYPRE_ParCSRMatrix A;
-   
+
    //Instantiate the preconditioner.
    HYPRE_EuclidCreate(comm, &eu);
-   
+
    //Optionally use the following three methods to set runtime options.
    // 1. pass options from command line or string array.
    HYPRE_EuclidSetParams(eu, argc, argv);
-   
+
    // 2. pass options from a configuration file.
    HYPRE_EuclidSetParamsFromFile(eu, "filename");
-   
+
    // 3. pass options using interface functions.
    HYPRE_EuclidSetLevel(eu, 3);
    ...
-   
+
    //Set Euclid as the preconditioning method for some
    //other solver, using the function calls HYPRE_EuclidSetup
    //and HYPRE_EuclidSolve.  We assume that the pcg_solver
@@ -75,13 +81,13 @@ our experience) will likely prove effective for minimizing execution time.
                        (HYPRE_PtrToSolverFcn) HYPRE_EuclidSolve,
                        (HYPRE_PtrToSolverFcn) HYPRE_EuclidSetup,
                        eu);
-   
-   //Solve the system by calling the Setup and Solve methods for, 
+
+   //Solve the system by calling the Setup and Solve methods for,
    //in this case, the HYPRE_PCG solver.  We assume that A, b, and x
    //have been properly initialized.
    HYPRE_PCGSetup(pcg_solver, (HYPRE_Matrix)A, (HYPRE_Vector)b, (HYPRE_Vector)x);
    HYPRE_PCGSolve(pcg_solver, (HYPRE_Matrix)parcsr_A, (HYPRE_Vector)b, (HYPRE_Vector)x);
-   
+
    //Destroy the Euclid preconditioning object.
    HYPRE_EuclidDestroy(eu);
 
@@ -118,7 +124,7 @@ recognized by Euclid, no harm should ensue.
 **Method 2.** To pass options on the command line, call
 
 .. code-block:: c
-   
+
    HYPRE_EuclidSetParams(HYPRE_Solver solver, int argc, char *argv[]);
 
 where ``argc`` and ``argv`` carry the usual connotation: ``main(int argc, char
@@ -126,7 +132,7 @@ where ``argc`` and ``argv`` carry the usual connotation: ``main(int argc, char
 options on the command line per the following example.
 
 .. code-block:: bash
-   
+
    mpirun -np 2 phoo -level 3
 
 Since Euclid looks for the ``database`` file when ``HYPRE_EuclidCreate`` is
@@ -149,13 +155,13 @@ you can then specify the configuration filename on the command line using the
 ``-db_filename filename`` option, e.g.,
 
 .. code-block:: bash
-   
+
    mpirun -np 2 phoo -db_filename ../myConfigFile
 
 **Method 4.** One can also set parameters via interface functions, e.g
 
 .. code-block:: c
-   
+
    int HYPRE_EuclidSetLevel(HYPRE_Solver solver, int level);
 
 For a full set of functions, see the reference manual.
@@ -192,13 +198,13 @@ Options Summary
   largest absolute value of any entry in the row. Guidance: try this in
   conjunction with -rowScale.  CAUTION: If the coefficient matrix :math:`A` is
   symmetric, this setting is likely to cause the filled matrix, :math:`F =
-  L+U-I`, to be unsymmetric.  This setting has no effect when ILUT factorization
+  L+U-I`, to be non-symmetric.  This setting has no effect when ILUT factorization
   is selected.
 
 * **-rowScale** Scale values prior to factorization such that the largest value
   in any row is +1 or -1.  Default: 0 (false).  CAUTION: If the coefficient
   matrix :math:`A` is symmetric, this setting is likely to cause the filled
-  matrix, :math:`F = L+U-I`, to be unsymmetric.  Guidance: if the matrix is
+  matrix, :math:`F = L+U-I`, to be non-symmetric.  Guidance: if the matrix is
   poorly scaled, turning on row scaling may help convergence.
 
 * **-ilut** :math:`\langle float \rangle` Use ILUT factorization instead of the
@@ -206,5 +212,4 @@ Options Summary
   tolerance, which is relative to the largest absolute value of any entry in the
   row being factored.  CAUTION: If the coefficient matrix :math:`A` is
   symmetric, this setting is likely to cause the filled matrix, :math:`F =
-  L+U-I`, to be unsymmetric.  NOTE: this option can only be used sequentially!
-
+  L+U-I`, to be non-symmetric.  NOTE: this option can only be used sequentially!

--- a/src/docs/usr-manual/solvers-euclid.rst
+++ b/src/docs/usr-manual/solvers-euclid.rst
@@ -9,7 +9,7 @@ Euclid
 
 .. warning::
    Euclid is not actively supported by the hypre development team. We recommend using
-   :ref:`hypre-ilu` for parallel ILU algorithms. This new ILU implementation includes
+   :ref:`ilu` for parallel ILU algorithms. This new ILU implementation includes
    64-bit integers support (for linear systems with more than 2,147,483,647 global
    unknowns) through both *mixedint* and *bigint* builds of hypre and NVIDIA/AMD GPUs
    support through the CUDA/HIP backends.

--- a/src/docs/usr-manual/solvers-fsai.rst
+++ b/src/docs/usr-manual/solvers-fsai.rst
@@ -55,6 +55,8 @@ parameters of FSAI can be set via the following calls:
    HYPRE_FSAISetMaxStepSize(HYPRE_Solver solver, HYPRE_Int max_step_size);
    HYPRE_FSAISetKapTolerance(HYPRE_Solver solver, HYPRE_Real kap_tolerance);
 
+.. _fsai-amg-smoother:
+
 FSAI as Smoother to BoomerAMG
 ------------------------------------------------------------------------------
 

--- a/src/docs/usr-manual/solvers-hypre-ilu.rst
+++ b/src/docs/usr-manual/solvers-hypre-ilu.rst
@@ -9,8 +9,8 @@ hypre-ILU
 ==============================================================================
 
 hypre-ILU is a suite of parallel incomplete LU factorization algorithms featuring dual
-threshold (ILUT) and level-based (ILUK) variants. Its implementation is based on a domain
-decomposition framework for achieving distributed parallelism. It can be used as
+threshold (ILUT) and level-based (ILUK) variants. The implementation is based on a domain
+decomposition framework for achieving distributed parallelism. hypre-ILU can be used as
 preconditioners for Krylov subspace methods, or smoothers for
 multigrid methods such as BoomerAMG and MGR.
 

--- a/src/docs/usr-manual/solvers-hypre-ilu.rst
+++ b/src/docs/usr-manual/solvers-hypre-ilu.rst
@@ -90,8 +90,8 @@ A short explanation for each of those functions and its parameters is given next
   * 11: GMRES with ILUT (GMRES-ILUT).
   * 20: NSH with ILUK (NSH-ILUK).
   * 21: NSH with ILUT (NSH-ILUT).
-  * 30: RAS with ILUK (GMRES-ILUK).
-  * 31: RAS with ILUT (GMRES-ILUT).
+  * 30: RAS with ILUK (RAS-ILUK).
+  * 31: RAS with ILUT (RAS-ILUT).
   * 40: ddPQ-GMRES with ILUK (ddPQ-GMRES-ILUK).
   * 41: ddPQ-GMRES with ILUT (ddPQ-GMRES-ILUT).
   * 50: GMRES with RAP-ILU0 with modified ILU0 (GMRES-RAP-ILU0).

--- a/src/docs/usr-manual/solvers-hypre-ilu.rst
+++ b/src/docs/usr-manual/solvers-hypre-ilu.rst
@@ -3,30 +3,31 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+.. _hypre-ilu:
 
 hypre-ILU
 ==============================================================================
 
-The hypre-ILU solver is a parallel ILU solver based on a domain decomposition 
+The hypre-ILU solver is a parallel ILU solver based on a domain decomposition
 framework. It may be use iteratively as a standalone solver or smoother, as well as a
-preconditioner for accelerators like Krylov subspace methods. This solver 
-implements various parallel variants of the dual threshold (truncation) incomplete 
+preconditioner for accelerators like Krylov subspace methods. This solver
+implements various parallel variants of the dual threshold (truncation) incomplete
 LU factorization - ILUT, and the level-based incomplete LU factorization - ILUk.
 
 
 Overview
 ------------------------------------------------------------------------------
-The parallel hypre-ILU solver follows a domain decomposition approach for solving 
-distributed sparse linear systems of equations. The strategy is to decompose the 
-domain into interior and interface nodes, where an interface node separates two 
-interior nodes from adjacent domains. In the purely algebraic setting, this is 
-equivalent to partitioning the matrix row data into local (processor-owned) data 
-and external (off-processor-owned) data. The resulting global view of the 
-partitioned matrix has (diagonal) blocks corresponding to local data, and 
-off-diagonal blocks corresponding to non-local data. The resulting parallel ILU 
-strategy is composed of a (local) block factorization and a (global) Schur 
-complement solve. Several strategies provided to efficiently solve the Schur 
-complement system. 
+The parallel hypre-ILU solver follows a domain decomposition approach for solving
+distributed sparse linear systems of equations. The strategy is to decompose the
+domain into interior and interface nodes, where an interface node separates two
+interior nodes from adjacent domains. In the purely algebraic setting, this is
+equivalent to partitioning the matrix row data into local (processor-owned) data
+and external (off-processor-owned) data. The resulting global view of the
+partitioned matrix has (diagonal) blocks corresponding to local data, and
+off-diagonal blocks corresponding to non-local data. The resulting parallel ILU
+strategy is composed of a (local) block factorization and a (global) Schur
+complement solve. Several strategies provided to efficiently solve the Schur
+complement system.
 
 The following represents a minimal set of functions, and some optional
 functions, to call to use the hypre_ILU solver. For simplicity, we ignore the function
@@ -35,14 +36,14 @@ on the parameters and their defaults.
 
 
 * ``HYPRE_ILUCreate:`` Create the hypre_ILU solver object.
-* ``HYPRE_ILUSetType:`` Set the type of ILU factorization to do. Here, the user specifies 
-  one of several flavors of parallel ILU based on the different combinations of local 
-  factorizations and global Schur complement solves. Please refer to the reference manual 
+* ``HYPRE_ILUSetType:`` Set the type of ILU factorization to do. Here, the user specifies
+  one of several flavors of parallel ILU based on the different combinations of local
+  factorizations and global Schur complement solves. Please refer to the reference manual
   for more details about the different options available to the user.
 * (Optional) ``HYPRE_ILUSetLevelOfFill:`` Set the level of fill used by the level-based ILUk strategy.
-* (Optional) ``HYPRE_ILUSetSchurMaxIter:`` Set the maximum number of iterations for solving 
+* (Optional) ``HYPRE_ILUSetSchurMaxIter:`` Set the maximum number of iterations for solving
   the Schur complement system.
-* (Optional) ``HYPRE_ILUSetMaxIter:`` Set the maximum number of iterations when used as a 
+* (Optional) ``HYPRE_ILUSetMaxIter:`` Set the maximum number of iterations when used as a
   solver or smoother.
 * ``HYPRE_ILUSetup:`` Setup and hypre_ILU solver object.
 * ``HYPRE_ILUSolve:`` Solve the linear system.

--- a/src/docs/usr-manual/solvers-hypre-ilu.rst
+++ b/src/docs/usr-manual/solvers-hypre-ilu.rst
@@ -235,6 +235,10 @@ configuration.
      - UVM-Setup and Solve
      - None
 
+.. hint::
+   For better setup performance on GPUs, disable local reordering by passing option
+   zero to ``HYPRE_ILUSetLocalReordering`` or ``HYPRE_BoomerAMGSetILULocalReordering``.
+
 .. note::
    hypre must be built with ``cuSPARSE`` support when running ILU on NVIDIA
    GPUs. Similarly, ``rocSPARSE`` is required when running ILU on AMD GPUs.

--- a/src/docs/usr-manual/solvers-hypre-ilu.rst
+++ b/src/docs/usr-manual/solvers-hypre-ilu.rst
@@ -8,47 +8,229 @@
 hypre-ILU
 ==============================================================================
 
-The hypre-ILU solver is a parallel ILU solver based on a domain decomposition
-framework. It may be use iteratively as a standalone solver or smoother, as well as a
-preconditioner for accelerators like Krylov subspace methods. This solver
-implements various parallel variants of the dual threshold (truncation) incomplete
-LU factorization - ILUT, and the level-based incomplete LU factorization - ILUk.
-
+hypre-ILU is a suite of parallel incomplete LU factorization algorithms featuring dual
+threshold (ILUT) and level-based (ILUK) variants. Its implementation is based on a domain
+decomposition framework for achieving distributed parallelism. It can be used as a
+standalone iterative solver, preconditioner for Krylov subspace methods, or smoother for
+multigrid methods such as BoomerAMG and MGR.
 
 Overview
 ------------------------------------------------------------------------------
-The parallel hypre-ILU solver follows a domain decomposition approach for solving
-distributed sparse linear systems of equations. The strategy is to decompose the
-domain into interior and interface nodes, where an interface node separates two
-interior nodes from adjacent domains. In the purely algebraic setting, this is
-equivalent to partitioning the matrix row data into local (processor-owned) data
-and external (off-processor-owned) data. The resulting global view of the
-partitioned matrix has (diagonal) blocks corresponding to local data, and
-off-diagonal blocks corresponding to non-local data. The resulting parallel ILU
-strategy is composed of a (local) block factorization and a (global) Schur
-complement solve. Several strategies provided to efficiently solve the Schur
-complement system.
 
-The following represents a minimal set of functions, and some optional
-functions, to call to use the hypre_ILU solver. For simplicity, we ignore the function
-parameters here, and refer the reader to the reference manual for more details
-on the parameters and their defaults.
+The domain decomposition framework in hypre-ILU consists of two main approaches. The first
+is based on an inexact block-Jacobi method where blocks (domains) are formed by local
+unknowns (owned by the current MPI task), and ILU is employed to solve approximately the
+local block systems. The second approach consists of splitting the matrix graph into
+interior and interface nodes, where an interface node separates two interior nodes from
+adjacent domains. In the purely algebraic setting, this is equivalent to partitioning the
+matrix row data into local (processor-owned) and external (off-processor-owned) data. The
+final parallel ILU strategy is a two-level method composed of a local block factorization
+and a global Schur complement solve. Several strategies are provided to solve the Schur
+complement (reduced) system efficiently.
 
+User-level functions
+------------------------------------------------------------------------------
 
-* ``HYPRE_ILUCreate:`` Create the hypre_ILU solver object.
-* ``HYPRE_ILUSetType:`` Set the type of ILU factorization to do. Here, the user specifies
-  one of several flavors of parallel ILU based on the different combinations of local
-  factorizations and global Schur complement solves. Please refer to the reference manual
-  for more details about the different options available to the user.
-* (Optional) ``HYPRE_ILUSetLevelOfFill:`` Set the level of fill used by the level-based ILUk strategy.
-* (Optional) ``HYPRE_ILUSetSchurMaxIter:`` Set the maximum number of iterations for solving
-  the Schur complement system.
-* (Optional) ``HYPRE_ILUSetMaxIter:`` Set the maximum number of iterations when used as a
-  solver or smoother.
-* ``HYPRE_ILUSetup:`` Setup and hypre_ILU solver object.
-* ``HYPRE_ILUSolve:`` Solve the linear system.
-* ``HYPRE_ILUDestroy:`` Destroy the hypre_ILU solver object
+A list of user-level functions for configuring hypre-ILU is given below, where each block
+of functions is marked as *Required*, *Recommended*, *Optional*, or *Exclusively
+required*. Note that the last two blocks of function calls are exclusively required, i.e.,
+the first block should be called only when hypre-ILU is used as a standalone solver, while
+the second block should be called only when it is used as a preconditioner to GMRES. In
+the last case, other Krylov methods can be chosen. We refer the reader to
+:ref:`ch-Solvers` for more information.
 
-For more details about additional solver options and parameters, please refer to
-the reference manual.  NOTE: The hypre_ILU solver is currently only supported by the
-IJ interface.
+.. code-block:: c
+
+ /* (Required) Create ILU solver */
+ HYPRE_ILUCreate(&ilu_solver);
+
+ /* (Recommended) General solver options */
+ HYPRE_ILUSetType(ilu_solver, ilu_type); /* 0, 1, 10, 11, 20, 21, 30, 31, 40, 41, 50 */
+ HYPRE_ILUSetMaxIter(ilu_solver, max_iter);
+ HYPRE_ILUSetTol(ilu_solver, tol);
+ HYPRE_ILUSetLocalReordering(ilu_solver, reordering); /* 0: none, 1: RCM */
+ HYPRE_ILUSetPrintLevel(ilu_solver, print_level);
+
+ /* (Optional) Function calls for ILUK variants */
+ HYPRE_ILUSetLevelOfFill(ilu_solver, fill);
+
+ /* (Optional) Function calls for ILUT variants */
+ HYPRE_ILUSetMaxNnzPerRow(ilu_solver, max_nnz_row);
+ HYPRE_ILUSetDropThreshold(ilu_solver, threshold);
+
+ /* (Optional) Function calls for GMRES-ILU or NSH-ILU */
+ HYPRE_ILUSetNSHDropThreshold(ilu_solver, threshold);
+ HYPRE_ILUSetSchurMaxIter(ilu_solver, schur_max_iter);
+
+ /* (Optional) Function calls for iterative ILU variants */
+ HYPRE_ILUSetTriSolve(ilu_solver, 0);
+ HYPRE_ILUSetLowerJacobiIters(ilu_solver, ljac_iters);
+ HYPRE_ILUSetUpperJacobiIters(ilu_solver, ujac_iters);
+
+ /* (Exclusively required) Function calls for using ILU as standalone solver */
+ HYPRE_ILUSetup(ilu_solver, parcsr_M, b, x);
+ HYPRE_ILUSolve(ilu_solver, parcsr_A, b, x);
+
+ /* (Exclusively required) Function calls for using ILU as preconditioner to GMRES */
+ HYPRE_GMRESSetup(gmres_solver, (HYPRE_Matrix)A, (HYPRE_Vector)b, (HYPRE_Vector)x);
+ HYPRE_GMRESSolve(gmres_solver, (HYPRE_Matrix)A, (HYPRE_Vector)b, (HYPRE_Vector)x);
+
+ /* (Required) Free memory */
+ HYPRE_ILUDestroy(ilu_solver);
+
+A short explanation for each of those functions and its parameters is given next.
+
+* ``HYPRE_ILUCreate`` Create the hypre_ILU solver object.
+* ``HYPRE_ILUDestroy`` Destroy the hypre_ILU solver object.
+* ``HYPRE_ILUSetType`` Set the type of ILU factorization. Options are:
+
+  * 0:  Block-Jacobi ILUK (BJ-ILUK).
+  * 1:  Block-Jacobi ILUT (BJ-ILUT).
+  * 10: GMRES with ILUK (GMRES-ILUK).
+  * 11: GMRES with ILUT (GMRES-ILUT).
+  * 20: NSH with ILUK (NSH-ILUK).
+  * 21: NSH with ILUT (NSH-ILUT).
+  * 30: RAS with ILUK (GMRES-ILUK).
+  * 31: RAS with ILUT (GMRES-ILUT).
+  * 40: ddPQ-GMRES with ILUK (ddPQ-GMRES-ILUK).
+  * 41: ddPQ-GMRES with ILUT (ddPQ-GMRES-ILUT).
+  * 50: GMRES with RAP-ILU0 with modified ILU0 (GMRES-RAP-ILU0).
+* ``HYPRE_ILUSetMaxIter`` Set the maximum number of ILU iterations. We recommend setting
+  this value to one when ILU is used as a preconditioner or smoother.
+* ``HYPRE_ILUSetTol`` Set the convergence tolerance for ILU. We recommend setting
+  this value to zero when ILU is used as a preconditioner or smoother.
+* ``HYPRE_ILUSetLocalReordering`` Set the local matrix reordering algorithm.
+
+  * 0: No reordering.
+  * 1: Reverse Cuthill–McKee (RCM).
+* ``HYPRE_ILUSetPrintLevel`` Set the verbosity level for algorithm statistics.
+
+  * 0: No output.
+  * 1: Print setup info.
+  * 2: Print solve info.
+  * 3: Print setup and solve info.
+* ``HYPRE_ILUSetLevelOfFill`` Set the level of fill used by the level-based ILUK
+  strategy.
+* ``HYPRE_ILUSetMaxNnzPerRow`` Set the maximum number of nonzero entries per row in the
+  triangular factors for ILUT.
+* ``HYPRE_ILUSetDropThreshold`` Set the threshold for dropping nonzero entries during the
+  construction of the triangular factors for ILUT.
+* ``HYPRE_ILUSetNSHDropThreshold`` Set the threshold for dropping nonzero entries during the
+  computation of the approximate inverse matrix via NSH-ILU.
+* ``HYPRE_ILUSetSchurMaxIter`` Set the maximum number of iterations for solving
+  the Schur complement system (GMRES-ILU or NSH-ILU).
+* ``HYPRE_ILUSetTriSolve`` Set triangular solve method used in ILU's solve phase. Option zero
+  refers to the iterative approach, which leads to good performance in GPUs, and option
+  one refers to the direct (exact) approach.
+* ``HYPRE_ILUSetLowerJacobiIters`` Set the number of iterations for solving the lower
+  triangular linear system. This option makes sense when enabling the iterative triangular
+  solve approach.
+* ``HYPRE_ILUSetUpperJacobiIters`` Same as previous function, but for the upper
+  triangular factor.
+* ``HYPRE_ILUSetup`` Setup a hypre_ILU solver object.
+* ``HYPRE_ILUSolve`` Solve the linear system with hypre_ILU.
+* ``HYPRE_ILUDestroy`` Destroy the hypre_ILU solver object.
+
+.. note::
+   For more details about hypre-ILU options and parameters, including their default
+   values, we refer the reader to hypre's reference manual or section :ref:`sec-ParCSR-Solvers`.
+
+.. _ilu-amg-smoother:
+
+ILU as Smoother for BoomerAMG
+------------------------------------------------------------------------------
+
+The following functions can be used to configure hypre-ILU as a smoother to BoomerAMG:
+
+.. code-block:: c
+
+ /* (Required) Set ILU as smoother to BoomerAMG */
+ HYPRE_BoomerAMGSetSmoothType(amg_solver, 5);
+ HYPRE_BoomerAMGSetSmoothNumLevels(amg_solver, num_levels);
+
+ /* (Optional) General ILU configuration parameters */
+ HYPRE_BoomerAMGSetILUType(amg_solver, ilu_type);
+ HYPRE_BoomerAMGSetILUMaxIter(amg_solver, ilu_max_iter);
+ HYPRE_BoomerAMGSetILULocalReordering(amg_solver, ilu_reordering);
+
+ /* (Optional) Function calls for ILUK smoother variants */
+ HYPRE_BoomerAMGSetILULevel(amg_solver, ilu_fill);
+
+ /* (Optional) Function calls for ILUT smoother variants */
+ HYPRE_BoomerAMGSetILUDroptol(amg_solver, ilu_threshold);
+ HYPRE_BoomerAMGSetILUMaxRowNnz(amg_solver, ilu_max_nnz_row);
+
+ /* (Optional) Function calls for iterative ILU smoother variants */
+ HYPRE_BoomerAMGSetILUTriSolve(amg_solver, 0);
+ HYPRE_BoomerAMGSetILULowerJacobiIters(amg_solver, ilu_ljac_iters);
+ HYPRE_BoomerAMGSetILUUpperJacobiIters(amg_solver, ilu_ujac_iters);
+
+where:
+
+* ``HYPRE_BoomerAMGSetSmoothNumLevels`` Enable smoothing in the first ``num_levels``
+  levels of AMG.
+* ``HYPRE_BoomerAMGSetILUType`` Set the type of ILU factorization. See ``HYPRE_ILUSetType``.
+* ``HYPRE_BoomerAMGSetILUMaxIter`` Set the maximum number of ILU smoother sweeps.
+* ``HYPRE_BoomerAMGSetILULocalReordering`` Set the local matrix reordering algorithm.
+* ``HYPRE_BoomerAMGSetILULevel`` Set ILUK's fill level.
+* ``HYPRE_BoomerAMGSetILUDroptol`` Set ILUT's threshold.
+* ``HYPRE_BoomerAMGSetILUMaxRowNnz`` Set ILUT's maximum number of nonzero entries per row.
+* ``HYPRE_BoomerAMGSetILUTriSolve`` Set triangular solve method. See ``HYPRE_ILUSetTriSolve``.
+* ``HYPRE_BoomerAMGSetILULowerJacobiIters`` Set the number of iterations for the L factor.
+* ``HYPRE_BoomerAMGSetILUUpperJacobiIters`` Same as previous function, but for the U factor.
+
+GPU support
+------------------------------------------------------------------------------
+
+The addition of GPU support to hypre-ILU is ongoing work. A few ILU algorithm types have
+already been fully ported to the CUDA and HIP backends, i.e., both their setup
+(factorization) and solve phases are executed on the device. Below is a detailed list of
+which phases (setup and solve) of the various ILU algorithms have been ported to GPUs. In
+the table, *UVM-Setup* indicates that the setup phase is executed on the CPU (host); at
+the same time, the triangular factors are stored in a memory space that is accessible from
+the GPU (device) via unified memory. This feature must be enabled during hypre's
+configuration.
+
+.. list-table::
+   :widths: 20 20 20 20
+   :header-rows: 1
+
+   * -
+     - CUDA (NVIDIA GPUs)
+     - HIP (AMD GPUs)
+     - SYCL (Intel GPUs)
+   * - **BJ-ILU0**
+     - Setup and Solve
+     - Setup and Solve
+     - None
+   * - **BJ-ILU(K/T)**
+     - UVM-Setup and Solve
+     - UVM-Setup and Solve
+     - None
+   * - **GMRES-ILU0**
+     - Setup and Solve
+     - Setup and Solve
+     - None
+   * - **GMRES-RAP-ILU0**
+     - UVM-Setup and Solve
+     - UVM-Setup and Solve
+     - None
+   * - **GMRES-ILU(K/T)**
+     - UVM-Setup and Solve
+     - UVM-Setup and Solve
+     - None
+   * - **ddPQ-GMRES-ILU(K/T)**
+     - UVM-Setup and Solve
+     - UVM-Setup and Solve
+     - None
+   * - **NSH-ILU(K/T)**
+     - UVM-Setup and Solve
+     - UVM-Setup and Solve
+     - None
+   * - **RAS-ILU(K/T)**
+     - UVM-Setup and Solve
+     - UVM-Setup and Solve
+     - None
+
+.. note::
+   The hypre-ILU method is currently only supported by the IJ interface.

--- a/src/docs/usr-manual/solvers-hypre-ilu.rst
+++ b/src/docs/usr-manual/solvers-hypre-ilu.rst
@@ -10,8 +10,8 @@ hypre-ILU
 
 hypre-ILU is a suite of parallel incomplete LU factorization algorithms featuring dual
 threshold (ILUT) and level-based (ILUK) variants. Its implementation is based on a domain
-decomposition framework for achieving distributed parallelism. It can be used as a
-standalone iterative solver, preconditioner for Krylov subspace methods, or smoother for
+decomposition framework for achieving distributed parallelism. It can be used as
+preconditioners for Krylov subspace methods, or smoothers for
 multigrid methods such as BoomerAMG and MGR.
 
 .. note::
@@ -20,16 +20,16 @@ multigrid methods such as BoomerAMG and MGR.
 Overview
 ------------------------------------------------------------------------------
 
-The domain decomposition framework in hypre-ILU consists of two main approaches. The first
-is based on an inexact block-Jacobi method where blocks (domains) are formed by local
-unknowns (owned by the current MPI task), and ILU is employed to solve approximately the
-local block systems. The second approach consists of splitting the matrix graph into
-interior and interface nodes, where an interface node separates two interior nodes from
-adjacent domains. In the purely algebraic setting, this is equivalent to partitioning the
-matrix row data into local (processor-owned) and external (off-processor-owned) data. The
-final parallel ILU strategy is a two-level method composed of a local block factorization
-and a global Schur complement solve. Several strategies are provided to solve the Schur
-complement (reduced) system efficiently.
+hypre-ILU utilizes a domain decomposition framework.
+A basic block-Jacobi approach involves performing inexact solves within the local domains owned by the processes,
+using parallel local ILU factorizations.
+In a more advanced approach, the unknowns are partitioned into interior and interface points,
+where the interface points separate the interior points in adjacent domains.
+In an algebraic context, this is equivalent to dividing the matrix rows into local (processor-owned) and
+external (off-processor-owned) blocks.
+The overall parallel ILU strategy is a two-level method that consists of ILU solves within the local blocks
+and a global solve involving the Schur complement system.
+Various iterative approaches are available for solving the Schur complement system.
 
 User-level functions
 ------------------------------------------------------------------------------

--- a/src/docs/usr-manual/solvers-hypre-ilu.rst
+++ b/src/docs/usr-manual/solvers-hypre-ilu.rst
@@ -14,6 +14,9 @@ decomposition framework for achieving distributed parallelism. It can be used as
 standalone iterative solver, preconditioner for Krylov subspace methods, or smoother for
 multigrid methods such as BoomerAMG and MGR.
 
+.. note::
+   The hypre-ILU method is currently only supported by the IJ interface.
+
 Overview
 ------------------------------------------------------------------------------
 
@@ -170,7 +173,7 @@ where:
 * ``HYPRE_BoomerAMGSetSmoothNumLevels`` Enable smoothing in the first ``num_levels``
   levels of AMG.
 * ``HYPRE_BoomerAMGSetILUType`` Set the type of ILU factorization. See ``HYPRE_ILUSetType``.
-* ``HYPRE_BoomerAMGSetILUMaxIter`` Set the maximum number of ILU smoother sweeps.
+* ``HYPRE_BoomerAMGSetILUMaxIter`` Set the number of ILU smoother sweeps.
 * ``HYPRE_BoomerAMGSetILULocalReordering`` Set the local matrix reordering algorithm.
 * ``HYPRE_BoomerAMGSetILULevel`` Set ILUK's fill level.
 * ``HYPRE_BoomerAMGSetILUDroptol`` Set ILUT's threshold.
@@ -233,4 +236,5 @@ configuration.
      - None
 
 .. note::
-   The hypre-ILU method is currently only supported by the IJ interface.
+   hypre must be built with ``cuSPARSE`` support when running ILU on NVIDIA
+   GPUs. Similarly, ``rocSPARSE`` is required when running ILU on AMD GPUs.

--- a/src/docs/usr-manual/solvers-ilu.rst
+++ b/src/docs/usr-manual/solvers-ilu.rst
@@ -3,41 +3,40 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-.. _hypre-ilu:
+.. _ilu:
 
-hypre-ILU
+ILU
 ==============================================================================
 
-hypre-ILU is a suite of parallel incomplete LU factorization algorithms featuring dual
-threshold (ILUT) and level-based (ILUK) variants. The implementation is based on a domain
-decomposition framework for achieving distributed parallelism. hypre-ILU can be used as
-preconditioners for Krylov subspace methods, or smoothers for
-multigrid methods such as BoomerAMG and MGR.
+ILU is a suite of parallel incomplete LU factorization algorithms featuring dual threshold
+(ILUT) and level-based (ILUK) variants. The implementation is based on a domain
+decomposition framework for achieving distributed parallelism. ILU can be used as a
+standalone iterative solver (this is not recommended), preconditioner for Krylov subspace
+methods, or smoother for multigrid methods such as BoomerAMG and MGR.
 
 .. note::
-   The hypre-ILU method is currently only supported by the IJ interface.
+   ILU is currently only supported by the IJ interface.
 
 Overview
 ------------------------------------------------------------------------------
 
-hypre-ILU utilizes a domain decomposition framework.
-A basic block-Jacobi approach involves performing inexact solves within the local domains owned by the processes,
-using parallel local ILU factorizations.
-In a more advanced approach, the unknowns are partitioned into interior and interface points,
-where the interface points separate the interior points in adjacent domains.
-In an algebraic context, this is equivalent to dividing the matrix rows into local (processor-owned) and
-external (off-processor-owned) blocks.
-The overall parallel ILU strategy is a two-level method that consists of ILU solves within the local blocks
-and a global solve involving the Schur complement system.
-Various iterative approaches are available for solving the Schur complement system.
+ILU utilizes a domain decomposition framework. A basic block-Jacobi approach involves
+performing inexact solutions within the local domains owned by the processes, using
+parallel local ILU factorizations. In a more advanced approach, the unknowns are
+partitioned into interior and interface points, where the interface points separate the
+interior points in adjacent domains. In an algebraic context, this is equivalent to
+dividing the matrix rows into local (processor-owned) and external (off-processor-owned)
+blocks. The overall parallel ILU strategy is a two-level method that consists of ILU
+solves within the local blocks and a global solve involving the Schur complement system,
+which various iterative approaches in this framework can solve.
 
 User-level functions
 ------------------------------------------------------------------------------
 
-A list of user-level functions for configuring hypre-ILU is given below, where each block
+A list of user-level functions for configuring ILU is given below, where each block
 of functions is marked as *Required*, *Recommended*, *Optional*, or *Exclusively
 required*. Note that the last two blocks of function calls are exclusively required, i.e.,
-the first block should be called only when hypre-ILU is used as a standalone solver, while
+the first block should be called only when ILU is used as a standalone solver, while
 the second block should be called only when it is used as a preconditioner to GMRES. In
 the last case, other Krylov methods can be chosen. We refer the reader to
 :ref:`ch-Solvers` for more information.
@@ -135,7 +134,7 @@ A short explanation for each of those functions and its parameters is given next
 * ``HYPRE_ILUDestroy`` Destroy the hypre_ILU solver object.
 
 .. note::
-   For more details about hypre-ILU options and parameters, including their default
+   For more details about ILU options and parameters, including their default
    values, we refer the reader to hypre's reference manual or section :ref:`sec-ParCSR-Solvers`.
 
 .. _ilu-amg-smoother:
@@ -143,7 +142,7 @@ A short explanation for each of those functions and its parameters is given next
 ILU as Smoother for BoomerAMG
 ------------------------------------------------------------------------------
 
-The following functions can be used to configure hypre-ILU as a smoother to BoomerAMG:
+The following functions can be used to configure ILU as a smoother to BoomerAMG:
 
 .. code-block:: c
 
@@ -185,14 +184,13 @@ where:
 GPU support
 ------------------------------------------------------------------------------
 
-The addition of GPU support to hypre-ILU is ongoing work. A few ILU algorithm types have
-already been fully ported to the CUDA and HIP backends, i.e., both their setup
-(factorization) and solve phases are executed on the device. Below is a detailed list of
-which phases (setup and solve) of the various ILU algorithms have been ported to GPUs. In
-the table, *UVM-Setup* indicates that the setup phase is executed on the CPU (host); at
-the same time, the triangular factors are stored in a memory space that is accessible from
-the GPU (device) via unified memory. This feature must be enabled during hypre's
-configuration.
+The addition of GPU support to ILU is ongoing work. A few algorithm types have already
+been fully ported to the CUDA and HIP backends, i.e., both their setup (factorization) and
+solve phases are executed on the device. Below is a detailed list of which phases (setup
+and solve) of the various ILU algorithms have been ported to GPUs. In the table,
+*UVM-Setup* indicates that the setup phase is executed on the CPU (host); at the same
+time, the triangular factors are stored in a memory space that is accessible from the GPU
+(device) via unified memory. This feature must be enabled during hypre's configuration.
 
 .. list-table::
    :widths: 20 20 20 20
@@ -237,7 +235,9 @@ configuration.
 
 .. hint::
    For better setup performance on GPUs, disable local reordering by passing option
-   zero to ``HYPRE_ILUSetLocalReordering`` or ``HYPRE_BoomerAMGSetILULocalReordering``.
+   zero to ``HYPRE_ILUSetLocalReordering`` or
+   ``HYPRE_BoomerAMGSetILULocalReordering``. This may degrade convergence of the iterative
+   solver.
 
 .. note::
    hypre must be built with ``cuSPARSE`` support when running ILU on NVIDIA

--- a/src/docs/usr-manual/solvers-pilut.rst
+++ b/src/docs/usr-manual/solvers-pilut.rst
@@ -13,7 +13,8 @@ PILUT: Parallel Incomplete Factorization
    PILUT is not actively supported by the hypre development team. We recommend using
    :ref:`hypre-ilu` for parallel ILU algorithms. This new ILU implementation includes
    64-bit integers support (for linear systems with more than 2,147,483,647 global
-   unknowns) and NVIDIA/AMD GPUs support through the CUDA/HIP backends.
+   unknowns) through both *mixedint* and *bigint* builds of hypre and NVIDIA/AMD GPUs
+   support through the CUDA/HIP backends.
 
 PILUT is a parallel preconditioner based on Saad's dual-threshold incomplete
 factorization algorithm. The original version of PILUT was done by Karypis and

--- a/src/docs/usr-manual/solvers-pilut.rst
+++ b/src/docs/usr-manual/solvers-pilut.rst
@@ -9,9 +9,11 @@
 PILUT: Parallel Incomplete Factorization
 ==============================================================================
 
-**Note:** this code is no longer supported by the hypre team. We recommend to
-use Euclid instead, which is more versatile and in general more efficient,
-especially when used with many processors.
+.. warning::
+   PILUT is not actively supported by the hypre development team. We recommend using
+   :ref:`hypre-ilu` for parallel ILU algorithms. This new ILU implementation includes
+   64-bit integers support (for linear systems with more than 2,147,483,647 global
+   unknowns) and NVIDIA/AMD GPUs support through the CUDA/HIP backends.
 
 PILUT is a parallel preconditioner based on Saad's dual-threshold incomplete
 factorization algorithm. The original version of PILUT was done by Karypis and
@@ -22,10 +24,10 @@ matrix implementations, including hypre's ParCSR format, PETSc's matrices, and
 ISIS++ RowMatrix. The algorithm produces an approximate factorization :math:`L U`,
 with the preconditioner :math:`M` defined by :math:`M = L U`.
 
-**Note:** PILUT produces a nonsymmetric preconditioner even when the original
-matrix is symmetric. Thus, it is generally inappropriate for preconditioning
-symmetric methods such as Conjugate Gradient.
-
+.. note::
+   PILUT produces a nonsymmetric preconditioner even when the original matrix is
+   symmetric. Thus, it is generally inappropriate for preconditioning symmetric methods
+   such as Conjugate Gradient.
 
 Parameters:
 ------------------------------------------------------------------------------

--- a/src/docs/usr-manual/solvers-pilut.rst
+++ b/src/docs/usr-manual/solvers-pilut.rst
@@ -11,7 +11,7 @@ PILUT: Parallel Incomplete Factorization
 
 .. warning::
    PILUT is not actively supported by the hypre development team. We recommend using
-   :ref:`hypre-ilu` for parallel ILU algorithms. This new ILU implementation includes
+   :ref:`ilu` for parallel ILU algorithms. This new ILU implementation includes
    64-bit integers support (for linear systems with more than 2,147,483,647 global
    unknowns) through both *mixedint* and *bigint* builds of hypre and NVIDIA/AMD GPUs
    support through the CUDA/HIP backends.

--- a/src/parcsr_ls/HYPRE_parcsr_ls.h
+++ b/src/parcsr_ls/HYPRE_parcsr_ls.h
@@ -1069,35 +1069,63 @@ HYPRE_Int HYPRE_BoomerAMGSetEuBJ(HYPRE_Solver solver,
  * For further explanation see description of ILU.
  **/
 HYPRE_Int HYPRE_BoomerAMGSetILUType( HYPRE_Solver  solver,
-                                     HYPRE_Int         ilu_type);
+                                     HYPRE_Int     ilu_type);
 
 /**
  * Defines level k for ILU(k) smoother
  * For further explanation see description of ILU.
  **/
 HYPRE_Int HYPRE_BoomerAMGSetILULevel( HYPRE_Solver  solver,
-                                      HYPRE_Int         ilu_lfil);
+                                      HYPRE_Int     ilu_lfil);
 
 /**
  * Defines max row nonzeros for ILUT smoother
  * For further explanation see description of ILU.
  **/
 HYPRE_Int HYPRE_BoomerAMGSetILUMaxRowNnz( HYPRE_Solver  solver,
-                                          HYPRE_Int         ilu_max_row_nnz);
+                                          HYPRE_Int     ilu_max_row_nnz);
 
 /**
  * Defines number of iterations for ILU smoother on each level
  * For further explanation see description of ILU.
  **/
 HYPRE_Int HYPRE_BoomerAMGSetILUMaxIter( HYPRE_Solver  solver,
-                                        HYPRE_Int         ilu_max_iter);
+                                        HYPRE_Int     ilu_max_iter);
 
 /**
  * Defines drop tolorance for iLUT smoother
  * For further explanation see description of ILU.
  **/
 HYPRE_Int HYPRE_BoomerAMGSetILUDroptol( HYPRE_Solver  solver,
-                                        HYPRE_Real        ilu_droptol);
+                                        HYPRE_Real    ilu_droptol);
+
+/**
+ * (Optional) Defines triangular solver for ILU(k,T) smoother: 0-iterative, 1-direct (default)
+ * For further explanation see description of ILU.
+ **/
+HYPRE_Int HYPRE_BoomerAMGSetILUTriSolve( HYPRE_Solver  solver,
+                                         HYPRE_Int     ilu_tri_solve);
+
+/**
+ * (Optional) Defines number of lower Jacobi iterations for ILU(k,T) smoother triangular solve.
+ * For further explanation see description of ILU.
+ **/
+HYPRE_Int HYPRE_BoomerAMGSetILULowerJacobiIters( HYPRE_Solver  solver,
+                                                 HYPRE_Int     ilu_lower_jacobi_iters);
+
+/**
+ * (Optional) Defines number of upper Jacobi iterations for ILU(k,T) smoother triangular solve.
+ * For further explanation see description of ILU.
+ **/
+HYPRE_Int HYPRE_BoomerAMGSetILUUpperJacobiIters( HYPRE_Solver  solver,
+                                                 HYPRE_Int     ilu_upper_jacobi_iters);
+
+/**
+ * Set Local Reordering paramter (1==RCM, 0==None)
+ * For further explanation see description of ILU.
+ **/
+HYPRE_Int HYPRE_BoomerAMGSetILULocalReordering( HYPRE_Solver solver,
+                                                HYPRE_Int    ilu_reordering_type);
 
 /**
  * (Optional) Defines maximum number of steps for FSAI.
@@ -1127,34 +1155,6 @@ HYPRE_Int HYPRE_BoomerAMGSetFSAIEigMaxIters(HYPRE_Solver solver,
  **/
 HYPRE_Int HYPRE_BoomerAMGSetFSAIKapTolerance(HYPRE_Solver solver,
                                              HYPRE_Real   kap_tolerance);
-
-/**
- * (Optional) Defines triangular solver for ILU(k,T) smoother: 0-iterative, 1-direct (default)
- * For further explanation see description of ILU.
- **/
-HYPRE_Int HYPRE_BoomerAMGSetILUTriSolve( HYPRE_Solver  solver,
-                                         HYPRE_Int     ilu_tri_solve);
-
-/**
- * (Optional) Defines number of lower Jacobi iterations for ILU(k,T) smoother triangular solve.
- * For further explanation see description of ILU.
- **/
-HYPRE_Int HYPRE_BoomerAMGSetILULowerJacobiIters( HYPRE_Solver  solver,
-                                                 HYPRE_Int     ilu_lower_jacobi_iters);
-
-/**
- * (Optional) Defines number of upper Jacobi iterations for ILU(k,T) smoother triangular solve.
- * For further explanation see description of ILU.
- **/
-HYPRE_Int HYPRE_BoomerAMGSetILUUpperJacobiIters( HYPRE_Solver  solver,
-                                                 HYPRE_Int     ilu_upper_jacobi_iters);
-
-/**
- * Set Local Reordering paramter (1==RCM, 0==None)
- * For further explanation see description of ILU.
- **/
-HYPRE_Int HYPRE_BoomerAMGSetILULocalReordering( HYPRE_Solver solver,
-                                                HYPRE_Int    ilu_reordering_type);
 
 /**
  * (Optional) Defines which parallel restriction operator is used.
@@ -4313,7 +4313,7 @@ HYPRE_MGRGetFinalRelativeResidualNorm( HYPRE_Solver solver,
 /**
  * @name ParCSR ILU Solver
  *
- * (Parallel) ILU smoother
+ * (Parallel) Incomplete LU factorization.
  *
  * @{
  **/
@@ -4321,12 +4321,14 @@ HYPRE_MGRGetFinalRelativeResidualNorm( HYPRE_Solver solver,
 /**
  * Create a solver object
  **/
-HYPRE_Int HYPRE_ILUCreate( HYPRE_Solver *solver );
+HYPRE_Int
+HYPRE_ILUCreate( HYPRE_Solver *solver );
 
 /**
  * Destroy a solver object
  **/
-HYPRE_Int HYPRE_ILUDestroy( HYPRE_Solver solver );
+HYPRE_Int
+HYPRE_ILUDestroy( HYPRE_Solver solver );
 
 /**
  * Setup the ILU solver or preconditioner.
@@ -4338,10 +4340,11 @@ HYPRE_Int HYPRE_ILUDestroy( HYPRE_Solver solver );
  * @param b right-hand-side of the linear system to be solved (Ignored by this function).
  * @param x approximate solution of the linear system to be solved (Ignored by this function).
  **/
-HYPRE_Int HYPRE_ILUSetup( HYPRE_Solver solver,
-                          HYPRE_ParCSRMatrix A,
-                          HYPRE_ParVector b,
-                          HYPRE_ParVector x      );
+HYPRE_Int
+HYPRE_ILUSetup( HYPRE_Solver solver,
+                HYPRE_ParCSRMatrix A,
+                HYPRE_ParVector b,
+                HYPRE_ParVector x      );
 /**
 * Solve the system or apply ILU as a preconditioner.
 * If used as a preconditioner, this function should be passed
@@ -4352,10 +4355,11 @@ HYPRE_Int HYPRE_ILUSetup( HYPRE_Solver solver,
 * @param b [IN] right hand side of the linear system to be solved
 * @param x [OUT] approximated solution of the linear system to be solved
 **/
-HYPRE_Int HYPRE_ILUSolve( HYPRE_Solver solver,
-                          HYPRE_ParCSRMatrix A,
-                          HYPRE_ParVector b,
-                          HYPRE_ParVector x      );
+HYPRE_Int
+HYPRE_ILUSolve( HYPRE_Solver solver,
+                HYPRE_ParCSRMatrix A,
+                HYPRE_ParVector b,
+                HYPRE_ParVector x      );
 
 /**
  * (Optional) Set maximum number of iterations if used as a solver.
@@ -4388,7 +4392,7 @@ HYPRE_Int
 HYPRE_ILUSetUpperJacobiIters( HYPRE_Solver solver, HYPRE_Int upper_jacobi_iterations );
 
 /**
- * (Optional) Set the convergence tolerance for the ILU smoother.
+ * (Optional) Set the convergence tolerance for ILU.
  * Use tol = 0.0 if ILU is used as a preconditioner. The default is 1.e-7.
  **/
 HYPRE_Int
@@ -4430,7 +4434,7 @@ HYPRE_Int
 HYPRE_ILUSetDropThresholdArray( HYPRE_Solver solver, HYPRE_Real *threshold );
 
 /**
- * (Optional) Set the threshold for dropping in Newton–Schulz–Hotelling iteration (NHS-ILU).
+ * (Optional) Set the threshold for dropping in Newton–Schulz–Hotelling iteration (NSH-ILU).
  * Any entries less than this threshold are dropped when forming the approximate inverse matrix.
  * The default is 1.0e-2.
  **/
@@ -4439,7 +4443,7 @@ HYPRE_ILUSetNSHDropThreshold( HYPRE_Solver solver, HYPRE_Real threshold );
 
 /**
  * (Optional) Set the array of thresholds for dropping in Newton–Schulz–Hotelling
- * iteration (for NHS-ILU).  Any fill-in less than thresholds is dropped when
+ * iteration (for NSH-ILU).  Any fill-in less than thresholds is dropped when
  * forming the approximate inverse matrix.
  *
  *    - threshold[0] : threshold for Minimal Residual iteration (initial guess for NSH).


### PR DESCRIPTION
- Add warnings for Euclid and PILUT redirecting users to hypre-ILU
- Rewrite hypre-ILU overview section
- Add new sections to hypre-ILU documentation: "User-level functions", "ILU as smoother for BoomerAMG", and "GPU support"
- Include info about new iterative ILU options
- Update BoomerAMG complex smoothers section

A read-the-docs compile of this branch can be found here: https://hypre.readthedocs.io/en/ilu-docs/
