### PR TITLE
Fix regression tests with-concurrent-hopscotch 

### DIFF
--- a/src/test/TEST_error/error.sh
+++ b/src/test/TEST_error/error.sh
@@ -37,3 +37,4 @@ egrep -v "hypre error" ${TNAME}.tmp        >  ${TNAME}.err
 #=============================================================================
 
 rm -f ${TNAME}.testdata*
+rm -f ${TNAME}.tmp

--- a/src/test/TEST_ij/lazy.jobs
+++ b/src/test/TEST_ij/lazy.jobs
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
+# HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#=============================================================================
+# Test library lazy initialization (sequential and parallel)
+#=============================================================================
+
+mpirun -np 1 ./ij                         > lazy.out.1.a
+mpirun -np 1 ./ij -lazy_device_init 1     > lazy.out.1.b
+
+mpirun -np 4 ./ij                         > lazy.out.2.a
+mpirun -np 4 ./ij -lazy_device_init 1     > lazy.out.2.b
+

--- a/src/test/TEST_ij/lazy.sh
+++ b/src/test/TEST_ij/lazy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
+# HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+TNAME=`basename $0 .sh`
+
+tail -3 ${TNAME}.out.1.a | head -2 > ${TNAME}.testdata
+tail -3 ${TNAME}.out.1.b | head -2 > ${TNAME}.testdata.temp
+diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+
+tail -3 ${TNAME}.out.2.a | head -2 > ${TNAME}.testdata
+tail -3 ${TNAME}.out.2.b | head -2 > ${TNAME}.testdata.temp
+diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+
+#=============================================================================
+# remove temporary files
+#=============================================================================
+
+rm -f ${TNAME}.testdata*

--- a/src/test/TEST_ij/lazy.sh
+++ b/src/test/TEST_ij/lazy.sh
@@ -8,11 +8,18 @@ TNAME=`basename $0 .sh`
 
 tail -3 ${TNAME}.out.1.a | head -2 > ${TNAME}.testdata
 tail -3 ${TNAME}.out.1.b | head -2 > ${TNAME}.testdata.temp
-diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+
+if [ -z $HYPRE_NO_SAVED ]; then
+   diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+fi
 
 tail -3 ${TNAME}.out.2.a | head -2 > ${TNAME}.testdata
 tail -3 ${TNAME}.out.2.b | head -2 > ${TNAME}.testdata.temp
-diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+
+
+if [ -z $HYPRE_NO_SAVED ]; then
+   diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+fi
 
 #=============================================================================
 # remove temporary files

--- a/src/test/TEST_ij/lazy.sh
+++ b/src/test/TEST_ij/lazy.sh
@@ -9,6 +9,7 @@ TNAME=`basename $0 .sh`
 tail -3 ${TNAME}.out.1.a | head -2 > ${TNAME}.testdata
 tail -3 ${TNAME}.out.1.b | head -2 > ${TNAME}.testdata.temp
 
+# Abuse HYPRE_NO_SAVED to skip the following diff with OMP
 if [ -z $HYPRE_NO_SAVED ]; then
    diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
 fi
@@ -16,7 +17,7 @@ fi
 tail -3 ${TNAME}.out.2.a | head -2 > ${TNAME}.testdata
 tail -3 ${TNAME}.out.2.b | head -2 > ${TNAME}.testdata.temp
 
-
+# Abuse HYPRE_NO_SAVED to skip the following diff with OMP
 if [ -z $HYPRE_NO_SAVED ]; then
    diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
 fi

--- a/src/test/TEST_ij/posneg.jobs
+++ b/src/test/TEST_ij/posneg.jobs
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
+# HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+## Solve Ax=b and -Ax=b, convergence should be the same
+mpirun -np 2 ./ij -solver 0 -rhsrand -negA 0 > posneg.out.400.p
+mpirun -np 2 ./ij -solver 0 -rhsrand -negA 1 > posneg.out.400.n
+mpirun -np 3 ./ij -solver 3 -rhsrand -negA 0 > posneg.out.401.p
+mpirun -np 3 ./ij -solver 3 -rhsrand -negA 1 > posneg.out.401.n
+mpirun -np 4 ./ij -cheby_eig_est 10 -cheby_order 4 -cheby_variant 0 -cheby_scale 1 -rlx 16 -negA 0 > posneg.out.402.p
+mpirun -np 4 ./ij -cheby_eig_est 10 -cheby_order 4 -cheby_variant 0 -cheby_scale 1 -rlx 16 -negA 1 > posneg.out.402.n
+mpirun -np 4 ./ij -solver 3 -cheby_eig_est 0 -cheby_order 3 -cheby_variant 1 -cheby_scale 1 -rlx 16 -negA 0 > posneg.out.403.p
+mpirun -np 4 ./ij -solver 3 -cheby_eig_est 0 -cheby_order 3 -cheby_variant 1 -cheby_scale 1 -rlx 16 -negA 1 > posneg.out.403.n
+
+

--- a/src/test/TEST_ij/posneg.sh
+++ b/src/test/TEST_ij/posneg.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
+# HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+TNAME=`basename $0 .sh`
+
+tail -3 ${TNAME}.out.400.p | head -2 > ${TNAME}.testdata
+tail -3 ${TNAME}.out.400.n | head -2 > ${TNAME}.testdata.temp
+
+if [ -z $HYPRE_NO_SAVED ]; then
+   diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+fi
+
+tail -3 ${TNAME}.out.401.p | head -2 > ${TNAME}.testdata
+tail -3 ${TNAME}.out.401.n | head -2 > ${TNAME}.testdata.temp
+
+if [ -z $HYPRE_NO_SAVED ]; then
+   diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+fi
+
+tail -3 ${TNAME}.out.402.p | head -2 > ${TNAME}.testdata
+tail -3 ${TNAME}.out.402.n | head -2 > ${TNAME}.testdata.temp
+
+if [ -z $HYPRE_NO_SAVED ]; then
+   diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+fi
+
+tail -3 ${TNAME}.out.403.p | head -2 > ${TNAME}.testdata
+tail -3 ${TNAME}.out.403.n | head -2 > ${TNAME}.testdata.temp
+
+if [ -z $HYPRE_NO_SAVED ]; then
+   diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+fi
+
+#=============================================================================
+# remove temporary files
+#=============================================================================
+
+rm -f ${TNAME}.testdata*
+

--- a/src/test/TEST_ij/posneg.sh
+++ b/src/test/TEST_ij/posneg.sh
@@ -9,6 +9,7 @@ TNAME=`basename $0 .sh`
 tail -3 ${TNAME}.out.400.p | head -2 > ${TNAME}.testdata
 tail -3 ${TNAME}.out.400.n | head -2 > ${TNAME}.testdata.temp
 
+# Abuse HYPRE_NO_SAVED to skip the following diff with OMP
 if [ -z $HYPRE_NO_SAVED ]; then
    diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
 fi
@@ -16,6 +17,7 @@ fi
 tail -3 ${TNAME}.out.401.p | head -2 > ${TNAME}.testdata
 tail -3 ${TNAME}.out.401.n | head -2 > ${TNAME}.testdata.temp
 
+# Abuse HYPRE_NO_SAVED to skip the following diff with OMP
 if [ -z $HYPRE_NO_SAVED ]; then
    diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
 fi
@@ -23,6 +25,7 @@ fi
 tail -3 ${TNAME}.out.402.p | head -2 > ${TNAME}.testdata
 tail -3 ${TNAME}.out.402.n | head -2 > ${TNAME}.testdata.temp
 
+# Abuse HYPRE_NO_SAVED to skip the following diff with OMP
 if [ -z $HYPRE_NO_SAVED ]; then
    diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
 fi
@@ -30,6 +33,7 @@ fi
 tail -3 ${TNAME}.out.403.p | head -2 > ${TNAME}.testdata
 tail -3 ${TNAME}.out.403.n | head -2 > ${TNAME}.testdata.temp
 
+# Abuse HYPRE_NO_SAVED to skip the following diff with OMP
 if [ -z $HYPRE_NO_SAVED ]; then
    diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
 fi

--- a/src/test/TEST_ij/solvers.jobs
+++ b/src/test/TEST_ij/solvers.jobs
@@ -126,16 +126,6 @@ mpirun -np 2 ./ij -solver 70 -mgr_nlevels 5 -mgr_bsize 2 -mgr_non_c_to_f 0 -mgr_
 mpirun -np 2 ./ij -solver 71 -mgr_nlevels 0 -mgr_bsize 2 -mgr_non_c_to_f 0 -mgr_frelax_method 0 -mgr_num_reserved_nodes 0 > solvers.out.212
 mpirun -np 2 ./ij -solver 71 -mgr_nlevels 1 -mgr_bsize 2 -mgr_non_c_to_f 0 -mgr_frelax_method 0 -mgr_num_reserved_nodes 0 > solvers.out.213
 
-## Solve Ax=b and -Ax=b, convergence should be the same
-mpirun -np 2 ./ij -solver 0 -rhsrand -negA 0 > solvers.out.400.p
-mpirun -np 2 ./ij -solver 0 -rhsrand -negA 1 > solvers.out.400.n
-mpirun -np 3 ./ij -solver 3 -rhsrand -negA 0 > solvers.out.401.p
-mpirun -np 3 ./ij -solver 3 -rhsrand -negA 1 > solvers.out.401.n
-mpirun -np 4 ./ij -cheby_eig_est 10 -cheby_order 4 -cheby_variant 0 -cheby_scale 1 -rlx 16 -negA 0 > solvers.out.402.p
-mpirun -np 4 ./ij -cheby_eig_est 10 -cheby_order 4 -cheby_variant 0 -cheby_scale 1 -rlx 16 -negA 1 > solvers.out.402.n
-mpirun -np 4 ./ij -solver 3 -cheby_eig_est 0 -cheby_order 3 -cheby_variant 1 -cheby_scale 1 -rlx 16 -negA 0 > solvers.out.403.p
-mpirun -np 4 ./ij -solver 3 -cheby_eig_est 0 -cheby_order 3 -cheby_variant 1 -cheby_scale 1 -rlx 16 -negA 1 > solvers.out.403.n
-
 ## Test relaxation methods 88 (L1 hybrid Symm. Gauss-Seidel with a convergent l1 term) and 89 (L1 Symm. hybrid Gauss-Seidel)
 mpirun -np 4 ./ij -fromfile data/tucker21935/IJ.A -solver 1 -rlx 88 > solvers.out.404
 mpirun -np 4 ./ij -fromfile data/tucker21935/IJ.A -solver 1 -rlx 89 > solvers.out.405

--- a/src/test/TEST_ij/solvers.sh
+++ b/src/test/TEST_ij/solvers.sh
@@ -33,23 +33,6 @@ tail -17 ${TNAME}.out.202 | head -6 > ${TNAME}.mgr_testdata.temp
 diff ${TNAME}.mgr_testdata ${TNAME}.mgr_testdata.temp >&2
 
 #=============================================================================
-tail -3 ${TNAME}.out.400.p | head -2 > ${TNAME}.testdata
-tail -3 ${TNAME}.out.400.n | head -2 > ${TNAME}.testdata.temp
-diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
-
-tail -3 ${TNAME}.out.401.p | head -2 > ${TNAME}.testdata
-tail -3 ${TNAME}.out.401.n | head -2 > ${TNAME}.testdata.temp
-diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
-
-tail -3 ${TNAME}.out.402.p | head -2 > ${TNAME}.testdata
-tail -3 ${TNAME}.out.402.n | head -2 > ${TNAME}.testdata.temp
-diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
-
-tail -3 ${TNAME}.out.403.p | head -2 > ${TNAME}.testdata
-tail -3 ${TNAME}.out.403.n | head -2 > ${TNAME}.testdata.temp
-diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
-
-#=============================================================================
 # compare with baseline case
 #=============================================================================
 

--- a/src/test/TEST_ij/state.jobs
+++ b/src/test/TEST_ij/state.jobs
@@ -11,19 +11,3 @@
 mpirun -np 1 ./ij -test_init > state.out.1
 mpirun -np 4 ./ij -test_init > state.out.100
 
-#=============================================================================
-# Test library lazy initialization (sequential and parallel)
-#=============================================================================
-
-mpirun -np 1 ./ij                         > state.out.1.a
-mpirun -np 1 ./ij     -lazy_device_init 1 > state.out.1.b
-
-mpirun -np 4 ./ij                         > state.out.2.a
-mpirun -np 4 ./ij -lazy_device_init 1     > state.out.2.b
-
-mpirun -np 1 ./struct                     > state.out.3.a
-mpirun -np 1 ./struct -lazy_device_init 1 > state.out.3.b
-
-mpirun -np 4 ./struct                     > state.out.4.a
-mpirun -np 4 ./struct -lazy_device_init 1 > state.out.4.b
-

--- a/src/test/TEST_ij/state.sh
+++ b/src/test/TEST_ij/state.sh
@@ -6,22 +6,6 @@
 
 TNAME=`basename $0 .sh`
 
-tail -3 ${TNAME}.out.1.a | head -2 > ${TNAME}.testdata
-tail -3 ${TNAME}.out.1.b | head -2 > ${TNAME}.testdata.temp
-diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
-
-tail -3 ${TNAME}.out.2.a | head -2 > ${TNAME}.testdata
-tail -3 ${TNAME}.out.2.b | head -2 > ${TNAME}.testdata.temp
-diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
-
-tail -3 ${TNAME}.out.3.a | head -2 > ${TNAME}.testdata
-tail -3 ${TNAME}.out.3.b | head -2 > ${TNAME}.testdata.temp
-diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
-
-tail -3 ${TNAME}.out.4.a | head -2 > ${TNAME}.testdata
-tail -3 ${TNAME}.out.4.b | head -2 > ${TNAME}.testdata.temp
-diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
-
 #=============================================================================
 # Compare with baseline case
 #=============================================================================
@@ -37,8 +21,3 @@ do
   tail -3 $i
 done > ${TNAME}.out
 
-#=============================================================================
-# remove temporary files
-#=============================================================================
-
-rm -f ${TNAME}.testdata*

--- a/src/test/TEST_struct/lazy.jobs
+++ b/src/test/TEST_struct/lazy.jobs
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
+# HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#=============================================================================
+# Test library lazy initialization (sequential and parallel)
+#=============================================================================
+
+mpirun -np 1 ./struct                         > lazy.out.1.a
+mpirun -np 1 ./struct -lazy_device_init 1     > lazy.out.1.b
+
+mpirun -np 4 ./struct                         > lazy.out.2.a
+mpirun -np 4 ./struct -lazy_device_init 1     > lazy.out.2.b
+

--- a/src/test/TEST_struct/lazy.sh
+++ b/src/test/TEST_struct/lazy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
+# HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+TNAME=`basename $0 .sh`
+
+tail -3 ${TNAME}.out.1.a | head -2 > ${TNAME}.testdata
+tail -3 ${TNAME}.out.1.b | head -2 > ${TNAME}.testdata.temp
+diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+
+tail -3 ${TNAME}.out.2.a | head -2 > ${TNAME}.testdata
+tail -3 ${TNAME}.out.2.b | head -2 > ${TNAME}.testdata.temp
+diff ${TNAME}.testdata ${TNAME}.testdata.temp >&2
+
+#=============================================================================
+# remove temporary files
+#=============================================================================
+
+rm -f ${TNAME}.testdata*


### PR DESCRIPTION
Concurrent-hopscotch (OMP) cannot guarantee some of the "diff" tests. So leave them out from the main test scripts and don't "diff" with `HYPRE_NO_SAVED`.

- [x] tux
- [x] lassen