### PR TITLE
Add memory usage monitoring functions

### DIFF
--- a/src/IJ_mv/IJMatrix_parcsr.c
+++ b/src/IJ_mv/IJMatrix_parcsr.c
@@ -299,6 +299,7 @@ hypre_IJMatrixInitializeParCSR_v2(hypre_IJMatrix *matrix, HYPRE_MemoryLocation m
                                                hypre_AuxParCSRMatrixDiagSizes(aux_matrix)[i];
             }
             hypre_CSRMatrixNumNonzeros(diag) = hypre_CSRMatrixI(diag)[local_num_rows];
+            hypre_CSRMatrixInitialize(diag);
          }
 
          if (hypre_AuxParCSRMatrixOffdSizes(aux_matrix))
@@ -309,6 +310,7 @@ hypre_IJMatrixInitializeParCSR_v2(hypre_IJMatrix *matrix, HYPRE_MemoryLocation m
                                                hypre_AuxParCSRMatrixOffdSizes(aux_matrix)[i];
             }
             hypre_CSRMatrixNumNonzeros(offd) = hypre_CSRMatrixI(offd)[local_num_rows];
+            hypre_CSRMatrixInitialize(offd);
          }
       }
 

--- a/src/IJ_mv/IJMatrix_parcsr.c
+++ b/src/IJ_mv/IJMatrix_parcsr.c
@@ -1033,7 +1033,7 @@ hypre_IJMatrixSetValuesParCSR( hypre_IJMatrix       *matrix,
       }
    }
 
-   HYPRE_PRINT_MEMORY_USAGE;
+   HYPRE_PRINT_MEMORY_USAGE(comm);
 
    return hypre_error_flag;
 }
@@ -1624,7 +1624,7 @@ hypre_IJMatrixAddToValuesParCSR( hypre_IJMatrix       *matrix,
       }
    }
 
-   HYPRE_PRINT_MEMORY_USAGE;
+   HYPRE_PRINT_MEMORY_USAGE(comm);
 
    return hypre_error_flag;
 }
@@ -2954,7 +2954,7 @@ hypre_IJMatrixAssembleParCSR(hypre_IJMatrix *matrix)
    hypre_AuxParCSRMatrixDestroy(aux_matrix);
    hypre_IJMatrixTranslator(matrix) = NULL;
 
-   HYPRE_PRINT_MEMORY_USAGE;
+   HYPRE_PRINT_MEMORY_USAGE(comm);
    HYPRE_ANNOTATE_FUNC_END;
 
    return hypre_error_flag;

--- a/src/IJ_mv/IJMatrix_parcsr.c
+++ b/src/IJ_mv/IJMatrix_parcsr.c
@@ -295,22 +295,20 @@ hypre_IJMatrixInitializeParCSR_v2(hypre_IJMatrix *matrix, HYPRE_MemoryLocation m
          {
             for (i = 0; i < local_num_rows; i++)
             {
-               hypre_CSRMatrixI(diag)[i + 1] = hypre_CSRMatrixI(diag)[i] + hypre_AuxParCSRMatrixDiagSizes(
-                                                  aux_matrix)[i];
+               hypre_CSRMatrixI(diag)[i + 1] = hypre_CSRMatrixI(diag)[i] +
+                                               hypre_AuxParCSRMatrixDiagSizes(aux_matrix)[i];
             }
             hypre_CSRMatrixNumNonzeros(diag) = hypre_CSRMatrixI(diag)[local_num_rows];
-            hypre_CSRMatrixInitialize(diag);
          }
 
          if (hypre_AuxParCSRMatrixOffdSizes(aux_matrix))
          {
             for (i = 0; i < local_num_rows; i++)
             {
-               hypre_CSRMatrixI(offd)[i + 1] = hypre_CSRMatrixI(offd)[i] + hypre_AuxParCSRMatrixOffdSizes(
-                                                  aux_matrix)[i];
+               hypre_CSRMatrixI(offd)[i + 1] = hypre_CSRMatrixI(offd)[i] +
+                                               hypre_AuxParCSRMatrixOffdSizes(aux_matrix)[i];
             }
             hypre_CSRMatrixNumNonzeros(offd) = hypre_CSRMatrixI(offd)[local_num_rows];
-            hypre_CSRMatrixInitialize(offd);
          }
       }
 
@@ -847,6 +845,7 @@ hypre_IJMatrixSetValuesParCSR( hypre_IJMatrix       *matrix,
          if (row >= row_partitioning[0] && row < row_partitioning[1])
          {
             row_local = (HYPRE_Int)(row - row_partitioning[0]);
+
             /* compute local row number */
             if (need_aux)
             {
@@ -1033,6 +1032,8 @@ hypre_IJMatrixSetValuesParCSR( hypre_IJMatrix       *matrix,
          }
       }
    }
+
+   hypre_MemoryPrintUsage(comm, __FUNCTION__, __LINE__);
 
    return hypre_error_flag;
 }
@@ -1622,6 +1623,8 @@ hypre_IJMatrixAddToValuesParCSR( hypre_IJMatrix       *matrix,
          }
       }
    }
+
+   hypre_MemoryPrintUsage(comm, __FUNCTION__, __LINE__);
 
    return hypre_error_flag;
 }
@@ -2951,6 +2954,7 @@ hypre_IJMatrixAssembleParCSR(hypre_IJMatrix *matrix)
    hypre_AuxParCSRMatrixDestroy(aux_matrix);
    hypre_IJMatrixTranslator(matrix) = NULL;
 
+   hypre_MemoryPrintUsage(comm, __FUNCTION__, __LINE__);
    HYPRE_ANNOTATE_FUNC_END;
 
    return hypre_error_flag;

--- a/src/IJ_mv/IJMatrix_parcsr.c
+++ b/src/IJ_mv/IJMatrix_parcsr.c
@@ -1033,7 +1033,7 @@ hypre_IJMatrixSetValuesParCSR( hypre_IJMatrix       *matrix,
       }
    }
 
-   hypre_MemoryPrintUsage(comm, __FUNCTION__, __LINE__);
+   HYPRE_PRINT_MEMORY_USAGE;
 
    return hypre_error_flag;
 }
@@ -1624,7 +1624,7 @@ hypre_IJMatrixAddToValuesParCSR( hypre_IJMatrix       *matrix,
       }
    }
 
-   hypre_MemoryPrintUsage(comm, __FUNCTION__, __LINE__);
+   HYPRE_PRINT_MEMORY_USAGE;
 
    return hypre_error_flag;
 }
@@ -2954,7 +2954,7 @@ hypre_IJMatrixAssembleParCSR(hypre_IJMatrix *matrix)
    hypre_AuxParCSRMatrixDestroy(aux_matrix);
    hypre_IJMatrixTranslator(matrix) = NULL;
 
-   hypre_MemoryPrintUsage(comm, __FUNCTION__, __LINE__);
+   HYPRE_PRINT_MEMORY_USAGE;
    HYPRE_ANNOTATE_FUNC_END;
 
    return hypre_error_flag;

--- a/src/IJ_mv/_hypre_IJ_mv.h
+++ b/src/IJ_mv/_hypre_IJ_mv.h
@@ -440,7 +440,8 @@ HYPRE_Int hypre_IJMatrixSetMaxOffProcElmtsParCSR ( hypre_IJMatrix *matrix,
 HYPRE_Int hypre_IJMatrixInitializeParCSR ( hypre_IJMatrix *matrix );
 HYPRE_Int hypre_IJMatrixGetRowCountsParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
                                              HYPRE_BigInt *rows, HYPRE_Int *ncols );
-HYPRE_Int hypre_IJMatrixGetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols, HYPRE_BigInt *rows,
+HYPRE_Int hypre_IJMatrixGetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols,
+                                          HYPRE_BigInt *rows,
                                           HYPRE_Int *row_indexes, HYPRE_BigInt *cols, HYPRE_Complex *values, HYPRE_Int zero_out );
 HYPRE_Int hypre_IJMatrixSetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols,
                                           const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,

--- a/src/IJ_mv/aux_parcsr_matrix.c
+++ b/src/IJ_mv/aux_parcsr_matrix.c
@@ -358,8 +358,8 @@ hypre_AuxParCSRMatrixInitialize_v2( hypre_AuxParCSRMatrix *matrix,
             for (i = 0; i < local_num_rows; i++)
             {
                row_space[i] = 30;
-               aux_j[i] = hypre_CTAlloc(HYPRE_BigInt, 30, HYPRE_MEMORY_HOST);
-               aux_data[i] = hypre_CTAlloc(HYPRE_Complex, 30, HYPRE_MEMORY_HOST);
+               aux_j[i] = hypre_CTAlloc(HYPRE_BigInt, row_space[i], HYPRE_MEMORY_HOST);
+               aux_data[i] = hypre_CTAlloc(HYPRE_Complex, row_space[i], HYPRE_MEMORY_HOST);
             }
             hypre_AuxParCSRMatrixRowSpace(matrix) = row_space;
          }

--- a/src/IJ_mv/protos.h
+++ b/src/IJ_mv/protos.h
@@ -70,7 +70,8 @@ HYPRE_Int hypre_IJMatrixSetMaxOffProcElmtsParCSR ( hypre_IJMatrix *matrix,
 HYPRE_Int hypre_IJMatrixInitializeParCSR ( hypre_IJMatrix *matrix );
 HYPRE_Int hypre_IJMatrixGetRowCountsParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
                                              HYPRE_BigInt *rows, HYPRE_Int *ncols );
-HYPRE_Int hypre_IJMatrixGetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols, HYPRE_BigInt *rows,
+HYPRE_Int hypre_IJMatrixGetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols,
+                                          HYPRE_BigInt *rows,
                                           HYPRE_Int *row_indexes, HYPRE_BigInt *cols, HYPRE_Complex *values, HYPRE_Int zero_out );
 HYPRE_Int hypre_IJMatrixSetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols,
                                           const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -341,6 +341,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
    }
 
    HYPRE_ANNOTATE_FUNC_BEGIN;
+   hypre_MemoryPrintUsage(comm, "BoomerAMG setup begin", 0);
 
    /* change in definition of standard and multipass interpolation, by
       eliminating interp_type 9 and 5 and setting sep_weight instead
@@ -4023,6 +4024,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
    }
 #endif
 
+   hypre_MemoryPrintUsage(comm, "BoomerAMG setup end", 0);
    HYPRE_ANNOTATE_FUNC_END;
 
    return (hypre_error_flag);

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -341,7 +341,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
    }
 
    HYPRE_ANNOTATE_FUNC_BEGIN;
-   hypre_MemoryPrintUsage(comm, "BoomerAMG setup begin", 0);
+   hypre_MemoryPrintUsage(comm, hypre_HandleLogLevel(hypre_handle()), "BoomerAMG setup begin", 0);
 
    /* change in definition of standard and multipass interpolation, by
       eliminating interp_type 9 and 5 and setting sep_weight instead
@@ -4024,7 +4024,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
    }
 #endif
 
-   hypre_MemoryPrintUsage(comm, "BoomerAMG setup end", 0);
+   hypre_MemoryPrintUsage(comm, hypre_HandleLogLevel(hypre_handle()), "BoomerAMG setup end", 0);
    HYPRE_ANNOTATE_FUNC_END;
 
    return (hypre_error_flag);

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -142,7 +142,7 @@ hypre_MGRSetup( void               *mgr_vdata,
    HYPRE_ANNOTATE_FUNC_BEGIN;
    hypre_GpuProfilingPushRange("MGRSetup");
    hypre_GpuProfilingPushRange("MGRSetup-Init");
-   hypre_MemoryPrintUsage(comm, "MGR setup begin", 0);
+   hypre_MemoryPrintUsage(comm, hypre_HandleLogLevel(hypre_handle()), "MGR setup begin", 0);
 
    block_size = (mgr_data -> block_size);
    block_jacobi_bsize = (mgr_data -> block_jacobi_bsize);
@@ -1706,7 +1706,7 @@ hypre_MGRSetup( void               *mgr_vdata,
    /* Print MGR and linear system info according to print level */
    hypre_MGRDataPrint(mgr_vdata);
 
-   hypre_MemoryPrintUsage(comm, "MGR setup end", 0);
+   hypre_MemoryPrintUsage(comm, hypre_HandleLogLevel(hypre_handle()), "MGR setup end", 0);
    HYPRE_ANNOTATE_FUNC_END;
    hypre_GpuProfilingPopRange();
 

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -142,6 +142,7 @@ hypre_MGRSetup( void               *mgr_vdata,
    HYPRE_ANNOTATE_FUNC_BEGIN;
    hypre_GpuProfilingPushRange("MGRSetup");
    hypre_GpuProfilingPushRange("MGRSetup-Init");
+   hypre_MemoryPrintUsage(comm, "MGR setup begin", 0);
 
    block_size = (mgr_data -> block_size);
    block_jacobi_bsize = (mgr_data -> block_jacobi_bsize);
@@ -1705,6 +1706,7 @@ hypre_MGRSetup( void               *mgr_vdata,
    /* Print MGR and linear system info according to print level */
    hypre_MGRDataPrint(mgr_vdata);
 
+   hypre_MemoryPrintUsage(comm, "MGR setup end", 0);
    HYPRE_ANNOTATE_FUNC_END;
    hypre_GpuProfilingPopRange();
 

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -112,6 +112,7 @@ main( hypre_int argc,
 {
    HYPRE_Int           arg_index;
    HYPRE_Int           print_usage;
+   HYPRE_Int           log_level = 0;
    HYPRE_Int           sparsity_known = 0;
    HYPRE_Int           add = 0;
    HYPRE_Int           check_constant = 0;
@@ -694,7 +695,12 @@ main( hypre_int argc,
 
    while ( (arg_index < argc) && (!print_usage) )
    {
-      if ( strcmp(argv[arg_index], "-frombinfile") == 0 )
+      if ( strcmp(argv[arg_index], "-ll") == 0 )
+      {
+         arg_index++;
+         log_level = atoi(argv[arg_index++]);
+      }
+      else if ( strcmp(argv[arg_index], "-frombinfile") == 0 )
       {
          arg_index++;
          build_matrix_type      = -2;
@@ -2302,6 +2308,10 @@ main( hypre_int argc,
          hypre_printf("\n");
          hypre_printf("Usage: %s [<options>]\n", argv[0]);
          hypre_printf("\n");
+         hypre_printf("  -ll                        : hypre's log level. \n");
+         hypre_printf("      0 = (default) No messaging.\n");
+         hypre_printf("      1 = Display memory usage statistics for each MPI rank.\n");
+         hypre_printf("      2 = Display aggregate memory usage statistics over MPI ranks.\n");
          hypre_printf("  -fromfile <filename>       : ");
          hypre_printf("matrix read from multiple files (IJ format)\n");
          hypre_printf("  -frombinfile <filename>    : ");
@@ -2745,6 +2755,9 @@ main( hypre_int argc,
       hypre_MemoryTrackerSetFileName(mem_tracker_name);
    }
 #endif
+
+   /* Set log level */
+   HYPRE_SetLogLevel(log_level);
 
    /* default memory location */
    HYPRE_SetMemoryLocation(memory_location);

--- a/src/utilities/HYPRE_handle.c
+++ b/src/utilities/HYPRE_handle.c
@@ -14,8 +14,19 @@
 #include "_hypre_utilities.h"
 
 /*--------------------------------------------------------------------------
+ * HYPRE_SetLogLevel
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_SetLogLevel( HYPRE_Int log_level )
+{
+   return hypre_SetLogLevel(log_level);
+}
+
+/*--------------------------------------------------------------------------
  * HYPRE_SetSpTransUseVendor
  *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 HYPRE_SetSpTransUseVendor( HYPRE_Int use_vendor )
 {
@@ -25,6 +36,7 @@ HYPRE_SetSpTransUseVendor( HYPRE_Int use_vendor )
 /*--------------------------------------------------------------------------
  * HYPRE_SetSpMVUseVendor
  *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 HYPRE_SetSpMVUseVendor( HYPRE_Int use_vendor )
 {
@@ -34,6 +46,7 @@ HYPRE_SetSpMVUseVendor( HYPRE_Int use_vendor )
 /*--------------------------------------------------------------------------
  * HYPRE_SetSpGemmUseVendor
  *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 HYPRE_SetSpGemmUseVendor( HYPRE_Int use_vendor )
 {
@@ -43,6 +56,7 @@ HYPRE_SetSpGemmUseVendor( HYPRE_Int use_vendor )
 /*--------------------------------------------------------------------------
  * HYPRE_SetUseGpuRand
  *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 HYPRE_SetUseGpuRand( HYPRE_Int use_gpu_rand )
 {
@@ -52,6 +66,7 @@ HYPRE_SetUseGpuRand( HYPRE_Int use_gpu_rand )
 /*--------------------------------------------------------------------------
  * HYPRE_SetGPUAwareMPI
  *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 HYPRE_SetGpuAwareMPI( HYPRE_Int use_gpu_aware_mpi )
 {

--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -232,6 +232,9 @@ HYPRE_Int HYPRE_PrintErrorMessages(MPI_Comm comm);
 /* Print GPU information */
 HYPRE_Int HYPRE_PrintDeviceInfo(void);
 
+/* Print memory usage */
+HYPRE_Int HYPRE_MemoryPrintUsage(MPI_Comm comm, const char *function, HYPRE_Int line);
+
 /*--------------------------------------------------------------------------
  * HYPRE Version routines
  *--------------------------------------------------------------------------*/

--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -232,8 +232,42 @@ HYPRE_Int HYPRE_PrintErrorMessages(MPI_Comm comm);
 /* Print GPU information */
 HYPRE_Int HYPRE_PrintDeviceInfo(void);
 
-/* Print memory usage */
-HYPRE_Int HYPRE_MemoryPrintUsage(MPI_Comm comm, const char *function, HYPRE_Int line);
+/**
+ * @brief Prints the memory usage of the current process.
+ *
+ * This function prints the memory usage details of the process to standard output.
+ * It provides information such as the virtual memory size, resident set size,
+ * and other related statistics including GPU memory usage for device builds.
+ *
+ * @param[in] comm      The MPI communicator. This parameter allows the function
+ *                      to print memory usage information for the process within
+ *                      the context of an MPI program.
+ *
+ * @param[in] level     The level of detail in the memory statistics output.
+ *                        - 1 : Display memory usage statistics for each MPI rank.
+ *                        - 2 : Display aggregate memory usage statistics over MPI ranks.
+ *
+ * @param[in] function  The name of the function from which `HYPRE_MemoryPrintUsage`
+ *                      is called. This is typically set to `__func__`, which
+ *                      automatically captures the name of the calling function.
+ *                      This variable can also be used to denote a region name.
+ *
+ * @param[in] line      The line number in the source file where `HYPRE_MemoryPrintUsage`
+ *                      is called. This is typically set to `__LINE__`, which
+ *                      automatically captures the line number. The line number can be
+ *                      omitted by passing a negative value to this variable.
+ *
+ * @return              Returns an integer status code. `0` indicates success, while
+ *                      a non-zero value indicates an error occurred.
+ *
+ * @note                The function is designed to be platform-independent but
+ *                      may provide different levels of detail depending on the
+ *                      underlying operating system (e.g., Linux, macOS). However,
+ *                      this function does not lead to correct memory usage statistics
+ *                      on Windows platforms.
+ */
+
+HYPRE_Int HYPRE_MemoryPrintUsage(MPI_Comm comm, HYPRE_Int level, const char *function, HYPRE_Int line);
 
 /*--------------------------------------------------------------------------
  * HYPRE Version routines

--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -267,7 +267,8 @@ HYPRE_Int HYPRE_PrintDeviceInfo(void);
  *                      on Windows platforms.
  */
 
-HYPRE_Int HYPRE_MemoryPrintUsage(MPI_Comm comm, HYPRE_Int level, const char *function, HYPRE_Int line);
+HYPRE_Int HYPRE_MemoryPrintUsage(MPI_Comm comm, HYPRE_Int level, const char *function,
+                                 HYPRE_Int line);
 
 /*--------------------------------------------------------------------------
  * HYPRE Version routines

--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -344,12 +344,111 @@ HYPRE_Int HYPRE_SetGPUMemoryPoolSize(HYPRE_Int bin_growth, HYPRE_Int min_bin, HY
  * HYPRE handle
  *--------------------------------------------------------------------------*/
 
-HYPRE_Int HYPRE_SetSpTransUseVendor( HYPRE_Int use_vendor );
-HYPRE_Int HYPRE_SetSpMVUseVendor( HYPRE_Int use_vendor );
+/**
+ * Sets the logging level for the HYPRE library.
+ *
+ * The following options are available for \e log_level:
+ *
+ *    - 0 : (default) No messaging.
+ *    - 1 : Display memory usage statistics for each MPI rank.
+ *    - 2 : Display aggregate memory usage statistics over MPI ranks.
+ *
+ * @note Log level codes can be combined using bitwise OR to enable multiple
+ *       logging behaviors simultaneously.
+ *
+ * @param log_level The logging level to set.
+ *
+ * @return Returns hypre's global error code, where 0 indicates success.
+ **/
+HYPRE_Int HYPRE_SetLogLevel(HYPRE_Int log_level);
+
+/**
+ * Specifies the algorithm used for sparse matrix transposition in device builds.
+ *
+ * The following options are available for \e use_vendor:
+ *
+ *    - 0 : Use hypre's internal implementation.
+ *    - 1 : (default) Use the vendor library's implementation. This includes:
+ *          - cuSPARSE for CUDA (HYPRE_USING_CUSPARSE)
+ *          - rocSPARSE for HIP (HYPRE_USING_ROCSPARSE)
+ *          - oneMKL for SYCL   (HYPRE_USING_ONEMKLSPARSE)
+ *
+ * @param use_vendor Indicates whether to use the internal or vendor-provided implementation.
+ *
+ * @return Returns hypre's global error code, where 0 indicates success.
+ **/
+HYPRE_Int HYPRE_SetSpTransUseVendor(HYPRE_Int use_vendor);
+
+/**
+ * Specifies the algorithm used for sparse matrix/vector multiplication in device builds.
+ *
+ * The following options are available for \e use_vendor:
+ *
+ *    - 0 : Use hypre's internal implementation.
+ *    - 1 : (default) Use the vendor library's implementation. This includes:
+ *          - cuSPARSE for CUDA (HYPRE_USING_CUSPARSE)
+ *          - rocSPARSE for HIP (HYPRE_USING_ROCSPARSE)
+ *          - oneMKL for SYCL   (HYPRE_USING_ONEMKLSPARSE)
+ *
+ * @param use_vendor Indicates whether to use the internal or vendor-provided implementation.
+ *
+ * @return Returns hypre's global error code, where 0 indicates success.
+ **/
+HYPRE_Int HYPRE_SetSpMVUseVendor(HYPRE_Int use_vendor);
+
+/**
+ * Specifies the algorithm used for sparse matrix/matrix multiplication in device builds.
+ *
+ * The following options are available for \e use_vendor:
+ *
+ *    - 0 : Use hypre's internal implementation.
+ *    - 1 : Use the vendor library's implementation. This includes:
+ *          - cuSPARSE for CUDA (HYPRE_USING_CUSPARSE)
+ *          - rocSPARSE for HIP (HYPRE_USING_ROCSPARSE)
+ *          - oneMKL for SYCL   (HYPRE_USING_ONEMKLSPARSE)
+ *
+ * @param use_vendor Indicates whether to use the internal or vendor-provided implementation.
+ *
+ * @note The default value is 1, except for CUDA builds, which is zero.
+ *
+ * @return Returns hypre's global error code, where 0 indicates success.
+ **/
+HYPRE_Int HYPRE_SetSpGemmUseVendor( HYPRE_Int use_vendor );
 /* Backwards compatibility with HYPRE_SetSpGemmUseCusparse() */
 #define HYPRE_SetSpGemmUseCusparse(use_vendor) HYPRE_SetSpGemmUseVendor(use_vendor)
-HYPRE_Int HYPRE_SetSpGemmUseVendor( HYPRE_Int use_vendor );
+
+/**
+ * Specifies the algorithm used for generating random numbers in device builds.
+ *
+ * The following options are available for \e use_curand:
+ *
+ *    - 0 : random numbers are generated on the host and copied to device memory.
+ *    - 1 : (default) Use the vendor library's implementation. This includes:
+ *          - cuSPARSE for CUDA (HYPRE_USING_CUSPARSE)
+ *          - rocSPARSE for HIP (HYPRE_USING_ROCSPARSE)
+ *          - oneMKL for SYCL   (HYPRE_USING_ONEMKLSPARSE)
+ *
+ * @param use_curand Indicates whether to use the vendor-provided implementation or not.
+ *
+ * @return Returns hypre's global error code, where 0 indicates success.
+ **/
+
 HYPRE_Int HYPRE_SetUseGpuRand( HYPRE_Int use_curand );
+
+/**
+ * Configures the usage of GPU-aware MPI for communication in device builds.
+ *
+ * The following options are available for \e use_gpu_aware_mpi:
+ *
+ *    - 0 : MPI buffers are transferred between device and host memory. Communication occurs on the host.
+ *    - 1 : MPI communication is performed directly from the device using device-resident buffers.
+ *
+ * @param use_gpu_aware_mpi Specifies whether to enable GPU-aware MPI communication or not.
+ *
+ * @note This option requires hypre to be configured with GPU-aware MPI support for it to take effect.
+ *
+ * @return Returns hypre's global error code, where 0 indicates success.
+ **/
 HYPRE_Int HYPRE_SetGpuAwareMPI( HYPRE_Int use_gpu_aware_mpi );
 
 /*--------------------------------------------------------------------------

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1272,10 +1272,10 @@ HYPRE_Int hypre_UmpireMemoryGetUsage(HYPRE_Real *memory);
 HYPRE_Int hypre_HostMemoryGetUsage(HYPRE_Real *mem);
 HYPRE_Int hypre_MemoryPrintUsage(MPI_Comm comm, HYPRE_Int level,
                                  const char *function, HYPRE_Int line);
-#define HYPRE_PRINT_MEMORY_USAGE hypre_MemoryPrintUsage(comm,\
-                                                        hypre_HandleLogLevel(hypre_handle()),\
-                                                        __FUNCTION__,\
-                                                        __LINE__)
+#define HYPRE_PRINT_MEMORY_USAGE(comm) hypre_MemoryPrintUsage(comm,\
+                                                              hypre_HandleLogLevel(hypre_handle()),\
+                                                              __FUNCTION__,\
+                                                              __LINE__)
 /* memory_dmalloc.c */
 HYPRE_Int hypre_InitMemoryDebugDML( HYPRE_Int id );
 HYPRE_Int hypre_FinalizeMemoryDebugDML( void );

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1274,7 +1274,7 @@ HYPRE_Int hypre_MemoryPrintUsage(MPI_Comm comm, HYPRE_Int level,
                                  const char *function, HYPRE_Int line);
 #define HYPRE_PRINT_MEMORY_USAGE(comm) hypre_MemoryPrintUsage(comm,\
                                                               hypre_HandleLogLevel(hypre_handle()),\
-                                                              __FUNCTION__,\
+                                                              __func__,\
                                                               __LINE__)
 /* memory_dmalloc.c */
 HYPRE_Int hypre_InitMemoryDebugDML( HYPRE_Int id );

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1460,6 +1460,7 @@ extern hypre_MemoryTracker *_hypre_memory_tracker;
 
 #endif /* #if defined(HYPRE_USING_MEMORY_TRACKER) */
 #endif /* #ifndef hypre_MEMORY_TRACKER_HEADER */
+
 /******************************************************************************
  * Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
@@ -2414,6 +2415,7 @@ HYPRE_Int hypre_GetSyncCudaCompute(HYPRE_Int *cuda_compute_stream_sync_ptr);
 HYPRE_Int hypre_ForceSyncComputeStream(hypre_Handle *hypre_handle);
 
 /* handle.c */
+HYPRE_Int hypre_SetLogLevel( HYPRE_Int log_level );
 HYPRE_Int hypre_SetSpTransUseVendor( HYPRE_Int use_vendor );
 HYPRE_Int hypre_SetSpMVUseVendor( HYPRE_Int use_vendor );
 HYPRE_Int hypre_SetSpGemmUseVendor( HYPRE_Int use_vendor );

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -21,6 +21,154 @@ extern "C" {
  * SPDX-License-Identifier: (Apache-2.0 OR MIT)
  ******************************************************************************/
 
+/******************************************************************************
+ *
+ * General structures and values
+ *
+ *****************************************************************************/
+
+#ifndef HYPRE_HANDLE_H
+#define HYPRE_HANDLE_H
+
+#if defined(HYPRE_USING_UMPIRE)
+#include "umpire/config.hpp"
+#if UMPIRE_VERSION_MAJOR >= 2022
+#include "umpire/interface/c_fortran/umpire.h"
+#define hypre_umpire_resourcemanager_make_allocator_pool umpire_resourcemanager_make_allocator_quick_pool
+#else
+#include "umpire/interface/umpire.h"
+#define hypre_umpire_resourcemanager_make_allocator_pool umpire_resourcemanager_make_allocator_pool
+#endif /* UMPIRE_VERSION_MAJOR >= 2022 */
+#define HYPRE_UMPIRE_POOL_NAME_MAX_LEN 1024
+#endif /* defined(HYPRE_USING_UMPIRE) */
+
+struct hypre_DeviceData;
+typedef struct hypre_DeviceData hypre_DeviceData;
+typedef void (*GPUMallocFunc)(void **, size_t);
+typedef void (*GPUMfreeFunc)(void *);
+
+typedef struct
+{
+   HYPRE_Int              log_level;
+   HYPRE_Int              hypre_error;
+   HYPRE_MemoryLocation   memory_location;
+   HYPRE_ExecutionPolicy  default_exec_policy;
+
+   /* the device buffers needed to do MPI communication for struct comm */
+   HYPRE_Complex         *struct_comm_recv_buffer;
+   HYPRE_Complex         *struct_comm_send_buffer;
+   HYPRE_Int              struct_comm_recv_buffer_size;
+   HYPRE_Int              struct_comm_send_buffer_size;
+
+   /* GPU MPI */
+#if defined(HYPRE_USING_GPU) || defined(HYPRE_USING_DEVICE_OPENMP)
+   HYPRE_Int              use_gpu_aware_mpi;
+#endif
+
+#if defined(HYPRE_USING_GPU)
+   hypre_DeviceData      *device_data;
+   HYPRE_Int              device_gs_method; /* device G-S options */
+#endif
+
+   /* user malloc/free function pointers */
+   GPUMallocFunc          user_device_malloc;
+   GPUMfreeFunc           user_device_free;
+
+#if defined(HYPRE_USING_UMPIRE)
+   char                   umpire_device_pool_name[HYPRE_UMPIRE_POOL_NAME_MAX_LEN];
+   char                   umpire_um_pool_name[HYPRE_UMPIRE_POOL_NAME_MAX_LEN];
+   char                   umpire_host_pool_name[HYPRE_UMPIRE_POOL_NAME_MAX_LEN];
+   char                   umpire_pinned_pool_name[HYPRE_UMPIRE_POOL_NAME_MAX_LEN];
+   size_t                 umpire_device_pool_size;
+   size_t                 umpire_um_pool_size;
+   size_t                 umpire_host_pool_size;
+   size_t                 umpire_pinned_pool_size;
+   size_t                 umpire_block_size;
+   HYPRE_Int              own_umpire_device_pool;
+   HYPRE_Int              own_umpire_um_pool;
+   HYPRE_Int              own_umpire_host_pool;
+   HYPRE_Int              own_umpire_pinned_pool;
+   umpire_resourcemanager umpire_rm;
+#endif
+
+#if defined(HYPRE_USING_MAGMA)
+   magma_queue_t          magma_queue;
+#endif
+} hypre_Handle;
+
+/* accessor macros to hypre_Handle */
+#define hypre_HandleLogLevel(hypre_handle)                       ((hypre_handle) -> log_level)
+#define hypre_HandleMemoryLocation(hypre_handle)                 ((hypre_handle) -> memory_location)
+#define hypre_HandleDefaultExecPolicy(hypre_handle)              ((hypre_handle) -> default_exec_policy)
+
+#define hypre_HandleStructCommRecvBuffer(hypre_handle)           ((hypre_handle) -> struct_comm_recv_buffer)
+#define hypre_HandleStructCommSendBuffer(hypre_handle)           ((hypre_handle) -> struct_comm_send_buffer)
+#define hypre_HandleStructCommRecvBufferSize(hypre_handle)       ((hypre_handle) -> struct_comm_recv_buffer_size)
+#define hypre_HandleStructCommSendBufferSize(hypre_handle)       ((hypre_handle) -> struct_comm_send_buffer_size)
+
+#define hypre_HandleDeviceData(hypre_handle)                     ((hypre_handle) -> device_data)
+#define hypre_HandleDeviceGSMethod(hypre_handle)                 ((hypre_handle) -> device_gs_method)
+#define hypre_HandleUseGpuAwareMPI(hypre_handle)                 ((hypre_handle) -> use_gpu_aware_mpi)
+
+#define hypre_HandleCurandGenerator(hypre_handle)                hypre_DeviceDataCurandGenerator(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleCublasHandle(hypre_handle)                   hypre_DeviceDataCublasHandle(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleCusparseHandle(hypre_handle)                 hypre_DeviceDataCusparseHandle(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleVendorSolverHandle(hypre_handle)             hypre_DeviceDataVendorSolverHandle(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleComputeStream(hypre_handle)                  hypre_DeviceDataComputeStream(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleCubBinGrowth(hypre_handle)                   hypre_DeviceDataCubBinGrowth(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleCubMinBin(hypre_handle)                      hypre_DeviceDataCubMinBin(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleCubMaxBin(hypre_handle)                      hypre_DeviceDataCubMaxBin(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleCubMaxCachedBytes(hypre_handle)              hypre_DeviceDataCubMaxCachedBytes(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleCubDevAllocator(hypre_handle)                hypre_DeviceDataCubDevAllocator(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleCubUvmAllocator(hypre_handle)                hypre_DeviceDataCubUvmAllocator(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleDevice(hypre_handle)                         hypre_DeviceDataDevice(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleDeviceMaxWorkGroupSize(hypre_handle)         hypre_DeviceDataDeviceMaxWorkGroupSize(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleDeviceMaxShmemPerBlock(hypre_handle)         hypre_DeviceDataDeviceMaxShmemPerBlock(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleDeviceMaxShmemPerBlockInited(hypre_handle)   hypre_DeviceDataDeviceMaxShmemPerBlockInited(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleComputeStreamNum(hypre_handle)               hypre_DeviceDataComputeStreamNum(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleReduceBuffer(hypre_handle)                   hypre_DeviceDataReduceBuffer(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleSpgemmUseVendor(hypre_handle)                hypre_DeviceDataSpgemmUseVendor(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleSpMVUseVendor(hypre_handle)                  hypre_DeviceDataSpMVUseVendor(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleSpTransUseVendor(hypre_handle)               hypre_DeviceDataSpTransUseVendor(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleSpgemmAlgorithm(hypre_handle)                hypre_DeviceDataSpgemmAlgorithm(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleSpgemmBinned(hypre_handle)                   hypre_DeviceDataSpgemmBinned(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleSpgemmNumBin(hypre_handle)                   hypre_DeviceDataSpgemmNumBin(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleSpgemmHighestBin(hypre_handle)               hypre_DeviceDataSpgemmHighestBin(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleSpgemmBlockNumDim(hypre_handle)              hypre_DeviceDataSpgemmBlockNumDim(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleSpgemmRownnzEstimateMethod(hypre_handle)     hypre_DeviceDataSpgemmRownnzEstimateMethod(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleSpgemmRownnzEstimateNsamples(hypre_handle)   hypre_DeviceDataSpgemmRownnzEstimateNsamples(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleSpgemmRownnzEstimateMultFactor(hypre_handle) hypre_DeviceDataSpgemmRownnzEstimateMultFactor(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleDeviceAllocator(hypre_handle)                hypre_DeviceDataDeviceAllocator(hypre_HandleDeviceData(hypre_handle))
+#define hypre_HandleUseGpuRand(hypre_handle)                     hypre_DeviceDataUseGpuRand(hypre_HandleDeviceData(hypre_handle))
+
+#define hypre_HandleUserDeviceMalloc(hypre_handle)               ((hypre_handle) -> user_device_malloc)
+#define hypre_HandleUserDeviceMfree(hypre_handle)                ((hypre_handle) -> user_device_free)
+
+#define hypre_HandleUmpireResourceMan(hypre_handle)              ((hypre_handle) -> umpire_rm)
+#define hypre_HandleUmpireDevicePoolSize(hypre_handle)           ((hypre_handle) -> umpire_device_pool_size)
+#define hypre_HandleUmpireUMPoolSize(hypre_handle)               ((hypre_handle) -> umpire_um_pool_size)
+#define hypre_HandleUmpireHostPoolSize(hypre_handle)             ((hypre_handle) -> umpire_host_pool_size)
+#define hypre_HandleUmpirePinnedPoolSize(hypre_handle)           ((hypre_handle) -> umpire_pinned_pool_size)
+#define hypre_HandleUmpireBlockSize(hypre_handle)                ((hypre_handle) -> umpire_block_size)
+#define hypre_HandleUmpireDevicePoolName(hypre_handle)           ((hypre_handle) -> umpire_device_pool_name)
+#define hypre_HandleUmpireUMPoolName(hypre_handle)               ((hypre_handle) -> umpire_um_pool_name)
+#define hypre_HandleUmpireHostPoolName(hypre_handle)             ((hypre_handle) -> umpire_host_pool_name)
+#define hypre_HandleUmpirePinnedPoolName(hypre_handle)           ((hypre_handle) -> umpire_pinned_pool_name)
+#define hypre_HandleOwnUmpireDevicePool(hypre_handle)            ((hypre_handle) -> own_umpire_device_pool)
+#define hypre_HandleOwnUmpireUMPool(hypre_handle)                ((hypre_handle) -> own_umpire_um_pool)
+#define hypre_HandleOwnUmpireHostPool(hypre_handle)              ((hypre_handle) -> own_umpire_host_pool)
+#define hypre_HandleOwnUmpirePinnedPool(hypre_handle)            ((hypre_handle) -> own_umpire_pinned_pool)
+
+#define hypre_HandleMagmaQueue(hypre_handle)                     ((hypre_handle) -> magma_queue)
+
+#endif
+/******************************************************************************
+ * Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+
 #ifndef hypre_STATE_HEADER
 #define hypre_STATE_HEADER
 
@@ -1000,18 +1148,6 @@ HYPRE_Int hypre_MPI_Info_free( hypre_MPI_Info *info );
 //#pragma omp requires unified_shared_memory
 #endif
 
-#if defined(HYPRE_USING_UMPIRE)
-#include "umpire/config.hpp"
-#if UMPIRE_VERSION_MAJOR >= 2022
-#include "umpire/interface/c_fortran/umpire.h"
-#define hypre_umpire_resourcemanager_make_allocator_pool umpire_resourcemanager_make_allocator_quick_pool
-#else
-#include "umpire/interface/umpire.h"
-#define hypre_umpire_resourcemanager_make_allocator_pool umpire_resourcemanager_make_allocator_pool
-#endif
-#define HYPRE_UMPIRE_POOL_NAME_MAX_LEN 1024
-#endif
-
 /* stringification:
  * _Pragma(string-literal), so we need to cast argument to a string
  * The three dots as last argument of the macro tells compiler that this is a variadic macro.
@@ -1129,6 +1265,12 @@ HYPRE_Int hypre_umpire_um_pooled_allocate(void **ptr, size_t nbytes);
 HYPRE_Int hypre_umpire_um_pooled_free(void *ptr);
 HYPRE_Int hypre_umpire_pinned_pooled_allocate(void **ptr, size_t nbytes);
 HYPRE_Int hypre_umpire_pinned_pooled_free(void *ptr);
+HYPRE_Int hypre_UmpireInit(hypre_Handle *hypre_handle_);
+HYPRE_Int hypre_UmpireFinalize(hypre_Handle *hypre_handle_);
+HYPRE_Int hypre_UmpireGetCurrentMemoryUsage(MPI_Comm comm, HYPRE_Real *current);
+HYPRE_Int hypre_UmpireMemoryGetUsage(HYPRE_Real *memory);
+HYPRE_Int hypre_HostMemoryGetUsage(HYPRE_Real *mem);
+HYPRE_Int hypre_MemoryPrintUsage(MPI_Comm comm, const char *function, HYPRE_Int line);
 
 /* memory_dmalloc.c */
 HYPRE_Int hypre_InitMemoryDebugDML( HYPRE_Int id );
@@ -1137,10 +1279,6 @@ char *hypre_MAllocDML( HYPRE_Int size, char *file, HYPRE_Int line );
 char *hypre_CAllocDML( HYPRE_Int count, HYPRE_Int elt_size, char *file, HYPRE_Int line );
 char *hypre_ReAllocDML( char *ptr, HYPRE_Int size, char *file, HYPRE_Int line );
 void hypre_FreeDML( char *ptr, char *file, HYPRE_Int line );
-
-/* GPU malloc prototype */
-typedef void (*GPUMallocFunc)(void **, size_t);
-typedef void (*GPUMfreeFunc)(void *);
 
 #ifdef __cplusplus
 }
@@ -1322,7 +1460,6 @@ extern hypre_MemoryTracker *_hypre_memory_tracker;
 
 #endif /* #if defined(HYPRE_USING_MEMORY_TRACKER) */
 #endif /* #ifndef hypre_MEMORY_TRACKER_HEADER */
-
 /******************************************************************************
  * Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
  * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
@@ -1767,138 +1904,6 @@ extern "C++"
  * SPDX-License-Identifier: (Apache-2.0 OR MIT)
  ******************************************************************************/
 
-/******************************************************************************
- *
- * General structures and values
- *
- *****************************************************************************/
-
-#ifndef HYPRE_HANDLE_H
-#define HYPRE_HANDLE_H
-
-struct hypre_DeviceData;
-typedef struct hypre_DeviceData hypre_DeviceData;
-
-typedef struct
-{
-   HYPRE_Int              hypre_error;
-   HYPRE_MemoryLocation   memory_location;
-   HYPRE_ExecutionPolicy  default_exec_policy;
-
-   /* the device buffers needed to do MPI communication for struct comm */
-   HYPRE_Complex         *struct_comm_recv_buffer;
-   HYPRE_Complex         *struct_comm_send_buffer;
-   HYPRE_Int              struct_comm_recv_buffer_size;
-   HYPRE_Int              struct_comm_send_buffer_size;
-
-   /* GPU MPI */
-#if defined(HYPRE_USING_GPU) || defined(HYPRE_USING_DEVICE_OPENMP)
-   HYPRE_Int              use_gpu_aware_mpi;
-#endif
-
-#if defined(HYPRE_USING_GPU)
-   hypre_DeviceData      *device_data;
-   HYPRE_Int              device_gs_method; /* device G-S options */
-#endif
-
-   /* user malloc/free function pointers */
-   GPUMallocFunc          user_device_malloc;
-   GPUMfreeFunc           user_device_free;
-
-#if defined(HYPRE_USING_UMPIRE)
-   char                   umpire_device_pool_name[HYPRE_UMPIRE_POOL_NAME_MAX_LEN];
-   char                   umpire_um_pool_name[HYPRE_UMPIRE_POOL_NAME_MAX_LEN];
-   char                   umpire_host_pool_name[HYPRE_UMPIRE_POOL_NAME_MAX_LEN];
-   char                   umpire_pinned_pool_name[HYPRE_UMPIRE_POOL_NAME_MAX_LEN];
-   size_t                 umpire_device_pool_size;
-   size_t                 umpire_um_pool_size;
-   size_t                 umpire_host_pool_size;
-   size_t                 umpire_pinned_pool_size;
-   size_t                 umpire_block_size;
-   HYPRE_Int              own_umpire_device_pool;
-   HYPRE_Int              own_umpire_um_pool;
-   HYPRE_Int              own_umpire_host_pool;
-   HYPRE_Int              own_umpire_pinned_pool;
-   umpire_resourcemanager umpire_rm;
-#endif
-
-#if defined(HYPRE_USING_MAGMA)
-   magma_queue_t          magma_queue;
-#endif
-} hypre_Handle;
-
-/* accessor macros to hypre_Handle */
-#define hypre_HandleMemoryLocation(hypre_handle)                 ((hypre_handle) -> memory_location)
-#define hypre_HandleDefaultExecPolicy(hypre_handle)              ((hypre_handle) -> default_exec_policy)
-
-#define hypre_HandleStructCommRecvBuffer(hypre_handle)           ((hypre_handle) -> struct_comm_recv_buffer)
-#define hypre_HandleStructCommSendBuffer(hypre_handle)           ((hypre_handle) -> struct_comm_send_buffer)
-#define hypre_HandleStructCommRecvBufferSize(hypre_handle)       ((hypre_handle) -> struct_comm_recv_buffer_size)
-#define hypre_HandleStructCommSendBufferSize(hypre_handle)       ((hypre_handle) -> struct_comm_send_buffer_size)
-
-#define hypre_HandleDeviceData(hypre_handle)                     ((hypre_handle) -> device_data)
-#define hypre_HandleDeviceGSMethod(hypre_handle)                 ((hypre_handle) -> device_gs_method)
-#define hypre_HandleUseGpuAwareMPI(hypre_handle)                 ((hypre_handle) -> use_gpu_aware_mpi)
-
-#define hypre_HandleCurandGenerator(hypre_handle)                hypre_DeviceDataCurandGenerator(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleCublasHandle(hypre_handle)                   hypre_DeviceDataCublasHandle(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleCusparseHandle(hypre_handle)                 hypre_DeviceDataCusparseHandle(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleVendorSolverHandle(hypre_handle)             hypre_DeviceDataVendorSolverHandle(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleComputeStream(hypre_handle)                  hypre_DeviceDataComputeStream(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleCubBinGrowth(hypre_handle)                   hypre_DeviceDataCubBinGrowth(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleCubMinBin(hypre_handle)                      hypre_DeviceDataCubMinBin(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleCubMaxBin(hypre_handle)                      hypre_DeviceDataCubMaxBin(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleCubMaxCachedBytes(hypre_handle)              hypre_DeviceDataCubMaxCachedBytes(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleCubDevAllocator(hypre_handle)                hypre_DeviceDataCubDevAllocator(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleCubUvmAllocator(hypre_handle)                hypre_DeviceDataCubUvmAllocator(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleDevice(hypre_handle)                         hypre_DeviceDataDevice(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleDeviceMaxWorkGroupSize(hypre_handle)         hypre_DeviceDataDeviceMaxWorkGroupSize(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleDeviceMaxShmemPerBlock(hypre_handle)         hypre_DeviceDataDeviceMaxShmemPerBlock(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleDeviceMaxShmemPerBlockInited(hypre_handle)   hypre_DeviceDataDeviceMaxShmemPerBlockInited(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleComputeStreamNum(hypre_handle)               hypre_DeviceDataComputeStreamNum(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleReduceBuffer(hypre_handle)                   hypre_DeviceDataReduceBuffer(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleSpgemmUseVendor(hypre_handle)                hypre_DeviceDataSpgemmUseVendor(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleSpMVUseVendor(hypre_handle)                  hypre_DeviceDataSpMVUseVendor(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleSpTransUseVendor(hypre_handle)               hypre_DeviceDataSpTransUseVendor(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleSpgemmAlgorithm(hypre_handle)                hypre_DeviceDataSpgemmAlgorithm(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleSpgemmBinned(hypre_handle)                   hypre_DeviceDataSpgemmBinned(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleSpgemmNumBin(hypre_handle)                   hypre_DeviceDataSpgemmNumBin(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleSpgemmHighestBin(hypre_handle)               hypre_DeviceDataSpgemmHighestBin(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleSpgemmBlockNumDim(hypre_handle)              hypre_DeviceDataSpgemmBlockNumDim(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleSpgemmRownnzEstimateMethod(hypre_handle)     hypre_DeviceDataSpgemmRownnzEstimateMethod(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleSpgemmRownnzEstimateNsamples(hypre_handle)   hypre_DeviceDataSpgemmRownnzEstimateNsamples(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleSpgemmRownnzEstimateMultFactor(hypre_handle) hypre_DeviceDataSpgemmRownnzEstimateMultFactor(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleDeviceAllocator(hypre_handle)                hypre_DeviceDataDeviceAllocator(hypre_HandleDeviceData(hypre_handle))
-#define hypre_HandleUseGpuRand(hypre_handle)                     hypre_DeviceDataUseGpuRand(hypre_HandleDeviceData(hypre_handle))
-
-#define hypre_HandleUserDeviceMalloc(hypre_handle)               ((hypre_handle) -> user_device_malloc)
-#define hypre_HandleUserDeviceMfree(hypre_handle)                ((hypre_handle) -> user_device_free)
-
-#define hypre_HandleUmpireResourceMan(hypre_handle)              ((hypre_handle) -> umpire_rm)
-#define hypre_HandleUmpireDevicePoolSize(hypre_handle)           ((hypre_handle) -> umpire_device_pool_size)
-#define hypre_HandleUmpireUMPoolSize(hypre_handle)               ((hypre_handle) -> umpire_um_pool_size)
-#define hypre_HandleUmpireHostPoolSize(hypre_handle)             ((hypre_handle) -> umpire_host_pool_size)
-#define hypre_HandleUmpirePinnedPoolSize(hypre_handle)           ((hypre_handle) -> umpire_pinned_pool_size)
-#define hypre_HandleUmpireBlockSize(hypre_handle)                ((hypre_handle) -> umpire_block_size)
-#define hypre_HandleUmpireDevicePoolName(hypre_handle)           ((hypre_handle) -> umpire_device_pool_name)
-#define hypre_HandleUmpireUMPoolName(hypre_handle)               ((hypre_handle) -> umpire_um_pool_name)
-#define hypre_HandleUmpireHostPoolName(hypre_handle)             ((hypre_handle) -> umpire_host_pool_name)
-#define hypre_HandleUmpirePinnedPoolName(hypre_handle)           ((hypre_handle) -> umpire_pinned_pool_name)
-#define hypre_HandleOwnUmpireDevicePool(hypre_handle)            ((hypre_handle) -> own_umpire_device_pool)
-#define hypre_HandleOwnUmpireUMPool(hypre_handle)                ((hypre_handle) -> own_umpire_um_pool)
-#define hypre_HandleOwnUmpireHostPool(hypre_handle)              ((hypre_handle) -> own_umpire_host_pool)
-#define hypre_HandleOwnUmpirePinnedPool(hypre_handle)            ((hypre_handle) -> own_umpire_pinned_pool)
-
-#define hypre_HandleMagmaQueue(hypre_handle)                     ((hypre_handle) -> magma_queue)
-
-#endif
-/******************************************************************************
- * Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
- * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
- *
- * SPDX-License-Identifier: (Apache-2.0 OR MIT)
- ******************************************************************************/
-
 #ifndef HYPRE_GSELIM_H
 #define HYPRE_GSELIM_H
 
@@ -2082,8 +2087,6 @@ HYPRE_Int hypre_SetDevice(hypre_int device_id, hypre_Handle *hypre_handle_);
 HYPRE_Int hypre_GetDevice(hypre_int *device_id);
 HYPRE_Int hypre_GetDeviceCount(hypre_int *device_count);
 HYPRE_Int hypre_GetDeviceLastError(void);
-HYPRE_Int hypre_UmpireInit(hypre_Handle *hypre_handle_);
-HYPRE_Int hypre_UmpireFinalize(hypre_Handle *hypre_handle_);
 HYPRE_Int hypre_GetDeviceMaxShmemSize(hypre_int device_id, hypre_int *max_size_ptr,
                                       hypre_int *max_size_optin_ptr);
 

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1270,8 +1270,12 @@ HYPRE_Int hypre_UmpireFinalize(hypre_Handle *hypre_handle_);
 HYPRE_Int hypre_UmpireGetCurrentMemoryUsage(MPI_Comm comm, HYPRE_Real *current);
 HYPRE_Int hypre_UmpireMemoryGetUsage(HYPRE_Real *memory);
 HYPRE_Int hypre_HostMemoryGetUsage(HYPRE_Real *mem);
-HYPRE_Int hypre_MemoryPrintUsage(MPI_Comm comm, const char *function, HYPRE_Int line);
-
+HYPRE_Int hypre_MemoryPrintUsage(MPI_Comm comm, HYPRE_Int level,
+                                 const char *function, HYPRE_Int line);
+#define HYPRE_PRINT_MEMORY_USAGE hypre_MemoryPrintUsage(comm,\
+                                                        hypre_HandleLogLevel(hypre_handle()),\
+                                                        __FUNCTION__,\
+                                                        __LINE__)
 /* memory_dmalloc.c */
 HYPRE_Int hypre_InitMemoryDebugDML( HYPRE_Int id );
 HYPRE_Int hypre_FinalizeMemoryDebugDML( void );

--- a/src/utilities/general.c
+++ b/src/utilities/general.c
@@ -31,9 +31,8 @@ hypre_Handle*
 hypre_HandleCreate(void)
 {
    hypre_Handle *hypre_handle_ = hypre_CTAlloc(hypre_Handle, 1, HYPRE_MEMORY_HOST);
-   const char* env_log_level = getenv("HYPRE_LOG_LEVEL");
 
-   hypre_HandleLogLevel(hypre_handle_) = (env_log_level) ? (HYPRE_Int) atoi(env_log_level) : 0;
+   hypre_HandleLogLevel(hypre_handle_) = 0;
    hypre_HandleMemoryLocation(hypre_handle_) = HYPRE_MEMORY_DEVICE;
 
 #if defined(HYPRE_USING_GPU) || defined(HYPRE_USING_DEVICE_OPENMP)

--- a/src/utilities/general.c
+++ b/src/utilities/general.c
@@ -497,10 +497,11 @@ HYPRE_PrintDeviceInfo(void)
 
 HYPRE_Int
 HYPRE_MemoryPrintUsage(MPI_Comm    comm,
+                       HYPRE_Int   level,
                        const char *function,
                        HYPRE_Int   line)
 {
-   return hypre_MemoryPrintUsage(comm, function, line);
+   return hypre_MemoryPrintUsage(comm, level, function, line);
 }
 
 /******************************************************************************

--- a/src/utilities/handle.c
+++ b/src/utilities/handle.c
@@ -14,7 +14,22 @@
 #include "_hypre_utilities.h"
 #include "_hypre_utilities.hpp"
 
-/* GPU SpTrans */
+/*--------------------------------------------------------------------------
+ * hypre_SetLogLevel
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_SetLogLevel(HYPRE_Int log_level)
+{
+   hypre_HandleLogLevel(hypre_handle()) = log_level;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_SetSpTransUseVendor
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_SetSpTransUseVendor( HYPRE_Int use_vendor )
 {
@@ -27,7 +42,10 @@ hypre_SetSpTransUseVendor( HYPRE_Int use_vendor )
    return hypre_error_flag;
 }
 
-/* GPU SpMV */
+/*--------------------------------------------------------------------------
+ * hypre_SetSpMVUseVendor
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_SetSpMVUseVendor( HYPRE_Int use_vendor )
 {
@@ -40,7 +58,10 @@ hypre_SetSpMVUseVendor( HYPRE_Int use_vendor )
    return hypre_error_flag;
 }
 
-/* GPU SpGemm */
+/*--------------------------------------------------------------------------
+ * hypre_SetSpGemmUseVendor
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_SetSpGemmUseVendor( HYPRE_Int use_vendor )
 {
@@ -52,6 +73,10 @@ hypre_SetSpGemmUseVendor( HYPRE_Int use_vendor )
 
    return hypre_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ * hypre_SetSpGemmAlgorithm
+ *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_SetSpGemmAlgorithm( HYPRE_Int value )
@@ -72,6 +97,10 @@ hypre_SetSpGemmAlgorithm( HYPRE_Int value )
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_SetSpGemmBinned
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_SetSpGemmBinned( HYPRE_Int value )
 {
@@ -83,6 +112,10 @@ hypre_SetSpGemmBinned( HYPRE_Int value )
 
    return hypre_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ * hypre_SetSpGemmRownnzEstimateMethod
+ *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_SetSpGemmRownnzEstimateMethod( HYPRE_Int value )
@@ -103,6 +136,10 @@ hypre_SetSpGemmRownnzEstimateMethod( HYPRE_Int value )
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_SetSpGemmRownnzEstimateNSamples
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_SetSpGemmRownnzEstimateNSamples( HYPRE_Int value )
 {
@@ -114,6 +151,10 @@ hypre_SetSpGemmRownnzEstimateNSamples( HYPRE_Int value )
 
    return hypre_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ * hypre_SetSpGemmRownnzEstimateMultFactor
+ *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_SetSpGemmRownnzEstimateMultFactor( HYPRE_Real value )
@@ -134,7 +175,10 @@ hypre_SetSpGemmRownnzEstimateMultFactor( HYPRE_Real value )
    return hypre_error_flag;
 }
 
-/* GPU Rand */
+/*--------------------------------------------------------------------------
+ * hypre_SetUseGpuRand
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_SetUseGpuRand( HYPRE_Int use_gpurand )
 {
@@ -146,6 +190,10 @@ hypre_SetUseGpuRand( HYPRE_Int use_gpurand )
 
    return hypre_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ * hypre_SetGaussSeidelMethod
+ *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_SetGaussSeidelMethod( HYPRE_Int gs_method )
@@ -159,6 +207,10 @@ hypre_SetGaussSeidelMethod( HYPRE_Int gs_method )
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_SetUserDeviceMalloc
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_SetUserDeviceMalloc(GPUMallocFunc func)
 {
@@ -170,6 +222,10 @@ hypre_SetUserDeviceMalloc(GPUMallocFunc func)
 
    return hypre_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ * hypre_SetUserDeviceMfree
+ *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_SetUserDeviceMfree(GPUMfreeFunc func)
@@ -183,6 +239,10 @@ hypre_SetUserDeviceMfree(GPUMfreeFunc func)
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_SetGpuAwareMPI
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_SetGpuAwareMPI( HYPRE_Int use_gpu_aware_mpi )
 {
@@ -193,6 +253,10 @@ hypre_SetGpuAwareMPI( HYPRE_Int use_gpu_aware_mpi )
 #endif
    return hypre_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ * hypre_GetGpuAwareMPI
+ *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_GetGpuAwareMPI(void)

--- a/src/utilities/handle.h
+++ b/src/utilities/handle.h
@@ -14,11 +14,26 @@
 #ifndef HYPRE_HANDLE_H
 #define HYPRE_HANDLE_H
 
+#if defined(HYPRE_USING_UMPIRE)
+#include "umpire/config.hpp"
+#if UMPIRE_VERSION_MAJOR >= 2022
+#include "umpire/interface/c_fortran/umpire.h"
+#define hypre_umpire_resourcemanager_make_allocator_pool umpire_resourcemanager_make_allocator_quick_pool
+#else
+#include "umpire/interface/umpire.h"
+#define hypre_umpire_resourcemanager_make_allocator_pool umpire_resourcemanager_make_allocator_pool
+#endif /* UMPIRE_VERSION_MAJOR >= 2022 */
+#define HYPRE_UMPIRE_POOL_NAME_MAX_LEN 1024
+#endif /* defined(HYPRE_USING_UMPIRE) */
+
 struct hypre_DeviceData;
 typedef struct hypre_DeviceData hypre_DeviceData;
+typedef void (*GPUMallocFunc)(void **, size_t);
+typedef void (*GPUMfreeFunc)(void *);
 
 typedef struct
 {
+   HYPRE_Int              log_level;
    HYPRE_Int              hypre_error;
    HYPRE_MemoryLocation   memory_location;
    HYPRE_ExecutionPolicy  default_exec_policy;
@@ -66,6 +81,7 @@ typedef struct
 } hypre_Handle;
 
 /* accessor macros to hypre_Handle */
+#define hypre_HandleLogLevel(hypre_handle)                       ((hypre_handle) -> log_level)
 #define hypre_HandleMemoryLocation(hypre_handle)                 ((hypre_handle) -> memory_location)
 #define hypre_HandleDefaultExecPolicy(hypre_handle)              ((hypre_handle) -> default_exec_policy)
 

--- a/src/utilities/headers
+++ b/src/utilities/headers
@@ -33,6 +33,7 @@ extern "C" {
 # Structures and prototypes
 #===========================================================================
 
+cat handle.h                   >> $INTERNAL_HEADER
 cat state.h                    >> $INTERNAL_HEADER
 cat general.h                  >> $INTERNAL_HEADER
 cat base.h                     >> $INTERNAL_HEADER
@@ -50,7 +51,6 @@ cat timing.h                   >> $INTERNAL_HEADER
 cat amg_linklist.h             >> $INTERNAL_HEADER
 cat exchange_data.h            >> $INTERNAL_HEADER
 cat caliper_instrumentation.h  >> $INTERNAL_HEADER
-cat handle.h                   >> $INTERNAL_HEADER
 cat gselim.h                   >> $INTERNAL_HEADER
 cat int_array.h                >> $INTERNAL_HEADER
 cat protos.h                   >> $INTERNAL_HEADER

--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -13,6 +13,9 @@
 
 #include "_hypre_utilities.h"
 #include "_hypre_utilities.hpp"
+#if !defined(_WIN32)
+#include <sys/sysinfo.h>
+#endif
 
 #if defined(HYPRE_USE_UMALLOC)
 #undef HYPRE_USE_UMALLOC
@@ -793,6 +796,7 @@ hypre_Memcpy_core(void *dst, void *src, size_t size, hypre_MemoryLocation loc_ds
 /*--------------------------------------------------------------------------*
  * ExecPolicy
  *--------------------------------------------------------------------------*/
+
 static inline HYPRE_ExecutionPolicy
 hypre_GetExecPolicy1_core(hypre_MemoryLocation location)
 {
@@ -1211,8 +1215,299 @@ hypre_GetPointerLocation(const void *ptr, hypre_MemoryLocation *memory_location)
    return ierr;
 }
 
-/*--------------------------------------------------------------------------*
- * Memory Pool
+/*--------------------------------------------------------------------------
+ * hypre_HostMemoryGetUsage
+ *
+ * Retrieves various memory usage statistics involving CPU RAM. The function
+ * fills an array with the memory data, converted to gigabytes (GB).
+ * Detailed info is given below:
+ *
+ *    - mem[0]: VmSize
+ *      The current virtual memory size used by the process. This includes
+ *      all memory the process can access, including memory that is swapped
+ *      out and memory allocated but not used.
+ *
+ *    - mem[1]: VmPeak
+ *      The peak virtual memory size used by the process during its lifetime.
+ *
+ *    - mem[2]: VmRSS
+ *      The resident set size, which is the portion of the process' memory
+ *      that is held in CPU RAM. This includes code, data, and stack space
+ *      but excludes swapped-out memory.
+ *
+ *    - mem[3]: VmHWM
+ *      The peak resident set size, which is the maximum amount of memory
+ *      that the process has had in CPU RAM at any point in time, aka.
+ *      high water mark.
+ *
+ *    - mem[4]: free
+ *      The amount of free CPU RAM available in the system.
+ *
+ *    - mem[5]: total
+ *      The total amount of CPU RAM installed in the system.
+ *
+ * This function doesn't return correct memory info for Windows environments.
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_HostMemoryGetUsage(HYPRE_Real *mem)
+{
+   size_t           vm_size  = 0;
+   size_t           vm_rss   = 0;
+   size_t           vm_hwm   = 0;
+   size_t           vm_peak  = 0;
+   size_t           tot_mem  = 0;
+   size_t           free_mem = 0;
+   HYPRE_Real       kb_to_gb = (HYPRE_Real) (1 << 20);
+   HYPRE_Real       b_to_gb  = (HYPRE_Real) (1 << 30);
+   char             line[512];
+   FILE            *file;
+
+   /* Sanity check */
+   if (!mem)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Mem is a NULL pointer!");
+      return hypre_error_flag;
+   }
+
+   /* Get system memory info */
+#if !defined(_WIN32)
+   struct sysinfo info;
+
+   if (sysinfo(&info) != 0)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Problem running sysinfo!");
+      return hypre_error_flag;
+   }
+   tot_mem  = info.totalram * info.mem_unit;
+   free_mem = info.freeram  * info.mem_unit;
+#endif
+
+   /* Function to get process memory info */
+   file = fopen("/proc/self/status", "r");
+   if (file == NULL)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Cannot open /proc/self/status!");
+      return hypre_error_flag;
+   }
+
+   while (fgets(line, sizeof(line), file))
+   {
+      (void) sscanf(line, "VmPeak: %zu kB", &vm_peak);
+      (void) sscanf(line, "VmSize: %zu kB", &vm_size);
+      (void) sscanf(line,  "VmRSS: %zu kB", &vm_rss);
+      (void) sscanf(line,  "VmHWM: %zu kB", &vm_hwm);
+   }
+   fclose(file);
+
+   /* Convert data to GB (double) */
+   mem[0] = vm_size  / kb_to_gb;
+   mem[1] = vm_peak  / kb_to_gb;
+   mem[2] = vm_rss   / kb_to_gb;
+   mem[3] = vm_hwm   / kb_to_gb;
+   mem[4] = free_mem / b_to_gb;
+   mem[5] = tot_mem  / b_to_gb;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_MemoryPrintUsage
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_MemoryPrintUsage(MPI_Comm    comm,
+                       const char *function,
+                       HYPRE_Int   line)
+{
+#if defined(HYPRE_USING_UMPIRE)
+   HYPRE_Int    ne = 14;
+#else
+   HYPRE_Int    ne = 6;
+#endif
+   HYPRE_Int    log_level = hypre_HandleLogLevel(hypre_handle());
+   HYPRE_Real   lmem[14];
+   HYPRE_Real   min[14];
+   HYPRE_Real   max[14];
+   HYPRE_Real   avg[14];
+   HYPRE_Real   ssq[14];
+   HYPRE_Real   std[14];
+   HYPRE_Real  *gmem = NULL;
+   HYPRE_Int    i, j, myid, nprocs, ndigits;
+   const char  *labels[] = {"Min", "Max", "Avg", "Std"};
+   HYPRE_Real  *data[]   = {min, max, avg, std};
+
+   /* Return if neither the 1st nor 2nd bits of log_level are set */
+   if (!(log_level & 0x3))
+   {
+      return hypre_error_flag;
+   }
+
+   /* Initialize locals */
+   for (j = 0; j < ne; j++)
+   {
+      lmem[j] = 0.0;
+      min[j]  = HYPRE_REAL_MAX;
+      max[j]  = 0.0;
+      avg[j]  = 0.0;
+      ssq[j]  = 0.0;
+      std[j]  = 0.0;
+   }
+
+   /* MPI variables */
+   hypre_MPI_Comm_size(comm, &nprocs);
+   hypre_MPI_Comm_rank(comm, &myid);
+   ndigits = hypre_ndigits(nprocs);
+
+   /* Work space for gathering memory info */
+   if (!myid)
+   {
+      gmem = hypre_CTAlloc(HYPRE_Real, ne * nprocs, HYPRE_MEMORY_HOST);
+   }
+
+   /* Get host memory info */
+   hypre_HostMemoryGetUsage(lmem);
+
+   /* Get umpire memory info */
+#if defined(HYPRE_USING_UMPIRE)
+   hypre_UmpireMemoryGetUsage(&lmem[6]);
+#endif
+
+   /* Gather memory info to rank 0 */
+   hypre_MPI_Gather(lmem, ne, hypre_MPI_REAL, gmem, ne, hypre_MPI_REAL, 0, comm);
+
+   /* Rank 0 computes min/max/avg/stddev statistics */
+   if (!myid && (log_level & 0x2))
+   {
+      for (i = 0; i < nprocs; i++)
+      {
+         for (j = 0; j < ne; j++)
+         {
+            if (gmem[ne * i + j] < min[j]) min[j] = gmem[ne * i + j];
+            if (gmem[ne * i + j] > max[j]) max[j] = gmem[ne * i + j];
+            avg[j] += gmem[ne * i + j];
+         }
+      }
+
+      for (j = 0; j < ne; j++)
+      {
+         avg[j] /= (HYPRE_Real) nprocs;
+      }
+
+      for (i = 0; i < nprocs; i++)
+      {
+         for (j = 0; j < ne; j++)
+         {
+            ssq[j] += hypre_pow(gmem[ne * i + j] - avg[j], 2) / (HYPRE_Real) nprocs;
+         }
+      }
+
+      for (j = 0; j < ne; j++)
+      {
+         std[j] = hypre_sqrt(ssq[j]);
+      }
+   }
+
+   /* Rank 0 prints the data */
+   if (!myid)
+   {
+      /* Local memory usage statistics */
+      if (log_level & 0x1)
+      {
+         for (i = 0; i < nprocs; i++)
+         {
+            if (line > 0)
+            {
+               hypre_printf("[%*d]: %s at line %d", ndigits, i, function, line);
+            }
+            else
+            {
+               hypre_printf("[%*d]: %s", ndigits, i, function);
+            }
+            hypre_printf(" | VmSize/Peak: (%5.2f / %5.2f) GB", gmem[ne * i + 0], gmem[ne * i + 1]);
+            hypre_printf(" | VmRSS/HWM: (%5.2f / %5.2f) GB", gmem[ne * i + 2], gmem[ne * i + 3]);
+            hypre_printf(" | Free/Total: (%5.2f / %6.2f) GB", gmem[ne * i + 4], gmem[ne * i + 5]);
+#if defined(HYPRE_USING_UMPIRE)
+            if (gmem[ne * i + 8] && gmem[ne * i + 9])
+            {
+               hypre_printf(" | DevSize/DevPeak: (%5.2f / %5.2f) GB",
+                            gmem[ne * i + 8], gmem[ne * i + 9]);
+            }
+            if (gmem[ne * i + 10] && gmem[ne * i + 11])
+            {
+               hypre_printf(" | UVmSize/UVmPeak: (%5.2f / %5.2f) GB",
+                            gmem[ne * i + 10], gmem[ne * i + 11]);
+            }
+#endif
+            hypre_printf("\n");
+         }
+      }
+
+      /* Global memory usage statistics */
+      if (log_level & 0x2)
+      {
+         hypre_printf("\nMemory usage across ranks - ");
+         if (line > 0)
+         {
+            hypre_printf("%s at line %d\n\n", function, line);
+         }
+         else
+         {
+            hypre_printf("%s\n\n", function);
+         }
+
+#if defined(HYPRE_USING_UMPIRE_UM)
+         hypre_printf("       | %-11s | %-11s | %-11s | %-11s | %-12s | %-12s | %-12s | %-12s\n",
+                      "VmSize (GB)", "VmPeak (GB)", "VmRSS (GB)", "VmHWM (GB)",
+                      "DevSize (GB)", "DevPeak (GB)", "UVmSize (GB)", "UVmPeak (GB)");
+         hypre_printf("   ----");
+         hypre_printf("+-------------+-------------+-------------+-------------");
+         hypre_printf("+--------------+--------------+--------------+-------------\n");
+         for (i = 0; i < 4; i++)
+         {
+            hypre_printf("   %-3s", labels[i]);
+            hypre_printf(" | %11.3f | %11.3f | %11.3f | %11.3f",
+                         data[i][0], data[i][1], data[i][2], data[i][3]);
+            hypre_printf(" | %12.3f | %12.3f | %12.3f | %12.3f\n",
+                         data[i][8], data[i][9], data[i][10], data[i][11]);
+         }
+
+#elif defined(HYPRE_USING_UMPIRE_DEVICE)
+         hypre_printf("       | %-11s | %-11s | %-11s | %-11s | %-12s | %-12s\n",
+                      "VmSize (GB)", "VmPeak (GB)", "VmRSS (GB)", "VmHWM (GB)",
+                      "DevSize (GB)", "DevPeak (GB)");
+         hypre_printf("   ----");
+         hypre_printf("+-------------+-------------+-------------+-------------");
+         hypre_printf("+--------------+--------------\n");
+         for (i = 0; i < 4; i++)
+         {
+            hypre_printf("   %-3s", labels[i]);
+            hypre_printf(" | %11.3f | %11.3f | %11.3f | %11.3f | %12.3f | %12.3f\n",
+                         data[i][0], data[i][1], data[i][2], data[i][3], data[i][8], data[i][9]);
+         }
+
+#else
+         hypre_printf("       | %11s | %11s | %11s | %11s\n",
+                      "VmSize (GB)", "VmPeak (GB)", "VmRSS (GB)", "VmHWM (GB)");
+         hypre_printf("   ----+-------------+-------------+-------------+------------\n");
+         for (i = 0; i < 4; i++)
+         {
+            hypre_printf("   %3s | %11.3f | %11.3f | %11.3f | %11.3f\n",
+                         labels[i], data[i][0], data[i][1], data[i][2], data[i][3]);
+         }
+#endif
+         hypre_printf("\n");
+      }
+   }
+   hypre_MPI_Barrier(comm);
+
+   hypre_TFree(gmem, HYPRE_MEMORY_HOST);
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_SetCubMemPoolSize
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
@@ -1247,6 +1542,10 @@ hypre_SetCubMemPoolSize(hypre_uint cub_bin_growth,
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * HYPRE_SetGPUMemoryPoolSize
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 HYPRE_SetGPUMemoryPoolSize(HYPRE_Int bin_growth,
                            HYPRE_Int min_bin,
@@ -1256,7 +1555,12 @@ HYPRE_SetGPUMemoryPoolSize(HYPRE_Int bin_growth,
    return hypre_SetCubMemPoolSize(bin_growth, min_bin, max_bin, max_cached_bytes);
 }
 
-#if defined(HYPRE_USING_DEVICE_POOL)
+#if defined(HYPRE_USING_DEVICE_POOL) && defined(HYPRE_USING_CUDA)
+
+/*--------------------------------------------------------------------------
+ * hypre_CachingMallocDevice
+ *--------------------------------------------------------------------------*/
+
 cudaError_t
 hypre_CachingMallocDevice(void **ptr, size_t nbytes)
 {
@@ -1275,11 +1579,19 @@ hypre_CachingMallocDevice(void **ptr, size_t nbytes)
    return hypre_HandleCubDevAllocator(hypre_handle()) -> DeviceAllocate(ptr, nbytes);
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_CachingFreeDevice
+ *--------------------------------------------------------------------------*/
+
 cudaError_t
 hypre_CachingFreeDevice(void *ptr)
 {
    return hypre_HandleCubDevAllocator(hypre_handle()) -> DeviceFree(ptr);
 }
+
+/*--------------------------------------------------------------------------
+ * hypre_CachingMallocManaged
+ *--------------------------------------------------------------------------*/
 
 cudaError_t
 hypre_CachingMallocManaged(void **ptr, size_t nbytes)
@@ -1299,11 +1611,19 @@ hypre_CachingMallocManaged(void **ptr, size_t nbytes)
    return hypre_HandleCubUvmAllocator(hypre_handle()) -> DeviceAllocate(ptr, nbytes);
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_CachingFreeManaged
+ *--------------------------------------------------------------------------*/
+
 cudaError_t
 hypre_CachingFreeManaged(void *ptr)
 {
    return hypre_HandleCubUvmAllocator(hypre_handle()) -> DeviceFree(ptr);
 }
+
+/*--------------------------------------------------------------------------
+ * hypre_DeviceDataCubCachingAllocatorCreate
+ *--------------------------------------------------------------------------*/
 
 hypre_cub_CachingDeviceAllocator *
 hypre_DeviceDataCubCachingAllocatorCreate(hypre_uint bin_growth,
@@ -1326,6 +1646,10 @@ hypre_DeviceDataCubCachingAllocatorCreate(hypre_uint bin_growth,
    return allocator;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_DeviceDataCubCachingAllocatorDestroy
+ *--------------------------------------------------------------------------*/
+
 void
 hypre_DeviceDataCubCachingAllocatorDestroy(hypre_DeviceData *data)
 {
@@ -1333,9 +1657,14 @@ hypre_DeviceDataCubCachingAllocatorDestroy(hypre_DeviceData *data)
    delete hypre_DeviceDataCubUvmAllocator(data);
 }
 
-#endif // #if defined(HYPRE_USING_DEVICE_POOL)
+#endif // #if defined(HYPRE_USING_DEVICE_POOL) && defined(HYPRE_USING_CUDA)
 
 #if defined(HYPRE_USING_UMPIRE_HOST)
+
+/*--------------------------------------------------------------------------
+ * hypre_umpire_host_pooled_allocate
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_umpire_host_pooled_allocate(void **ptr, size_t nbytes)
 {
@@ -1365,6 +1694,10 @@ hypre_umpire_host_pooled_allocate(void **ptr, size_t nbytes)
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_umpire_host_pooled_free
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_umpire_host_pooled_free(void *ptr)
 {
@@ -1381,6 +1714,10 @@ hypre_umpire_host_pooled_free(void *ptr)
 
    return hypre_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ * hypre_umpire_host_pooled_realloc
+ *--------------------------------------------------------------------------*/
 
 void *
 hypre_umpire_host_pooled_realloc(void *ptr, size_t size)
@@ -1401,6 +1738,11 @@ hypre_umpire_host_pooled_realloc(void *ptr, size_t size)
 #endif
 
 #if defined(HYPRE_USING_UMPIRE_DEVICE)
+
+/*--------------------------------------------------------------------------
+ * hypre_umpire_device_pooled_allocate
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_umpire_device_pooled_allocate(void **ptr, size_t nbytes)
 {
@@ -1434,6 +1776,10 @@ hypre_umpire_device_pooled_allocate(void **ptr, size_t nbytes)
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_umpire_device_pooled_free
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_umpire_device_pooled_free(void *ptr)
 {
@@ -1453,6 +1799,11 @@ hypre_umpire_device_pooled_free(void *ptr)
 #endif
 
 #if defined(HYPRE_USING_UMPIRE_UM)
+
+/*--------------------------------------------------------------------------
+ * hypre_umpire_um_pooled_allocate
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_umpire_um_pooled_allocate(void **ptr, size_t nbytes)
 {
@@ -1483,6 +1834,10 @@ hypre_umpire_um_pooled_allocate(void **ptr, size_t nbytes)
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_umpire_um_pooled_free
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_umpire_um_pooled_free(void *ptr)
 {
@@ -1502,6 +1857,11 @@ hypre_umpire_um_pooled_free(void *ptr)
 #endif
 
 #if defined(HYPRE_USING_UMPIRE_PINNED)
+
+/*--------------------------------------------------------------------------
+ * hypre_umpire_pinned_pooled_allocate
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_umpire_pinned_pooled_allocate(void **ptr, size_t nbytes)
 {
@@ -1532,6 +1892,10 @@ hypre_umpire_pinned_pooled_allocate(void **ptr, size_t nbytes)
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_umpire_pinned_pooled_free
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_umpire_pinned_pooled_free(void *ptr)
 {
@@ -1549,3 +1913,281 @@ hypre_umpire_pinned_pooled_free(void *ptr)
    return hypre_error_flag;
 }
 #endif
+
+/******************************************************************************
+ *
+ * hypre Umpire
+ *
+ *****************************************************************************/
+
+#if defined(HYPRE_USING_UMPIRE)
+
+/*--------------------------------------------------------------------------
+ * hypre_UmpireInit
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_UmpireInit(hypre_Handle *hypre_handle_)
+{
+   umpire_resourcemanager_get_instance(&hypre_HandleUmpireResourceMan(hypre_handle_));
+
+   hypre_HandleUmpireDevicePoolSize(hypre_handle_) = 4LL * (1 << 30); // 4 GB
+   hypre_HandleUmpireUMPoolSize(hypre_handle_)     = 4LL * (1 << 30); // 4 GB
+   hypre_HandleUmpireHostPoolSize(hypre_handle_)   = 4LL * (1 << 30); // 4 GB
+   hypre_HandleUmpirePinnedPoolSize(hypre_handle_) = 4LL * (1 << 30); // 4 GB
+
+   hypre_HandleUmpireBlockSize(hypre_handle_) = 512;
+
+   strcpy(hypre_HandleUmpireDevicePoolName(hypre_handle_), "HYPRE_DEVICE_POOL");
+   strcpy(hypre_HandleUmpireUMPoolName(hypre_handle_),     "HYPRE_UM_POOL");
+   strcpy(hypre_HandleUmpireHostPoolName(hypre_handle_),   "HYPRE_HOST_POOL");
+   strcpy(hypre_HandleUmpirePinnedPoolName(hypre_handle_), "HYPRE_PINNED_POOL");
+
+   hypre_HandleOwnUmpireDevicePool(hypre_handle_) = 0;
+   hypre_HandleOwnUmpireUMPool(hypre_handle_)     = 0;
+   hypre_HandleOwnUmpireHostPool(hypre_handle_)   = 0;
+   hypre_HandleOwnUmpirePinnedPool(hypre_handle_) = 0;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_UmpireFinalize
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_UmpireFinalize(hypre_Handle *hypre_handle_)
+{
+   umpire_resourcemanager *rm_ptr = &hypre_HandleUmpireResourceMan(hypre_handle_);
+   umpire_allocator allocator;
+
+#if defined(HYPRE_USING_UMPIRE_HOST)
+   if (hypre_HandleOwnUmpireHostPool(hypre_handle_))
+   {
+      const char *pool_name = hypre_HandleUmpireHostPoolName(hypre_handle_);
+      umpire_resourcemanager_get_allocator_by_name(rm_ptr, pool_name, &allocator);
+      umpire_allocator_release(&allocator);
+   }
+#endif
+
+#if defined(HYPRE_USING_UMPIRE_DEVICE)
+   if (hypre_HandleOwnUmpireDevicePool(hypre_handle_))
+   {
+      const char *pool_name = hypre_HandleUmpireDevicePoolName(hypre_handle_);
+      umpire_resourcemanager_get_allocator_by_name(rm_ptr, pool_name, &allocator);
+      umpire_allocator_release(&allocator);
+   }
+#endif
+
+#if defined(HYPRE_USING_UMPIRE_UM)
+   if (hypre_HandleOwnUmpireUMPool(hypre_handle_))
+   {
+      const char *pool_name = hypre_HandleUmpireUMPoolName(hypre_handle_);
+      umpire_resourcemanager_get_allocator_by_name(rm_ptr, pool_name, &allocator);
+      umpire_allocator_release(&allocator);
+   }
+#endif
+
+#if defined(HYPRE_USING_UMPIRE_PINNED)
+   if (hypre_HandleOwnUmpirePinnedPool(hypre_handle_))
+   {
+      const char *pool_name = hypre_HandleUmpirePinnedPoolName(hypre_handle_);
+      umpire_resourcemanager_get_allocator_by_name(rm_ptr, pool_name, &allocator);
+      umpire_allocator_release(&allocator);
+   }
+#endif
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_UmpireMemoryGetUsage
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_UmpireMemoryGetUsage(HYPRE_Real *memory)
+{
+   hypre_Handle                 *handle = hypre_handle();
+   umpire_resourcemanager       *rm_ptr = &hypre_HandleUmpireResourceMan(handle);
+   umpire_allocator              allocator;
+
+   size_t                        memoryB[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+   HYPRE_Int                     i;
+
+   /* Sanity check */
+   if (!memory)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "memory is a NULL pointer!");
+      return hypre_error_flag;
+   }
+
+#if defined(HYPRE_USING_UMPIRE_HOST)
+   if (hypre_HandleOwnUmpireHostPool(handle))
+   {
+      const char *pool_name = hypre_HandleUmpireHostPoolName(handle);
+      umpire_resourcemanager_get_allocator_by_name(rm_ptr, pool_name, &allocator);
+      memoryB[0] = umpire_allocator_get_current_size(&allocator);
+      memoryB[1] = umpire_allocator_get_high_watermark(&allocator);
+   }
+#endif
+
+#if defined(HYPRE_USING_UMPIRE_DEVICE)
+   if (hypre_HandleOwnUmpireDevicePool(handle))
+   {
+      const char *pool_name = hypre_HandleUmpireDevicePoolName(handle);
+      umpire_resourcemanager_get_allocator_by_name(rm_ptr, pool_name, &allocator);
+      memoryB[2] = umpire_allocator_get_current_size(&allocator);
+      memoryB[3] = umpire_allocator_get_high_watermark(&allocator);
+   }
+#endif
+
+#if defined(HYPRE_USING_UMPIRE_UM)
+   if (hypre_HandleOwnUmpireUMPool(handle))
+   {
+      const char *pool_name = hypre_HandleUmpireUMPoolName(handle);
+      umpire_resourcemanager_get_allocator_by_name(rm_ptr, pool_name, &allocator);
+      memoryB[4] = umpire_allocator_get_current_size(&allocator);
+      memoryB[5] = umpire_allocator_get_high_watermark(&allocator);
+   }
+#endif
+
+#if defined(HYPRE_USING_UMPIRE_PINNED)
+   if (hypre_HandleOwnUmpirePinnedPool(handle))
+   {
+      const char *pool_name = hypre_HandleUmpirePinnedPoolName(handle);
+      umpire_resourcemanager_get_allocator_by_name(rm_ptr, pool_name, &allocator);
+      memoryB[6] = umpire_allocator_get_current_size(&allocator);
+      memoryB[7] = umpire_allocator_get_high_watermark(&allocator);
+   }
+#endif
+
+   /* Convert bytes to GB */
+   for (i = 0; i < 8; i++)
+   {
+      memory[i] = ((HYPRE_Real) memoryB[i]) / ((HYPRE_Real) (1 << 30));
+   }
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_SetUmpireDevicePoolSize
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_SetUmpireDevicePoolSize(size_t nbytes)
+{
+   hypre_HandleUmpireDevicePoolSize(hypre_handle()) = nbytes;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_SetUmpireUMPoolSize
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_SetUmpireUMPoolSize(size_t nbytes)
+{
+   hypre_HandleUmpireUMPoolSize(hypre_handle()) = nbytes;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_SetUmpireHostPoolSize
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_SetUmpireHostPoolSize(size_t nbytes)
+{
+   hypre_HandleUmpireHostPoolSize(hypre_handle()) = nbytes;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_SetUmpirePinnedPoolSize
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_SetUmpirePinnedPoolSize(size_t nbytes)
+{
+   hypre_HandleUmpirePinnedPoolSize(hypre_handle()) = nbytes;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_SetUmpireDevicePoolName
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_SetUmpireDevicePoolName(const char *pool_name)
+{
+   if (strlen(pool_name) > HYPRE_UMPIRE_POOL_NAME_MAX_LEN)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+
+   strcpy(hypre_HandleUmpireDevicePoolName(hypre_handle()), pool_name);
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_SetUmpireUMPoolName
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_SetUmpireUMPoolName(const char *pool_name)
+{
+   if (strlen(pool_name) > HYPRE_UMPIRE_POOL_NAME_MAX_LEN)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+
+   strcpy(hypre_HandleUmpireUMPoolName(hypre_handle()), pool_name);
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_SetUmpireHostPoolName
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_SetUmpireHostPoolName(const char *pool_name)
+{
+   if (strlen(pool_name) > HYPRE_UMPIRE_POOL_NAME_MAX_LEN)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+
+   strcpy(hypre_HandleUmpireHostPoolName(hypre_handle()), pool_name);
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_SetUmpirePinnedPoolName
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_SetUmpirePinnedPoolName(const char *pool_name)
+{
+   if (strlen(pool_name) > HYPRE_UMPIRE_POOL_NAME_MAX_LEN)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+
+   strcpy(hypre_HandleUmpirePinnedPoolName(hypre_handle()), pool_name);
+
+   return hypre_error_flag;
+}
+
+#endif /* #if defined(HYPRE_USING_UMPIRE) */

--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -1342,7 +1342,7 @@ hypre_HostMemoryGetUsage(HYPRE_Real *mem)
    vm_hwm  *= 1024;
 #endif
 
-   /* Convert data from bytes to GB (double) */
+   /* Convert data from bytes to GB (HYPRE_Real) */
    mem[0] = vm_size  / b_to_gb;
    mem[1] = vm_peak  / b_to_gb;
    mem[2] = vm_rss   / b_to_gb;

--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -1292,7 +1292,8 @@ hypre_HostMemoryGetUsage(HYPRE_Real *mem)
    free_mem = (size_t) vm_stat.free_count * (size_t) vm_page_size;
 
    /* Get the task info */
-   if (task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&t_info, &t_info_count) != KERN_SUCCESS)
+   if (task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&t_info,
+                 &t_info_count) != KERN_SUCCESS)
    {
       hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Problem running task_info!");
       return hypre_error_flag;
@@ -1424,8 +1425,8 @@ hypre_MemoryPrintUsage(MPI_Comm    comm,
       {
          for (j = 0; j < ne; j++)
          {
-            if (gmem[ne * i + j] < min[j]) min[j] = gmem[ne * i + j];
-            if (gmem[ne * i + j] > max[j]) max[j] = gmem[ne * i + j];
+            if (gmem[ne * i + j] < min[j]) { min[j] = gmem[ne * i + j]; }
+            if (gmem[ne * i + j] > max[j]) { max[j] = gmem[ne * i + j]; }
             avg[j] += gmem[ne * i + j];
          }
       }

--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -1278,7 +1278,6 @@ hypre_HostMemoryGetUsage(HYPRE_Real *mem)
    mach_msg_type_number_t   t_info_count = TASK_BASIC_INFO_COUNT;
    mach_msg_type_number_t   count = HOST_VM_INFO_COUNT;
    vm_statistics_data_t     vm_stat;
-   kern_return_t            kr;
    hypre_int                mib[2] = {CTL_HW, HW_MEMSIZE};
    size_t                   length = sizeof(size_t);
 
@@ -1288,7 +1287,13 @@ hypre_HostMemoryGetUsage(HYPRE_Real *mem)
       return hypre_error_flag;
    }
 
-   kr = host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t)&vm_stat, &count);
+   if (host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t)&vm_stat, &count) !=
+       KERN_SUCCESS)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Problem running host_statistics!");
+      return hypre_error_flag;
+   }
+
    free_mem = (size_t) vm_stat.free_count * (size_t) vm_page_size;
 
    /* Get the task info */

--- a/src/utilities/memory.h
+++ b/src/utilities/memory.h
@@ -201,7 +201,7 @@ HYPRE_Int hypre_MemoryPrintUsage(MPI_Comm comm, HYPRE_Int level,
                                  const char *function, HYPRE_Int line);
 #define HYPRE_PRINT_MEMORY_USAGE(comm) hypre_MemoryPrintUsage(comm,\
                                                               hypre_HandleLogLevel(hypre_handle()),\
-                                                              __FUNCTION__,\
+                                                              __func__,\
                                                               __LINE__)
 /* memory_dmalloc.c */
 HYPRE_Int hypre_InitMemoryDebugDML( HYPRE_Int id );

--- a/src/utilities/memory.h
+++ b/src/utilities/memory.h
@@ -197,8 +197,12 @@ HYPRE_Int hypre_UmpireFinalize(hypre_Handle *hypre_handle_);
 HYPRE_Int hypre_UmpireGetCurrentMemoryUsage(MPI_Comm comm, HYPRE_Real *current);
 HYPRE_Int hypre_UmpireMemoryGetUsage(HYPRE_Real *memory);
 HYPRE_Int hypre_HostMemoryGetUsage(HYPRE_Real *mem);
-HYPRE_Int hypre_MemoryPrintUsage(MPI_Comm comm, const char *function, HYPRE_Int line);
-
+HYPRE_Int hypre_MemoryPrintUsage(MPI_Comm comm, HYPRE_Int level,
+                                 const char *function, HYPRE_Int line);
+#define HYPRE_PRINT_MEMORY_USAGE hypre_MemoryPrintUsage(comm,\
+                                                        hypre_HandleLogLevel(hypre_handle()),\
+                                                        __FUNCTION__,\
+                                                        __LINE__)
 /* memory_dmalloc.c */
 HYPRE_Int hypre_InitMemoryDebugDML( HYPRE_Int id );
 HYPRE_Int hypre_FinalizeMemoryDebugDML( void );

--- a/src/utilities/memory.h
+++ b/src/utilities/memory.h
@@ -75,18 +75,6 @@
 //#pragma omp requires unified_shared_memory
 #endif
 
-#if defined(HYPRE_USING_UMPIRE)
-#include "umpire/config.hpp"
-#if UMPIRE_VERSION_MAJOR >= 2022
-#include "umpire/interface/c_fortran/umpire.h"
-#define hypre_umpire_resourcemanager_make_allocator_pool umpire_resourcemanager_make_allocator_quick_pool
-#else
-#include "umpire/interface/umpire.h"
-#define hypre_umpire_resourcemanager_make_allocator_pool umpire_resourcemanager_make_allocator_pool
-#endif
-#define HYPRE_UMPIRE_POOL_NAME_MAX_LEN 1024
-#endif
-
 /* stringification:
  * _Pragma(string-literal), so we need to cast argument to a string
  * The three dots as last argument of the macro tells compiler that this is a variadic macro.
@@ -204,6 +192,12 @@ HYPRE_Int hypre_umpire_um_pooled_allocate(void **ptr, size_t nbytes);
 HYPRE_Int hypre_umpire_um_pooled_free(void *ptr);
 HYPRE_Int hypre_umpire_pinned_pooled_allocate(void **ptr, size_t nbytes);
 HYPRE_Int hypre_umpire_pinned_pooled_free(void *ptr);
+HYPRE_Int hypre_UmpireInit(hypre_Handle *hypre_handle_);
+HYPRE_Int hypre_UmpireFinalize(hypre_Handle *hypre_handle_);
+HYPRE_Int hypre_UmpireGetCurrentMemoryUsage(MPI_Comm comm, HYPRE_Real *current);
+HYPRE_Int hypre_UmpireMemoryGetUsage(HYPRE_Real *memory);
+HYPRE_Int hypre_HostMemoryGetUsage(HYPRE_Real *mem);
+HYPRE_Int hypre_MemoryPrintUsage(MPI_Comm comm, const char *function, HYPRE_Int line);
 
 /* memory_dmalloc.c */
 HYPRE_Int hypre_InitMemoryDebugDML( HYPRE_Int id );
@@ -212,10 +206,6 @@ char *hypre_MAllocDML( HYPRE_Int size, char *file, HYPRE_Int line );
 char *hypre_CAllocDML( HYPRE_Int count, HYPRE_Int elt_size, char *file, HYPRE_Int line );
 char *hypre_ReAllocDML( char *ptr, HYPRE_Int size, char *file, HYPRE_Int line );
 void hypre_FreeDML( char *ptr, char *file, HYPRE_Int line );
-
-/* GPU malloc prototype */
-typedef void (*GPUMallocFunc)(void **, size_t);
-typedef void (*GPUMfreeFunc)(void *);
 
 #ifdef __cplusplus
 }

--- a/src/utilities/memory.h
+++ b/src/utilities/memory.h
@@ -199,10 +199,10 @@ HYPRE_Int hypre_UmpireMemoryGetUsage(HYPRE_Real *memory);
 HYPRE_Int hypre_HostMemoryGetUsage(HYPRE_Real *mem);
 HYPRE_Int hypre_MemoryPrintUsage(MPI_Comm comm, HYPRE_Int level,
                                  const char *function, HYPRE_Int line);
-#define HYPRE_PRINT_MEMORY_USAGE hypre_MemoryPrintUsage(comm,\
-                                                        hypre_HandleLogLevel(hypre_handle()),\
-                                                        __FUNCTION__,\
-                                                        __LINE__)
+#define HYPRE_PRINT_MEMORY_USAGE(comm) hypre_MemoryPrintUsage(comm,\
+                                                              hypre_HandleLogLevel(hypre_handle()),\
+                                                              __FUNCTION__,\
+                                                              __LINE__)
 /* memory_dmalloc.c */
 HYPRE_Int hypre_InitMemoryDebugDML( HYPRE_Int id );
 HYPRE_Int hypre_FinalizeMemoryDebugDML( void );

--- a/src/utilities/protos.h
+++ b/src/utilities/protos.h
@@ -53,8 +53,6 @@ HYPRE_Int hypre_SetDevice(hypre_int device_id, hypre_Handle *hypre_handle_);
 HYPRE_Int hypre_GetDevice(hypre_int *device_id);
 HYPRE_Int hypre_GetDeviceCount(hypre_int *device_count);
 HYPRE_Int hypre_GetDeviceLastError(void);
-HYPRE_Int hypre_UmpireInit(hypre_Handle *hypre_handle_);
-HYPRE_Int hypre_UmpireFinalize(hypre_Handle *hypre_handle_);
 HYPRE_Int hypre_GetDeviceMaxShmemSize(hypre_int device_id, hypre_int *max_size_ptr,
                                       hypre_int *max_size_optin_ptr);
 

--- a/src/utilities/protos.h
+++ b/src/utilities/protos.h
@@ -380,6 +380,7 @@ HYPRE_Int hypre_GetSyncCudaCompute(HYPRE_Int *cuda_compute_stream_sync_ptr);
 HYPRE_Int hypre_ForceSyncComputeStream(hypre_Handle *hypre_handle);
 
 /* handle.c */
+HYPRE_Int hypre_SetLogLevel( HYPRE_Int log_level );
 HYPRE_Int hypre_SetSpTransUseVendor( HYPRE_Int use_vendor );
 HYPRE_Int hypre_SetSpMVUseVendor( HYPRE_Int use_vendor );
 HYPRE_Int hypre_SetSpGemmUseVendor( HYPRE_Int use_vendor );


### PR DESCRIPTION
This PR adds the functions:

- `hypre_HostMemoryGetUsage`: retrieves CPU RAM stats (VmSize, VmPeak, VmRSS, VmHWM)
- `hypre_UmpireMemoryGetUsage`: retrieves GPU RAM stats via umpire (DevSize, DevPeak, ...)
- `hypre_MemoryPrintUsage`: prints memory usage for stdout
- `HYPRE_MemoryPrintUsage`: public API for calling `hypre_MemoryPrintUsage`

Additionally, a new `log_level` member is added to the `hypre_handle` structure. This member enables users to toggle the memory usage functions on or off. `log_level` can be configured via an environment variable, providing easy and fast access to the new memory monitoring capabilities for both users and developers.

Example usage with hypredrive:

```
$ HYPRE_LOG_LEVEL=1 mpirun -np 4 ./hypredrive examples/ex2.yml

Using HYPRE_DEVELOP_STRING: v2.31.0-11-g5de2c5cee (memory)

Running on 4 MPI ranks
------------------------------------------------------------------------------------
general: 
  use_millisec: on
linear_system: 
  rhs_filename: data/ps3d10pt7/np4/IJ.out.b
  matrix_filename: data/ps3d10pt7/np4/IJ.out.A
solver: 
  pcg: 
    max_iter: 100
    two_norm: yes
    rel_change: no
    print_level: 2
    relative_tol: 1.0e-6
    absolute_tol: 0.0
    residual_tol: 0.0
    conv_fac_tol: 0.0
preconditioner: 
  amg: 
    tolerance: 0.0
    max_iter: 1
    print_level: 1
    interpolation: 
      prolongation_type: extended+i
      restriction_type: p_transpose
      trunc_factor: 0.0
      max_nnz_row: 4
    coarsening: 
      type: pmis
      strong_th: 0.25
      seq_amg_th: 0
      max_coarse_size: 64
      min_coarse_size: 0
      max_levels: 25
      num_functions: 1
      rap2: off
      mod_rap2: on
      keep_transpose: off
      max_row_sum: 0.9
    aggressive: 
      num_levels: 0
      num_paths: 1
      prolongation_type: multipass
      trunc_factor: 0.0
      max_nnz_row: 0
      P12_trunc_factor: 0.0
      P12_max_elements: 0
    relaxation: 
      down_type: forward-hl1gs
      up_type: backward-hl1gs
      coarse_type: ge
      down_sweeps: -1
      up_sweeps: -1
      coarse_sweeps: 1
      num_sweeps: 1
      order: 0
      weight: 1.0
      outer_weight: 1.0
    smoother: 
      type: fsai
      num_levels: 0
      num_sweeps: 1
------------------------------------------------------------------------------------
[0]: hypre_IJMatrixSetValuesParCSR at line 1036 | VmSize/Peak: (12.88 / 12.91) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.32 /  62.71) GB
[1]: hypre_IJMatrixSetValuesParCSR at line 1036 | VmSize/Peak: (12.88 / 12.90) GB | VmRSS/HWM: ( 1.80 /  1.80) GB | Free/Total: (42.32 /  62.71) GB
[2]: hypre_IJMatrixSetValuesParCSR at line 1036 | VmSize/Peak: (12.88 / 12.91) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.32 /  62.71) GB
[3]: hypre_IJMatrixSetValuesParCSR at line 1036 | VmSize/Peak: (12.88 / 12.90) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.32 /  62.71) GB
[0]: hypre_IJMatrixAssembleParCSR at line 2957 | VmSize/Peak: (12.88 / 12.91) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.32 /  62.71) GB
[1]: hypre_IJMatrixAssembleParCSR at line 2957 | VmSize/Peak: (12.88 / 12.90) GB | VmRSS/HWM: ( 1.80 /  1.80) GB | Free/Total: (42.32 /  62.71) GB
[2]: hypre_IJMatrixAssembleParCSR at line 2957 | VmSize/Peak: (12.88 / 12.91) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.32 /  62.71) GB
[3]: hypre_IJMatrixAssembleParCSR at line 2957 | VmSize/Peak: (12.88 / 12.90) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.32 /  62.71) GB
====================================================================================
Solving linear system #0 with 1000 rows and 6400 nonzeros...
[0]: BoomerAMG setup begin | VmSize/Peak: (21.01 / 21.04) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.32 /  62.71) GB | UVmSize/UVmPeak: ( 0.00 /  0.00) GB
[1]: BoomerAMG setup begin | VmSize/Peak: (21.01 / 21.04) GB | VmRSS/HWM: ( 1.80 /  1.80) GB | Free/Total: (42.32 /  62.71) GB | UVmSize/UVmPeak: ( 0.00 /  0.00) GB
[2]: BoomerAMG setup begin | VmSize/Peak: (21.01 / 21.04) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.32 /  62.71) GB | UVmSize/UVmPeak: ( 0.00 /  0.00) GB
[3]: BoomerAMG setup begin | VmSize/Peak: (21.01 / 21.04) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.32 /  62.71) GB | UVmSize/UVmPeak: ( 0.00 /  0.00) GB


 Num MPI tasks = 4

 Num OpenMP threads = 1


BoomerAMG SETUP PARAMETERS:

 Max levels = 25
 Num levels = 3

 Strength Threshold = 0.250000
 Interpolation Truncation Factor = 0.000000
 Maximum Row Sum Threshold for Dependency Weakening = 0.900000

 Coarsening Type = PMIS 
 measures are determined locally


 No global partition option chosen.

 Interpolation = extended+i interpolation

Operator Matrix Information:

             nonzero            entries/row          row sums
lev    rows  entries sparse   min  max     avg      min         max
======================================================================
  0    1000     6400  0.006     4    7     6.4   0.000e+00   3.000e+00
  1     362     7678  0.059     7   43    21.2  -3.234e-15   4.291e+00
  2      60     1994  0.554    17   54    33.2   8.050e-01   5.553e+00


Interpolation Matrix Information:
                    entries/row        min        max            row sums
lev  rows x cols  min  max  avgW     weight      weight       min         max
================================================================================
  0  1000 x 362     1    4   4.0   5.263e-02   4.167e-01   4.000e-01   1.000e+00
  1   362 x 60      1    4   3.9   5.635e-03   5.457e-01   1.308e-01   1.000e+00


     Complexity:   grid = 1.422000
               operator = 2.511250
                 memory = 3.161094




BoomerAMG SOLVER PARAMETERS:

  Maximum number of cycles:         1 
  Stopping Tolerance:               0.000000e+00 
  Cycle type (1 = V, 2 = W, etc.):  1

  Relaxation Parameters:
   Visiting Grid:                     down   up  coarse
            Number of sweeps:            1    1     1 
   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:     13   14     9 
   Point types, partial sweeps (1=C, -1=F):
                  Pre-CG relaxation (down):   0
                   Post-CG relaxation (up):   0
                             Coarsest grid:   0

[0]: BoomerAMG setup end | VmSize/Peak: (21.08 / 21.08) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.30 /  62.71) GB | UVmSize/UVmPeak: ( 0.00 /  0.00) GB
[1]: BoomerAMG setup end | VmSize/Peak: (21.08 / 21.14) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.30 /  62.71) GB | UVmSize/UVmPeak: ( 0.00 /  0.00) GB
[2]: BoomerAMG setup end | VmSize/Peak: (21.08 / 21.08) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.30 /  62.71) GB | UVmSize/UVmPeak: ( 0.00 /  0.00) GB
[3]: BoomerAMG setup end | VmSize/Peak: (21.08 / 21.14) GB | VmRSS/HWM: ( 1.81 /  1.81) GB | Free/Total: (42.30 /  62.71) GB | UVmSize/UVmPeak: ( 0.00 /  0.00) GB
<b,b>: 1.000000e+03


Iters       ||r||_2     conv.rate  ||r||_2/||b||_2
-----    ------------   ---------  ------------ 
    1    1.064402e+01    0.336593    3.365933e-01
    2    7.508307e-01    0.070540    2.374335e-02
    3    5.602217e-02    0.074614    1.771577e-03
    4    3.965849e-03    0.070791    1.254112e-04
    5    2.628232e-04    0.066272    8.311198e-06
    6    1.756500e-05    0.066832    5.554540e-07


====================================================================================


STATISTICS SUMMARY:

+------------+-------------+-------------+-------------+-------------+-------------+
|            |    LS build |       setup |       solve |    relative |             |
|      Entry |  times [ms] |  times [ms] |  times [ms] |   res. norm |       iters |
+------------+-------------+-------------+-------------+-------------+-------------+
|          0 |       4.132 |     282.530 |     234.172 |    5.55e-07 |           6 |
+------------+-------------+-------------+-------------+-------------+-------------+
```