### PR TITLE
fix recursive make error

### DIFF
--- a/src/seq_block_mv/Makefile
+++ b/src/seq_block_mv/Makefile
@@ -36,7 +36,7 @@ SONAME = libHYPRE_seq_block_mv-${HYPRE_RELEASE_VERSION}${HYPRE_LIB_SUFFIX}
 ##################################################################
 
 all:
-	make lib
+	$(MAKE) lib
 
 lib: libHYPRE_seq_block_mv${HYPRE_LIB_SUFFIX}
 	cp -fR $(srcdir)/_hypre_seq_block_mv.h $(HYPRE_BUILD_DIR)/include


### PR DESCRIPTION
```
svcpetsc@petsc-gpu-02:/scratch/svcpetsc/petsc/arch-linux-c-debug/externalpackages/git.hypre/src$ /scratch/svcpetsc/petsc/arch-linux-c-debug/bin/make -j8 <snip>
make[1]: Entering directory '/scratch/svcpetsc/petsc/arch-linux-c-debug/externalpackages/git.hypre/src/seq_block_mv' make lib
make[2]: *** internal error: invalid --jobserver-auth string 'fifo:/tmp/GMfifo1249586'.  Stop.
```

ref: https://gitlab.com/petsc/petsc/-/merge_requests/7298