### PR TITLE
make hypre_bind_device back compatible

### DIFF
--- a/src/test/ams_driver.c
+++ b/src/test/ams_driver.c
@@ -142,7 +142,7 @@ main (hypre_int argc,
     * GPU Device binding
     * Must be done before HYPRE_Initialize() and should not be changed after
     *-----------------------------------------------------------------*/
-   hypre_bind_device(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
+   hypre_bind_device_id(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
 
    /*-----------------------------------------------------------
     * Initialize : must be the first HYPRE function to call

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -532,7 +532,7 @@ main( hypre_int argc,
     * GPU Device binding
     * Must be done before HYPRE_Initialize() and should not be changed after
     *-----------------------------------------------------------------*/
-   hypre_bind_device(device_id, myid, num_procs, hypre_MPI_COMM_WORLD);
+   hypre_bind_device_id(device_id, myid, num_procs, hypre_MPI_COMM_WORLD);
 
    /*-----------------------------------------------------------
     * Initialize : must be the first HYPRE function to call

--- a/src/test/ij_assembly.c
+++ b/src/test/ij_assembly.c
@@ -117,7 +117,7 @@ main( hypre_int  argc,
     * GPU Device binding
     * Must be done before HYPRE_Initialize() and should not be changed after
     *-----------------------------------------------------------------*/
-   hypre_bind_device(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
+   hypre_bind_device_id(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
 
    /* Initialize Hypre */
    /* Initialize Hypre: must be the first Hypre function to call */

--- a/src/test/ij_device.c
+++ b/src/test/ij_device.c
@@ -118,7 +118,7 @@ main( hypre_int argc,
     * GPU Device binding
     * Must be done before HYPRE_Initialize() and should not be changed after
     *-----------------------------------------------------------------*/
-   hypre_bind_device(myid, num_procs, hypre_MPI_COMM_WORLD);
+   hypre_bind_device_id(myid, num_procs, hypre_MPI_COMM_WORLD);
 
    /*-----------------------------------------------------------
     * Initialize : must be the first HYPRE function to call

--- a/src/test/ij_mm.c
+++ b/src/test/ij_mm.c
@@ -795,7 +795,7 @@ main( hypre_int argc,
     * GPU Device binding
     * Must be done before HYPRE_Initialize() and should not be changed after
     *-----------------------------------------------------------------*/
-   hypre_bind_device(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
+   hypre_bind_device_id(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
 
    /*-----------------------------------------------------------
     * Initialize : must be the first HYPRE function to call

--- a/src/test/maxwell_unscaled.c
+++ b/src/test/maxwell_unscaled.c
@@ -1379,7 +1379,7 @@ main( hypre_int argc,
     * GPU Device binding
     * Must be done before HYPRE_Initialize() and should not be changed after
     *-----------------------------------------------------------------*/
-   hypre_bind_device(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
+   hypre_bind_device_id(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
 
    /*-----------------------------------------------------------
     * Initialize : must be the first HYPRE function to call

--- a/src/test/sstruct.c
+++ b/src/test/sstruct.c
@@ -2487,7 +2487,7 @@ main( hypre_int argc,
       }
    }
 
-   hypre_bind_device(device_id, myid, num_procs, comm);
+   hypre_bind_device_id(device_id, myid, num_procs, comm);
 
    /*-----------------------------------------------------------
     * Initialize : must be the first HYPRE function to call

--- a/src/test/sstruct_fac.c
+++ b/src/test/sstruct_fac.c
@@ -1301,7 +1301,7 @@ main( hypre_int argc,
     * GPU Device binding
     * Must be done before HYPRE_Initialize() and should not be changed after
     *-----------------------------------------------------------------*/
-   hypre_bind_device(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
+   hypre_bind_device_id(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
 
    /*-----------------------------------------------------------
     * Initialize : must be the first HYPRE function to call

--- a/src/test/struct.c
+++ b/src/test/struct.c
@@ -216,7 +216,7 @@ main( hypre_int argc,
       }
    }
 
-   hypre_bind_device(device_id, myid, num_procs, hypre_MPI_COMM_WORLD);
+   hypre_bind_device_id(device_id, myid, num_procs, hypre_MPI_COMM_WORLD);
 
    /*-----------------------------------------------------------
     * Initialize : must be the first HYPRE function to call

--- a/src/test/struct_migrate.c
+++ b/src/test/struct_migrate.c
@@ -67,7 +67,7 @@ main( hypre_int argc,
     * GPU Device binding
     * Must be done before HYPRE_Initialize() and should not be changed after
     *-----------------------------------------------------------------*/
-   hypre_bind_device(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
+   hypre_bind_device_id(-1, myid, num_procs, hypre_MPI_COMM_WORLD);
 
    /*-----------------------------------------------------------
     * Initialize : must be the first HYPRE function to call

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -2357,7 +2357,8 @@ HYPRE_Int hypre_CurandUniformSingle( HYPRE_Int n, float *urand, HYPRE_Int set_se
 
 HYPRE_Int hypre_ResetDeviceRandGenerator( hypre_ulonglongint seed, hypre_ulonglongint offset );
 
-HYPRE_Int hypre_bind_device(HYPRE_Int device_id_in, HYPRE_Int myid, HYPRE_Int nproc, MPI_Comm comm);
+HYPRE_Int hypre_bind_device_id(HYPRE_Int device_id_in, HYPRE_Int myid, HYPRE_Int nproc, MPI_Comm comm);
+HYPRE_Int hypre_bind_device(HYPRE_Int myid, HYPRE_Int nproc, MPI_Comm comm);
 
 /* nvtx.c */
 void hypre_GpuProfilingPushRangeColor(const char *name, HYPRE_Int cid);

--- a/src/utilities/device_utils.c
+++ b/src/utilities/device_utils.c
@@ -2956,10 +2956,10 @@ HYPRE_SetSYCLDevice(sycl::device user_device)
  *--------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_bind_device( HYPRE_Int device_id_in,
-                   HYPRE_Int myid,
-                   HYPRE_Int nproc,
-                   MPI_Comm  comm )
+hypre_bind_device_id( HYPRE_Int device_id_in,
+                      HYPRE_Int myid,
+                      HYPRE_Int nproc,
+                      MPI_Comm  comm )
 {
 #if defined(HYPRE_USING_GPU) || defined(HYPRE_USING_DEVICE_OPENMP)
    /* proc id (rank) on the running node */
@@ -3017,3 +3017,12 @@ hypre_bind_device( HYPRE_Int device_id_in,
 
    return hypre_error_flag;
 }
+
+HYPRE_Int
+hypre_bind_device( HYPRE_Int myid,
+                   HYPRE_Int nproc,
+                   MPI_Comm  comm )
+{
+   return hypre_bind_device_id(-1, myid, nproc, comm);
+}
+

--- a/src/utilities/protos.h
+++ b/src/utilities/protos.h
@@ -355,7 +355,8 @@ HYPRE_Int hypre_CurandUniformSingle( HYPRE_Int n, float *urand, HYPRE_Int set_se
 
 HYPRE_Int hypre_ResetDeviceRandGenerator( hypre_ulonglongint seed, hypre_ulonglongint offset );
 
-HYPRE_Int hypre_bind_device(HYPRE_Int device_id_in, HYPRE_Int myid, HYPRE_Int nproc, MPI_Comm comm);
+HYPRE_Int hypre_bind_device_id(HYPRE_Int device_id_in, HYPRE_Int myid, HYPRE_Int nproc, MPI_Comm comm);
+HYPRE_Int hypre_bind_device(HYPRE_Int myid, HYPRE_Int nproc, MPI_Comm comm);
 
 /* nvtx.c */
 void hypre_GpuProfilingPushRangeColor(const char *name, HYPRE_Int cid);


### PR DESCRIPTION
We changed the interface of `hypre_bind_device` in a previous release. Some code like AMG benchmark needs this developer-level function, so the change broke their code. In this PR, we change the function prototype back and rename the function with the new interface to a different function name.

- [x] tux
- [x] lassen
- [x] tioga