### PR TITLE
[WIP] Add pkg-config output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ config.log
 config.status
 Makefile.config
 HYPRE_config.h
+HYPRE.pc
 autom4te.cache
 src/TAGS
 hypre/

--- a/src/Makefile
+++ b/src/Makefile
@@ -179,12 +179,13 @@ checkpar:
         echo "Testing SStruct ..."; \
         (cd test; ./runtest.sh -tol 1.e-06 -mpi "$(CHECKRUN)" TEST_sstruct/solvers.sh); \
         (cd test; ./checktest.sh); \
-        (cd test; ./cleantest.sh); 
+        (cd test; ./cleantest.sh);
 
 install: all
 	@ \
 	echo "Installing hypre ..."; \
-	${HYPRE_SRC_TOP_DIR}/config/mkinstalldirs ${HYPRE_LIB_INSTALL} ${HYPRE_INC_INSTALL}; \
+	${HYPRE_SRC_TOP_DIR}/config/mkinstalldirs \
+        ${HYPRE_LIB_INSTALL} ${HYPRE_INC_INSTALL} ${HYPRE_PKGCONFIG_INSTALL}; \
 	HYPRE_PWD=`pwd`; \
 	cd ${HYPRE_BUILD_DIR}/lib; HYPRE_FROMDIR=`pwd`; \
 	cd $$HYPRE_PWD; \
@@ -200,9 +201,17 @@ install: all
 	then \
 	  cp -fR $$HYPRE_FROMDIR/* $$HYPRE_TODIR; \
 	fi; \
+	cd ${HYPRE_SRC_TOP_DIR}/config; HYPRE_FROMDIR=`pwd`; \
+	cd $$HYPRE_PWD; \
+	cd ${HYPRE_PKGCONFIG_INSTALL}; HYPRE_TODIR=`pwd`; \
+	if [ "$$HYPRE_FROMDIR" != "$$HYPRE_TODIR" ]; \
+	then \
+	  cp -fR $$HYPRE_FROMDIR/HYPRE.pc $$HYPRE_TODIR; \
+	fi; \
 	cd $$HYPRE_PWD; \
 	chmod -R a+rX,u+w,go-w ${HYPRE_LIB_INSTALL}; \
 	chmod -R a+rX,u+w,go-w ${HYPRE_INC_INSTALL}; \
+	chmod -R a+rX,u+w,go-w ${HYPRE_PKGCONFIG_INSTALL}; \
 	echo
 
 clean:

--- a/src/config/HYPRE.pc.in
+++ b/src/config/HYPRE.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @HYPRE_NAME@
+Description: Parallel solvers for sparse linear systems featuring multigrid methods.
+Version: @HYPRE_VERSION@
+Libs: -L${libdir} -Wl,-rpath,${libdir} -lHYPRE @LIBS@ @CALIPER_LIBS@ @HYPRE_CUDA_LIBS@ @HYPRE_HIP_LIBS@ @HYPRE_SYCL_LIBS@ @HYPRE_RAJA_LIB_DIR@ @HYPRE_RAJA_LIB@ @HYPRE_KOKKOS_LIB_DIR@ @HYPRE_KOKKOS_LIB@ @HYPRE_UMPIRE_LIB_DIR@ @HYPRE_UMPIRE_LIB@ @HYPRE_MAGMA_LIB_DIR@ @HYPRE_MAGMA_LIB@
+Cflags: -I${includedir} @CALIPER_INCLUDE@ @HYPRE_CUDA_INCLUDE@ @HYPRE_HIP_INCL@ @HYPRE_SYCL_INCL@ @HYPRE_RAJA_INCLUDE@ @HYPRE_KOKKOS_INCLUDE@ @HYPRE_UMPIRE_INCLUDE@ @HYPRE_MAGMA_INCLUDE@ @HYPRE_NAP_INCLUDE@

--- a/src/config/Makefile.config.in
+++ b/src/config/Makefile.config.in
@@ -30,6 +30,7 @@ HYPRE_BUILD_DIR   = @HYPRE_SRCDIR@/hypre
 HYPRE_INSTALL_DIR = @HYPRE_INSTALLDIR@
 HYPRE_LIB_INSTALL = @HYPRE_LIBINSTALL@
 HYPRE_INC_INSTALL = @HYPRE_INCINSTALL@
+HYPRE_PKGCONFIG_INSTALL = @HYPRE_LIBINSTALL@/pkgconfig
 
 HYPRE_LIB_SUFFIX = @HYPRE_LIBSUFFIX@
 
@@ -169,12 +170,6 @@ SUPERLU_LIBS    = @SUPERLU_LIBS@
 ##################################################################
 DSUPERLU_INCLUDE = @DSUPERLU_INCLUDE@
 DSUPERLU_LIBS    = @DSUPERLU_LIBS@
-
-##################################################################
-##  MAGMA options
-##################################################################
-MAGMA_INCLUDE = @MAGMA_INCLUDE@
-MAGMA_LIBS    = @MAGMA_LIBS@
 
 ##################################################################
 ##  FEI options

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -3089,5 +3089,6 @@ dnl *********************************************************************
 dnl * Define the files to be configured and made
 dnl *********************************************************************
 AC_CONFIG_FILES([config/Makefile.config])
+AC_CONFIG_FILES([config/HYPRE.pc])
 
 AC_OUTPUT

--- a/src/configure
+++ b/src/configure
@@ -663,8 +663,6 @@ HYPRE_MAGMA_INCLUDE
 HYPRE_MAGMA_LIB_DIR
 CALIPER_LIBS
 CALIPER_INCLUDE
-MAGMA_LIBS
-MAGMA_INCLUDE
 HYPRE_SYCL_LIBS
 HYPRE_SYCL_INCL
 HYPRE_HIP_LIBS
@@ -858,9 +856,6 @@ with_superlu_lib
 with_dsuperlu
 with_dsuperlu_include
 with_dsuperlu_lib
-with_magma
-with_magma_include
-with_magma_lib
 with_fei_inc_dir
 with_mli
 with_MPI
@@ -4582,30 +4577,6 @@ then :
 fi
 
 
-if test "x$with_magma" = "xyes"; then :
-
-$as_echo "#define HYPRE_USING_MAGMA 1" >>confdefs.h
-
-fi
-
-
-# Check whether --with-magma-include was given.
-if test "${with_magma_include+set}" = set; then :
-  withval=$with_magma_include; for dmagma_inc_dir in $withval; do
-    MAGMA_INCLUDE="-I$magma_inc_dir $MAGMA_INCLUDE"
- done
-
-fi
-
-
-
-# Check whether --with-magma-lib was given.
-if test "${with_magma_lib+set}" = set; then :
-  withval=$with_magma_lib; for magma_lib in $withval; do
-    MAGMA_LIBS="$MAGMA_LIBS $magma_lib"
- done
-
-fi
 
 
 # Check whether --with-fei-inc-dir was given.
@@ -11415,6 +11386,8 @@ printf "%s\n" "#define HYPRE_LINUX 1" >>confdefs.h
 
 ac_config_files="$ac_config_files config/Makefile.config"
 
+ac_config_files="$ac_config_files config/HYPRE.pc"
+
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -12102,6 +12075,7 @@ do
   case $ac_config_target in
     "HYPRE_config.h") CONFIG_HEADERS="$CONFIG_HEADERS HYPRE_config.h:config/HYPRE_config.h.in" ;;
     "config/Makefile.config") CONFIG_FILES="$CONFIG_FILES config/Makefile.config" ;;
+    "config/HYPRE.pc") CONFIG_FILES="$CONFIG_FILES config/HYPRE.pc" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac


### PR DESCRIPTION
This PR adds `pkg-config` info to the installation directory of HYPRE (`hypre-install-path/lib/pkgconfig/HYPRE.pc`)

This is a metadata file that application codes can use to gather details about HYPRE, including information on how to compile and link against it.

Example:
```bash
$ export PKG_CONFIG_PATH=hypre-install-path/lib/pkgconfig
$ $(CC) `pkg-config --cflags --libs HYPRE` -o myapp myapp.c
```

This fulfills [xSDK - R5](https://github.com/xsdk-project/xsdk-community-policies/blob/77e588c1cb8a4e3936fbc8c6af28c53dbfd54acc/package_policies/R5.md), particularly [this line](https://github.com/xsdk-project/xsdk-community-policies/blob/77e588c1cb8a4e3936fbc8c6af28c53dbfd54acc/package_policies/R5.md?plain=1#L7)