### PR TITLE
Add filtering option to AMG

### DIFF
--- a/src/parcsr_ls/HYPRE_parcsr_amg.c
+++ b/src/parcsr_ls/HYPRE_parcsr_amg.c
@@ -1509,21 +1509,47 @@ HYPRE_BoomerAMGSetFSAIKapTolerance( HYPRE_Solver  solver,
 }
 
 /*--------------------------------------------------------------------------
- * HYPRE_BoomerAMGSetNumFunctions, HYPRE_BoomerAMGGetNumFunctions
+ * HYPRE_BoomerAMGSetNumFunctions
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 HYPRE_BoomerAMGSetNumFunctions( HYPRE_Solver  solver,
-                                HYPRE_Int          num_functions  )
+                                HYPRE_Int     num_functions  )
 {
    return ( hypre_BoomerAMGSetNumFunctions( (void *) solver, num_functions ) );
 }
 
+/*--------------------------------------------------------------------------
+ * HYPRE_BoomerAMGGetNumFunctions
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 HYPRE_BoomerAMGGetNumFunctions( HYPRE_Solver  solver,
-                                HYPRE_Int        * num_functions  )
+                                HYPRE_Int     *num_functions  )
 {
    return ( hypre_BoomerAMGGetNumFunctions( (void *) solver, num_functions ) );
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_BoomerAMGSetFilterFunctions
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_BoomerAMGSetFilterFunctions( HYPRE_Solver  solver,
+                                   HYPRE_Int     filter_functions  )
+{
+   return ( hypre_BoomerAMGSetFilterFunctions( (void *) solver, filter_functions ) );
+}
+
+/*--------------------------------------------------------------------------
+ * HYPRE_BoomerAMGGetFilterFunctions
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_BoomerAMGGetFilterFunctions( HYPRE_Solver  solver,
+                                   HYPRE_Int    *filter_functions  )
+{
+   return ( hypre_BoomerAMGGetFilterFunctions( (void *) solver, filter_functions ) );
 }
 
 /*--------------------------------------------------------------------------
@@ -1546,7 +1572,6 @@ HYPRE_BoomerAMGSetNodalLevels( HYPRE_Solver  solver,
 {
    return ( hypre_BoomerAMGSetNodalLevels( (void *) solver, nodal_levels ) );
 }
-
 
 /*--------------------------------------------------------------------------
  * HYPRE_BoomerAMGSetNodalDiag

--- a/src/parcsr_ls/HYPRE_parcsr_ls.h
+++ b/src/parcsr_ls/HYPRE_parcsr_ls.h
@@ -170,7 +170,19 @@ HYPRE_Int HYPRE_BoomerAMGGetFinalRelativeResidualNorm(HYPRE_Solver  solver,
  * The default is 1, i.e. a scalar system.
  **/
 HYPRE_Int HYPRE_BoomerAMGSetNumFunctions(HYPRE_Solver solver,
-                                         HYPRE_Int          num_functions);
+                                         HYPRE_Int    num_functions);
+
+/**
+ * (Optional) Sets filtering for system of PDEs (\e num_functions > 1).
+ *
+ * \param filter_functions An integer flag to enable or disable filtering of inter-variable
+ * connections in the input matrix used for preconditioning.
+ *   - A value of 0 (default) indicates no filtering, preserving all inter-variable connections.
+ *   - A value of 1 enables filtering, removing inter-variable connections to lower
+ *     operator and memory complexities.
+ **/
+HYPRE_Int HYPRE_BoomerAMGSetFilterFunctions(HYPRE_Solver solver,
+                                            HYPRE_Int    filter_functions);
 
 /**
  * (Optional) Sets the mapping that assigns the function to each variable,

--- a/src/parcsr_ls/HYPRE_parcsr_ls.h
+++ b/src/parcsr_ls/HYPRE_parcsr_ls.h
@@ -180,6 +180,11 @@ HYPRE_Int HYPRE_BoomerAMGSetNumFunctions(HYPRE_Solver solver,
  *   - A value of 0 (default) indicates no filtering, preserving all inter-variable connections.
  *   - A value of 1 enables filtering, removing inter-variable connections to lower
  *     operator and memory complexities.
+ *
+ * @note This option assumes that variables are stored in an interleaved format,
+ *       where multiple variables are combined in a single vector. Enabling filtering
+ *       can be beneficial when the problem has multiple coupled variables (functions)
+ *       that are not strongly coupled.
  **/
 HYPRE_Int HYPRE_BoomerAMGSetFilterFunctions(HYPRE_Solver solver,
                                             HYPRE_Int    filter_functions);

--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -110,6 +110,7 @@ typedef struct
    hypre_ParCSRMatrix  *A;
    HYPRE_Int            num_variables;
    HYPRE_Int            num_functions;
+   HYPRE_Int            filter_functions;
    HYPRE_Int            nodal;
    HYPRE_Int            nodal_levels;
    HYPRE_Int            nodal_diag;
@@ -380,8 +381,9 @@ typedef struct
 #define hypre_ParAMGDataOuterWt(amg_data) ((amg_data)->outer_wt)
 
 /* problem data parameters */
-#define  hypre_ParAMGDataNumVariables(amg_data)  ((amg_data)->num_variables)
+#define hypre_ParAMGDataNumVariables(amg_data)  ((amg_data)->num_variables)
 #define hypre_ParAMGDataNumFunctions(amg_data) ((amg_data)->num_functions)
+#define hypre_ParAMGDataFilterFunctions(amg_data) ((amg_data)->filter_functions)
 #define hypre_ParAMGDataNodal(amg_data) ((amg_data)->nodal)
 #define hypre_ParAMGDataNodalLevels(amg_data) ((amg_data)->nodal_levels)
 #define hypre_ParAMGDataNodalDiag(amg_data) ((amg_data)->nodal_diag)
@@ -1980,6 +1982,8 @@ HYPRE_Int HYPRE_BoomerAMGSetFSAIThreshold ( HYPRE_Solver solver, HYPRE_Real thre
 HYPRE_Int HYPRE_BoomerAMGSetFSAIKapTolerance ( HYPRE_Solver solver, HYPRE_Real kap_tolerance );
 HYPRE_Int HYPRE_BoomerAMGSetNumFunctions ( HYPRE_Solver solver, HYPRE_Int num_functions );
 HYPRE_Int HYPRE_BoomerAMGGetNumFunctions ( HYPRE_Solver solver, HYPRE_Int *num_functions );
+HYPRE_Int HYPRE_BoomerAMGSetFilterFunctions ( HYPRE_Solver solver, HYPRE_Int filter_functions );
+HYPRE_Int HYPRE_BoomerAMGGetFilterFunctions ( HYPRE_Solver solver, HYPRE_Int *filter_functions );
 HYPRE_Int HYPRE_BoomerAMGSetNodal ( HYPRE_Solver solver, HYPRE_Int nodal );
 HYPRE_Int HYPRE_BoomerAMGSetNodalLevels ( HYPRE_Solver solver, HYPRE_Int nodal_levels );
 HYPRE_Int HYPRE_BoomerAMGSetNodalDiag ( HYPRE_Solver solver, HYPRE_Int nodal );
@@ -2568,6 +2572,8 @@ HYPRE_Int hypre_BoomerAMGSetCoordinates ( void *data, float *coordinates );
 HYPRE_Int hypre_BoomerAMGGetGridHierarchy(void *data, HYPRE_Int *cgrid );
 HYPRE_Int hypre_BoomerAMGSetNumFunctions ( void *data, HYPRE_Int num_functions );
 HYPRE_Int hypre_BoomerAMGGetNumFunctions ( void *data, HYPRE_Int *num_functions );
+HYPRE_Int hypre_BoomerAMGSetFilterFunctions ( void *data, HYPRE_Int filter_functions );
+HYPRE_Int hypre_BoomerAMGGetFilterFunctions ( void *data, HYPRE_Int *filter_functions );
 HYPRE_Int hypre_BoomerAMGSetNodal ( void *data, HYPRE_Int nodal );
 HYPRE_Int hypre_BoomerAMGSetNodalLevels ( void *data, HYPRE_Int nodal_levels );
 HYPRE_Int hypre_BoomerAMGSetNodalDiag ( void *data, HYPRE_Int nodal );

--- a/src/parcsr_ls/par_amg.c
+++ b/src/parcsr_ls/par_amg.c
@@ -48,6 +48,7 @@ hypre_BoomerAMGCreate( void )
    HYPRE_Int    setup_type;
    HYPRE_Int    P_max_elmts;
    HYPRE_Int    num_functions;
+   HYPRE_Int    filter_functions;
    HYPRE_Int    nodal, nodal_levels, nodal_diag;
    HYPRE_Int    keep_same_sign;
    HYPRE_Int    num_paths;
@@ -182,6 +183,7 @@ hypre_BoomerAMGCreate( void )
    agg_P_max_elmts = 0;
    agg_P12_max_elmts = 0;
    num_functions = 1;
+   filter_functions = 0;
    nodal = 0;
    nodal_levels = max_levels;
    nodal_diag = 0;
@@ -359,6 +361,7 @@ hypre_BoomerAMGCreate( void )
    hypre_BoomerAMGSetAggPMaxElmts(amg_data, agg_P_max_elmts);
    hypre_BoomerAMGSetAggP12MaxElmts(amg_data, agg_P12_max_elmts);
    hypre_BoomerAMGSetNumFunctions(amg_data, num_functions);
+   hypre_BoomerAMGSetFilterFunctions(amg_data, filter_functions);
    hypre_BoomerAMGSetNodal(amg_data, nodal);
    hypre_BoomerAMGSetNodalLevels(amg_data, nodal_levels);
    hypre_BoomerAMGSetNodal(amg_data, nodal_diag);
@@ -3201,9 +3204,13 @@ hypre_BoomerAMGSetNumFunctions( void     *data,
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_BoomerAMGGetNumFunctions
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
-hypre_BoomerAMGGetNumFunctions( void     *data,
-                                HYPRE_Int     * num_functions )
+hypre_BoomerAMGGetNumFunctions( void      *data,
+                                HYPRE_Int *num_functions )
 {
    hypre_ParAMGData  *amg_data = (hypre_ParAMGData*) data;
 
@@ -3213,6 +3220,51 @@ hypre_BoomerAMGGetNumFunctions( void     *data,
       return hypre_error_flag;
    }
    *num_functions = hypre_ParAMGDataNumFunctions(amg_data);
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_BoomerAMGSetFilterFunctions
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_BoomerAMGSetFilterFunctions( void      *data,
+                                   HYPRE_Int  filter_functions )
+{
+   hypre_ParAMGData  *amg_data = (hypre_ParAMGData*) data;
+
+   if (!amg_data)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+   if (filter_functions < 0 || filter_functions > 1)
+   {
+      hypre_error_in_arg(2);
+      return hypre_error_flag;
+   }
+   hypre_ParAMGDataFilterFunctions(amg_data) = filter_functions;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_BoomerAMGGetFilterFunctions
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_BoomerAMGGetFilterFunctions( void      *data,
+                                   HYPRE_Int *filter_functions )
+{
+   hypre_ParAMGData  *amg_data = (hypre_ParAMGData*) data;
+
+   if (!amg_data)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+   *filter_functions = hypre_ParAMGDataFilterFunctions(amg_data);
 
    return hypre_error_flag;
 }

--- a/src/parcsr_ls/par_amg.h
+++ b/src/parcsr_ls/par_amg.h
@@ -92,6 +92,7 @@ typedef struct
    hypre_ParCSRMatrix  *A;
    HYPRE_Int            num_variables;
    HYPRE_Int            num_functions;
+   HYPRE_Int            filter_functions;
    HYPRE_Int            nodal;
    HYPRE_Int            nodal_levels;
    HYPRE_Int            nodal_diag;
@@ -362,8 +363,9 @@ typedef struct
 #define hypre_ParAMGDataOuterWt(amg_data) ((amg_data)->outer_wt)
 
 /* problem data parameters */
-#define  hypre_ParAMGDataNumVariables(amg_data)  ((amg_data)->num_variables)
+#define hypre_ParAMGDataNumVariables(amg_data)  ((amg_data)->num_variables)
 #define hypre_ParAMGDataNumFunctions(amg_data) ((amg_data)->num_functions)
+#define hypre_ParAMGDataFilterFunctions(amg_data) ((amg_data)->filter_functions)
 #define hypre_ParAMGDataNodal(amg_data) ((amg_data)->nodal)
 #define hypre_ParAMGDataNodalLevels(amg_data) ((amg_data)->nodal_levels)
 #define hypre_ParAMGDataNodalDiag(amg_data) ((amg_data)->nodal_diag)

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -31,8 +31,9 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                       hypre_ParVector    *f,
                       hypre_ParVector    *u )
 {
-   MPI_Comm            comm = hypre_ParCSRMatrixComm(A);
-   hypre_ParAMGData   *amg_data = (hypre_ParAMGData*) amg_vdata;
+   MPI_Comm             comm = hypre_ParCSRMatrixComm(A);
+   hypre_ParAMGData    *amg_data = (hypre_ParAMGData*) amg_vdata;
+   hypre_ParCSRMatrix  *A_tilde = A;
 
    /* Data Structure variables */
    HYPRE_Int            num_vectors;
@@ -135,6 +136,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
 #endif
    HYPRE_Int      *grid_relax_type = hypre_ParAMGDataGridRelaxType(amg_data);
    HYPRE_Int       num_functions = hypre_ParAMGDataNumFunctions(amg_data);
+   HYPRE_Int       filter_functions = hypre_ParAMGDataFilterFunctions(amg_data);
    HYPRE_Int       nodal = hypre_ParAMGDataNodal(amg_data);
    HYPRE_Int       nodal_levels = hypre_ParAMGDataNodalLevels(amg_data);
    HYPRE_Int       nodal_diag = hypre_ParAMGDataNodalDiag(amg_data);
@@ -768,7 +770,13 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
       }
    }
 
-   A_array[0] = A;
+   /* Eliminate inter-variable connections among functions for preconditioning purposes */
+   if (num_functions > 1 && filter_functions)
+   {
+      hypre_ParCSRMatrixBlkFilter(A, num_functions, &A_tilde);
+   }
+
+   A_array[0] = A_tilde;
 
    /* interp vectors setup */
    if (interp_vec_variant == 1)
@@ -776,7 +784,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
       num_levels_interp_vectors = interp_vec_first_level + 1;
       hypre_ParAMGNumLevelsInterpVectors(amg_data) = num_levels_interp_vectors;
    }
-   if ( interp_vec_variant > 0 &&  num_interp_vectors > 0)
+   if (interp_vec_variant > 0 && num_interp_vectors > 0)
    {
       interp_vectors_array =  hypre_CTAlloc(hypre_ParVector**, num_levels_interp_vectors,
                                             HYPRE_MEMORY_HOST);
@@ -3810,6 +3818,13 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
              (additive > -1 && additive < num_levels) )
    {
       hypre_CreateLambda(amg_data);
+   }
+
+   /* Destroy filtered matrix */
+   if (A_tilde != A)
+   {
+      hypre_ParCSRMatrixDestroy(A_tilde);
+      A_array[0] = A;
    }
 
    if (cum_nnz_AP > 0.0)

--- a/src/parcsr_ls/par_stats.c
+++ b/src/parcsr_ls/par_stats.c
@@ -65,6 +65,8 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
 
 
    HYPRE_Int      num_levels;
+   HYPRE_Int      num_functions;
+   HYPRE_Int      filter_functions;
    HYPRE_Int      coarsen_type;
    HYPRE_Int      interp_type;
    HYPRE_Int      restri_type;
@@ -160,6 +162,8 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
    A_array = hypre_ParAMGDataAArray(amg_data);
    P_array = hypre_ParAMGDataPArray(amg_data);
    num_levels = hypre_ParAMGDataNumLevels(amg_data);
+   num_functions = hypre_ParAMGDataNumFunctions(amg_data);
+   filter_functions = hypre_ParAMGDataFilterFunctions(amg_data);
    coarsen_type = hypre_ParAMGDataCoarsenType(amg_data);
    interp_type = hypre_ParAMGDataInterpType(amg_data);
    restri_type = hypre_ParAMGDataRestriction(amg_data); /* RL */
@@ -401,6 +405,12 @@ hypre_BoomerAMGSetupStats( void               *amg_vdata,
       {
          hypre_printf(" Restriction = local approximate ideal restriction (Neumann AIR-%d)\n",
                       restri_type - 3);
+      }
+
+      if (num_functions > 1)
+      {
+         hypre_printf(" Number of functions = %d\n", num_functions);
+         hypre_printf(" Functions filtering is %s\n", (filter_functions > 0) ? "on" : "off");
       }
 
       if (block_mode)

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -527,6 +527,8 @@ HYPRE_Int HYPRE_BoomerAMGSetFSAIThreshold ( HYPRE_Solver solver, HYPRE_Real thre
 HYPRE_Int HYPRE_BoomerAMGSetFSAIKapTolerance ( HYPRE_Solver solver, HYPRE_Real kap_tolerance );
 HYPRE_Int HYPRE_BoomerAMGSetNumFunctions ( HYPRE_Solver solver, HYPRE_Int num_functions );
 HYPRE_Int HYPRE_BoomerAMGGetNumFunctions ( HYPRE_Solver solver, HYPRE_Int *num_functions );
+HYPRE_Int HYPRE_BoomerAMGSetFilterFunctions ( HYPRE_Solver solver, HYPRE_Int filter_functions );
+HYPRE_Int HYPRE_BoomerAMGGetFilterFunctions ( HYPRE_Solver solver, HYPRE_Int *filter_functions );
 HYPRE_Int HYPRE_BoomerAMGSetNodal ( HYPRE_Solver solver, HYPRE_Int nodal );
 HYPRE_Int HYPRE_BoomerAMGSetNodalLevels ( HYPRE_Solver solver, HYPRE_Int nodal_levels );
 HYPRE_Int HYPRE_BoomerAMGSetNodalDiag ( HYPRE_Solver solver, HYPRE_Int nodal );
@@ -1115,6 +1117,8 @@ HYPRE_Int hypre_BoomerAMGSetCoordinates ( void *data, float *coordinates );
 HYPRE_Int hypre_BoomerAMGGetGridHierarchy(void *data, HYPRE_Int *cgrid );
 HYPRE_Int hypre_BoomerAMGSetNumFunctions ( void *data, HYPRE_Int num_functions );
 HYPRE_Int hypre_BoomerAMGGetNumFunctions ( void *data, HYPRE_Int *num_functions );
+HYPRE_Int hypre_BoomerAMGSetFilterFunctions ( void *data, HYPRE_Int filter_functions );
+HYPRE_Int hypre_BoomerAMGGetFilterFunctions ( void *data, HYPRE_Int *filter_functions );
 HYPRE_Int hypre_BoomerAMGSetNodal ( void *data, HYPRE_Int nodal );
 HYPRE_Int hypre_BoomerAMGSetNodalLevels ( void *data, HYPRE_Int nodal_levels );
 HYPRE_Int hypre_BoomerAMGSetNodalDiag ( void *data, HYPRE_Int nodal );

--- a/src/parcsr_mv/CMakeLists.txt
+++ b/src/parcsr_mv/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SRCS
   par_csr_bool_matop.c
   par_csr_bool_matrix.c
   par_csr_communication.c
+  par_csr_filter.c
   par_csr_matop.c
   par_csr_matrix.c
   par_csr_matrix_stats.c

--- a/src/parcsr_mv/Makefile
+++ b/src/parcsr_mv/Makefile
@@ -44,6 +44,7 @@ FILES =\
  par_csr_bool_matop.c\
  par_csr_bool_matrix.c\
  par_csr_communication.c\
+ par_csr_filter.c\
  par_csr_matop.c\
  par_csr_matrix.c\
  par_csr_matrix_stats.c\

--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -934,6 +934,10 @@ HYPRE_Int hypre_ParCSRFindExtendCommPkg(MPI_Comm comm, HYPRE_BigInt global_num_c
                                         hypre_IJAssumedPart *apart, HYPRE_Int indices_len, HYPRE_BigInt *indices,
                                         hypre_ParCSRCommPkg **extend_comm_pkg);
 
+/* par_csr_filter.c */
+HYPRE_Int hypre_ParCSRMatrixBlkFilter(hypre_ParCSRMatrix *A,
+                                      HYPRE_Int block_size, hypre_ParCSRMatrix **B_ptr);
+
 /* par_csr_matop.c */
 HYPRE_Int hypre_ParCSRMatrixScale(hypre_ParCSRMatrix *A, HYPRE_Complex scalar);
 void hypre_ParMatmul_RowSizes ( HYPRE_MemoryLocation memory_location, HYPRE_Int **C_diag_i,

--- a/src/parcsr_mv/par_csr_filter.c
+++ b/src/parcsr_mv/par_csr_filter.c
@@ -1,0 +1,222 @@
+/******************************************************************************
+ * Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+
+/******************************************************************************
+ *
+ * Member functions for hypre_ParCSRMatrix class.
+ *
+ *****************************************************************************/
+
+#include "_hypre_parcsr_mv.h"
+
+/*--------------------------------------------------------------------------
+ * hypre_ParCSRMatrixBlkFilterHost
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_ParCSRMatrixBlkFilterHost( hypre_ParCSRMatrix  *A,
+                                 HYPRE_Int            block_size,
+                                 hypre_ParCSRMatrix **B_ptr )
+{
+   MPI_Comm             comm              = hypre_ParCSRMatrixComm(A);
+   HYPRE_BigInt         global_num_rows   = hypre_ParCSRMatrixGlobalNumRows(A);
+   HYPRE_BigInt         global_num_cols   = hypre_ParCSRMatrixGlobalNumCols(A);
+   HYPRE_BigInt        *row_starts        = hypre_ParCSRMatrixRowStarts(A);
+   HYPRE_BigInt        *col_starts        = hypre_ParCSRMatrixColStarts(A);
+   HYPRE_BigInt        *col_map_offd_A    = hypre_ParCSRMatrixColMapOffd(A);
+   HYPRE_MemoryLocation memory_location   = hypre_ParCSRMatrixMemoryLocation(A);
+
+   hypre_CSRMatrix     *A_diag            = hypre_ParCSRMatrixDiag(A);
+   HYPRE_Int            num_rows          = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Int           *A_diag_i          = hypre_CSRMatrixI(A_diag);
+   HYPRE_Int           *A_diag_j          = hypre_CSRMatrixJ(A_diag);
+   HYPRE_Complex       *A_diag_a          = hypre_CSRMatrixData(A_diag);
+
+   hypre_CSRMatrix     *A_offd            = hypre_ParCSRMatrixOffd(A);
+   HYPRE_Int           *A_offd_i          = hypre_CSRMatrixI(A_offd);
+   HYPRE_Int           *A_offd_j          = hypre_CSRMatrixJ(A_offd);
+   HYPRE_Complex       *A_offd_a          = hypre_CSRMatrixData(A_offd);
+   HYPRE_Int            num_cols_offd_A   = hypre_CSRMatrixNumCols(A_offd);
+
+   /* Output matrix variables */
+   hypre_ParCSRMatrix  *B;
+   hypre_CSRMatrix     *B_diag, *B_offd;
+   HYPRE_Int           *B_diag_i, *B_offd_i;
+   HYPRE_Int           *B_diag_j, *B_offd_j;
+   HYPRE_Complex       *B_diag_a, *B_offd_a;
+   HYPRE_BigInt        *col_map_offd_B;
+   HYPRE_Int            num_cols_offd_B;
+   HYPRE_Int            B_diag_nnz, B_offd_nnz;
+
+   /* Local variables */
+   HYPRE_BigInt         big_block_size    = (HYPRE_BigInt) block_size;
+   HYPRE_Int            i, j, c;
+   HYPRE_Int           *marker;
+
+   /*-----------------------------------------------------------------------
+    *  Sanity checks
+    *-----------------------------------------------------------------------*/
+
+   if (block_size < 1)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "block size must be greater than one!\n");
+      return hypre_error_flag;
+   }
+
+   if (global_num_rows % big_block_size)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "block size is not a divisor of the number of rows!\n");
+      return hypre_error_flag;
+   }
+
+   if (row_starts[0] % big_block_size)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "block size is not a divisor of the first global row!\n");
+      return hypre_error_flag;
+   }
+
+   if (global_num_rows != global_num_cols)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Function not implemented for rectangular matrices!\n");
+      return hypre_error_flag;
+   }
+
+   /*-----------------------------------------------------------------------
+    *  First pass: compute nonzero counts of B
+    *-----------------------------------------------------------------------*/
+
+   B_diag_nnz = B_offd_nnz = 0;
+   for (i = 0; i < num_rows; i++)
+   {
+      c = i % block_size;
+
+      for (j = A_diag_i[i]; j < A_diag_i[i + 1]; j++)
+      {
+         if (c == (A_diag_j[j] % block_size))
+         {
+            B_diag_nnz++;
+         }
+      }
+
+      for (j = A_offd_i[i]; j < A_offd_i[i + 1]; j++)
+      {
+         if (c == (HYPRE_Int) (col_map_offd_A[A_offd_j[j]] % big_block_size))
+         {
+            B_offd_nnz++;
+         }
+      }
+   }
+
+   /*-----------------------------------------------------------------------
+    *  Create and initialize output matrix
+    *-----------------------------------------------------------------------*/
+
+   B = hypre_ParCSRMatrixCreate(comm, global_num_rows, global_num_cols,
+                                row_starts, col_starts, num_cols_offd_A,
+                                B_diag_nnz, B_offd_nnz);
+
+   hypre_ParCSRMatrixInitialize_v2(B, memory_location);
+
+   B_diag   = hypre_ParCSRMatrixDiag(B);
+   B_diag_i = hypre_CSRMatrixI(B_diag);
+   B_diag_j = hypre_CSRMatrixJ(B_diag);
+   B_diag_a = hypre_CSRMatrixData(B_diag);
+
+   B_offd   = hypre_ParCSRMatrixOffd(B);
+   B_offd_i = hypre_CSRMatrixI(B_offd);
+   B_offd_j = hypre_CSRMatrixJ(B_offd);
+   B_offd_a = hypre_CSRMatrixData(B_offd);
+
+   col_map_offd_B = hypre_ParCSRMatrixColMapOffd(B);
+
+   /*-----------------------------------------------------------------------
+    *  Second pass: Fill entries of B
+    *-----------------------------------------------------------------------*/
+
+   marker = hypre_CTAlloc(HYPRE_Int, num_cols_offd_A, HYPRE_MEMORY_HOST);
+
+   for (i = 0; i < num_rows; i++)
+   {
+      c = i % block_size;
+
+      B_diag_i[i + 1] = B_diag_i[i];
+      for (j = A_diag_i[i]; j < A_diag_i[i + 1]; j++)
+      {
+         if (c == (A_diag_j[j] % block_size))
+         {
+            B_diag_j[B_diag_i[i + 1]] = A_diag_j[j];
+            B_diag_a[B_diag_i[i + 1]] = A_diag_a[j];
+            B_diag_i[i + 1]++;
+         }
+      }
+
+      B_offd_i[i + 1] = B_offd_i[i];
+      for (j = A_offd_i[i]; j < A_offd_i[i + 1]; j++)
+      {
+         if (c == (HYPRE_Int) (col_map_offd_A[A_offd_j[j]] % big_block_size))
+         {
+            B_offd_j[B_offd_i[i + 1]] = A_offd_j[j];
+            B_offd_a[B_offd_i[i + 1]] = A_offd_a[j];
+            B_offd_i[i + 1]++;
+            marker[A_offd_j[j]] = 1;
+         }
+      }
+   }
+
+   /* Update col_map array */
+   num_cols_offd_B = 0;
+   for (i = 0; i < num_cols_offd_A; i++)
+   {
+      if (marker[i])
+      {
+         col_map_offd_B[num_cols_offd_B++] = col_map_offd_A[i];
+      }
+   }
+   hypre_CSRMatrixNumCols(B_offd) = num_cols_offd_B;
+   hypre_TFree(marker, HYPRE_MEMORY_HOST);
+
+   /* Update global nonzeros */
+   hypre_ParCSRMatrixSetDNumNonzeros(B);
+   hypre_ParCSRMatrixNumNonzeros(B) = (HYPRE_BigInt) hypre_ParCSRMatrixDNumNonzeros(B);
+   hypre_MatvecCommPkgCreate(B);
+
+   /* Set output pointer */
+   *B_ptr = B;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_ParCSRMatrixBlkFilter
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_ParCSRMatrixBlkFilter( hypre_ParCSRMatrix  *A,
+                             HYPRE_Int            block_size,
+                             hypre_ParCSRMatrix **B_ptr )
+{
+#if defined(HYPRE_USING_GPU)
+   hypre_ParCSRMatrix     *h_A;
+   HYPRE_ExecutionPolicy   exec = hypre_GetExecPolicy1( hypre_ParCSRMatrixMemoryLocation(A) );
+
+   if (exec == HYPRE_EXEC_DEVICE)
+   {
+      /* TODO (VPM): device implementation */
+      h_A = hypre_ParCSRMatrixClone(A, 1, HYPRE_MEMORY_HOST);
+      hypre_ParCSRMatrixBlkFilterHost(h_A, block_size, B_ptr);
+
+      hypre_ParCSRMatrixDestroy(h_A);
+      hypre_ParCSRMatrixMigrate(*B_ptr, HYPRE_MEMORY_DEVICE);
+   }
+   else
+#endif
+   {
+      hypre_ParCSRMatrixBlkFilterHost(A, block_size, B_ptr);
+   }
+
+   return hypre_error_flag;
+}

--- a/src/parcsr_mv/par_csr_filter.c
+++ b/src/parcsr_mv/par_csr_filter.c
@@ -206,7 +206,7 @@ hypre_ParCSRMatrixBlkFilter( hypre_ParCSRMatrix  *A,
    if (exec == HYPRE_EXEC_DEVICE)
    {
       /* TODO (VPM): device implementation */
-      h_A = hypre_ParCSRMatrixClone(A, 1, HYPRE_MEMORY_HOST);
+      h_A = hypre_ParCSRMatrixClone_v2(A, 1, HYPRE_MEMORY_HOST);
       hypre_ParCSRMatrixBlkFilterHost(h_A, block_size, B_ptr);
 
       hypre_ParCSRMatrixDestroy(h_A);

--- a/src/parcsr_mv/par_csr_matrix.c
+++ b/src/parcsr_mv/par_csr_matrix.c
@@ -2783,6 +2783,7 @@ hypre_FillResponseParToCSRMatrix( void       *p_recv_contact_buf,
 
 /*--------------------------------------------------------------------------
  * hypre_ParCSRMatrixUnion
+ *
  * Creates and returns a new matrix whose elements are the union of A and B.
  * Data is not copied, only structural information is created.
  * A and B must have the same communicator, numbers and distributions of rows
@@ -2851,14 +2852,17 @@ hypre_ParCSRMatrixUnion( hypre_ParCSRMatrix *A,
  * hypre_ParCSRMatrixTruncate
  *
  * Perform dual truncation of ParCSR matrix.
+ *
  * This code is adapted from original BoomerAMGInterpTruncate()
+ *
  * A: parCSR matrix to be modified
  * tol: relative tolerance or truncation factor for dropping small terms
  * max_row_elmts: maximum number of (largest) nonzero elements to keep.
  * rescale: Boolean on whether or not to scale resulting matrix. Scaling for
- * each row satisfies: sum(nonzero values before dropping)/ sum(nonzero values after dropping),
- * this way, the application of the truncated matrix on a constant vector is the same as that of
- * the original matrix.
+ *   each row satisfies: sum(nonzero values before dropping) /
+ *                       sum(nonzero values after dropping),
+ *   this way, the application of the truncated matrix on a constant vector
+ *   is the same as that of the original matrix.
  * nrm_type: type of norm used for dropping with tol.
  * -- 0 = infinity-norm
  * -- 1 = 1-norm

--- a/src/parcsr_mv/protos.h
+++ b/src/parcsr_mv/protos.h
@@ -273,6 +273,10 @@ HYPRE_Int hypre_ParCSRFindExtendCommPkg(MPI_Comm comm, HYPRE_BigInt global_num_c
                                         hypre_IJAssumedPart *apart, HYPRE_Int indices_len, HYPRE_BigInt *indices,
                                         hypre_ParCSRCommPkg **extend_comm_pkg);
 
+/* par_csr_filter.c */
+HYPRE_Int hypre_ParCSRMatrixBlkFilter(hypre_ParCSRMatrix *A,
+                                      HYPRE_Int block_size, hypre_ParCSRMatrix **B_ptr);
+
 /* par_csr_matop.c */
 HYPRE_Int hypre_ParCSRMatrixScale(hypre_ParCSRMatrix *A, HYPRE_Complex scalar);
 void hypre_ParMatmul_RowSizes ( HYPRE_MemoryLocation memory_location, HYPRE_Int **C_diag_i,

--- a/src/test/TEST_ij/solvers.jobs
+++ b/src/test/TEST_ij/solvers.jobs
@@ -65,6 +65,12 @@ mpirun -np 2 ./ij -n 20 20 20 -sysL 2 -nf 2 > solvers.out.sysu
 mpirun -np 2 ./ij -n 20 20 20 -sysL 2 -nf 2 -nodal 1 -smtype 6 -smlv 10 -dom 1 -ov 0 > solvers.out.sysh
 mpirun -np 2 ./ij -n 20 20 20 -sysL 2 -nf 2 -interptype 10 -Pmx 6 > solvers.out.sysn
 
+#systems AMG using unknown approach and filtering
+mpirun -np 1 ./ij -solver 1 -n 8 8 8 -sysL 2 -nf 2 -ff 1 > solvers.out.27
+mpirun -np 1 ./ij -solver 1 -n 8 8 8 -sysL 3 -nf 3 -ff 1 > solvers.out.28
+mpirun -np 4 ./ij -solver 1 -n 8 8 8 -sysL 2 -nf 2 -ff 1 > solvers.out.29
+mpirun -np 4 ./ij -solver 1 -n 8 8 8 -sysL 3 -nf 3 -ff 1 > solvers.out.30
+
 #LGMRS and FlexGMRES
 mpirun -np 2 ./ij -solver 50 -rhsrand > solvers.out.101
 mpirun -np 2 ./ij -solver 51 -rhsrand > solvers.out.102

--- a/src/test/TEST_ij/solvers.saved
+++ b/src/test/TEST_ij/solvers.saved
@@ -157,6 +157,22 @@ Final Relative Residual Norm = 9.578132e-09
                 operator = 2.866563
                    cycle = 5.732747
 
+# Output file: solvers.out.27
+Iterations = 12
+Final Relative Residual Norm = 5.893893e-09
+
+# Output file: solvers.out.28
+Iterations = 18
+Final Relative Residual Norm = 3.448418e-09
+
+# Output file: solvers.out.29
+Iterations = 13
+Final Relative Residual Norm = 4.536558e-09
+
+# Output file: solvers.out.30
+Iterations = 19
+Final Relative Residual Norm = 3.853111e-09
+
 # Output file: solvers.out.101
 LGMRES Iterations = 83
 Final LGMRES Relative Residual Norm = 8.591967e-09
@@ -308,4 +324,3 @@ Final Relative Residual Norm = 8.259159e-09
 # Output file: solvers.out.405
 Iterations = 24
 Final Relative Residual Norm = 6.793588e-09
-

--- a/src/test/TEST_ij/solvers.saved.lassen
+++ b/src/test/TEST_ij/solvers.saved.lassen
@@ -158,20 +158,20 @@ Final Relative Residual Norm = 7.167937e-09
                    cycle = 5.473918
 
 # Output file: solvers.out.27
-Iterations = 12
-Final Relative Residual Norm = 5.893893e-09
+Iterations = 17
+Final Relative Residual Norm = 4.472032e-09
 
 # Output file: solvers.out.28
-Iterations = 18
-Final Relative Residual Norm = 3.448418e-09
+Iterations = 25
+Final Relative Residual Norm = 4.134529e-09
 
 # Output file: solvers.out.29
-Iterations = 13
-Final Relative Residual Norm = 4.536558e-09
+Iterations = 17
+Final Relative Residual Norm = 7.555200e-09
 
 # Output file: solvers.out.30
-Iterations = 19
-Final Relative Residual Norm = 3.853111e-09
+Iterations = 23
+Final Relative Residual Norm = 8.408484e-09
 
 # Output file: solvers.out.101
 LGMRES Iterations = 83

--- a/src/test/TEST_ij/solvers.saved.lassen
+++ b/src/test/TEST_ij/solvers.saved.lassen
@@ -157,6 +157,22 @@ Final Relative Residual Norm = 7.167937e-09
                 operator = 2.737043
                    cycle = 5.473918
 
+# Output file: solvers.out.27
+Iterations = 12
+Final Relative Residual Norm = 5.893893e-09
+
+# Output file: solvers.out.28
+Iterations = 18
+Final Relative Residual Norm = 3.448418e-09
+
+# Output file: solvers.out.29
+Iterations = 13
+Final Relative Residual Norm = 4.536558e-09
+
+# Output file: solvers.out.30
+Iterations = 19
+Final Relative Residual Norm = 3.853111e-09
+
 # Output file: solvers.out.101
 LGMRES Iterations = 83
 Final LGMRES Relative Residual Norm = 8.591967e-09
@@ -308,4 +324,3 @@ Final Relative Residual Norm = 8.548826e-09
 # Output file: solvers.out.405
 Iterations = 22
 Final Relative Residual Norm = 7.996427e-09
-

--- a/src/test/TEST_ij/solvers.saved.lassen_cpu
+++ b/src/test/TEST_ij/solvers.saved.lassen_cpu
@@ -159,11 +159,11 @@ Final Relative Residual Norm = 9.458475e-09
 
 # Output file: solvers.out.27
 Iterations = 12
-Final Relative Residual Norm = 5.893893e-09
+Final Relative Residual Norm = 5.876623e-09
 
 # Output file: solvers.out.28
 Iterations = 18
-Final Relative Residual Norm = 3.448418e-09
+Final Relative Residual Norm = 3.457366e-09
 
 # Output file: solvers.out.29
 Iterations = 13

--- a/src/test/TEST_ij/solvers.saved.lassen_cpu
+++ b/src/test/TEST_ij/solvers.saved.lassen_cpu
@@ -157,6 +157,22 @@ Final Relative Residual Norm = 9.458475e-09
                 operator = 2.866222
                    cycle = 5.732066
 
+# Output file: solvers.out.27
+Iterations = 12
+Final Relative Residual Norm = 5.893893e-09
+
+# Output file: solvers.out.28
+Iterations = 18
+Final Relative Residual Norm = 3.448418e-09
+
+# Output file: solvers.out.29
+Iterations = 13
+Final Relative Residual Norm = 4.536558e-09
+
+# Output file: solvers.out.30
+Iterations = 19
+Final Relative Residual Norm = 3.853111e-09
+
 # Output file: solvers.out.101
 LGMRES Iterations = 83
 Final LGMRES Relative Residual Norm = 8.591967e-09
@@ -308,4 +324,3 @@ Final Relative Residual Norm = 8.259159e-09
 # Output file: solvers.out.405
 Iterations = 24
 Final Relative Residual Norm = 6.793588e-09
-

--- a/src/test/TEST_ij/solvers.saved.sunspot
+++ b/src/test/TEST_ij/solvers.saved.sunspot
@@ -158,20 +158,20 @@ Final Relative Residual Norm = 4.168189e-09
                    cycle = 5.451054
 
 # Output file: solvers.out.27
-Iterations = 12
-Final Relative Residual Norm = 5.893893e-09
+Iterations = 17
+Final Relative Residual Norm = 4.472032e-09
 
 # Output file: solvers.out.28
-Iterations = 18
-Final Relative Residual Norm = 3.448418e-09
+Iterations = 25
+Final Relative Residual Norm = 4.134529e-09
 
 # Output file: solvers.out.29
-Iterations = 13
-Final Relative Residual Norm = 4.536558e-09
+Iterations = 17
+Final Relative Residual Norm = 7.555200e-09
 
 # Output file: solvers.out.30
-Iterations = 19
-Final Relative Residual Norm = 3.853111e-09
+Iterations = 23
+Final Relative Residual Norm = 8.408484e-09
 
 # Output file: solvers.out.101
 LGMRES Iterations = 83

--- a/src/test/TEST_ij/solvers.saved.sunspot
+++ b/src/test/TEST_ij/solvers.saved.sunspot
@@ -157,6 +157,22 @@ Final Relative Residual Norm = 4.168189e-09
                 operator = 2.725611
                    cycle = 5.451054
 
+# Output file: solvers.out.27
+Iterations = 12
+Final Relative Residual Norm = 5.893893e-09
+
+# Output file: solvers.out.28
+Iterations = 18
+Final Relative Residual Norm = 3.448418e-09
+
+# Output file: solvers.out.29
+Iterations = 13
+Final Relative Residual Norm = 4.536558e-09
+
+# Output file: solvers.out.30
+Iterations = 19
+Final Relative Residual Norm = 3.853111e-09
+
 # Output file: solvers.out.101
 LGMRES Iterations = 83
 Final LGMRES Relative Residual Norm = 8.591967e-09
@@ -308,4 +324,3 @@ Final Relative Residual Norm = 8.560163e-09
 # Output file: solvers.out.405
 Iterations = 22
 Final Relative Residual Norm = 7.991509e-09
-

--- a/src/test/TEST_ij/solvers.sh
+++ b/src/test/TEST_ij/solvers.sh
@@ -115,6 +115,10 @@ if [ "$OUTCOUNT" != "$RUNCOUNT" ]; then
 fi
 
 FILES="\
+ ${TNAME}.out.27\
+ ${TNAME}.out.28\
+ ${TNAME}.out.29\
+ ${TNAME}.out.30\
  ${TNAME}.out.101\
  ${TNAME}.out.102\
  ${TNAME}.out.103\

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -189,6 +189,7 @@ main( hypre_int argc,
    HYPRE_Int          *ncols;
    HYPRE_BigInt       *col_inds;
    HYPRE_Int          *dof_func;
+   HYPRE_Int           filter_functions = 0;
    HYPRE_Int           num_functions = 1;
    HYPRE_Int           num_paths = 1;
    HYPRE_Int           agg_num_levels = 0;
@@ -1147,6 +1148,11 @@ main( hypre_int argc,
       {
          arg_index++;
          num_functions = atoi(argv[arg_index++]);
+      }
+      else if ( strcmp(argv[arg_index], "-ff") == 0 )
+      {
+         arg_index++;
+         filter_functions = atoi(argv[arg_index++]);
       }
       else if ( strcmp(argv[arg_index], "-agg_nl") == 0 )
       {
@@ -2492,6 +2498,7 @@ main( hypre_int argc,
          hypre_printf("  -jtr  <val>            : set truncation threshold for Jacobi interpolation = val \n");
          hypre_printf("  -Ssw  <val>            : set S-commpkg-switch = val \n");
          hypre_printf("  -mxrs <val>            : set AMG maximum row sum threshold for dependency weakening \n");
+         hypre_printf("  -ff <0/1>              : set filtering based on functions for systems AMG\n");
          hypre_printf("  -nf <val>              : set number of functions for systems AMG\n");
          hypre_printf("  -numsamp <val>         : set number of sample vectors for GSMG\n");
 
@@ -4511,7 +4518,7 @@ main( hypre_int argc,
       HYPRE_BoomerAMGSetFSAIThreshold(amg_solver, fsai_threshold);
       HYPRE_BoomerAMGSetFSAIEigMaxIters(amg_solver, fsai_eig_max_iters);
       HYPRE_BoomerAMGSetFSAIKapTolerance(amg_solver, fsai_kap_tolerance);
-
+      HYPRE_BoomerAMGSetFilterFunctions(amg_solver, filter_functions);
       HYPRE_BoomerAMGSetNumFunctions(amg_solver, num_functions);
       HYPRE_BoomerAMGSetAggNumLevels(amg_solver, agg_num_levels);
       HYPRE_BoomerAMGSetAggInterpType(amg_solver, agg_interp_type);
@@ -4831,6 +4838,7 @@ main( hypre_int argc,
       HYPRE_BoomerAMGSetFSAIThreshold(amg_solver, fsai_threshold);
       HYPRE_BoomerAMGSetFSAIEigMaxIters(amg_solver, fsai_eig_max_iters);
       HYPRE_BoomerAMGSetFSAIKapTolerance(amg_solver, fsai_kap_tolerance);
+      HYPRE_BoomerAMGSetFilterFunctions(amg_solver, filter_functions);
       HYPRE_BoomerAMGSetNumFunctions(amg_solver, num_functions);
       HYPRE_BoomerAMGSetAggNumLevels(amg_solver, agg_num_levels);
       HYPRE_BoomerAMGSetAggInterpType(amg_solver, agg_interp_type);
@@ -5019,6 +5027,7 @@ main( hypre_int argc,
          HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
          HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
          HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+         HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
          HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
          HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
          HYPRE_BoomerAMGSetAggInterpType(pcg_precond, agg_interp_type);
@@ -5250,6 +5259,7 @@ main( hypre_int argc,
          HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
          HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
          HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+         HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
          HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
          HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
          HYPRE_BoomerAMGSetAggInterpType(pcg_precond, agg_interp_type);
@@ -5814,6 +5824,7 @@ main( hypre_int argc,
             HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
             HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
             HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+            HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
             HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
             HYPRE_BoomerAMGSetNumPaths(pcg_precond, num_paths);
             HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
@@ -5923,6 +5934,7 @@ main( hypre_int argc,
             HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
             HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
             HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+            HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
             HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
             HYPRE_BoomerAMGSetNumPaths(pcg_precond, num_paths);
             HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
@@ -6240,6 +6252,7 @@ main( hypre_int argc,
             HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
             HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
             HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+            HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
             HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
             HYPRE_BoomerAMGSetNumPaths(pcg_precond, num_paths);
             HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
@@ -6360,6 +6373,7 @@ main( hypre_int argc,
             HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
             HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
             HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+            HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
             HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
             HYPRE_BoomerAMGSetNumPaths(pcg_precond, num_paths);
             HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
@@ -6740,6 +6754,7 @@ main( hypre_int argc,
          HYPRE_BoomerAMGSetMaxLevels(amg_precond, max_levels);
          HYPRE_BoomerAMGSetMaxRowSum(amg_precond, max_row_sum);
          HYPRE_BoomerAMGSetDebugFlag(amg_precond, debug_flag);
+         HYPRE_BoomerAMGSetFilterFunctions(amg_precond, filter_functions);
          HYPRE_BoomerAMGSetNumFunctions(amg_precond, num_functions);
          HYPRE_BoomerAMGSetAggNumLevels(amg_precond, agg_num_levels);
          HYPRE_BoomerAMGSetAggInterpType(amg_precond, agg_interp_type);
@@ -6984,6 +6999,7 @@ main( hypre_int argc,
          HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
          HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
          HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+         HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
          HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
          HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
          HYPRE_BoomerAMGSetAggInterpType(pcg_precond, agg_interp_type);
@@ -7325,6 +7341,7 @@ main( hypre_int argc,
          HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
          HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
          HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+         HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
          HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
          HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
          HYPRE_BoomerAMGSetAggInterpType(pcg_precond, agg_interp_type);
@@ -7548,6 +7565,7 @@ main( hypre_int argc,
          HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
          HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
          HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+         HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
          HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
          HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
          HYPRE_BoomerAMGSetAggInterpType(pcg_precond, agg_interp_type);
@@ -7980,6 +7998,7 @@ main( hypre_int argc,
          HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
          HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
          HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+         HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
          HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
          HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
          HYPRE_BoomerAMGSetAggInterpType(pcg_precond, agg_interp_type);
@@ -8398,6 +8417,7 @@ main( hypre_int argc,
          HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
          HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
          HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+         HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
          HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
          HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
          HYPRE_BoomerAMGSetAggInterpType(pcg_precond, agg_interp_type);
@@ -8760,6 +8780,7 @@ main( hypre_int argc,
          HYPRE_BoomerAMGSetMaxLevels(pcg_precond, max_levels);
          HYPRE_BoomerAMGSetMaxRowSum(pcg_precond, max_row_sum);
          HYPRE_BoomerAMGSetDebugFlag(pcg_precond, debug_flag);
+         HYPRE_BoomerAMGSetFilterFunctions(pcg_precond, filter_functions);
          HYPRE_BoomerAMGSetNumFunctions(pcg_precond, num_functions);
          HYPRE_BoomerAMGSetAggNumLevels(pcg_precond, agg_num_levels);
          HYPRE_BoomerAMGSetAggInterpType(pcg_precond, agg_interp_type);


### PR DESCRIPTION
Adds a filtering option to AMG targeting systems of PDEs.

Filtering is done in the input matrix to BoomerAMG to remove inter-variable couplings. This only affects the matrix used for preconditioning purposes.

The new option leads to smaller operator complexities at the expense of more linear solver iterations (in general). This can be turned on via `HYPRE_BoomerAMGSetFilterFunctions`

A few results obtained with linear elasticity matrices, using a single core and `-solver 1 -nf 3 -th 0.6`:

![setup](https://github.com/user-attachments/assets/fef3224c-6793-4583-be61-98b14476ca97)
![solve](https://github.com/user-attachments/assets/64b1f852-8752-4b0c-b7c0-ab7c40ea4b20)

