### PR TITLE
Keep smooth_num_levels in sync with amg_data

### DIFF
--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -957,6 +957,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
    agg_P_max_elmts = hypre_ParAMGDataAggPMaxElmts(amg_data);
    agg_P12_max_elmts = hypre_ParAMGDataAggP12MaxElmts(amg_data);
    jacobi_trunc_threshold = hypre_ParAMGDataJacobiTruncThreshold(amg_data);
+   smooth_num_levels = hypre_ParAMGDataSmoothNumLevels(amg_data);
    if (smooth_num_levels > level)
    {
       smoother = hypre_CTAlloc(HYPRE_Solver, smooth_num_levels, HYPRE_MEMORY_HOST);


### PR DESCRIPTION
Hi hypre team,

@lindsayad came across an out-of-bounds memory error in `par_amg_setup.c` that arises the following way:

- `smooth_num_levels` can become less than `hypre_ParAMGDataSmoothNumLevels(amg_data)` on [line 575](https://github.com/hypre-space/hypre/blob/03b9d3d090e73a0841e22017992cac7e2e085407/src/parcsr_ls/par_amg_setup.c#L575).
- `smooth_num_levels` is then used to allocate `smoothers` on [line 962](https://github.com/hypre-space/hypre/blob/03b9d3d090e73a0841e22017992cac7e2e085407/src/parcsr_ls/par_amg_setup.c#L962)
- `smooth_num_levels` is then set equal to `hypre_ParAMGDataSmoothNumLevels(amg_data)` on [line 3229](https://github.com/hypre-space/hypre/blob/03b9d3d090e73a0841e22017992cac7e2e085407/src/parcsr_ls/par_amg_setup.c#L3229)
- `smooth_num_levels` (which is now potentially larger than the array bounds of `smoothers` is used to bound access to that array in several places such as [line 3695](https://github.com/hypre-space/hypre/blob/03b9d3d090e73a0841e22017992cac7e2e085407/src/parcsr_ls/par_amg_setup.c#L3695)

This pull request makes sure that `smoot_num_levels` is reset to `hypre_ParAMGDataSmoothNumLevels(amg_data)` before `smoothers` is allocated, which appears to fix the memory issues when tested in valgrind.