### PR TITLE
Bugs fixed related to transposed operations

### DIFF
--- a/src/parcsr_mv/communicationT.c
+++ b/src/parcsr_mv/communicationT.c
@@ -360,7 +360,7 @@ hypre_MatTCommPkgCreate_core (
                            }
                         }
             */
-            for ( kc = row_starts[my_id]; kc < row_starts[my_id + 1]; kc++ )
+            for ( kc = row_starts[0]; kc < row_starts[1]; kc++ )
             {
                if ( kc == col && i != my_id )
                {

--- a/src/parcsr_mv/par_csr_aat.c
+++ b/src/parcsr_mv/par_csr_aat.c
@@ -389,11 +389,6 @@ hypre_ParCSRAAt(hypre_ParCSRMatrix  *A)
    n_rows_A = hypre_ParCSRMatrixGlobalNumRows(A);
    n_cols_A = hypre_ParCSRMatrixGlobalNumCols(A);
 
-   if (n_cols_A != n_rows_A)
-   {
-      hypre_error_w_msg(HYPRE_ERROR_GENERIC, " Error! Incompatible matrix dimensions!\n");
-      return NULL;
-   }
    /*-----------------------------------------------------------------------
     *  Extract A_ext, i.e. portion of A that is stored on neighbor procs
     *  and needed locally for A^T in the matrix matrix product A*A^T
@@ -405,7 +400,7 @@ hypre_ParCSRAAt(hypre_ParCSRMatrix  *A)
        * If there exists no CommPkg for A, a CommPkg is generated using
        * equally load balanced partitionings
        *--------------------------------------------------------------------*/
-      if (!hypre_ParCSRMatrixCommPkg(A))
+      if (!hypre_ParCSRMatrixCommPkgT(A))
       {
          hypre_MatTCommPkgCreate(A);
       }


### PR DESCRIPTION
I noticed a few minor bugs related to transposed operations (one related to issue #1070 ). 

I have fixed all the ones I knew how to do it, but I believe there is still one more bug that I am no sure how to fix. In /src/parcsr_mv/communicationT.c col_starts is used as if it was an array of length num_procs+1, but this is no longer true. 
https://github.com/hypre-space/hypre/blob/ee74c20e7a84e4e48eec142c6bb6ff2a75db72f1/src/parcsr_mv/communicationT.c#L262

Is a possible fix the communication of column start positions and locally constructing a different col_starts_ array with all the column starts for all process, or is there a better alternative with communication involved?