### PR TITLE
fix checkpar to pass on armhf, ppc64el and detect test failures and define hypre_FinalizeAllTimings()

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -171,15 +171,15 @@ checkpar:
         set -e; \
         (cd test; $(MAKE) all); \
         echo "Testing IJ ..."; \
-        (cd test; ./runtest.sh -tol 1.e-06 -mpi "$(CHECKRUN)" TEST_ij/solvers.sh); \
+        (cd test; ./runtest.sh -atol 1.e-06 -mpi "$(CHECKRUN)" TEST_ij/solvers.sh); \
         (cd test; ./checktest.sh); \
         (cd test; ./cleantest.sh); \
         echo "Testing Struct ..."; \
-        (cd test; ./runtest.sh -tol 1.e-06 -mpi "$(CHECKRUN)" TEST_struct/solvers.sh); \
+        (cd test; ./runtest.sh -atol 1.e-06 -mpi "$(CHECKRUN)" TEST_struct/solvers.sh); \
         (cd test; ./checktest.sh); \
         (cd test; ./cleantest.sh); \
         echo "Testing SStruct ..."; \
-        (cd test; ./runtest.sh -tol 1.e-06 -mpi "$(CHECKRUN)" TEST_sstruct/solvers.sh); \
+        (cd test; ./runtest.sh -atol 1.e-06 -mpi "$(CHECKRUN)" TEST_sstruct/solvers.sh); \
         (cd test; ./checktest.sh); \
         (cd test; ./cleantest.sh); 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -158,6 +158,7 @@ test: all
 check:
 	@ \
 	echo "Checking the library ..."; \
+	set -e; \
 	(cd test; $(MAKE) all); \
 	(cd test; $(CHECKRUN) ./ij $(PARMS) 2> ij.err); \
 	(cd test; $(CHECKRUN) ./struct $(PARMS) 2> struct.err); \
@@ -167,6 +168,7 @@ check:
 checkpar:
 	@ \
         echo "Checking the library ..."; \
+        set -e; \
         (cd test; $(MAKE) all); \
         echo "Testing IJ ..."; \
         (cd test; ./runtest.sh -tol 1.e-06 -mpi "$(CHECKRUN)" TEST_ij/solvers.sh); \

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,10 @@ default: all
 # Include all variables defined by configure
 include config/Makefile.config
 
+# Tolerance level for checkpar tests
+# The value of the variable can be set when calling `make checkpar`
+HYPRE_CHECKPAR_TOL ?= 1e-6
+
 # These are the directories for internal blas, lapack and general utilities
 HYPRE_BASIC_DIRS =\
  blas\
@@ -171,15 +175,15 @@ checkpar:
         set -e; \
         (cd test; $(MAKE) all); \
         echo "Testing IJ ..."; \
-        (cd test; ./runtest.sh -atol 1.e-06 -mpi "$(CHECKRUN)" TEST_ij/solvers.sh); \
+        (cd test; ./runtest.sh -atol $(HYPRE_CHECKPAR_TOL) -mpi "$(CHECKRUN)" TEST_ij/solvers.sh); \
         (cd test; ./checktest.sh); \
         (cd test; ./cleantest.sh); \
         echo "Testing Struct ..."; \
-        (cd test; ./runtest.sh -atol 1.e-06 -mpi "$(CHECKRUN)" TEST_struct/solvers.sh); \
+        (cd test; ./runtest.sh -atol $(HYPRE_CHECKPAR_TOL) -mpi "$(CHECKRUN)" TEST_struct/solvers.sh); \
         (cd test; ./checktest.sh); \
         (cd test; ./cleantest.sh); \
         echo "Testing SStruct ..."; \
-        (cd test; ./runtest.sh -atol 1.e-06 -mpi "$(CHECKRUN)" TEST_sstruct/solvers.sh); \
+        (cd test; ./runtest.sh -atol $(HYPRE_CHECKPAR_TOL) -mpi "$(CHECKRUN)" TEST_sstruct/solvers.sh); \
         (cd test; ./checktest.sh); \
         (cd test; ./cleantest.sh); 
 

--- a/src/test/checktest.sh
+++ b/src/test/checktest.sh
@@ -19,6 +19,8 @@ cat <<EOF
    script is being run from within the hypre 'test' directory, and all of the
    'TEST_*' directories are checked.
 
+   Returns 0 if all tests pass, 1 if any test fails.
+
    Example usage: $0 TEST_struct TEST_ij
 
 EOF
@@ -36,6 +38,7 @@ else
 fi
 $RESET                     # Restore nullglob setting
 
+error_code=0
 echo ""
 for testdir in $testdirs
 do
@@ -47,7 +50,9 @@ do
          SZ=`ls -l $file | awk '{print $5}'`
          if [ $SZ != 0 ]
          then
-            echo "FAILED : $file  ($SZ)"
+            echo -e "FAILED : $file  ($SZ)\n"
+            cat $file
+            error_code=1
          else
             echo "    OK : $file"
          fi
@@ -55,3 +60,4 @@ do
       echo ""
    fi
 done
+exit $error_code

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1283,6 +1283,7 @@ HYPRE_Real time_get_cpu_seconds_( void );
 
 #define hypre_InitializeTiming(name) 0
 #define hypre_FinalizeTiming(index)
+#define hypre_FinalizeAllTimings()
 #define hypre_IncFLOPCount(inc)
 #define hypre_BeginTiming(i)
 #define hypre_EndTiming(i)

--- a/src/utilities/timing.h
+++ b/src/utilities/timing.h
@@ -40,6 +40,7 @@ HYPRE_Real time_get_cpu_seconds_( void );
 
 #define hypre_InitializeTiming(name) 0
 #define hypre_FinalizeTiming(index)
+#define hypre_FinalizeAllTimings()
 #define hypre_IncFLOPCount(inc)
 #define hypre_BeginTiming(i)
 #define hypre_EndTiming(i)


### PR DESCRIPTION
Enable tests to detect failure and to pass on less common architectures such as armhf, ppc64el.

Introduces Make variable HYPRE_CHECKPAR_TOL with default value 1e-6 suitable for "normal" architectures, allowing a relaxed tolerance to be set where needed. For instance.  [debian builds](https://buildd.debian.org/status/package.php?p=hypre) need HYPRE_CHECKPAR_TOL=1e-3 on arm64 i386 ppc64el s390x hppa powerpc ppc64.

Taken from debian patch [fix_make_check.patch](https://salsa.debian.org/science-team/hypre/-/blob/master/debian/patches/fix_make_check.patch).

Fixes: #955

Also applies debian patch [no_timings_finalizeAllTimings.patch](https://salsa.debian.org/science-team/hypre/-/blob/master/debian/patches/no_timings_finalizeAllTimings.patch) fixing definitions missed by PR #519.

Tests:

- [x] tux
- [x] lassen
- [x] tioga
- [x] sunspot