### PR TITLE
Asynchronous device to device hipMemcpy

### DIFF
--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -650,7 +650,10 @@ hypre_Memcpy_core(void *dst, void *src, size_t size, hypre_MemoryLocation loc_ds
 #endif
 
 #if defined(HYPRE_USING_HIP)
-      HYPRE_HIP_CALL( hipMemcpy(dst, src, size, hipMemcpyDeviceToDevice) );
+      // hipMemcpy(DtoD) causes a host-side synchronization, unlike cudaMemcpy(DtoD),
+      // use hipMemcpyAsync to get cuda's more performant behavior. For more info see:
+      // https://github.com/mfem/mfem/pull/2780
+      HYPRE_HIP_CALL( hipMemcpyAsync(dst, src, size, hipMemcpyDeviceToDevice) );
 #endif
 
 #if defined(HYPRE_USING_SYCL)
@@ -778,7 +781,10 @@ hypre_Memcpy_core(void *dst, void *src, size_t size, hypre_MemoryLocation loc_ds
 #endif
 
 #if defined(HYPRE_USING_HIP)
-      HYPRE_HIP_CALL( hipMemcpy(dst, src, size, hipMemcpyDeviceToDevice) );
+      // hipMemcpy(DtoD) causes a host-side synchronization, unlike cudaMemcpy(DtoD),
+      // use hipMemcpyAsync to get cuda's more performant behavior. For more info see:
+      // https://github.com/mfem/mfem/pull/2780
+      HYPRE_HIP_CALL( hipMemcpyAsync(dst, src, size, hipMemcpyDeviceToDevice) );
 #endif
 
 #if defined(HYPRE_USING_SYCL)


### PR DESCRIPTION
Switch `hipMemcpy` to `hipMemcpyAsync` for device to device copies to avoid unneeded host-side syncs; matches cuda's performant behavior.

See https://github.com/mfem/mfem/pull/2780