### PR TITLE
Fix check-double autotest script

### DIFF
--- a/AUTOTEST/check-double.sh
+++ b/AUTOTEST/check-double.sh
@@ -38,6 +38,6 @@ find . -type f -print | egrep '[.]*[.](c|cc|cpp|cxx|C|h|hpp|hxx|H)$' |
   egrep -v '/FEI_mv' |
   egrep -v '/hypre/include' > check-double.files
 
-egrep '(^|[^[:alnum:]_]+)double([^[:alnum:]_]+|$)' `cat check-double.files` >&2
+egrep '(^|[^[:alnum:]_-]+)double([^[:alnum:]_-]+|$)' `cat check-double.files` >&2
 
 rm -f check-double.files


### PR DESCRIPTION
This fixes a recent false positive in the check-double autotest script.  The updated script ignores '-' before and after the string "double", so it will not detect "long-double" in a comment, for example.  This should still find all valid instances of the `double` keyword.
