### PR TITLE
New print level codes in MGR

### DIFF
--- a/src/parcsr_ls/HYPRE_parcsr_ls.h
+++ b/src/parcsr_ls/HYPRE_parcsr_ls.h
@@ -4285,27 +4285,29 @@ HYPRE_Int HYPRE_MGRSetCoarseSolver(HYPRE_Solver             solver,
 /**
  * @brief (Optional) Set the verbosity level for MGR.
  *
- * @details You can control what information gets printed by specifying the
- * output levels using this function. Each option corresponds to a specific type
- * of information, and you can activate several of them at the same time by summing
- * their respective numeric codes, which are given below:
+ * @details Control what information gets printed by specifying the output levels
+ * using this function. Each option corresponds to a specific type of information, and you
+ * can activate several of them at the same time by summing their respective numeric codes,
+*  which are given below:
  *
- *   - 1:  Print MGR's setup information.
- *   - 2:  Print MGR's solve information.
- *   - 4:  Print MGR's parameters information.
- *   - 8:  Set print mode for matrices and vectors to ASCII (binary mode is used by default)
- *   - 16: Print the finest level matrix to NP files where NP is the number of ranks.
- *   - 32: Print the finest level right-hand-side to NP files.
+ *   - 1:   Print MGR's setup information.
+ *   - 2:   Print MGR's solve information.
+ *   - 4:   Print MGR's parameters information.
+ *   - 8:   Set print mode for matrices and vectors to ASCII (binary mode is used by default)
+ *   - 16:  Print the finest level matrix to NP files where NP is the number of ranks.
+ *   - 32:  Print the finest level right-hand-side to NP files.
+ *   - 64:  Print the coarsest level matrix to NP files.
+ *   - 128: Print the full MGR hierarchy (operator, interpolation, and restriction).
  *
  * @param solver [IN] The solver to configure.
  * @param print_level [IN] The desired output level.
  *
- * @example To print setup information (1); matrix (16) and rhs (32) to binary files,
+ * @example To print setup information (1); fine matrix (16) and rhs (32) to binary files,
  * set \c print_level to 49 (1 + 16 + 32). In the previous example, to use ASCII
  * files for matrices and vectors, set \c print_level to 57 (1 + 8 + 16 + 32).
  *
  * @note The default print level is zero, which means no information will be
- * printed by default.
+ * printed by default. Options starting from 8 are intended for developers' usage.
  **/
 HYPRE_Int
 HYPRE_MGRSetPrintLevel( HYPRE_Solver solver,

--- a/src/parcsr_ls/par_mgr.h
+++ b/src/parcsr_ls/par_mgr.h
@@ -91,7 +91,7 @@ typedef struct
    HYPRE_Int             max_iter;
    HYPRE_Int             relax_order;
    HYPRE_Int            *num_relax_sweeps;
-   char                 *info_path;
+   char                 *data_path;
 
    HYPRE_Solver          coarse_grid_solver;
    HYPRE_Int           (*coarse_grid_solver_setup)(void*, void*, void*, void*);


### PR DESCRIPTION
This PR adds two print level codes for MGR intended for developers:

- Code 64: Print the coarsest level matrix to NP files.
- Code 128: Print the full MGR hierarchy (operator, interpolation, and restriction).

This PR also:
- Cleans MGR's setup implementation by removing old debugging macros
- Completes the work started with #976