### PR TITLE
Tux regression test fixes for rhel9 system

### DIFF
--- a/AUTOTEST/machine-tux-spack.sh
+++ b/AUTOTEST/machine-tux-spack.sh
@@ -37,7 +37,9 @@ src_dir=`cd $1; pwd`
 shift
 
 # OpenMPI limits the number of processes available by default - override
+# RDF: The first environment variable didn't work for me
 export OMPI_MCA_rmaps_base_oversubscribe=1
+export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
 
 # Basic build and run tests
 
@@ -53,19 +55,21 @@ export OMPI_MCA_rmaps_base_oversubscribe=1
 # Use the develop branch for superlu-dist
 superludistspec="superlu-dist@develop"
 spackspec="hypre@develop~debug+superlu-dist ^$superludistspec"
-spack install $spackspec
+# The --fresh option will ensure the latest versions of dependencies are used
+spack install --fresh $spackspec
 spack load    $spackspec
 spackdir=`spack location -i $spackspec`
 test.sh basic.sh ../src -co: -mo: -spack $spackdir -ro: -superlu
 ./renametest.sh basic $output_dir/basic-dsuperlu
 
 # Clean-up spack build
-spack spec --yaml $spackspec > test.yaml
-grep ' hash:' test.yaml | sed -e 's/^.*: /\//' | xargs spack mark -e
-spack gc -y
-grep ' hash:' test.yaml | sed -e 's/^.*: /\//' | xargs spack mark -i
-rm -f test.yaml
-spack clean --all
+# RDF: Commenting out PR #481 (for now) to test the '--fresh' option above (faster)
+# spack spec --yaml $spackspec > test.yaml
+# grep ' hash:' test.yaml | sed -e 's/^.*: /\//' | xargs spack mark -e
+# spack gc -y
+# grep ' hash:' test.yaml | sed -e 's/^.*: /\//' | xargs spack mark -i
+# rm -f test.yaml
+# spack clean --all
 spack uninstall -yR $superludistspec
 
 # Echo to stderr all nonempty error files in $output_dir

--- a/src/examples/ex12f.f
+++ b/src/examples/ex12f.f
@@ -508,5 +508,4 @@
 !     Finalize MPI
       call MPI_Finalize(ierr)
 
-      stop
       end

--- a/src/examples/ex12f_cptr.f
+++ b/src/examples/ex12f_cptr.f
@@ -499,5 +499,4 @@
 
       stat = device_free(p_values)
 
-      stop
       end

--- a/src/examples/ex5f_cptr.f
+++ b/src/examples/ex5f_cptr.f
@@ -507,5 +507,4 @@
       stat = device_free(p_tmpi)
       stat = device_free(p_values)
 
-      stop
       end

--- a/src/sstruct_ls/HYPRE_sstruct_ls.h
+++ b/src/sstruct_ls/HYPRE_sstruct_ls.h
@@ -618,7 +618,7 @@ HYPRE_SStructMaxwellSetGrad(HYPRE_SStructSolver solver,
  **/
 HYPRE_Int
 HYPRE_SStructMaxwellSetRfactors(HYPRE_SStructSolver solver,
-                                HYPRE_Int           rfactors[HYPRE_MAXDIM]);
+                                HYPRE_Int          *rfactors);
 
 /**
  * Finds the physical boundary row ranks on all levels.
@@ -626,7 +626,7 @@ HYPRE_SStructMaxwellSetRfactors(HYPRE_SStructSolver solver,
 HYPRE_Int
 HYPRE_SStructMaxwellPhysBdy(HYPRE_SStructGrid  *grid_l,
                             HYPRE_Int           num_levels,
-                            HYPRE_Int           rfactors[HYPRE_MAXDIM],
+                            HYPRE_Int          *rfactors,
                             HYPRE_Int        ***BdryRanks_ptr,
                             HYPRE_Int         **BdryRanksCnt_ptr );
 

--- a/src/sstruct_ls/HYPRE_sstruct_maxwell.c
+++ b/src/sstruct_ls/HYPRE_sstruct_maxwell.c
@@ -111,7 +111,7 @@ HYPRE_SStructMaxwellSetGrad( HYPRE_SStructSolver  solver,
  *--------------------------------------------------------------------------*/
 HYPRE_Int
 HYPRE_SStructMaxwellSetRfactors( HYPRE_SStructSolver  solver,
-                                 HYPRE_Int            rfactors[3] )
+                                 HYPRE_Int           *rfactors )
 {
    return ( hypre_MaxwellSetRfactors( (void *)         solver,
                                       rfactors ) );
@@ -234,7 +234,7 @@ HYPRE_SStructMaxwellGetFinalRelativeResidualNorm( HYPRE_SStructSolver  solver,
 HYPRE_Int
 HYPRE_SStructMaxwellPhysBdy( HYPRE_SStructGrid  *grid_l,
                              HYPRE_Int           num_levels,
-                             HYPRE_Int           rfactors[3],
+                             HYPRE_Int          *rfactors,
                              HYPRE_Int        ***BdryRanks_ptr,
                              HYPRE_Int         **BdryRanksCnt_ptr )
 {

--- a/src/sstruct_ls/_hypre_sstruct_ls.h
+++ b/src/sstruct_ls/_hypre_sstruct_ls.h
@@ -484,7 +484,7 @@ HYPRE_Int HYPRE_SStructMaxwellSolve2 ( HYPRE_SStructSolver solver, HYPRE_SStruct
 HYPRE_Int HYPRE_MaxwellGrad ( HYPRE_SStructGrid grid, HYPRE_ParCSRMatrix *T );
 HYPRE_Int HYPRE_SStructMaxwellSetGrad ( HYPRE_SStructSolver solver, HYPRE_ParCSRMatrix T );
 HYPRE_Int HYPRE_SStructMaxwellSetRfactors ( HYPRE_SStructSolver solver,
-                                            HYPRE_Int rfactors [HYPRE_MAXDIM]);
+                                            HYPRE_Int *rfactors);
 HYPRE_Int HYPRE_SStructMaxwellSetTol ( HYPRE_SStructSolver solver, HYPRE_Real tol );
 HYPRE_Int HYPRE_SStructMaxwellSetConstantCoef ( HYPRE_SStructSolver solver,
                                                 HYPRE_Int constant_coef );
@@ -502,7 +502,7 @@ HYPRE_Int HYPRE_SStructMaxwellGetNumIterations ( HYPRE_SStructSolver solver,
 HYPRE_Int HYPRE_SStructMaxwellGetFinalRelativeResidualNorm ( HYPRE_SStructSolver solver,
                                                              HYPRE_Real *norm );
 HYPRE_Int HYPRE_SStructMaxwellPhysBdy ( HYPRE_SStructGrid *grid_l, HYPRE_Int num_levels,
-                                        HYPRE_Int rfactors [HYPRE_MAXDIM], HYPRE_Int ***BdryRanks_ptr, HYPRE_Int **BdryRanksCnt_ptr );
+                                        HYPRE_Int *rfactors, HYPRE_Int ***BdryRanks_ptr, HYPRE_Int **BdryRanksCnt_ptr );
 HYPRE_Int HYPRE_SStructMaxwellEliminateRowsCols ( HYPRE_ParCSRMatrix parA, HYPRE_Int nrows,
                                                   HYPRE_Int *rows );
 HYPRE_Int HYPRE_SStructMaxwellZeroVector ( HYPRE_ParVector v, HYPRE_Int *rows, HYPRE_Int nrows );

--- a/src/sstruct_ls/maxwell_TV.c
+++ b/src/sstruct_ls/maxwell_TV.c
@@ -169,7 +169,7 @@ hypre_MaxwellTVDestroy( void *maxwell_vdata )
  *--------------------------------------------------------------------------*/
 HYPRE_Int
 hypre_MaxwellSetRfactors(void         *maxwell_vdata,
-                         HYPRE_Int     rfactor[3] )
+                         HYPRE_Int     rfactor[HYPRE_MAXDIM] )
 {
    hypre_MaxwellData *maxwell_data   = (hypre_MaxwellData *)maxwell_vdata;
    hypre_Index       *maxwell_rfactor = (maxwell_data -> rfactor);

--- a/src/test/TEST_ams/solvers.saved
+++ b/src/test/TEST_ams/solvers.saved
@@ -37,81 +37,81 @@
 # Output file: solvers.out.4
 
 Iterations = 6
-Final Relative Residual Norm = 6.440027e-07
+Final Relative Residual Norm = 6.440062e-07
 
 # Output file: solvers.out.5
 
 Iterations = 6
-Final Relative Residual Norm = 6.440027e-07
+Final Relative Residual Norm = 6.440062e-07
 
 # Output file: solvers.out.6
 
 Iterations = 9
-Final Relative Residual Norm = 9.646705e-07
+Final Relative Residual Norm = 9.646675e-07
 
 # Output file: solvers.out.7
 
 Iterations = 9
-Final Relative Residual Norm = 9.646705e-07
+Final Relative Residual Norm = 9.646675e-07
 
 # Output file: solvers.out.12
 
 Iterations = 18
-Final Relative Residual Norm = 4.160115e-03
+Final Relative Residual Norm = 4.151612e-03
 
 # Output file: solvers.out.8
 
-Eigenvalue lambda   3.02357653918323e+01
-Eigenvalue lambda   3.03135374700825e+01
-Eigenvalue lambda   3.85013899426296e+01
-Eigenvalue lambda   5.14395940109411e+01
-Eigenvalue lambda   5.15742481830257e+01
-Residual   4.25157808772846e-05
-Residual   4.19035189193737e-05
-Residual   4.81288033011393e-05
-Residual   7.10760463298080e-05
-Residual   8.91382143494275e-05
+Eigenvalue lambda   3.02357653918321e+01
+Eigenvalue lambda   3.03135374700838e+01
+Eigenvalue lambda   3.85013899426301e+01
+Eigenvalue lambda   5.14395940109376e+01
+Eigenvalue lambda   5.15742481830319e+01
+Residual   4.25157808820118e-05
+Residual   4.19035189015216e-05
+Residual   4.81288033055862e-05
+Residual   7.10760463267777e-05
+Residual   8.91382144508726e-05
 
 17 iterations
 # Output file: solvers.out.9
 
-Eigenvalue lambda   3.02357653918323e+01
-Eigenvalue lambda   3.03135374700825e+01
-Eigenvalue lambda   3.85013899426296e+01
-Eigenvalue lambda   5.14395940109411e+01
-Eigenvalue lambda   5.15742481830257e+01
-Residual   4.25157808772846e-05
-Residual   4.19035189193737e-05
-Residual   4.81288033011393e-05
-Residual   7.10760463298080e-05
-Residual   8.91382143494275e-05
+Eigenvalue lambda   3.02357653918321e+01
+Eigenvalue lambda   3.03135374700838e+01
+Eigenvalue lambda   3.85013899426301e+01
+Eigenvalue lambda   5.14395940109376e+01
+Eigenvalue lambda   5.15742481830319e+01
+Residual   4.25157808820118e-05
+Residual   4.19035189015216e-05
+Residual   4.81288033055862e-05
+Residual   7.10760463267777e-05
+Residual   8.91382144508726e-05
 
 17 iterations
 # Output file: solvers.out.10
 
-Eigenvalue lambda   3.02357653920282e+01
-Eigenvalue lambda   3.03135374703452e+01
-Eigenvalue lambda   3.85013899427150e+01
-Eigenvalue lambda   5.14395940116978e+01
-Eigenvalue lambda   5.15742481833418e+01
-Residual   8.05720052499174e-05
-Residual   9.77366136433341e-05
-Residual   5.87715311094864e-05
-Residual   1.00991497914808e-04
-Residual   9.93611224113933e-05
+Eigenvalue lambda   3.02357653920285e+01
+Eigenvalue lambda   3.03135374703450e+01
+Eigenvalue lambda   3.85013899427157e+01
+Eigenvalue lambda   5.14395940117001e+01
+Eigenvalue lambda   5.15742481833368e+01
+Residual   8.05720052532315e-05
+Residual   9.77366136479502e-05
+Residual   5.87715311287244e-05
+Residual   1.00991497909373e-04
+Residual   9.93611224218808e-05
 
 23 iterations
 # Output file: solvers.out.11
 
-Eigenvalue lambda   3.02357653920282e+01
-Eigenvalue lambda   3.03135374703452e+01
-Eigenvalue lambda   3.85013899427150e+01
-Eigenvalue lambda   5.14395940116978e+01
-Eigenvalue lambda   5.15742481833418e+01
-Residual   8.05720052499174e-05
-Residual   9.77366136433341e-05
-Residual   5.87715311094864e-05
-Residual   1.00991497914808e-04
-Residual   9.93611224113933e-05
+Eigenvalue lambda   3.02357653920285e+01
+Eigenvalue lambda   3.03135374703450e+01
+Eigenvalue lambda   3.85013899427157e+01
+Eigenvalue lambda   5.14395940117001e+01
+Eigenvalue lambda   5.15742481833368e+01
+Residual   8.05720052532315e-05
+Residual   9.77366136479502e-05
+Residual   5.87715311287244e-05
+Residual   1.00991497909373e-04
+Residual   9.93611224218808e-05
 
 23 iterations

--- a/src/test/TEST_ij/fsai.saved
+++ b/src/test/TEST_ij/fsai.saved
@@ -64,15 +64,15 @@ Final Relative Residual Norm = 5.414675e-09
 
 # Output file: fsai.out.16
 Iterations = 171
-Final Relative Residual Norm = 5.030044e-09
+Final Relative Residual Norm = 4.941318e-09
 
 # Output file: fsai.out.17
 Iterations = 126
-Final Relative Residual Norm = 9.008720e-09
+Final Relative Residual Norm = 9.030852e-09
 
 # Output file: fsai.out.18
-Iterations = 184
-Final Relative Residual Norm = 8.225265e-09
+Iterations = 185
+Final Relative Residual Norm = 4.894088e-09
 
 # Output file: fsai.out.100
 Iterations = 1
@@ -149,3 +149,4 @@ Final Relative Residual Norm = 2.318909e-09
 # Output file: fsai.out.118
 Iterations = 35
 Final Relative Residual Norm = 2.996819e-09
+

--- a/src/test/TEST_ij/smoother.saved
+++ b/src/test/TEST_ij/smoother.saved
@@ -40,7 +40,7 @@ Final Relative Residual Norm = 5.359205e-09
 
 # Output file: smoother.out.7
 BoomerAMG Iterations = 18
-Final Relative Residual Norm = 7.334920e-09
+Final Relative Residual Norm = 7.334921e-09
 
 # Output file: smoother.out.8
 BoomerAMG Iterations = 11

--- a/src/test/TEST_ij/solvers.saved
+++ b/src/test/TEST_ij/solvers.saved
@@ -219,7 +219,7 @@ Final Relative Residual Norm = 8.452076e-09
 
 # Output file: solvers.out.112
 GMRES Iterations = 23
-Final GMRES Relative Residual Norm = 3.979844e-09
+Final GMRES Relative Residual Norm = 3.979845e-09
 
 # Output file: solvers.out.113
 GMRES Iterations = 25
@@ -324,3 +324,4 @@ Final Relative Residual Norm = 8.259159e-09
 # Output file: solvers.out.405
 Iterations = 24
 Final Relative Residual Norm = 6.793588e-09
+

--- a/src/test/TEST_ij/vector.saved
+++ b/src/test/TEST_ij/vector.saved
@@ -57,23 +57,23 @@ Final FlexGMRES Relative Residual Norm = 7.982372e-09
 
 # Output file: vector.out.B6
 Iterations = 18
-Final Residual Norm = 3.923978e-09
+Final Relative Residual Norm = 3.923978e-09
 
 # Output file: vector.out.B7
 Iterations = 18
-Final Residual Norm = 3.923978e-09
+Final Relative Residual Norm = 3.923978e-09
 
 # Output file: vector.out.B8
 Iterations = 18
-Final Residual Norm = 3.923978e-09
+Final Relative Residual Norm = 3.923978e-09
 
 # Output file: vector.out.B9
 Iterations = 18
-Final Residual Norm = 3.923978e-09
+Final Relative Residual Norm = 3.923978e-09
 
 # Output file: vector.out.B10
 Iterations = 18
-Final Residual Norm = 3.923978e-09
+Final Relative Residual Norm = 3.923978e-09
 
 # Output file: vector.out.B100
 Iterations = 18
@@ -85,7 +85,7 @@ Final GMRES Relative Residual Norm = 7.982371e-09
 
 # Output file: vector.out.B102
 Iterations = 202
-Final Relative Residual Norm = 9.575020e-09
+Final Relative Residual Norm = 9.504933e-09
 
 # Output file: vector.out.B103
 BiCGSTAB Iterations = 12
@@ -101,20 +101,21 @@ Final FlexGMRES Relative Residual Norm = 7.982371e-09
 
 # Output file: vector.out.B106
 Iterations = 18
-Final Residual Norm = 3.923978e-09
+Final Relative Residual Norm = 3.923978e-09
 
 # Output file: vector.out.B107
 Iterations = 18
-Final Residual Norm = 3.923978e-09
+Final Relative Residual Norm = 3.923978e-09
 
 # Output file: vector.out.B108
 Iterations = 18
-Final Residual Norm = 3.923978e-09
+Final Relative Residual Norm = 3.923978e-09
 
 # Output file: vector.out.B109
 Iterations = 18
-Final Residual Norm = 3.923978e-09
+Final Relative Residual Norm = 3.923978e-09
 
 # Output file: vector.out.B110
 Iterations = 18
-Final Residual Norm = 3.923978e-09
+Final Relative Residual Norm = 3.923978e-09
+

--- a/src/test/TEST_longdouble/solvers_ij.saved
+++ b/src/test/TEST_longdouble/solvers_ij.saved
@@ -121,11 +121,11 @@ Final Relative Residual Norm = 8.514971e-17
 
 # Output file: solvers_ij.out.112
 GMRES Iterations = 43
-Final GMRES Relative Residual Norm = 8.442909e-17
+Final GMRES Relative Residual Norm = 8.435563e-17
 
 # Output file: solvers_ij.out.113
 GMRES Iterations = 50
-Final GMRES Relative Residual Norm = 7.190168e-17
+Final GMRES Relative Residual Norm = 7.198289e-17
 
 # Output file: solvers_ij.out.114
 BoomerAMG Iterations = 33
@@ -137,9 +137,9 @@ Final Relative Residual Norm = 7.295558e-17
 
 # Output file: solvers_ij.out.116
 GMRES Iterations = 18
-Final GMRES Relative Residual Norm = 3.547070e-17
+Final GMRES Relative Residual Norm = 3.539225e-17
 
 # Output file: solvers_ij.out.117
 GMRES Iterations = 18
-Final GMRES Relative Residual Norm = 3.382750e-17
+Final GMRES Relative Residual Norm = 3.377119e-17
 

--- a/src/test/TEST_single/solvers_ij.saved
+++ b/src/test/TEST_single/solvers_ij.saved
@@ -93,19 +93,19 @@ Final FlexGMRES Relative Residual Norm = 1.566998e-05
 
 # Output file: solvers_ij.out.105
 Iterations = 9
-Final Relative Residual Norm = 2.436061e-05
+Final Relative Residual Norm = 2.436053e-05
 
 # Output file: solvers_ij.out.106
 Iterations = 9
-Final Relative Residual Norm = 2.436061e-05
+Final Relative Residual Norm = 2.436053e-05
 
 # Output file: solvers_ij.out.107
 Iterations = 12
-Final Relative Residual Norm = 6.371655e-05
+Final Relative Residual Norm = 6.371622e-05
 
 # Output file: solvers_ij.out.108
 Iterations = 12
-Final Relative Residual Norm = 6.371655e-05
+Final Relative Residual Norm = 6.371622e-05
 
 # Output file: solvers_ij.out.109
 Iterations = 9
@@ -117,15 +117,15 @@ Final Relative Residual Norm = 8.952637e-05
 
 # Output file: solvers_ij.out.111
 Iterations = 15
-Final Relative Residual Norm = 8.953387e-05
+Final Relative Residual Norm = 8.953385e-05
 
 # Output file: solvers_ij.out.112
 GMRES Iterations = 12
-Final GMRES Relative Residual Norm = 5.901872e-05
+Final GMRES Relative Residual Norm = 5.912302e-05
 
 # Output file: solvers_ij.out.113
 GMRES Iterations = 13
-Final GMRES Relative Residual Norm = 7.924740e-05
+Final GMRES Relative Residual Norm = 7.921693e-05
 
 # Output file: solvers_ij.out.114
 BoomerAMG Iterations = 9
@@ -137,9 +137,9 @@ Final Relative Residual Norm = 3.870274e-05
 
 # Output file: solvers_ij.out.116
 GMRES Iterations = 6
-Final GMRES Relative Residual Norm = 3.056660e-05
+Final GMRES Relative Residual Norm = 3.071691e-05
 
 # Output file: solvers_ij.out.117
 GMRES Iterations = 6
-Final GMRES Relative Residual Norm = 3.009877e-05
+Final GMRES Relative Residual Norm = 3.018834e-05
 

--- a/src/test/TEST_superlu/sludist.saved
+++ b/src/test/TEST_superlu/sludist.saved
@@ -14,5 +14,5 @@ Final Relative Residual Norm = 3.172597e-08
 
 
 GMRES Iterations = 8
-Final GMRES Relative Residual Norm = 5.973547e-08
+Final GMRES Relative Residual Norm = 5.950181e-08
 


### PR DESCRIPTION
The RHEL9 upgrade resulted in compiler version changes, etc. that broke some of the regression tests.  Most of the changes are because of new compiler warnings and saved file differences.  There are still one or two things to fix, but this is mostly ready to merge.
