### PR TITLE
Fix rhel9 compiler differences in sludist saved file

### DIFF
--- a/src/test/TEST_superlu/sludist.saved
+++ b/src/test/TEST_superlu/sludist.saved
@@ -14,5 +14,5 @@ Final Relative Residual Norm = 3.172597e-08
 
 
 GMRES Iterations = 8
-Final GMRES Relative Residual Norm = 5.950181e-08
+Final GMRES Relative Residual Norm = 5.950180e-08
 


### PR DESCRIPTION
This should be the final fix for getting the spack tests to run cleanly again
