### PR TITLE
skip transpose test with OMP

### DIFF
--- a/src/test/ij_assembly.c
+++ b/src/test/ij_assembly.c
@@ -303,6 +303,13 @@ main( hypre_int  argc,
    hypre_HandleDefaultExecPolicy(hypre_handle()) = default_exec_policy;
 #endif
 
+#if defined(HYPRE_USING_OPENMP)
+   if (hypre_GetExecPolicy1(memory_location) == HYPRE_EXEC_HOST)
+   {
+      mode = mode & ~2; /* skip AddTranspose with OMP */
+   }
+#endif
+
    /*-----------------------------------------------------------
     * Build matrix entries
     *-----------------------------------------------------------*/


### PR DESCRIPTION
This PR removes the test of assembling $A^T$ using the IJ interface on CPUs with OpenMP, since the test violates an assumption made by the IJ interface.