### PR TITLE
use hipPointerAttribute_t.type as HIP is removing hipPointerAttribute_t.memoryType

### DIFF
--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -1142,11 +1142,19 @@ hypre_GetPointerLocation(const void *ptr, hypre_MemoryLocation *memory_location)
    {
       *memory_location = hypre_MEMORY_UNIFIED;
    }
+#if (HIP_VERSION_MAJOR >= 6)
+   else if (attr.type == hipMemoryTypeDevice)
+#else // (HIP_VERSION_MAJOR < 6)
    else if (attr.memoryType == hipMemoryTypeDevice)
+#endif // (HIP_VERSION_MAJOR >= 6)
    {
       *memory_location = hypre_MEMORY_DEVICE;
    }
+#if (HIP_VERSION_MAJOR >= 6)
+   else if (attr.type == hipMemoryTypeHost)
+#else // (HIP_VERSION_MAJOR < 6)
    else if (attr.memoryType == hipMemoryTypeHost)
+#endif // (HIP_VERSION_MAJOR >= 6)
    {
       *memory_location = hypre_MEMORY_HOST_PINNED;
    }


### PR DESCRIPTION
- In ROCm6.0 hipPointerAttribute_t.memoryType will be removed from HIP.
- Instead hipPointerAttribute_t.type to be used.
- This is causing build failure for AMG

