### PR TITLE
Improve MGR robustness

### DIFF
--- a/src/parcsr_ls/par_ge_device.c
+++ b/src/parcsr_ls/par_ge_device.c
@@ -114,6 +114,9 @@ hypre_GaussElimSetupDevice(hypre_ParAMGData *amg_data,
                      "Missing dependency library for running gaussian elimination!");
 #endif
 
+   /* Free memory */
+   hypre_TFree(d_ierr, HYPRE_MEMORY_DEVICE);
+
    if (ierr < 0)
    {
       hypre_sprintf(msg, "Problem with getrf's %d-th input argument", -ierr);
@@ -154,6 +157,9 @@ hypre_GaussElimSetupDevice(hypre_ParAMGData *amg_data,
                                              &ierr));
 
 #elif defined(HYPRE_USING_CUSOLVER)
+      /* Allocate space for device error code */
+      d_ierr = hypre_CTAlloc(HYPRE_Int, 1, HYPRE_MEMORY_DEVICE);
+
       /* Create identity dense matrix */
       hypre_Memset((void*) A_work, 0,
                    (size_t) global_size * sizeof(HYPRE_Real),
@@ -179,6 +185,9 @@ hypre_GaussElimSetupDevice(hypre_ParAMGData *amg_data,
       hypre_TMemcpy(A_mat, A_work, HYPRE_Real, global_size,
                     HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
 
+      /* Free memory */
+      hypre_TFree(d_ierr, HYPRE_MEMORY_DEVICE);
+
 #elif defined(HYPRE_USING_ROCSOLVER)
 
       /**************
@@ -190,9 +199,6 @@ hypre_GaussElimSetupDevice(hypre_ParAMGData *amg_data,
                         "Missing dependency library for running gaussian elimination!");
 #endif
    }
-
-   /* Free memory */
-   hypre_TFree(d_ierr, HYPRE_MEMORY_DEVICE);
 
    return hypre_error_flag;
 }

--- a/src/parcsr_ls/par_mgr_device.c
+++ b/src/parcsr_ls/par_mgr_device.c
@@ -579,7 +579,7 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
 #else
    HYPRE_Int            *pivots;
    HYPRE_Complex       **tmpdiag_aop;
-   HYPRE_Int            *infos;
+   HYPRE_Int            *info;
 #endif
    HYPRE_Int            *blk_row_indices;
    HYPRE_Complex        *tmpdiag;
@@ -592,7 +592,7 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
 
    /* Additional variables for debugging */
 #if HYPRE_DEBUG
-   HYPRE_Int            *h_infos;
+   HYPRE_Int            *h_info;
    HYPRE_Int             k, myid;
 
    hypre_MPI_Comm_rank(hypre_ParCSRMatrixComm(A), &myid);
@@ -664,7 +664,7 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
     *-----------------------------------------------------------------*/
    {
       dim3 bDim = hypre_GetDefaultDeviceBlockDimension();
-      dim3 gDim = hypre_GetDefaultDeviceGridDimension(num_rows / blk_size, "warp", bDim);
+      dim3 gDim = hypre_GetDefaultDeviceGridDimension(num_blocks, "warp", bDim);
 
       if (CF_marker)
       {
@@ -692,15 +692,15 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
 
       /* Memory allocation */
       tmpdiag     = hypre_TAlloc(HYPRE_Complex, bdiag_size, HYPRE_MEMORY_DEVICE);
-      diag_aop    = hypre_TAlloc(HYPRE_Complex *, num_rows, HYPRE_MEMORY_DEVICE);
+      diag_aop    = hypre_TAlloc(HYPRE_Complex *, num_blocks, HYPRE_MEMORY_DEVICE);
 #if defined(HYPRE_USING_ONEMKLBLAS)
       pivots      = hypre_CTAlloc(std::int64_t, num_rows * blk_size, HYPRE_MEMORY_DEVICE);
 #else
       pivots      = hypre_CTAlloc(HYPRE_Int, num_rows * blk_size, HYPRE_MEMORY_DEVICE);
-      tmpdiag_aop = hypre_TAlloc(HYPRE_Complex *, num_rows, HYPRE_MEMORY_DEVICE);
-      infos       = hypre_CTAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_DEVICE);
+      tmpdiag_aop = hypre_TAlloc(HYPRE_Complex *, num_blocks, HYPRE_MEMORY_DEVICE);
+      info        = hypre_CTAlloc(HYPRE_Int, num_blocks, HYPRE_MEMORY_DEVICE);
 #if defined (HYPRE_DEBUG)
-      h_infos     = hypre_TAlloc(HYPRE_Int,  num_rows, HYPRE_MEMORY_HOST);
+      h_info      = hypre_TAlloc(HYPRE_Int,  num_blocks, HYPRE_MEMORY_HOST);
 #endif
 
       /* Memory copy */
@@ -708,11 +708,11 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
                     HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
 
       /* Set work array of pointers */
-      hypreDevice_ComplexArrayToArrayOfPtrs(num_rows, bs2, tmpdiag, tmpdiag_aop);
+      hypreDevice_ComplexArrayToArrayOfPtrs(num_blocks, bs2, tmpdiag, tmpdiag_aop);
 #endif
 
       /* Set array of pointers */
-      hypreDevice_ComplexArrayToArrayOfPtrs(num_rows, bs2, B_diag_data, diag_aop);
+      hypreDevice_ComplexArrayToArrayOfPtrs(num_blocks, bs2, B_diag_data, diag_aop);
 
       /* Compute LU factorization */
 #if defined(HYPRE_USING_CUBLAS)
@@ -721,7 +721,7 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
                                                   tmpdiag_aop,
                                                   blk_size,
                                                   pivots,
-                                                  infos,
+                                                  info,
                                                   num_blocks));
 #elif defined(HYPRE_USING_ROCSOLVER)
       HYPRE_ROCSOLVER_CALL(rocsolver_dgetrf_batched(hypre_HandleVendorSolverHandle(hypre_handle()),
@@ -731,7 +731,7 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
                                                     blk_size,
                                                     pivots,
                                                     blk_size,
-                                                    infos,
+                                                    info,
                                                     num_blocks));
 
 #elif defined(HYPRE_USING_ONEMKLBLAS)
@@ -775,20 +775,20 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
 #endif
 
 #if defined (HYPRE_DEBUG) && !defined(HYPRE_USING_ONEMKLBLAS)
-      hypre_TMemcpy(h_infos, infos, HYPRE_Int, num_rows, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
-      for (k = 0; k < num_rows; k++)
+      hypre_TMemcpy(h_info, info, HYPRE_Int, num_blocks, HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+      for (k = 0; k < num_blocks; k++)
       {
-         if (h_infos[k] != 0)
+         if (h_info[k] != 0)
          {
-            if (h_infos[k] < 0)
+            if (h_info[k] < 0)
             {
                hypre_printf("[%d]: LU fact. failed at system %d, parameter %d ",
-                            myid, k, h_infos[k]);
+                            myid, k, h_info[k]);
             }
             else
             {
                hypre_printf("[%d]: Singular U(%d, %d) at system %d",
-                            myid, h_infos[k], h_infos[k], k);
+                            myid, h_info[k], h_info[k], k);
             }
          }
       }
@@ -803,7 +803,7 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
                                                   pivots,
                                                   diag_aop,
                                                   blk_size,
-                                                  infos,
+                                                  info,
                                                   num_blocks));
 #elif defined(HYPRE_USING_ROCSOLVER)
       HYPRE_ROCSOLVER_CALL(rocsolver_dgetri_batched(hypre_HandleVendorSolverHandle(hypre_handle()),
@@ -812,7 +812,7 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
                                                     blk_size,
                                                     pivots,
                                                     blk_size,
-                                                    infos,
+                                                    info,
                                                     num_blocks));
 #elif defined(HYPRE_USING_ONEMKLBLAS)
       HYPRE_ONEMKL_CALL( oneapi::mkl::lapack::getri_batch( *hypre_HandleComputeStream(hypre_handle()),
@@ -838,9 +838,9 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
       hypre_TFree(scratchpad, HYPRE_MEMORY_DEVICE);
 #else
       hypre_TFree(tmpdiag_aop, HYPRE_MEMORY_DEVICE);
-      hypre_TFree(infos, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(info, HYPRE_MEMORY_DEVICE);
 #if defined (HYPRE_DEBUG)
-      hypre_TFree(h_infos, HYPRE_MEMORY_HOST);
+      hypre_TFree(h_info, HYPRE_MEMORY_HOST);
 #endif
 #endif
 

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -1906,6 +1906,9 @@ hypre_MGRSetup( void               *mgr_vdata,
             (GSElimData[i] -> F_array) = &F_fine_array[1];
             (GSElimData[i] -> U_array) = &U_fine_array[1];
 
+            /* Save current error code to a temporary variable */
+            hypre_error_code_save();
+
             // setup Gaussian Elim. in the F-relaxation step. Here, we apply GSElim at level 0
             // since we have a single matrix (and not an array of matrices).
             // hypre_printf("Setting GSElim Solver %d \n", Frelax_type[i]);
@@ -1918,12 +1921,10 @@ hypre_MGRSetup( void               *mgr_vdata,
                (mgr_data -> GSElimData)[i] = NULL;
 
                Frelax_type[i] = 7; /* Jacobi */
-               if (!my_id)
+               if (print_level)
                {
-                  hypre_sprintf(msg, "Switching F-relaxation at level %d to Jacobi", my_id, i);
-                  hypre_error_w_msg(HYPRE_ERROR_GENERIC, msg);
+                  hypre_ParPrintf(comm, "Switching F-relaxation at level %d to Jacobi", my_id, i);
                }
-               HYPRE_ClearAllErrors();
 
                /* Compute l1_norms if needed */
                if (!l1_norms[i])
@@ -1938,6 +1939,9 @@ hypre_MGRSetup( void               *mgr_vdata,
                   }
                }
             }
+
+            /* Restore error code prior to GaussElimSetup call */
+            hypre_error_code_restore();
          }
       }
    }

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -1915,7 +1915,7 @@ hypre_MGRSetup( void               *mgr_vdata,
             hypre_GaussElimSetup(GSElimData[i], i, Frelax_type[i]);
 
             /* Fallback to Jacobi when Gaussian Elim. is not successful */
-            if (HYPRE_GetMaxGlobalError(hypre_ParCSRMatrixComm(A_array[i])))
+            if (HYPRE_GetGlobalError(hypre_ParCSRMatrixComm(A_array[i])))
             {
                hypre_MGRDestroyGSElimData((mgr_data -> GSElimData)[i]);
                (mgr_data -> GSElimData)[i] = NULL;

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -1923,7 +1923,7 @@ hypre_MGRSetup( void               *mgr_vdata,
                Frelax_type[i] = 7; /* Jacobi */
                if (print_level)
                {
-                  hypre_ParPrintf(comm, "Switching F-relaxation at level %d to Jacobi", my_id, i);
+                  hypre_ParPrintf(comm, "Switching F-relaxation at level %d to Jacobi", i);
                }
 
                /* Compute l1_norms if needed */

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -1830,7 +1830,7 @@ hypre_MGRSetup( void               *mgr_vdata,
       TODO (VPM): move this block closer to global smoother setup */
    for (j = 0; j < num_c_levels; j++)
    {
-      if (((mgr_data -> num_relax_sweeps)[j] > 0) && (l1_norms[j] == NULL))
+      if (!l1_norms[j])
       {
          /* Compute l1_norms according to relaxation type */
          hypre_BoomerAMGRelaxComputeL1Norms(A_array[j], Frelax_type[j],
@@ -1838,8 +1838,7 @@ hypre_MGRSetup( void               *mgr_vdata,
                                             &l1_norms_data);
          if (l1_norms_data)
          {
-            nloc = hypre_ParCSRMatrixNumRows(A_array[j]);
-            l1_norms[j] = hypre_SeqVectorCreate(nloc);
+            l1_norms[j] = hypre_SeqVectorCreate(hypre_ParCSRMatrixNumRows(A_array[j]));
             hypre_VectorData(l1_norms[j]) = l1_norms_data;
             hypre_VectorMemoryLocation(l1_norms[j]) = memory_location;
          }
@@ -1911,6 +1910,34 @@ hypre_MGRSetup( void               *mgr_vdata,
             // since we have a single matrix (and not an array of matrices).
             // hypre_printf("Setting GSElim Solver %d \n", Frelax_type[i]);
             hypre_GaussElimSetup(GSElimData[i], i, Frelax_type[i]);
+
+            /* Fallback to Jacobi when Gaussian Elim. is not successful */
+            if (HYPRE_GetMaxGlobalError(hypre_ParCSRMatrixComm(A_array[i])))
+            {
+               hypre_MGRDestroyGSElimData((mgr_data -> GSElimData)[i]);
+               (mgr_data -> GSElimData)[i] = NULL;
+
+               Frelax_type[i] = 7; /* Jacobi */
+               if (!my_id)
+               {
+                  hypre_sprintf(msg, "Switching F-relaxation at level %d to Jacobi", my_id, i);
+                  hypre_error_w_msg(HYPRE_ERROR_GENERIC, msg);
+               }
+               HYPRE_ClearAllErrors();
+
+               /* Compute l1_norms if needed */
+               if (!l1_norms[i])
+               {
+                  hypre_BoomerAMGRelaxComputeL1Norms(A_array[i], Frelax_type[i], 0, 0, NULL,
+                                                     &l1_norms_data);
+                  if (l1_norms_data)
+                  {
+                     l1_norms[i] = hypre_SeqVectorCreate(hypre_ParCSRMatrixNumRows(A_array[i]));
+                     hypre_VectorData(l1_norms[i]) = l1_norms_data;
+                     hypre_VectorMemoryLocation(l1_norms[i]) = memory_location;
+                  }
+               }
+            }
          }
       }
    }

--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -197,8 +197,9 @@ HYPRE_Int HYPRE_Finalized(void);
  * HYPRE error user functions
  *--------------------------------------------------------------------------*/
 
-/* Return the max. value of the current hypre error flag among all ranks */
-HYPRE_Int HYPRE_GetMaxGlobalError(MPI_Comm comm);
+
+/* Return an aggregate error code representing the collective status of all ranks */
+HYPRE_Int HYPRE_GetGlobalError(MPI_Comm comm);
 
 /* Return the current hypre error flag */
 HYPRE_Int HYPRE_GetError(void);

--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -197,6 +197,9 @@ HYPRE_Int HYPRE_Finalized(void);
  * HYPRE error user functions
  *--------------------------------------------------------------------------*/
 
+/* Return the max. value of the current hypre error flag among all ranks */
+HYPRE_Int HYPRE_GetMaxGlobalError(MPI_Comm comm);
+
 /* Return the current hypre error flag */
 HYPRE_Int HYPRE_GetError(void);
 

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -515,10 +515,14 @@ extern hypre_Error hypre__global_error;
  *--------------------------------------------------------------------------*/
 
 void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, const char *msg);
+void hypre_error_handler_rank_0(HYPRE_Int myid, const char *filename, HYPRE_Int line,
+                                HYPRE_Int ierr, const char *msg);
 
-#define hypre_error(IERR)  hypre_error_handler(__FILE__, __LINE__, IERR, NULL)
-#define hypre_error_w_msg(IERR, msg)  hypre_error_handler(__FILE__, __LINE__, IERR, msg)
-#define hypre_error_in_arg(IARG)  hypre_error(HYPRE_ERROR_ARG | IARG<<3)
+#define hypre_error(IERR) hypre_error_handler(__FILE__, __LINE__, IERR, NULL)
+#define hypre_error_rank_0(i, IERR) hypre_error_handler_rank_0(i, __FILE__, __LINE__, IERR, NULL)
+#define hypre_error_w_msg(IERR, msg) hypre_error_handler(__FILE__, __LINE__, IERR, msg)
+#define hypre_error_w_msg_rank_0(i, IERR, msg) hypre_error_handler(i, __FILE__, __LINE__, IERR, msg)
+#define hypre_error_in_arg(IARG) hypre_error(HYPRE_ERROR_ARG | IARG<<3)
 
 #if defined(HYPRE_DEBUG)
 /* host assert */
@@ -543,7 +547,6 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
 #endif
 
 #endif /* hypre_ERROR_HEADER */
-
 /******************************************************************************
  * Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -500,6 +500,7 @@ HYPRE_Int hypre_ParPrintf(MPI_Comm comm, const char *format, ...);
 typedef struct
 {
    HYPRE_Int  error_flag;
+   HYPRE_Int  temp_error_flag;
    HYPRE_Int  print_to_memory;
    char      *memory;
    HYPRE_Int  mem_sz;
@@ -509,6 +510,7 @@ typedef struct
 
 extern hypre_Error hypre__global_error;
 #define hypre_error_flag  hypre__global_error.error_flag
+#define hypre_error_temp_flag  hypre__global_error.temp_error_flag
 
 /*--------------------------------------------------------------------------
  * HYPRE error macros
@@ -517,6 +519,8 @@ extern hypre_Error hypre__global_error;
 void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, const char *msg);
 void hypre_error_handler_rank_0(HYPRE_Int myid, const char *filename, HYPRE_Int line,
                                 HYPRE_Int ierr, const char *msg);
+void hypre_error_code_save(void);
+void hypre_error_code_restore(void);
 
 #define hypre_error(IERR) hypre_error_handler(__FILE__, __LINE__, IERR, NULL)
 #define hypre_error_rank_0(i, IERR) hypre_error_handler_rank_0(i, __FILE__, __LINE__, IERR, NULL)
@@ -2048,7 +2052,8 @@ HYPRE_Int hypre_GetDeviceCount(hypre_int *device_count);
 HYPRE_Int hypre_GetDeviceLastError(void);
 HYPRE_Int hypre_UmpireInit(hypre_Handle *hypre_handle_);
 HYPRE_Int hypre_UmpireFinalize(hypre_Handle *hypre_handle_);
-HYPRE_Int hypre_GetDeviceMaxShmemSize(hypre_int device_id, hypre_int *max_size_ptr, hypre_int *max_size_optin_ptr);
+HYPRE_Int hypre_GetDeviceMaxShmemSize(hypre_int device_id, hypre_int *max_size_ptr,
+                                      hypre_int *max_size_optin_ptr);
 
 /* matrix_stats.h */
 hypre_MatrixStats* hypre_MatrixStatsCreate( void );

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -517,15 +517,11 @@ extern hypre_Error hypre__global_error;
  *--------------------------------------------------------------------------*/
 
 void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, const char *msg);
-void hypre_error_handler_rank_0(HYPRE_Int myid, const char *filename, HYPRE_Int line,
-                                HYPRE_Int ierr, const char *msg);
 void hypre_error_code_save(void);
 void hypre_error_code_restore(void);
 
 #define hypre_error(IERR) hypre_error_handler(__FILE__, __LINE__, IERR, NULL)
-#define hypre_error_rank_0(i, IERR) hypre_error_handler_rank_0(i, __FILE__, __LINE__, IERR, NULL)
 #define hypre_error_w_msg(IERR, msg) hypre_error_handler(__FILE__, __LINE__, IERR, msg)
-#define hypre_error_w_msg_rank_0(i, IERR, msg) hypre_error_handler(i, __FILE__, __LINE__, IERR, msg)
 #define hypre_error_in_arg(IARG) hypre_error(HYPRE_ERROR_ARG | IARG<<3)
 
 #if defined(HYPRE_DEBUG)

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -614,6 +614,7 @@ extern "C" {
 #define MPI_MAX             hypre_MPI_MAX
 #define MPI_LOR             hypre_MPI_LOR
 #define MPI_LAND            hypre_MPI_LAND
+#define MPI_BOR             hypre_MPI_BOR
 #define MPI_SUCCESS         hypre_MPI_SUCCESS
 #define MPI_STATUSES_IGNORE hypre_MPI_STATUSES_IGNORE
 
@@ -727,6 +728,7 @@ typedef HYPRE_Int  hypre_MPI_Info;
 #define  hypre_MPI_MAX 2
 #define  hypre_MPI_LOR 3
 #define  hypre_MPI_LAND 4
+#define  hypre_MPI_BOR 5
 #define  hypre_MPI_SUCCESS 0
 #define  hypre_MPI_STATUSES_IGNORE 0
 
@@ -775,6 +777,7 @@ typedef MPI_User_function    hypre_MPI_User_function;
 #define  hypre_MPI_MIN MPI_MIN
 #define  hypre_MPI_MAX MPI_MAX
 #define  hypre_MPI_LOR MPI_LOR
+#define  hypre_MPI_BOR MPI_BOR
 #define  hypre_MPI_SUCCESS MPI_SUCCESS
 #define  hypre_MPI_STATUSES_IGNORE MPI_STATUSES_IGNORE
 

--- a/src/utilities/error.c
+++ b/src/utilities/error.c
@@ -88,6 +88,40 @@ hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, const 
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
 
+void
+hypre_error_handler_rank_0(HYPRE_Int   myid,
+                           const char *filename,
+                           HYPRE_Int   line,
+                           HYPRE_Int   ierr,
+                           const char *msg)
+{
+   /* Update error code in all ranks */
+   hypre__global_error.error_flag |= ierr;
+
+   /* Print message only from rank 0 */
+   if (!myid)
+   {
+      hypre_error_handler(filename, line, ierr, msg);
+   }
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_GetMaxGlobalError(MPI_Comm comm)
+{
+   HYPRE_Int global_error_flag;
+
+   hypre_MPI_Allreduce(&hypre_error_flag, &global_error_flag, 1,
+                       HYPRE_MPI_INT, hypre_MPI_MAX, comm);
+
+   return global_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 HYPRE_GetError(void)
 {

--- a/src/utilities/error.c
+++ b/src/utilities/error.c
@@ -115,12 +115,12 @@ hypre_error_code_restore(void)
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
-HYPRE_GetMaxGlobalError(MPI_Comm comm)
+HYPRE_GetGlobalError(MPI_Comm comm)
 {
    HYPRE_Int global_error_flag;
 
    hypre_MPI_Allreduce(&hypre_error_flag, &global_error_flag, 1,
-                       HYPRE_MPI_INT, hypre_MPI_MAX, comm);
+                       HYPRE_MPI_INT, hypre_MPI_BOR, comm);
 
    return global_error_flag;
 }

--- a/src/utilities/error.c
+++ b/src/utilities/error.c
@@ -89,26 +89,6 @@ hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, const 
  *--------------------------------------------------------------------------*/
 
 void
-hypre_error_handler_rank_0(HYPRE_Int   myid,
-                           const char *filename,
-                           HYPRE_Int   line,
-                           HYPRE_Int   ierr,
-                           const char *msg)
-{
-   /* Update error code in all ranks */
-   hypre__global_error.error_flag |= ierr;
-
-   /* Print message only from rank 0 */
-   if (!myid)
-   {
-      hypre_error_handler(filename, line, ierr, msg);
-   }
-}
-
-/*--------------------------------------------------------------------------
- *--------------------------------------------------------------------------*/
-
-void
 hypre_error_code_save(void)
 {
    /* Store the current error code in a temporary variable */

--- a/src/utilities/error.c
+++ b/src/utilities/error.c
@@ -8,7 +8,7 @@
 #include "_hypre_utilities.h"
 
 /* Global variable for error handling */
-hypre_Error hypre__global_error = {0, 0, NULL, 0, 0};
+hypre_Error hypre__global_error = {0, 0, 0, NULL, 0, 0};
 
 /*--------------------------------------------------------------------------
  * Process the error raised on the given line of the given source file
@@ -103,6 +103,32 @@ hypre_error_handler_rank_0(HYPRE_Int   myid,
    {
       hypre_error_handler(filename, line, ierr, msg);
    }
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+void
+hypre_error_code_save(void)
+{
+   /* Store the current error code in a temporary variable */
+   hypre_error_temp_flag = hypre_error_flag;
+
+   /* Reset current error code */
+   HYPRE_ClearAllErrors();
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+void
+hypre_error_code_restore(void)
+{
+   /* Restore hypre's error code */
+   hypre_error_flag = hypre_error_temp_flag;
+
+   /* Reset temporary error code */
+   hypre_error_temp_flag = 0;
 }
 
 /*--------------------------------------------------------------------------

--- a/src/utilities/error.h
+++ b/src/utilities/error.h
@@ -34,15 +34,11 @@ extern hypre_Error hypre__global_error;
  *--------------------------------------------------------------------------*/
 
 void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, const char *msg);
-void hypre_error_handler_rank_0(HYPRE_Int myid, const char *filename, HYPRE_Int line,
-                                HYPRE_Int ierr, const char *msg);
 void hypre_error_code_save(void);
 void hypre_error_code_restore(void);
 
 #define hypre_error(IERR) hypre_error_handler(__FILE__, __LINE__, IERR, NULL)
-#define hypre_error_rank_0(i, IERR) hypre_error_handler_rank_0(i, __FILE__, __LINE__, IERR, NULL)
 #define hypre_error_w_msg(IERR, msg) hypre_error_handler(__FILE__, __LINE__, IERR, msg)
-#define hypre_error_w_msg_rank_0(i, IERR, msg) hypre_error_handler(i, __FILE__, __LINE__, IERR, msg)
 #define hypre_error_in_arg(IARG) hypre_error(HYPRE_ERROR_ARG | IARG<<3)
 
 #if defined(HYPRE_DEBUG)

--- a/src/utilities/error.h
+++ b/src/utilities/error.h
@@ -32,10 +32,14 @@ extern hypre_Error hypre__global_error;
  *--------------------------------------------------------------------------*/
 
 void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, const char *msg);
+void hypre_error_handler_rank_0(HYPRE_Int myid, const char *filename, HYPRE_Int line,
+                                HYPRE_Int ierr, const char *msg);
 
-#define hypre_error(IERR)  hypre_error_handler(__FILE__, __LINE__, IERR, NULL)
-#define hypre_error_w_msg(IERR, msg)  hypre_error_handler(__FILE__, __LINE__, IERR, msg)
-#define hypre_error_in_arg(IARG)  hypre_error(HYPRE_ERROR_ARG | IARG<<3)
+#define hypre_error(IERR) hypre_error_handler(__FILE__, __LINE__, IERR, NULL)
+#define hypre_error_rank_0(i, IERR) hypre_error_handler_rank_0(i, __FILE__, __LINE__, IERR, NULL)
+#define hypre_error_w_msg(IERR, msg) hypre_error_handler(__FILE__, __LINE__, IERR, msg)
+#define hypre_error_w_msg_rank_0(i, IERR, msg) hypre_error_handler(i, __FILE__, __LINE__, IERR, msg)
+#define hypre_error_in_arg(IARG) hypre_error(HYPRE_ERROR_ARG | IARG<<3)
 
 #if defined(HYPRE_DEBUG)
 /* host assert */
@@ -60,4 +64,3 @@ void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, c
 #endif
 
 #endif /* hypre_ERROR_HEADER */
-

--- a/src/utilities/error.h
+++ b/src/utilities/error.h
@@ -17,6 +17,7 @@
 typedef struct
 {
    HYPRE_Int  error_flag;
+   HYPRE_Int  temp_error_flag;
    HYPRE_Int  print_to_memory;
    char      *memory;
    HYPRE_Int  mem_sz;
@@ -26,6 +27,7 @@ typedef struct
 
 extern hypre_Error hypre__global_error;
 #define hypre_error_flag  hypre__global_error.error_flag
+#define hypre_error_temp_flag  hypre__global_error.temp_error_flag
 
 /*--------------------------------------------------------------------------
  * HYPRE error macros
@@ -34,6 +36,8 @@ extern hypre_Error hypre__global_error;
 void hypre_error_handler(const char *filename, HYPRE_Int line, HYPRE_Int ierr, const char *msg);
 void hypre_error_handler_rank_0(HYPRE_Int myid, const char *filename, HYPRE_Int line,
                                 HYPRE_Int ierr, const char *msg);
+void hypre_error_code_save(void);
+void hypre_error_code_restore(void);
 
 #define hypre_error(IERR) hypre_error_handler(__FILE__, __LINE__, IERR, NULL)
 #define hypre_error_rank_0(i, IERR) hypre_error_handler_rank_0(i, __FILE__, __LINE__, IERR, NULL)

--- a/src/utilities/mpistubs.h
+++ b/src/utilities/mpistubs.h
@@ -65,6 +65,7 @@ extern "C" {
 #define MPI_MAX             hypre_MPI_MAX
 #define MPI_LOR             hypre_MPI_LOR
 #define MPI_LAND            hypre_MPI_LAND
+#define MPI_BOR             hypre_MPI_BOR
 #define MPI_SUCCESS         hypre_MPI_SUCCESS
 #define MPI_STATUSES_IGNORE hypre_MPI_STATUSES_IGNORE
 
@@ -178,6 +179,7 @@ typedef HYPRE_Int  hypre_MPI_Info;
 #define  hypre_MPI_MAX 2
 #define  hypre_MPI_LOR 3
 #define  hypre_MPI_LAND 4
+#define  hypre_MPI_BOR 5
 #define  hypre_MPI_SUCCESS 0
 #define  hypre_MPI_STATUSES_IGNORE 0
 
@@ -226,6 +228,7 @@ typedef MPI_User_function    hypre_MPI_User_function;
 #define  hypre_MPI_MIN MPI_MIN
 #define  hypre_MPI_MAX MPI_MAX
 #define  hypre_MPI_LOR MPI_LOR
+#define  hypre_MPI_BOR MPI_BOR
 #define  hypre_MPI_SUCCESS MPI_SUCCESS
 #define  hypre_MPI_STATUSES_IGNORE MPI_STATUSES_IGNORE
 

--- a/src/utilities/protos.h
+++ b/src/utilities/protos.h
@@ -55,7 +55,8 @@ HYPRE_Int hypre_GetDeviceCount(hypre_int *device_count);
 HYPRE_Int hypre_GetDeviceLastError(void);
 HYPRE_Int hypre_UmpireInit(hypre_Handle *hypre_handle_);
 HYPRE_Int hypre_UmpireFinalize(hypre_Handle *hypre_handle_);
-HYPRE_Int hypre_GetDeviceMaxShmemSize(hypre_int device_id, hypre_int *max_size_ptr, hypre_int *max_size_optin_ptr);
+HYPRE_Int hypre_GetDeviceMaxShmemSize(hypre_int device_id, hypre_int *max_size_ptr,
+                                      hypre_int *max_size_optin_ptr);
 
 /* matrix_stats.h */
 hypre_MatrixStats* hypre_MatrixStatsCreate( void );


### PR DESCRIPTION
Improve MGR robustness when Gaussian Elimination is used as F-relaxation.

A new logic has been added: If GE fails, then fall back to Jacobi.

In addition, this PR improves MGR's memory usage by reducing the size of certain allocations.