### PR TITLE
Add missing parcsr F90 sources to CMakelists

### DIFF
--- a/src/parcsr_ls/CMakeLists.txt
+++ b/src/parcsr_ls/CMakeLists.txt
@@ -27,6 +27,8 @@ set(SRCS
   F90_HYPRE_parcsr_pcg.c
   F90_HYPRE_parcsr_pilut.c
   F90_HYPRE_parcsr_schwarz.c
+  F90_HYPRE_parcsr_mgr.c
+  F90_HYPRE_parcsr_ilu.c
   F90_HYPRE_ams.c
   gen_redcs_mat.c
   HYPRE_parcsr_amg.c


### PR DESCRIPTION
This pull request implements the inclusion of ILU and MGR parcsr Fortran interface sources into the CMake build files. Previously, these were exclusively present in the Makefile build setup.