### PR TITLE
Add HYPRE_MGRSetLevelPMaxElmts

### DIFF
--- a/src/parcsr_ls/HYPRE_parcsr_ls.h
+++ b/src/parcsr_ls/HYPRE_parcsr_ls.h
@@ -4288,7 +4288,7 @@ HYPRE_MGRSetCoarseGridPrintLevel( HYPRE_Solver solver,
 
 /**
  * (Optional) Set the threshold for dropping small entries on the coarse grid at each level.
- * No dropping is applied if \e threshold = 0.0 (default). 
+ * No dropping is applied if \e threshold = 0.0 (default).
  **/
 HYPRE_Int
 HYPRE_MGRSetTruncateCoarseGridThreshold( HYPRE_Solver solver,
@@ -4387,11 +4387,18 @@ HYPRE_MGRGetCoarseGridConvergenceFactor( HYPRE_Solver solver,
                                          HYPRE_Real *conv_factor );
 
 /**
- * (Optional) Set the number of maximum points for interpolation operator.
+ * (Optional) Set the maximum number of nonzeros per row for interpolation operators.
  **/
 HYPRE_Int
 HYPRE_MGRSetPMaxElmts( HYPRE_Solver solver,
                        HYPRE_Int P_max_elmts );
+
+/**
+ * (Optional) Set the maximum number of nonzeros per row for interpolation operators for each level.
+ **/
+HYPRE_Int
+HYPRE_MGRSetLevelPMaxElmts( HYPRE_Solver solver,
+                            HYPRE_Int *P_max_elmts );
 
 /**
  * (Optional) Return the norm of the final relative residual.

--- a/src/parcsr_ls/HYPRE_parcsr_mgr.c
+++ b/src/parcsr_ls/HYPRE_parcsr_mgr.c
@@ -557,13 +557,23 @@ HYPRE_MGRSetGlobalSmoothCycle( HYPRE_Solver solver,
 }
 
 /*--------------------------------------------------------------------------
- * HYPRE_MGRSetMaxPElmts
+ * HYPRE_MGRSetPMaxElmts
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 HYPRE_MGRSetPMaxElmts( HYPRE_Solver solver, HYPRE_Int P_max_elmts )
 {
    return hypre_MGRSetPMaxElmts(solver, P_max_elmts);
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_MGRSetLevelPMaxElmts
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_MGRSetLevelPMaxElmts( HYPRE_Solver solver, HYPRE_Int *P_max_elmts )
+{
+   return hypre_MGRSetLevelPMaxElmts(solver, P_max_elmts);
 }
 
 /*--------------------------------------------------------------------------

--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -3663,6 +3663,7 @@ HYPRE_Int hypre_MGRSetBlockJacobiBlockSize( void *mgr_vdata, HYPRE_Int blk_size 
 HYPRE_Int hypre_MGRSetLogging( void *mgr_vdata, HYPRE_Int logging );
 HYPRE_Int hypre_MGRSetMaxIter( void *mgr_vdata, HYPRE_Int max_iter );
 HYPRE_Int hypre_MGRSetPMaxElmts( void *mgr_vdata, HYPRE_Int P_max_elmts );
+HYPRE_Int hypre_MGRSetLevelPMaxElmts( void *mgr_vdata, HYPRE_Int *P_max_elmts );
 HYPRE_Int hypre_MGRSetTol( void *mgr_vdata, HYPRE_Real tol );
 #ifdef HYPRE_USING_DSUPERLU
 void *hypre_MGRDirectSolverCreate( void );

--- a/src/parcsr_ls/par_mgr.c
+++ b/src/parcsr_ls/par_mgr.c
@@ -92,7 +92,7 @@ hypre_MGRCreate(void)
    (mgr_data -> trunc_factor) = 0.0;
    (mgr_data -> max_row_sum) = 0.9;
    (mgr_data -> strong_threshold) = 0.25;
-   (mgr_data -> P_max_elmts) = 0;
+   (mgr_data -> P_max_elmts) = NULL;
 
    (mgr_data -> coarse_grid_solver) = NULL;
    (mgr_data -> coarse_grid_solver_setup) = NULL;
@@ -5798,13 +5798,49 @@ hypre_MGRSetLevelSmoothIters( void *mgr_vdata, HYPRE_Int *gsmooth_iters )
    return hypre_error_flag;
 }
 
-/* Set the maximum number of non-zero entries for restriction
-   and interpolation operator if classical AMG interpolation is used */
+/* Set the maximum number of non-zero entries for interpolation operators */
 HYPRE_Int
-hypre_MGRSetPMaxElmts( void *mgr_vdata, HYPRE_Int P_max_elmts)
+hypre_MGRSetPMaxElmts(void *mgr_vdata, HYPRE_Int P_max_elmts)
 {
    hypre_ParMGRData   *mgr_data = (hypre_ParMGRData*) mgr_vdata;
-   (mgr_data -> P_max_elmts) = P_max_elmts;
+   HYPRE_Int           max_num_coarse_levels = (mgr_data -> max_num_coarse_levels);
+   HYPRE_Int           i;
+
+   /* Allocate internal P_max_elmts if needed */
+   if (!(mgr_data -> P_max_elmts))
+   {
+      (mgr_data -> P_max_elmts) = hypre_CTAlloc(HYPRE_Int, max_num_coarse_levels, HYPRE_MEMORY_HOST);
+   }
+
+   /* Set all P_max_elmts entries to the value passed as input */
+   for (i = 0; i < max_num_coarse_levels; i++)
+   {
+      (mgr_data -> P_max_elmts)[i] = P_max_elmts;
+   }
+
+   return hypre_error_flag;
+}
+
+/* Set the maximum number of non-zero entries for interpolation operators per level */
+HYPRE_Int
+hypre_MGRSetLevelPMaxElmts(void *mgr_vdata, HYPRE_Int *P_max_elmts)
+{
+   hypre_ParMGRData   *mgr_data = (hypre_ParMGRData*) mgr_vdata;
+   HYPRE_Int           max_num_coarse_levels = (mgr_data -> max_num_coarse_levels);
+   HYPRE_Int           i;
+
+   /* Allocate internal P_max_elmts if needed */
+   if (!(mgr_data -> P_max_elmts))
+   {
+      (mgr_data -> P_max_elmts) = hypre_CTAlloc(HYPRE_Int, max_num_coarse_levels, HYPRE_MEMORY_HOST);
+   }
+
+   /* Set all P_max_elmts entries to the value passed as input */
+   for (i = 0; i < max_num_coarse_levels; i++)
+   {
+      (mgr_data -> P_max_elmts)[i] = (P_max_elmts) ? P_max_elmts[i] : 0;
+   }
+
    return hypre_error_flag;
 }
 

--- a/src/parcsr_ls/par_mgr.h
+++ b/src/parcsr_ls/par_mgr.h
@@ -58,7 +58,7 @@ typedef struct
    HYPRE_Real            strong_threshold;
    HYPRE_Real            trunc_factor;
    HYPRE_Real            S_commpkg_switch;
-   HYPRE_Int             P_max_elmts;
+   HYPRE_Int            *P_max_elmts;
    HYPRE_Int             num_iterations;
 
    hypre_Vector        **l1_norms;

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -61,7 +61,7 @@ hypre_MGRSetup( void               *mgr_vdata,
    HYPRE_Int  *num_relax_sweeps = (mgr_data -> num_relax_sweeps);
    HYPRE_Int num_interp_sweeps = (mgr_data -> num_interp_sweeps);
    HYPRE_Int num_restrict_sweeps = (mgr_data -> num_interp_sweeps);
-   HYPRE_Int max_elmts = (mgr_data -> P_max_elmts);
+   HYPRE_Int *max_elmts = (mgr_data -> P_max_elmts);
    HYPRE_Real   max_row_sum = (mgr_data -> max_row_sum);
    HYPRE_Real   strong_threshold = (mgr_data -> strong_threshold);
    HYPRE_Real   trunc_factor = (mgr_data -> trunc_factor);
@@ -1165,7 +1165,7 @@ hypre_MGRSetup( void               *mgr_vdata,
          }
          hypre_MGRBuildInterp(A_array[lev], A_FF, A_FC, CF_marker, Wp,
                               coarse_pnts_global, 1, dof_func_buff_data,
-                              debug_flag, trunc_factor, max_elmts,
+                              debug_flag, trunc_factor, max_elmts[lev],
                               block_jacobi_bsize, &P, interp_type[lev],
                               num_interp_sweeps);
       }
@@ -1173,7 +1173,7 @@ hypre_MGRSetup( void               *mgr_vdata,
       {
          hypre_MGRBuildInterp(A_array[lev], A_FF, A_FC, CF_marker, S,
                               coarse_pnts_global, 1, dof_func_buff_data,
-                              debug_flag, trunc_factor, max_elmts,
+                              debug_flag, trunc_factor, max_elmts[lev],
                               block_jacobi_bsize, &P, interp_type[lev],
                               num_interp_sweeps);
       }
@@ -1338,7 +1338,7 @@ hypre_MGRSetup( void               *mgr_vdata,
             //            if (restrict_type[lev] > 0)
             {
                hypre_MGRBuildRestrict(A_array[lev], A_FF, A_FC, CF_marker, coarse_pnts_global, 1,
-                                      dof_func_buff_data, debug_flag, trunc_factor, max_elmts,
+                                      dof_func_buff_data, debug_flag, trunc_factor, max_elmts[lev],
                                       strong_threshold, max_row_sum, block_num_f_points, &RT,
                                       restrict_type[lev], num_restrict_sweeps);
 
@@ -1378,7 +1378,7 @@ hypre_MGRSetup( void               *mgr_vdata,
                                                      block_num_f_points,
                                                      set_c_points_method,
                                                      mgr_coarse_grid_method[lev],
-                                                     max_elmts, CF_marker, &RAP_ptr);
+                                                     max_elmts[lev], CF_marker, &RAP_ptr);
             }
 
             if (interp_type[lev] == 12)
@@ -1411,7 +1411,7 @@ hypre_MGRSetup( void               *mgr_vdata,
             }
             hypre_MGRBuildRestrict(A_array[lev], A_FF, A_FC, CF_marker,
                                    coarse_pnts_global, 1, dof_func_buff_data,
-                                   debug_flag, trunc_factor, max_elmts,
+                                   debug_flag, trunc_factor, max_elmts[lev],
                                    strong_threshold, max_row_sum,
                                    block_jacobi_bsize, &RT, restrict_type[lev],
                                    num_restrict_sweeps);

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -2253,6 +2253,7 @@ HYPRE_Int hypre_MGRSetBlockJacobiBlockSize( void *mgr_vdata, HYPRE_Int blk_size 
 HYPRE_Int hypre_MGRSetLogging( void *mgr_vdata, HYPRE_Int logging );
 HYPRE_Int hypre_MGRSetMaxIter( void *mgr_vdata, HYPRE_Int max_iter );
 HYPRE_Int hypre_MGRSetPMaxElmts( void *mgr_vdata, HYPRE_Int P_max_elmts );
+HYPRE_Int hypre_MGRSetLevelPMaxElmts( void *mgr_vdata, HYPRE_Int *P_max_elmts );
 HYPRE_Int hypre_MGRSetTol( void *mgr_vdata, HYPRE_Real tol );
 #ifdef HYPRE_USING_DSUPERLU
 void *hypre_MGRDirectSolverCreate( void );


### PR DESCRIPTION
Add HYPRE_MGRSetLevelPMaxElmts, its private interface, and accompanying code.

This function sets the max. number of nonzero entries in the interpolation operators for each level of MGR's hierarchy.

Solves the first bullet point listed in https://github.com/GEOS-DEV/GEOS/pull/2409