### PR TITLE
row_indexes for IJMatrixGetValues

### DIFF
--- a/src/IJ_mv/HYPRE_IJMatrix.c
+++ b/src/IJ_mv/HYPRE_IJMatrix.c
@@ -118,6 +118,59 @@ HYPRE_IJMatrixCreate( MPI_Comm        comm,
 }
 
 /*--------------------------------------------------------------------------
+ * HYPRE_IJMatrixPartialClone
+ *
+ * Creates a new IJMatrix with data copied from an existing matrix except
+ * for the members:
+ *    1) hypre_IJMatrixObject
+ *    2) hypre_IJMatrixTranslator
+ *    3) hypre_IJMatrixAssumedPart
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_IJMatrixPartialClone( HYPRE_IJMatrix  matrix_in,
+                            HYPRE_IJMatrix *matrix_out )
+{
+   hypre_IJMatrix *ijmatrix_in = (hypre_IJMatrix *) matrix_in;
+   hypre_IJMatrix *ijmatrix_out;
+   HYPRE_BigInt    ilower;
+   HYPRE_BigInt    iupper;
+   HYPRE_BigInt    jlower;
+   HYPRE_BigInt    jupper;
+
+   if (!ijmatrix_in)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+
+   HYPRE_IJMatrixGetLocalRange(ijmatrix_in, &ilower, &iupper, &jlower, &jupper);
+
+   ijmatrix_out = hypre_CTAlloc(hypre_IJMatrix, 1, HYPRE_MEMORY_HOST);
+
+   hypre_IJMatrixComm(ijmatrix_out)               = hypre_IJMatrixComm(ijmatrix_in);
+   hypre_IJMatrixObject(ijmatrix_out)             = NULL;
+   hypre_IJMatrixTranslator(ijmatrix_out)         = NULL;
+   hypre_IJMatrixAssumedPart(ijmatrix_out)        = NULL;
+   hypre_IJMatrixObjectType(ijmatrix_out)         = hypre_IJMatrixObjectType(ijmatrix_in);
+   hypre_IJMatrixAssembleFlag(ijmatrix_out)       = 0;
+   hypre_IJMatrixPrintLevel(ijmatrix_out)         = hypre_IJMatrixPrintLevel(ijmatrix_in);
+   hypre_IJMatrixOMPFlag(ijmatrix_out)            = hypre_IJMatrixOMPFlag(ijmatrix_in);
+   hypre_IJMatrixGlobalFirstRow(ijmatrix_out)     = hypre_IJMatrixGlobalFirstRow(ijmatrix_in);
+   hypre_IJMatrixGlobalFirstCol(ijmatrix_out)     = hypre_IJMatrixGlobalFirstCol(ijmatrix_in);
+   hypre_IJMatrixGlobalNumRows(ijmatrix_out)      = hypre_IJMatrixGlobalNumRows(ijmatrix_in);
+   hypre_IJMatrixGlobalNumCols(ijmatrix_out)      = hypre_IJMatrixGlobalNumCols(ijmatrix_in);
+   hypre_IJMatrixRowPartitioning(ijmatrix_out)[0] = ilower;
+   hypre_IJMatrixRowPartitioning(ijmatrix_out)[1] = iupper + 1;
+   hypre_IJMatrixColPartitioning(ijmatrix_out)[0] = jlower;
+   hypre_IJMatrixColPartitioning(ijmatrix_out)[1] = jupper + 1;
+
+   *matrix_out = (HYPRE_IJMatrix) ijmatrix_out;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
@@ -814,7 +867,133 @@ HYPRE_IJMatrixGetValues( HYPRE_IJMatrix matrix,
    if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
    {
       hypre_IJMatrixGetValuesParCSR( ijmatrix, nrows, ncols,
-                                     rows, cols, values );
+                                     rows, NULL, cols, values, 0 );
+   }
+   else
+   {
+      hypre_error_in_arg(1);
+   }
+
+   return hypre_error_flag;
+
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_IJMatrixGetValues2( HYPRE_IJMatrix matrix,
+                          HYPRE_Int      nrows,
+                          HYPRE_Int     *ncols,
+                          HYPRE_BigInt  *rows,
+                          HYPRE_Int     *row_indexes,
+                          HYPRE_BigInt  *cols,
+                          HYPRE_Complex *values )
+{
+   hypre_IJMatrix *ijmatrix = (hypre_IJMatrix *) matrix;
+
+   if (nrows == 0)
+   {
+      return hypre_error_flag;
+   }
+
+   if (!ijmatrix)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+
+   if (!ncols)
+   {
+      hypre_error_in_arg(3);
+      return hypre_error_flag;
+   }
+
+   if (!rows)
+   {
+      hypre_error_in_arg(4);
+      return hypre_error_flag;
+   }
+
+   if (!cols)
+   {
+      hypre_error_in_arg(5);
+      return hypre_error_flag;
+   }
+
+   if (!values)
+   {
+      hypre_error_in_arg(6);
+      return hypre_error_flag;
+   }
+
+   if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
+   {
+      hypre_IJMatrixGetValuesParCSR( ijmatrix, nrows, ncols,
+                                     rows, row_indexes, cols, values, 0 );
+   }
+   else
+   {
+      hypre_error_in_arg(1);
+   }
+
+   return hypre_error_flag;
+
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_IJMatrixGetValuesAndZero( HYPRE_IJMatrix matrix,
+                                HYPRE_Int      nrows,
+                                HYPRE_Int     *ncols,
+                                HYPRE_BigInt  *rows,
+                                HYPRE_Int     *row_indexes,
+                                HYPRE_BigInt  *cols,
+                                HYPRE_Complex *values )
+{
+   hypre_IJMatrix *ijmatrix = (hypre_IJMatrix *) matrix;
+
+   if (nrows == 0)
+   {
+      return hypre_error_flag;
+   }
+
+   if (!ijmatrix)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+
+   if (!ncols)
+   {
+      hypre_error_in_arg(3);
+      return hypre_error_flag;
+   }
+
+   if (!rows)
+   {
+      hypre_error_in_arg(4);
+      return hypre_error_flag;
+   }
+
+   if (!cols)
+   {
+      hypre_error_in_arg(5);
+      return hypre_error_flag;
+   }
+
+   if (!values)
+   {
+      hypre_error_in_arg(6);
+      return hypre_error_flag;
+   }
+
+   if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
+   {
+      hypre_IJMatrixGetValuesParCSR( ijmatrix, nrows, ncols,
+                                     rows, row_indexes, cols, values, 1 );
    }
    else
    {

--- a/src/IJ_mv/HYPRE_IJMatrix.c
+++ b/src/IJ_mv/HYPRE_IJMatrix.c
@@ -927,14 +927,25 @@ HYPRE_IJMatrixGetValues2( HYPRE_IJMatrix matrix,
       return hypre_error_flag;
    }
 
-   if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
+#if defined(HYPRE_USING_GPU)
+   HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_IJMatrixMemoryLocation(matrix) );
+
+   if (exec == HYPRE_EXEC_DEVICE)
    {
-      hypre_IJMatrixGetValuesParCSR( ijmatrix, nrows, ncols,
-                                     rows, row_indexes, cols, values, 0 );
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "HYPRE_IJMatrixGetValues not implemented for GPUs!");
    }
    else
+#endif
    {
-      hypre_error_in_arg(1);
+      if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
+      {
+         hypre_IJMatrixGetValuesParCSR( ijmatrix, nrows, ncols,
+                                        rows, row_indexes, cols, values, 0 );
+      }
+      else
+      {
+         hypre_error_in_arg(1);
+      }
    }
 
    return hypre_error_flag;
@@ -945,13 +956,13 @@ HYPRE_IJMatrixGetValues2( HYPRE_IJMatrix matrix,
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
-HYPRE_IJMatrixGetValuesAndZero( HYPRE_IJMatrix matrix,
-                                HYPRE_Int      nrows,
-                                HYPRE_Int     *ncols,
-                                HYPRE_BigInt  *rows,
-                                HYPRE_Int     *row_indexes,
-                                HYPRE_BigInt  *cols,
-                                HYPRE_Complex *values )
+HYPRE_IJMatrixGetValuesAndZeroOut( HYPRE_IJMatrix matrix,
+                                   HYPRE_Int      nrows,
+                                   HYPRE_Int     *ncols,
+                                   HYPRE_BigInt  *rows,
+                                   HYPRE_Int     *row_indexes,
+                                   HYPRE_BigInt  *cols,
+                                   HYPRE_Complex *values )
 {
    hypre_IJMatrix *ijmatrix = (hypre_IJMatrix *) matrix;
 
@@ -990,14 +1001,25 @@ HYPRE_IJMatrixGetValuesAndZero( HYPRE_IJMatrix matrix,
       return hypre_error_flag;
    }
 
-   if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
+#if defined(HYPRE_USING_GPU)
+   HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_IJMatrixMemoryLocation(matrix) );
+
+   if (exec == HYPRE_EXEC_DEVICE)
    {
-      hypre_IJMatrixGetValuesParCSR( ijmatrix, nrows, ncols,
-                                     rows, row_indexes, cols, values, 1 );
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "HYPRE_IJMatrixGetValues not implemented for GPUs!");
    }
    else
+#endif
    {
-      hypre_error_in_arg(1);
+      if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
+      {
+         hypre_IJMatrixGetValuesParCSR( ijmatrix, nrows, ncols,
+                                        rows, row_indexes, cols, values, 1 );
+      }
+      else
+      {
+         hypre_error_in_arg(1);
+      }
    }
 
    return hypre_error_flag;

--- a/src/IJ_mv/HYPRE_IJ_mv.h
+++ b/src/IJ_mv/HYPRE_IJ_mv.h
@@ -245,13 +245,13 @@ HYPRE_Int HYPRE_IJMatrixGetValues2(HYPRE_IJMatrix  matrix,
  * Same as IJMatrixGetValues2, but zeros out the entries after getting them.
  *
  **/
-HYPRE_Int HYPRE_IJMatrixGetValuesAndZero(HYPRE_IJMatrix  matrix,
-                                         HYPRE_Int       nrows,
-                                         HYPRE_Int      *ncols,
-                                         HYPRE_BigInt   *rows,
-                                         HYPRE_Int      *row_indexes,
-                                         HYPRE_BigInt   *cols,
-                                         HYPRE_Complex  *values);
+HYPRE_Int HYPRE_IJMatrixGetValuesAndZeroOut(HYPRE_IJMatrix  matrix,
+                                            HYPRE_Int       nrows,
+                                            HYPRE_Int      *ncols,
+                                            HYPRE_BigInt   *rows,
+                                            HYPRE_Int      *row_indexes,
+                                            HYPRE_BigInt   *cols,
+                                            HYPRE_Complex  *values);
 
 /**
  * Set the storage type of the matrix object to be constructed.

--- a/src/IJ_mv/HYPRE_IJ_mv.h
+++ b/src/IJ_mv/HYPRE_IJ_mv.h
@@ -223,6 +223,37 @@ HYPRE_Int HYPRE_IJMatrixGetValues(HYPRE_IJMatrix  matrix,
                                   HYPRE_Complex  *values);
 
 /**
+ * Gets values for \e nrows rows or partial rows of the matrix.
+ *
+ * Same as IJMatrixGetValues, but with an additional \e row_indexes array
+ * that provides indexes into the \e cols and \e values arrays.  Because
+ * of this, there can be gaps between the row data in these latter two arrays.
+ *
+ **/
+HYPRE_Int HYPRE_IJMatrixGetValues2(HYPRE_IJMatrix  matrix,
+                                   HYPRE_Int       nrows,
+                                   HYPRE_Int      *ncols,
+                                   HYPRE_BigInt   *rows,
+                                   HYPRE_Int      *row_indexes,
+                                   HYPRE_BigInt   *cols,
+                                   HYPRE_Complex  *values);
+
+/**
+ * Gets values for \e nrows rows or partial rows of the matrix
+ * and zeros out those entries in the matrix.
+ *
+ * Same as IJMatrixGetValues2, but zeros out the entries after getting them.
+ *
+ **/
+HYPRE_Int HYPRE_IJMatrixGetValuesAndZero(HYPRE_IJMatrix  matrix,
+                                         HYPRE_Int       nrows,
+                                         HYPRE_Int      *ncols,
+                                         HYPRE_BigInt   *rows,
+                                         HYPRE_Int      *row_indexes,
+                                         HYPRE_BigInt   *cols,
+                                         HYPRE_Complex  *values);
+
+/**
  * Set the storage type of the matrix object to be constructed.
  * Currently, \e type can only be \c HYPRE_PARCSR.
  *
@@ -344,6 +375,30 @@ HYPRE_Int HYPRE_IJMatrixPrint(HYPRE_IJMatrix  matrix,
                               const char     *filename);
 
 /**
+ * Transpose an IJMatrix.
+ **/
+HYPRE_Int
+HYPRE_IJMatrixTranspose( HYPRE_IJMatrix  matrix_A,
+                         HYPRE_IJMatrix *matrix_AT );
+
+/**
+ * Computes the infinity norm of an IJMatrix
+ **/
+HYPRE_Int
+HYPRE_IJMatrixNorm( HYPRE_IJMatrix  matrix,
+                    HYPRE_Real     *norm );
+
+/**
+ * Performs C = alpha*A + beta*B
+ **/
+HYPRE_Int
+HYPRE_IJMatrixAdd( HYPRE_Complex    alpha,
+                   HYPRE_IJMatrix   matrix_A,
+                   HYPRE_Complex    beta,
+                   HYPRE_IJMatrix   matrix_B,
+                   HYPRE_IJMatrix  *matrix_C );
+
+/**
  * Print the matrix to file in binary format. This is mainly for debugging purposes.
  **/
 HYPRE_Int HYPRE_IJMatrixPrintBinary(HYPRE_IJMatrix  matrix,
@@ -356,7 +411,6 @@ HYPRE_Int HYPRE_IJMatrixReadBinary(const char     *filename,
                                    MPI_Comm        comm,
                                    HYPRE_Int       type,
                                    HYPRE_IJMatrix *matrix_ptr);
-
 
 /**@}*/
 

--- a/src/IJ_mv/IJMatrix_parcsr.c
+++ b/src/IJ_mv/IJMatrix_parcsr.c
@@ -414,8 +414,10 @@ hypre_IJMatrixGetValuesParCSR( hypre_IJMatrix *matrix,
                                HYPRE_Int       nrows,
                                HYPRE_Int      *ncols,
                                HYPRE_BigInt   *rows,
+                               HYPRE_Int      *row_indexes,
                                HYPRE_BigInt   *cols,
-                               HYPRE_Complex  *values)
+                               HYPRE_Complex  *values,
+                               HYPRE_Int       zero_out)
 {
    MPI_Comm             comm = hypre_IJMatrixComm(matrix);
    hypre_ParCSRMatrix  *par_matrix = (hypre_ParCSRMatrix *) hypre_IJMatrixObject(matrix);
@@ -473,6 +475,7 @@ hypre_IJMatrixGetValuesParCSR( hypre_IJMatrix *matrix,
       col_map_offd = hypre_ParCSRMatrixColMapOffd(par_matrix);
    }
 
+   /* WM: question - what does rows < 0 signify? Do I need to add row_indexes here? */
    if (nrows < 0)
    {
       nrows = -nrows;
@@ -509,11 +512,19 @@ hypre_IJMatrixGetValuesParCSR( hypre_IJMatrix *matrix,
             {
                cols[indx] = (HYPRE_BigInt)diag_j[j] + col_0;
                values[indx++] = diag_data[j];
+               if (zero_out)
+               {
+                  diag_data[j] = 0.0;
+               }
             }
             for (j = offd_i[row_local]; j < offd_i[row_local + 1]; j++)
             {
                cols[indx] = col_map_offd[offd_j[j]];
                values[indx++] = offd_data[j];
+               if (zero_out)
+               {
+                  offd_data[j] = 0.0;
+               }
             }
             counter[i + 1] = indx;
          }
@@ -540,7 +551,6 @@ hypre_IJMatrixGetValuesParCSR( hypre_IJMatrix *matrix,
    }
    else
    {
-      indx = 0;
       for (ii = 0; ii < nrows; ii++)
       {
          row = rows[ii];
@@ -549,6 +559,7 @@ hypre_IJMatrixGetValuesParCSR( hypre_IJMatrix *matrix,
          {
             continue;
          }
+         indx = row_indexes[ii];
          if (row >= row_partitioning[0] && row < row_partitioning[1])
          {
             row_local = (HYPRE_Int)(row - row_partitioning[0]);
@@ -565,6 +576,10 @@ hypre_IJMatrixGetValuesParCSR( hypre_IJMatrix *matrix,
                      if (col_map_offd[offd_j[j]] == col_indx)
                      {
                         values[indx] = offd_data[j];
+                        if (zero_out)
+                        {
+                           offd_data[j] = 0.0;
+                        }
                         break;
                      }
                   }
@@ -577,6 +592,10 @@ hypre_IJMatrixGetValuesParCSR( hypre_IJMatrix *matrix,
                      if (diag_j[j] == (HYPRE_Int)col_indx)
                      {
                         values[indx] = diag_data[j];
+                        if (zero_out)
+                        {
+                           diag_data[j] = 0.0;
+                        }
                         break;
                      }
                   }

--- a/src/IJ_mv/IJMatrix_parcsr.c
+++ b/src/IJ_mv/IJMatrix_parcsr.c
@@ -475,7 +475,6 @@ hypre_IJMatrixGetValuesParCSR( hypre_IJMatrix *matrix,
       col_map_offd = hypre_ParCSRMatrixColMapOffd(par_matrix);
    }
 
-   /* WM: question - what does rows < 0 signify? Do I need to add row_indexes here? */
    if (nrows < 0)
    {
       nrows = -nrows;

--- a/src/IJ_mv/_hypre_IJ_mv.h
+++ b/src/IJ_mv/_hypre_IJ_mv.h
@@ -440,8 +440,8 @@ HYPRE_Int hypre_IJMatrixSetMaxOffProcElmtsParCSR ( hypre_IJMatrix *matrix,
 HYPRE_Int hypre_IJMatrixInitializeParCSR ( hypre_IJMatrix *matrix );
 HYPRE_Int hypre_IJMatrixGetRowCountsParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
                                              HYPRE_BigInt *rows, HYPRE_Int *ncols );
-HYPRE_Int hypre_IJMatrixGetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols,
-                                          HYPRE_BigInt *rows, HYPRE_BigInt *cols, HYPRE_Complex *values );
+HYPRE_Int hypre_IJMatrixGetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols, HYPRE_BigInt *rows,
+                                          HYPRE_Int *row_indexes, HYPRE_BigInt *cols, HYPRE_Complex *values, HYPRE_Int zero_out );
 HYPRE_Int hypre_IJMatrixSetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols,
                                           const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
                                           const HYPRE_Complex *values );
@@ -539,6 +539,7 @@ HYPRE_Int hypre_IJVectorUpdateValuesDevice( hypre_IJVector *vector, HYPRE_Int nu
 /* HYPRE_IJMatrix.c */
 HYPRE_Int HYPRE_IJMatrixCreate ( MPI_Comm comm, HYPRE_BigInt ilower, HYPRE_BigInt iupper,
                                  HYPRE_BigInt jlower, HYPRE_BigInt jupper, HYPRE_IJMatrix *matrix );
+HYPRE_Int HYPRE_IJMatrixPartialClone ( HYPRE_IJMatrix matrix_in, HYPRE_IJMatrix *matrix_out );
 HYPRE_Int HYPRE_IJMatrixDestroy ( HYPRE_IJMatrix matrix );
 HYPRE_Int HYPRE_IJMatrixInitialize ( HYPRE_IJMatrix matrix );
 HYPRE_Int HYPRE_IJMatrixSetPrintLevel ( HYPRE_IJMatrix matrix, HYPRE_Int print_level );

--- a/src/IJ_mv/protos.h
+++ b/src/IJ_mv/protos.h
@@ -70,8 +70,8 @@ HYPRE_Int hypre_IJMatrixSetMaxOffProcElmtsParCSR ( hypre_IJMatrix *matrix,
 HYPRE_Int hypre_IJMatrixInitializeParCSR ( hypre_IJMatrix *matrix );
 HYPRE_Int hypre_IJMatrixGetRowCountsParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
                                              HYPRE_BigInt *rows, HYPRE_Int *ncols );
-HYPRE_Int hypre_IJMatrixGetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols,
-                                          HYPRE_BigInt *rows, HYPRE_BigInt *cols, HYPRE_Complex *values );
+HYPRE_Int hypre_IJMatrixGetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols, HYPRE_BigInt *rows,
+                                          HYPRE_Int *row_indexes, HYPRE_BigInt *cols, HYPRE_Complex *values, HYPRE_Int zero_out );
 HYPRE_Int hypre_IJMatrixSetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols,
                                           const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
                                           const HYPRE_Complex *values );
@@ -169,6 +169,7 @@ HYPRE_Int hypre_IJVectorUpdateValuesDevice( hypre_IJVector *vector, HYPRE_Int nu
 /* HYPRE_IJMatrix.c */
 HYPRE_Int HYPRE_IJMatrixCreate ( MPI_Comm comm, HYPRE_BigInt ilower, HYPRE_BigInt iupper,
                                  HYPRE_BigInt jlower, HYPRE_BigInt jupper, HYPRE_IJMatrix *matrix );
+HYPRE_Int HYPRE_IJMatrixPartialClone ( HYPRE_IJMatrix matrix_in, HYPRE_IJMatrix *matrix_out );
 HYPRE_Int HYPRE_IJMatrixDestroy ( HYPRE_IJMatrix matrix );
 HYPRE_Int HYPRE_IJMatrixInitialize ( HYPRE_IJMatrix matrix );
 HYPRE_Int HYPRE_IJMatrixSetPrintLevel ( HYPRE_IJMatrix matrix, HYPRE_Int print_level );


### PR DESCRIPTION
Add option to pass row_indexes to the IJMatrixGetValues routines. This aligns with existing implementation for the SetValues routines and is necessary for upcoming functionality in the recmat branch.