### PR TITLE
Fix coarsen type

### DIFF
--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -89,6 +89,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
 
    HYPRE_MemoryLocation memory_location = hypre_ParCSRMatrixMemoryLocation(A);
    hypre_ParAMGDataMemoryLocation(amg_data) = memory_location;
+   HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1(memory_location);
 
    /* Local variables */
    HYPRE_Int           *CF_marker;
@@ -696,7 +697,6 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
    if (num_C_points_coarse > 0)
    {
 #if defined(HYPRE_USING_GPU)
-      HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1(memory_location);
       if (exec == HYPRE_EXEC_DEVICE)
       {
 #if defined(HYPRE_USING_SYCL)
@@ -752,7 +752,6 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
       offset = (HYPRE_Int) ( first_local_row % ((HYPRE_BigInt) num_functions) );
 
 #if defined(HYPRE_USING_GPU)
-      HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1(memory_location);
       if (exec == HYPRE_EXEC_DEVICE)
       {
          hypre_BoomerAMGInitDofFuncDevice(hypre_IntArrayData(dof_func), local_size, offset, num_functions);

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -3126,10 +3126,13 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
       }
 
 #if defined(HYPRE_USING_GPU)
-      HYPRE_Real size = ((HYPRE_Real) fine_size ) * .75;
-      if (coarsen_type > 0 && coarse_size >= (HYPRE_BigInt) size)
+      if (exec == HYPRE_EXEC_DEVICE)
       {
-         coarsen_type = 0;
+         HYPRE_Real size = ((HYPRE_Real)fine_size) * .75;
+         if (coarsen_type > 0 && coarse_size >= (HYPRE_BigInt)size)
+         {
+            coarsen_type = 0;
+         }
       }
 #endif
 

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -121,7 +121,6 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
    HYPRE_Int       setup_type;
    HYPRE_BigInt    fine_size;
    HYPRE_Int       offset;
-   HYPRE_Real      size;
    HYPRE_Int       not_finished_coarsening = 1;
    HYPRE_Int       coarse_threshold = hypre_ParAMGDataMaxCoarseSize(amg_data);
    HYPRE_Int       min_coarse_size = hypre_ParAMGDataMinCoarseSize(amg_data);
@@ -3127,11 +3126,13 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
          A_array[level] = A_H;
       }
 
-      size = ((HYPRE_Real) fine_size ) * .75;
+#if defined(HYPRE_USING_GPU)
+      HYPRE_Real size = ((HYPRE_Real) fine_size ) * .75;
       if (coarsen_type > 0 && coarse_size >= (HYPRE_BigInt) size)
       {
          coarsen_type = 0;
       }
+#endif
 
       {
          HYPRE_Int max_thresh = hypre_max(coarse_threshold, seq_threshold);

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -3126,7 +3126,8 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
       }
 
 #if defined(HYPRE_USING_GPU)
-      if (exec == HYPRE_EXEC_DEVICE)
+      if (exec == HYPRE_EXEC_HOST)
+#endif
       {
          HYPRE_Real size = ((HYPRE_Real)fine_size) * .75;
          if (coarsen_type > 0 && coarse_size >= (HYPRE_BigInt)size)
@@ -3134,7 +3135,6 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
             coarsen_type = 0;
          }
       }
-#endif
 
       {
          HYPRE_Int max_thresh = hypre_max(coarse_threshold, seq_threshold);

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -89,7 +89,9 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
 
    HYPRE_MemoryLocation memory_location = hypre_ParCSRMatrixMemoryLocation(A);
    hypre_ParAMGDataMemoryLocation(amg_data) = memory_location;
+#if defined(HYPRE_USING_GPU)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1(memory_location);
+#endif
 
    /* Local variables */
    HYPRE_Int           *CF_marker;

--- a/src/test/TEST_ij/solvers.saved.lassen
+++ b/src/test/TEST_ij/solvers.saved.lassen
@@ -251,7 +251,7 @@ Final Relative Residual Norm = 7.317392e-09
 
 # Output file: solvers.out.201
 MGR Iterations = 9
-Final Relative Residual Norm = 1.807958e-09
+Final Relative Residual Norm = 1.802890e-09
 
 # Output file: solvers.out.202
 MGR Iterations = 8
@@ -259,7 +259,7 @@ Final Relative Residual Norm = 7.317392e-09
 
 # Output file: solvers.out.203
 MGR Iterations = 9
-Final Relative Residual Norm = 1.807958e-09
+Final Relative Residual Norm = 1.802890e-09
 
 # Output file: solvers.out.204
 MGR Iterations = 74
@@ -283,7 +283,7 @@ Final Relative Residual Norm = 5.064272e-09
 
 # Output file: solvers.out.209
 MGR Iterations = 15
-Final Relative Residual Norm = 4.616163e-09
+Final Relative Residual Norm = 7.693914e-09
 
 # Output file: solvers.out.210
 MGR Iterations = 23
@@ -291,7 +291,7 @@ Final Relative Residual Norm = 4.625304e-09
 
 # Output file: solvers.out.211
 MGR Iterations = 29
-Final Relative Residual Norm = 7.457096e-09
+Final Relative Residual Norm = 8.665192e-09
 
 # Output file: solvers.out.212
 Iterations = 11

--- a/src/test/TEST_ij/solvers.saved.sunspot
+++ b/src/test/TEST_ij/solvers.saved.sunspot
@@ -251,7 +251,7 @@ Final Relative Residual Norm = 1.247303e-09
 
 # Output file: solvers.out.201
 MGR Iterations = 9
-Final Relative Residual Norm = 3.697256e-09
+Final Relative Residual Norm = 3.708381e-09
 
 # Output file: solvers.out.202
 MGR Iterations = 9
@@ -259,7 +259,7 @@ Final Relative Residual Norm = 1.247303e-09
 
 # Output file: solvers.out.203
 MGR Iterations = 9
-Final Relative Residual Norm = 3.697256e-09
+Final Relative Residual Norm = 3.708381e-09
 
 # Output file: solvers.out.204
 MGR Iterations = 74


### PR DESCRIPTION
This PR removes a potential `coarsen_type` change in AMG setup on GPUs. The CPU code remains the same.

- [x] tux
- [x] lassen
- [x] sunspot