### PR TITLE
CMake: add CUDA dependencies for downstream packages

### DIFF
--- a/src/config/HYPREConfig.cmake.in
+++ b/src/config/HYPREConfig.cmake.in
@@ -73,4 +73,11 @@ if(HYPRE_WITH_OPENMP)
   find_dependency(OpenMP)
 endif()
 
+if(HYPRE_WITH_CUDA)
+  find_dependency(CUDA REQUIRED)
+  if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+    find_dependency(CUDAToolkit REQUIRED)
+  endif()
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/HYPRETargets.cmake")


### PR DESCRIPTION
Added `find_dependency` calls which mirror `find_package` in `cmake/HYPRE_SetupCUDAToolkit.cmake`. Without this the downstream app has to add the same dependency paths as the hypre build