### PR TITLE
Add `hypre_ceildiv`

### DIFF
--- a/src/parcsr_ls/par_mgr.c
+++ b/src/parcsr_ls/par_mgr.c
@@ -3108,8 +3108,7 @@ hypre_MGRComputeNonGalerkinCoarseGrid(hypre_ParCSRMatrix    *A,
       }
       else
       {
-         /* TODO (VPM): Shouldn't blk_inv_size = bsize for method == 3? Check with DOK */
-         HYPRE_Int blk_inv_size = method == 2 ? bsize : 1;
+         HYPRE_Int blk_inv_size = method == 2 ? 1 : bsize;
          hypre_ParCSRMatrixBlockDiagMatrix(A_ff, blk_inv_size, -1, NULL, 1, &A_ff_inv);
          hypre_ParCSRMatrix *Wr = NULL;
          Wr = hypre_ParCSRMatMat(A_cf_truncated, A_ff_inv);

--- a/src/parcsr_ls/par_mgr_device.c
+++ b/src/parcsr_ls/par_mgr_device.c
@@ -648,7 +648,7 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
    }
 
    /* Compute block info */
-   num_blocks = (num_points - 1) / blk_size + 1;
+   num_blocks = num_points ? (1 + (num_points - 1) / blk_size) : 0;
    bdiag_size = num_blocks * bs2;
 
    if (num_points % blk_size)
@@ -935,7 +935,7 @@ hypre_ParCSRMatrixBlockDiagMatrixDevice( hypre_ParCSRMatrix  *A,
                                            point_type );
 #endif
    }
-   num_blocks  = 1 + (B_diag_num_rows - 1) / blk_size;
+   num_blocks  = B_diag_num_rows ? (1 + (B_diag_num_rows - 1) / blk_size) : 0;
    B_diag_size = blk_size * (blk_size * num_blocks);
 
    /*-----------------------------------------------------------------

--- a/src/parcsr_ls/par_mgr_device.c
+++ b/src/parcsr_ls/par_mgr_device.c
@@ -616,6 +616,12 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
       return hypre_error_flag;
    }
 
+   /* Return if the local matrix is empty */
+   if (!num_rows)
+   {
+      return hypre_error_flag;
+   }
+
    /*-----------------------------------------------------------------
     * Initial
     *-----------------------------------------------------------------*/

--- a/src/parcsr_ls/par_mgr_device.c
+++ b/src/parcsr_ls/par_mgr_device.c
@@ -654,7 +654,7 @@ hypre_ParCSRMatrixExtractBlockDiagDevice( hypre_ParCSRMatrix   *A,
    }
 
    /* Compute block info */
-   num_blocks = num_points ? (1 + (num_points - 1) / blk_size) : 0;
+   num_blocks = hypre_ceildiv(num_points, blk_size);
    bdiag_size = num_blocks * bs2;
 
    if (num_points % blk_size)
@@ -941,7 +941,7 @@ hypre_ParCSRMatrixBlockDiagMatrixDevice( hypre_ParCSRMatrix  *A,
                                            point_type );
 #endif
    }
-   num_blocks  = B_diag_num_rows ? (1 + (B_diag_num_rows - 1) / blk_size) : 0;
+   num_blocks  = hypre_ceildiv(B_diag_num_rows, blk_size);
    B_diag_size = blk_size * (blk_size * num_blocks);
 
    /*-----------------------------------------------------------------

--- a/src/seq_block_mv/dense_block_matrix.c
+++ b/src/seq_block_mv/dense_block_matrix.c
@@ -28,8 +28,8 @@ hypre_DenseBlockMatrixCreate( HYPRE_Int  row_major,
    HYPRE_Int                num_blocks[2];
 
    /* Compute number of blocks */
-   num_blocks[0] = 1 + ((num_rows - 1) / num_rows_block);
-   num_blocks[1] = 1 + ((num_cols - 1) / num_cols_block);
+   num_blocks[0] = num_rows ? (1 + ((num_rows - 1) / num_rows_block)) : 0;
+   num_blocks[1] = num_cols ? (1 + ((num_cols - 1) / num_cols_block)) : 0;
    if (num_blocks[0] != num_blocks[1])
    {
       hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Invalid number of blocks!");

--- a/src/seq_block_mv/dense_block_matrix.c
+++ b/src/seq_block_mv/dense_block_matrix.c
@@ -28,8 +28,8 @@ hypre_DenseBlockMatrixCreate( HYPRE_Int  row_major,
    HYPRE_Int                num_blocks[2];
 
    /* Compute number of blocks */
-   num_blocks[0] = num_rows ? (1 + ((num_rows - 1) / num_rows_block)) : 0;
-   num_blocks[1] = num_cols ? (1 + ((num_cols - 1) / num_cols_block)) : 0;
+   num_blocks[0] = hypre_ceildiv(num_rows, num_rows_block);
+   num_blocks[1] = hypre_ceildiv(num_cols, num_cols_block);
    if (num_blocks[0] != num_blocks[1])
    {
       hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Invalid number of blocks!");

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -133,6 +133,10 @@ typedef double                 hypre_double;
 #endif
 #endif
 
+#ifndef hypre_ceildiv
+#define hypre_ceildiv(a, b) (((a) + (b) - 1) / (b))
+#endif
+
 #ifndef hypre_ceil
 #if defined(HYPRE_SINGLE)
 #define hypre_ceil ceilf

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -133,6 +133,8 @@ typedef double                 hypre_double;
 #endif
 #endif
 
+/* Macro for ceiling division. It assumes non-negative dividend and positive divisor.
+   The result of this macro might need to be casted to an integer type depending on the use case */
 #ifndef hypre_ceildiv
 #define hypre_ceildiv(a, b) (((a) + (b) - 1) / (b))
 #endif

--- a/src/utilities/general.h
+++ b/src/utilities/general.h
@@ -93,6 +93,10 @@ typedef double                 hypre_double;
 #endif
 #endif
 
+#ifndef hypre_ceildiv
+#define hypre_ceildiv(a, b) (((a) + (b) - 1) / (b))
+#endif
+
 #ifndef hypre_ceil
 #if defined(HYPRE_SINGLE)
 #define hypre_ceil ceilf

--- a/src/utilities/general.h
+++ b/src/utilities/general.h
@@ -93,6 +93,8 @@ typedef double                 hypre_double;
 #endif
 #endif
 
+/* Macro for ceiling division. It assumes non-negative dividend and positive divisor.
+   The result of this macro might need to be casted to an integer type depending on the use case */
 #ifndef hypre_ceildiv
 #define hypre_ceildiv(a, b) (((a) + (b) - 1) / (b))
 #endif


### PR DESCRIPTION
Add a macro for computing division where the result is always rounded up to the nearest integer.

This fixes a bug in master for the case when the dividend is zero.