### PR TITLE
Add HYPRE_GetExecutionPolicyName

### DIFF
--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -249,7 +249,16 @@ typedef enum _HYPRE_MemoryLocation
    HYPRE_MEMORY_DEVICE
 } HYPRE_MemoryLocation;
 
+/**
+ * (Optional) Sets the default (abstract) memory location.
+ **/
+
 HYPRE_Int HYPRE_SetMemoryLocation(HYPRE_MemoryLocation memory_location);
+
+/**
+ * (Optional) Gets a pointer to the default (abstract) memory location.
+ **/
+
 HYPRE_Int HYPRE_GetMemoryLocation(HYPRE_MemoryLocation *memory_location);
 
 #include <stdlib.h>
@@ -265,8 +274,22 @@ typedef enum _HYPRE_ExecutionPolicy
    HYPRE_EXEC_DEVICE
 } HYPRE_ExecutionPolicy;
 
+/**
+ * (Optional) Sets the default execution policy.
+ **/
+
 HYPRE_Int HYPRE_SetExecutionPolicy(HYPRE_ExecutionPolicy exec_policy);
+
+/**
+ * (Optional) Gets a pointer to the default execution policy.
+ **/
+
 HYPRE_Int HYPRE_GetExecutionPolicy(HYPRE_ExecutionPolicy *exec_policy);
+
+/**
+ * (Optional) Returns a string denoting the execution policy passed as input.
+ **/
+
 const char* HYPRE_GetExecutionPolicyName(HYPRE_ExecutionPolicy exec_policy);
 
 /*--------------------------------------------------------------------------

--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -267,6 +267,7 @@ typedef enum _HYPRE_ExecutionPolicy
 
 HYPRE_Int HYPRE_SetExecutionPolicy(HYPRE_ExecutionPolicy exec_policy);
 HYPRE_Int HYPRE_GetExecutionPolicy(HYPRE_ExecutionPolicy *exec_policy);
+const char* HYPRE_GetExecutionPolicyName(HYPRE_ExecutionPolicy exec_policy);
 
 /*--------------------------------------------------------------------------
  * HYPRE UMPIRE

--- a/src/utilities/general.c
+++ b/src/utilities/general.c
@@ -662,3 +662,31 @@ HYPRE_GetExecutionPolicy(HYPRE_ExecutionPolicy *exec_policy)
 
    return hypre_error_flag;
 }
+
+const char*
+HYPRE_GetExecutionPolicyName(HYPRE_ExecutionPolicy exec_policy)
+{
+   switch (exec_policy)
+   {
+      case HYPRE_EXEC_HOST:
+         return "Host";
+
+      case HYPRE_EXEC_DEVICE:
+#if defined(HYPRE_USING_GPU) || defined(HYPRE_USING_DEVICE_OPENMP)
+#if defined(HYPRE_USING_CUDA)
+         return "Device (CUDA)";
+#elif defined(HYPRE_USING_HIP)
+         return "Device (HIP)";
+#elif defined(HYPRE_USING_SYCL)
+         return "Device (SYCL)";
+#else
+         return "Device (OpenMP)";
+#endif
+#else
+         return "Host";
+#endif
+      case HYPRE_EXEC_UNDEFINED:
+      default:
+         return "Undefined";
+   }
+}


### PR DESCRIPTION
This routine (to be used in a following PR) returns a string denoting the execution policy in use.