### PR TITLE
Fix build with umpire host pool

### DIFF
--- a/AUTOTEST/check-mem.sh
+++ b/AUTOTEST/check-mem.sh
@@ -38,7 +38,9 @@ find . -type f -print | egrep '[.]*[.](c|cc|cpp|cxx|C|h|hpp|hxx|H)$' |
   egrep -v '/FEI_mv' |
   egrep -v '/hypre/include' |
   egrep -v '/utilities/memory_tracker.c' |
-  egrep -v '/utilities/memory.c' > check-mem.files
+  egrep -v '/utilities/memory.c' |
+  egrep -v '/utilities/general.c' |
+  egrep -v '/utilities/device_utils.c' > check-mem.files
 
 egrep '(^|[^[:alnum:]_]+)malloc[[:space:]]*\('  `cat check-mem.files` >&2
 egrep '(^|[^[:alnum:]_]+)calloc[[:space:]]*\('  `cat check-mem.files` >&2

--- a/src/utilities/device_utils.c
+++ b/src/utilities/device_utils.c
@@ -25,7 +25,7 @@ hypre_DeviceDataCreate()
 {
    /* Note: this allocation is done directly with calloc in order to
       avoid a segmentation fault when building with HYPRE_USING_UMPIRE_HOST */
-   hypre_DeviceData *data = (hypre_DeviceData*) calloc(sizeof(hypre_DeviceData), 1);
+   hypre_DeviceData *data = (hypre_DeviceData*) calloc(1, sizeof(hypre_DeviceData));
 
 #if defined(HYPRE_USING_SYCL)
    hypre_DeviceDataDevice(data)           = nullptr;

--- a/src/utilities/device_utils.c
+++ b/src/utilities/device_utils.c
@@ -23,7 +23,9 @@
 hypre_DeviceData*
 hypre_DeviceDataCreate()
 {
-   hypre_DeviceData *data = hypre_CTAlloc(hypre_DeviceData, 1, HYPRE_MEMORY_HOST);
+   /* Note: this allocation is done directly with calloc in order to
+      avoid a segmentation fault when building with HYPRE_USING_UMPIRE_HOST */
+   hypre_DeviceData *data = (hypre_DeviceData*) calloc(sizeof(hypre_DeviceData), 1);
 
 #if defined(HYPRE_USING_SYCL)
    hypre_DeviceDataDevice(data)           = nullptr;
@@ -165,7 +167,8 @@ hypre_DeviceDataDestroy(hypre_DeviceData *data)
    data->device = nullptr;
 #endif
 
-   hypre_TFree(data, HYPRE_MEMORY_HOST);
+   /* Note: Directly using free since this variable was allocated with calloc */
+   free((void*) data);
 }
 
 /*--------------------------------------------------------------------
@@ -3025,4 +3028,3 @@ hypre_bind_device( HYPRE_Int myid,
 {
    return hypre_bind_device_id(-1, myid, nproc, comm);
 }
-

--- a/src/utilities/general.c
+++ b/src/utilities/general.c
@@ -32,7 +32,7 @@ hypre_HandleCreate(void)
 {
    /* Note: this allocation is done directly with calloc in order to
       avoid a segmentation fault when building with HYPRE_USING_UMPIRE_HOST */
-   hypre_Handle *hypre_handle_ = (hypre_Handle*) calloc(sizeof(hypre_Handle), 1);
+   hypre_Handle *hypre_handle_ = (hypre_Handle*) calloc(1, sizeof(hypre_Handle));
 
    hypre_HandleLogLevel(hypre_handle_) = 0;
    hypre_HandleMemoryLocation(hypre_handle_) = HYPRE_MEMORY_DEVICE;

--- a/src/utilities/general.c
+++ b/src/utilities/general.c
@@ -30,7 +30,9 @@ hypre_handle(void)
 hypre_Handle*
 hypre_HandleCreate(void)
 {
-   hypre_Handle *hypre_handle_ = hypre_CTAlloc(hypre_Handle, 1, HYPRE_MEMORY_HOST);
+   /* Note: this allocation is done directly with calloc in order to
+      avoid a segmentation fault when building with HYPRE_USING_UMPIRE_HOST */
+   hypre_Handle *hypre_handle_ = (hypre_Handle*) calloc(sizeof(hypre_Handle), 1);
 
    hypre_HandleLogLevel(hypre_handle_) = 0;
    hypre_HandleMemoryLocation(hypre_handle_) = HYPRE_MEMORY_DEVICE;
@@ -71,7 +73,8 @@ hypre_HandleDestroy(hypre_Handle *hypre_handle_)
    hypre_HandleDeviceData(hypre_handle_) = NULL;
 #endif
 
-   hypre_TFree(hypre_handle_, HYPRE_MEMORY_HOST);
+   /* Note: Directly using free since this variable was allocated with calloc */
+   free((void*) hypre_handle_);
 
    return hypre_error_flag;
 }

--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -605,6 +605,11 @@ static inline void
 hypre_Memcpy_core(void *dst, void *src, size_t size, hypre_MemoryLocation loc_dst,
                   hypre_MemoryLocation loc_src)
 {
+   if (size == 0)
+   {
+      return;
+   }
+
 #if defined(HYPRE_USING_SYCL)
    sycl::queue* q = hypre_HandleComputeStream(hypre_handle());
 #endif
@@ -1471,19 +1476,28 @@ hypre_MemoryPrintUsage(MPI_Comm    comm,
             {
                hypre_printf("[%*d]: %s", ndigits, i, function);
             }
-            hypre_printf(" | VmSize/Peak: (%5.2f / %5.2f) GB", gmem[ne * i + 0], gmem[ne * i + 1]);
-            hypre_printf(" | VmRSS/HWM: (%5.2f / %5.2f) GB", gmem[ne * i + 2], gmem[ne * i + 3]);
-            hypre_printf(" | Free/Total: (%5.2f / %6.2f) GB", gmem[ne * i + 4], gmem[ne * i + 5]);
+            hypre_printf(" | Vm[Size,RSS]/[Peak,HWM]: (%.2f, %.2f / %.2f, %.2f) GB", gmem[ne * i + 0], gmem[ne * i + 2], gmem[ne * i + 1], gmem[ne * i + 3]);
+            hypre_printf(" | Free/Total: (%.2f / %.2f)", gmem[ne * i + 4], gmem[ne * i + 5]);
 #if defined(HYPRE_USING_UMPIRE)
-            if (gmem[ne * i + 8] && gmem[ne * i + 9])
+            if (gmem[ne * i + 7])
             {
-               hypre_printf(" | DevSize/DevPeak: (%5.2f / %5.2f) GB",
+               hypre_printf(" | UmpHSize/UmpHPeak: (%.2f / %.2f)",
+                            gmem[ne * i + 6], gmem[ne * i + 7]);
+            }
+            if (gmem[ne * i + 9])
+            {
+               hypre_printf(" | UmpDPeak/UmpDPeak: (%.2f / %.2f)",
                             gmem[ne * i + 8], gmem[ne * i + 9]);
             }
-            if (gmem[ne * i + 10] && gmem[ne * i + 11])
+            if (gmem[ne * i + 11])
             {
-               hypre_printf(" | UVmSize/UVmPeak: (%5.2f / %5.2f) GB",
+               hypre_printf(" | UmpUPeak/UmpUPeak: (%.2f / %.2f)",
                             gmem[ne * i + 10], gmem[ne * i + 11]);
+            }
+            if (gmem[ne * i + 13])
+            {
+               hypre_printf(" | UmpPSize/UmpPPeak: (%.2f / %.2f)",
+                            gmem[ne * i + 12], gmem[ne * i + 13]);
             }
 #endif
             hypre_printf("\n");
@@ -1503,47 +1517,57 @@ hypre_MemoryPrintUsage(MPI_Comm    comm,
             hypre_printf("%s\n\n", function);
          }
 
+         /* Print header */
+         hypre_printf("       | %11s | %11s | %11s | %11s",
+                      "VmSize (GB)", "VmPeak (GB)", "VmRSS (GB)", "VmHWM (GB)");
+#if defined(HYPRE_USING_UMPIRE_HOST)
+         hypre_printf(" | %13s | %13s", "UmpHSize (GB)", "UmpHPeak (GB)");
+#endif
+#if defined(HYPRE_USING_UMPIRE_DEVICE)
+         hypre_printf(" | %13s | %13s", "UmpDSize (GB)", "UmpDPeak (GB)");
+#endif
 #if defined(HYPRE_USING_UMPIRE_UM)
-         hypre_printf("       | %-11s | %-11s | %-11s | %-11s | %-12s | %-12s | %-12s | %-12s\n",
-                      "VmSize (GB)", "VmPeak (GB)", "VmRSS (GB)", "VmHWM (GB)",
-                      "DevSize (GB)", "DevPeak (GB)", "UVmSize (GB)", "UVmPeak (GB)");
-         hypre_printf("   ----");
-         hypre_printf("+-------------+-------------+-------------+-------------");
-         hypre_printf("+--------------+--------------+--------------+-------------\n");
+         hypre_printf(" | %13s | %13s", "UmpUSize (GB)", "UmpUPeak (GB)");
+#endif
+#if defined(HYPRE_USING_UMPIRE_PINNED)
+         hypre_printf(" | %13s | %13s", "UmpPSize (GB)", "UmpPPeak (GB)")
+#endif
+         hypre_printf("\n");
+         hypre_printf("   ----+-------------+-------------+-------------+------------");
+#if defined(HYPRE_USING_UMPIRE_HOST)
+         hypre_printf("-+---------------+--------------");
+#endif
+#if defined(HYPRE_USING_UMPIRE_DEVICE)
+         hypre_printf("-+---------------+--------------");
+#endif
+#if defined(HYPRE_USING_UMPIRE_UM)
+         hypre_printf("-+---------------+--------------");
+#endif
+#if defined(HYPRE_USING_UMPIRE_PINNED)
+         hypre_printf("-+---------------+--------------");
+#endif
+         hypre_printf("\n");
+
+         /* Print table */
          for (i = 0; i < 4; i++)
          {
             hypre_printf("   %-3s", labels[i]);
             hypre_printf(" | %11.3f | %11.3f | %11.3f | %11.3f",
                          data[i][0], data[i][1], data[i][2], data[i][3]);
-            hypre_printf(" | %12.3f | %12.3f | %12.3f | %12.3f\n",
-                         data[i][8], data[i][9], data[i][10], data[i][11]);
-         }
-
-#elif defined(HYPRE_USING_UMPIRE_DEVICE)
-         hypre_printf("       | %-11s | %-11s | %-11s | %-11s | %-12s | %-12s\n",
-                      "VmSize (GB)", "VmPeak (GB)", "VmRSS (GB)", "VmHWM (GB)",
-                      "DevSize (GB)", "DevPeak (GB)");
-         hypre_printf("   ----");
-         hypre_printf("+-------------+-------------+-------------+-------------");
-         hypre_printf("+--------------+--------------\n");
-         for (i = 0; i < 4; i++)
-         {
-            hypre_printf("   %-3s", labels[i]);
-            hypre_printf(" | %11.3f | %11.3f | %11.3f | %11.3f | %12.3f | %12.3f\n",
-                         data[i][0], data[i][1], data[i][2], data[i][3], data[i][8], data[i][9]);
-         }
-
-#else
-         hypre_printf("       | %11s | %11s | %11s | %11s\n",
-                      "VmSize (GB)", "VmPeak (GB)", "VmRSS (GB)", "VmHWM (GB)");
-         hypre_printf("   ----+-------------+-------------+-------------+------------\n");
-         for (i = 0; i < 4; i++)
-         {
-            hypre_printf("   %3s | %11.3f | %11.3f | %11.3f | %11.3f\n",
-                         labels[i], data[i][0], data[i][1], data[i][2], data[i][3]);
-         }
+#if defined(HYPRE_USING_UMPIRE_HOST)
+            hypre_printf(" | %13.3f | %13.3f", data[i][6], data[i][7]);
 #endif
-         hypre_printf("\n");
+#if defined(HYPRE_USING_UMPIRE_DEVICE)
+            hypre_printf(" | %13.3f | %13.3f", data[i][8], data[i][9]);
+#endif
+#if defined(HYPRE_USING_UMPIRE_UM)
+            hypre_printf(" | %13.3f | %13.3f", data[i][10], data[i][11]);
+#endif
+#if defined(HYPRE_USING_UMPIRE_PINNED)
+            hypre_printf(" | %13.3f | %13.3f", data[i][12], data[i][13]);
+#endif
+            hypre_printf("\n");
+         }
       }
    }
    hypre_MPI_Barrier(comm);

--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -1482,7 +1482,9 @@ hypre_MemoryPrintUsage(MPI_Comm    comm,
             {
                hypre_printf("[%*d]: %s", ndigits, i, function);
             }
-            hypre_printf(" | Vm[Size,RSS]/[Peak,HWM]: (%.2f, %.2f / %.2f, %.2f) GB", gmem[ne * i + 0], gmem[ne * i + 2], gmem[ne * i + 1], gmem[ne * i + 3]);
+            hypre_printf(" | Vm[Size,RSS]/[Peak,HWM]: (%.2f, %.2f / %.2f, %.2f) GB",
+                         gmem[ne * i + 0], gmem[ne * i + 2],
+                         gmem[ne * i + 1], gmem[ne * i + 3]);
             hypre_printf(" | Free/Total: (%.2f / %.2f)", gmem[ne * i + 4], gmem[ne * i + 5]);
 #if defined(HYPRE_USING_UMPIRE)
             if (gmem[ne * i + 7])


### PR DESCRIPTION
This PR fixes the build when using the `--with-umpire-host` option.

The build was broken due to a call to `hypre_CTAlloc` happening prior to umpire's initialization. The solution here is to use `calloc` instead in a couple of places.

This PR also updates memory usage reporting with umpire's host pool info.