### PR TITLE
Regression test fixes

### DIFF
--- a/src/sstruct_ls/ssamg_interp.c
+++ b/src/sstruct_ls/ssamg_interp.c
@@ -547,6 +547,10 @@ hypre_SSAMGSetupInterpOp( hypre_SStructMatrix  *A,
                      hypre_TFree(indices[j], HYPRE_MEMORY_HOST);
                   }
                }
+               for (j = 0; j < ndim; j++)
+               {
+                  hypre_TFree(indices[j], HYPRE_MEMORY_HOST);
+               }
             }
             hypre_BoxDestroy(compute_box);
          }
@@ -588,6 +592,7 @@ hypre_SSAMGSetupInterpOp( hypre_SStructMatrix  *A,
       }
       hypre_CSRMatrixI(zero_diag)[ hypre_CSRMatrixNumRows(zero_diag) ] = hypre_CSRMatrixNumRows(zero_diag);
       hypre_ParCSRMatrixAdd(1.0, zero, 1.0, A_bndry, &A_u_aug);
+      hypre_ParCSRMatrixDestroy(A_bndry);
       hypre_ParCSRMatrixDestroy(zero);
 
       /* Get CF splitting */
@@ -675,6 +680,10 @@ hypre_SSAMGSetupInterpOp( hypre_SStructMatrix  *A,
 
                /* Increment box start index */
                box_start_index += hypre_BoxVolume(compute_box);
+
+               /* Clean up */
+               hypre_BoxDestroy(compute_box);
+               hypre_BoxDestroy(shrink_box);
             }
          }
       }

--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -2113,9 +2113,14 @@ hypre_SStructMatrixCompressUToS( HYPRE_SStructMatrix A, HYPRE_Int action )
                      hypre_SStructMatrixSetInterPartValues(A, part, hypre_BoxArrayBox(indices_boxa, j), var, nSentries, Sentries,
                                                            hypre_BoxArrayBox(indices_boxa, j), values, 1);
                   }
+                  hypre_TFree(values, HYPRE_MEMORY_DEVICE);
                }
                hypre_BoxArrayDestroy(indices_boxa);
                indices_boxa = NULL;
+            }
+            for (j = 0; j < ndim; j++)
+            {
+                hypre_TFree(indices[j], HYPRE_MEMORY_HOST);
             }
 
          } /* Loop over boxes */

--- a/src/test/TEST_sstruct/addtovalues.saved
+++ b/src/test/TEST_sstruct/addtovalues.saved
@@ -1,10 +1,10 @@
 # Output file: addtovalues.out.0
-Iterations = 9
-Final Relative Residual Norm = 7.226958e-07
+Iterations = 8
+Final Relative Residual Norm = 9.531730e-07
 
 # Output file: addtovalues.out.1
-Iterations = 9
-Final Relative Residual Norm = 7.226958e-07
+Iterations = 8
+Final Relative Residual Norm = 9.531730e-07
 
 # Output file: addtovalues.out.2
 Iterations = 34
@@ -15,12 +15,12 @@ Iterations = 34
 Final Relative Residual Norm = 5.437407e-07
 
 # Output file: addtovalues.out.4
-Iterations = 11
-Final Relative Residual Norm = 9.051371e-07
+Iterations = 9
+Final Relative Residual Norm = 4.767660e-07
 
 # Output file: addtovalues.out.5
-Iterations = 11
-Final Relative Residual Norm = 9.051371e-07
+Iterations = 9
+Final Relative Residual Norm = 4.767660e-07
 
 # Output file: addtovalues.out.6
 Iterations = 44

--- a/src/test/TEST_sstruct/amr2d.saved
+++ b/src/test/TEST_sstruct/amr2d.saved
@@ -51,20 +51,20 @@ Iterations = 18
 Final Relative Residual Norm = 5.252407e-07
 
 # Output file: amr2d.out.14
-Iterations = 27
-Final Relative Residual Norm = 7.805414e-07
+Iterations = 28
+Final Relative Residual Norm = 8.819880e-07
 
 # Output file: amr2d.out.15
-Iterations = 27
-Final Relative Residual Norm = 7.805414e-07
+Iterations = 28
+Final Relative Residual Norm = 8.819880e-07
 
 # Output file: amr2d.out.16
 Iterations = 10
-Final Relative Residual Norm = 7.402909e-07
+Final Relative Residual Norm = 7.820153e-07
 
 # Output file: amr2d.out.17
 Iterations = 10
-Final Relative Residual Norm = 7.402909e-07
+Final Relative Residual Norm = 7.820153e-07
 
 # Output file: amr2d.out.18
 Iterations = 6
@@ -73,3 +73,4 @@ Final Relative Residual Norm = 9.552005e-08
 # Output file: amr2d.out.19
 Iterations = 6
 Final Relative Residual Norm = 3.452407e-07
+

--- a/src/test/TEST_sstruct/miller.saved
+++ b/src/test/TEST_sstruct/miller.saved
@@ -7,12 +7,12 @@ Iterations = 6
 Final Relative Residual Norm = 9.625406e-08
 
 # Output file: miller.out.2
-Iterations = 20
-Final Relative Residual Norm = 6.435649e-07
+Iterations = 19
+Final Relative Residual Norm = 6.262284e-07
 
 # Output file: miller.out.3
-Iterations = 10
-Final Relative Residual Norm = 4.480771e-07
+Iterations = 9
+Final Relative Residual Norm = 2.271618e-07
 
 # Output file: miller.out.10
 Iterations = 15
@@ -24,11 +24,11 @@ Final Relative Residual Norm = 4.230245e-07
 
 # Output file: miller.out.12
 Iterations = 15
-Final Relative Residual Norm = 8.305357e-07
+Final Relative Residual Norm = 7.558636e-07
 
 # Output file: miller.out.13
 Iterations = 8
-Final Relative Residual Norm = 4.176263e-07
+Final Relative Residual Norm = 3.637652e-07
 
 # Output file: miller.out.20
 Iterations = 18
@@ -40,11 +40,11 @@ Final Relative Residual Norm = 8.758757e-08
 
 # Output file: miller.out.22
 Iterations = 19
-Final Relative Residual Norm = 9.392660e-07
+Final Relative Residual Norm = 9.371028e-07
 
 # Output file: miller.out.23
 Iterations = 8
-Final Relative Residual Norm = 3.238280e-07
+Final Relative Residual Norm = 3.235898e-07
 
 # Output file: miller.out.30
 Iterations = 37
@@ -55,12 +55,12 @@ Iterations = 5
 Final Relative Residual Norm = 8.323418e-07
 
 # Output file: miller.out.32
-Iterations = 55
-Final Relative Residual Norm = 9.095622e-07
+Iterations = 48
+Final Relative Residual Norm = 9.184883e-07
 
 # Output file: miller.out.33
 Iterations = 12
-Final Relative Residual Norm = 7.496717e-07
+Final Relative Residual Norm = 2.123878e-07
 
 # Output file: miller.out.40
 Iterations = 3
@@ -71,9 +71,10 @@ Iterations = 2
 Final Relative Residual Norm = 2.571870e-07
 
 # Output file: miller.out.42
-Iterations = 5
+Iterations = 4
 Final Relative Residual Norm = 4.398907e-07
 
 # Output file: miller.out.43
 Iterations = 3
 Final Relative Residual Norm = 3.093709e-07
+

--- a/src/test/TEST_sstruct/solvers.saved
+++ b/src/test/TEST_sstruct/solvers.saved
@@ -154,6 +154,62 @@ Final Relative Residual Norm = 7.137571e-07
 Iterations = 19
 Final Relative Residual Norm = 8.792117e-07
 
+# Output file: solvers.out.44
+Iterations = 16
+Final Relative Residual Norm = 5.860172e-07
+
+# Output file: solvers.out.45
+Iterations = 16
+Final Relative Residual Norm = 5.860172e-07
+
+# Output file: solvers.out.46
+Iterations = 5
+Final Relative Residual Norm = 7.996753e-07
+
+# Output file: solvers.out.47
+Iterations = 5
+Final Relative Residual Norm = 7.996753e-07
+
+# Output file: solvers.out.48
+Iterations = 19
+Final Relative Residual Norm = 9.434710e-07
+
+# Output file: solvers.out.49
+Iterations = 19
+Final Relative Residual Norm = 9.434710e-07
+
+# Output file: solvers.out.50
+Iterations = 10
+Final Relative Residual Norm = 2.753941e-07
+
+# Output file: solvers.out.51
+Iterations = 10
+Final Relative Residual Norm = 3.019416e-07
+
+# Output file: solvers.out.52
+Iterations = 13
+Final Relative Residual Norm = 3.764193e-07
+
+# Output file: solvers.out.53
+Iterations = 13
+Final Relative Residual Norm = 3.764193e-07
+
+# Output file: solvers.out.56
+Iterations = 9
+Final Relative Residual Norm = 4.326545e-07
+
+# Output file: solvers.out.57
+Iterations = 9
+Final Relative Residual Norm = 4.663609e-07
+
+# Output file: solvers.out.58
+Iterations = 15
+Final Relative Residual Norm = 7.581156e-07
+
+# Output file: solvers.out.59
+Iterations = 15
+Final Relative Residual Norm = 7.581156e-07
+
 # Output file: solvers.out.121
 Iterations = 8
 Final Relative Residual Norm = 1.773482e-07

--- a/src/test/TEST_sstruct/solvers.saved
+++ b/src/test/TEST_sstruct/solvers.saved
@@ -38,7 +38,6 @@ Final Relative Residual Norm = 9.036190e-07
 Iterations = 4
 Final Relative Residual Norm = 9.340817e-07
 
-# Output file: solvers.out.14
 # Output file: solvers.out.15
 Iterations = 5
 Final Relative Residual Norm = 4.012141e-07

--- a/src/test/TEST_sstruct/solvers.sh
+++ b/src/test/TEST_sstruct/solvers.sh
@@ -52,6 +52,20 @@ FILES="\
  ${TNAME}.out.41\
  ${TNAME}.out.42\
  ${TNAME}.out.43\
+ ${TNAME}.out.44\
+ ${TNAME}.out.45\
+ ${TNAME}.out.46\
+ ${TNAME}.out.47\
+ ${TNAME}.out.48\
+ ${TNAME}.out.49\
+ ${TNAME}.out.50\
+ ${TNAME}.out.51\
+ ${TNAME}.out.52\
+ ${TNAME}.out.53\
+ ${TNAME}.out.56\
+ ${TNAME}.out.57\
+ ${TNAME}.out.58\
+ ${TNAME}.out.59\
  ${TNAME}.out.121\
  ${TNAME}.out.122\
  ${TNAME}.out.123\

--- a/src/test/TEST_sstruct/solvers.sh
+++ b/src/test/TEST_sstruct/solvers.sh
@@ -23,7 +23,6 @@ FILES="\
  ${TNAME}.out.9\
  ${TNAME}.out.10\
  ${TNAME}.out.11\
- ${TNAME}.out.14\
  ${TNAME}.out.15\
  ${TNAME}.out.16\
  ${TNAME}.out.17\
@@ -81,6 +80,7 @@ FILES="\
 # ${TNAME}.out.6\
 # ${TNAME}.out.12\
 # ${TNAME}.out.13\
+# ${TNAME}.out.14\
 
 for i in $FILES
 do

--- a/src/test/TEST_sstruct/sstruct.in.addtoval_cellcentre
+++ b/src/test/TEST_sstruct/sstruct.in.addtoval_cellcentre
@@ -25,10 +25,10 @@ StencilCreate: 1 [7]
 StencilSetEntry: 0  0 [ 0  0  0] 0 0.0
 StencilSetEntry: 0  1 [-1  0  0] 0 0.0
 StencilSetEntry: 0  2 [ 1  0  0] 0 0.0
-StencilSetEntry: 0  3 [ 0  1  0] 0 0.0
-StencilSetEntry: 0  4 [ 0 -1  0] 0 0.0
-StencilSetEntry: 0  5 [ 0  0  1] 0 0.0
-StencilSetEntry: 0  6 [ 0  0 -1] 0 0.0
+StencilSetEntry: 0  3 [ 0 -1  0] 0 0.0
+StencilSetEntry: 0  4 [ 0  1  0] 0 0.0
+StencilSetEntry: 0  5 [ 0  0 -1] 0 0.0
+StencilSetEntry: 0  6 [ 0  0  1] 0 0.0
 
 ###########################################################
 
@@ -42,6 +42,14 @@ GraphSetStencil: 0 0 0
 
 MatrixAddToValues: 0  (1- 1- 1-) (4+ 4+ 4+) 0 4 [0 1 2 3] [6.0 -1.0 -1.0 -1.0]
 MatrixAddToValues: 0  (1- 1- 1-) (4+ 4+ 4+) 0 3 [  4 5 6] [    -1.0 -1.0 -1.0]
+
+# Adjust boundary
+MatrixAddToValues: 0  (1- 1- 1-) (1- 4+ 4+) 0 1 [1] [1.0]
+MatrixAddToValues: 0  (4+ 1- 1-) (4+ 4+ 4+) 0 1 [2] [1.0]
+MatrixAddToValues: 0  (1- 1- 1-) (4+ 1- 4+) 0 1 [3] [1.0]
+MatrixAddToValues: 0  (1- 4+ 1-) (4+ 4+ 4+) 0 1 [4] [1.0]
+MatrixAddToValues: 0  (1- 1- 1-) (4+ 4+ 1-) 0 1 [5] [1.0]
+MatrixAddToValues: 0  (1- 1- 4+) (4+ 4+ 4+) 0 1 [6] [1.0]
 
 ###########################################################
 

--- a/src/test/TEST_sstruct/sstruct.in.noaddtoval_cellcentre
+++ b/src/test/TEST_sstruct/sstruct.in.noaddtoval_cellcentre
@@ -25,15 +25,26 @@ StencilCreate: 1 [7]
 StencilSetEntry: 0  0 [ 0  0  0] 0 6.0
 StencilSetEntry: 0  1 [-1  0  0] 0 -1.0
 StencilSetEntry: 0  2 [ 1  0  0] 0 -1.0
-StencilSetEntry: 0  3 [ 0  1  0] 0 -1.0
-StencilSetEntry: 0  4 [ 0 -1  0] 0 -1.0
-StencilSetEntry: 0  5 [ 0  0  1] 0 -1.0
-StencilSetEntry: 0  6 [ 0  0 -1] 0 -1.0
+StencilSetEntry: 0  3 [ 0 -1  0] 0 -1.0
+StencilSetEntry: 0  4 [ 0  1  0] 0 -1.0
+StencilSetEntry: 0  5 [ 0  0 -1] 0 -1.0
+StencilSetEntry: 0  6 [ 0  0  1] 0 -1.0
 
 ###########################################################
 
 # GraphSetStencil: part var stencil_num
 GraphSetStencil: 0 0 0
+
+###########################################################
+
+# MatrixSetValues: \
+#   part ilower(ndim) iupper(ndim) stride[ndim] var entry value
+MatrixSetValues: 0 (1- 1- 1-) (1- 4+ 4+) [1 1 1] 0 1 0.0
+MatrixSetValues: 0 (4+ 1- 1-) (4+ 4+ 4+) [1 1 1] 0 2 0.0
+MatrixSetValues: 0 (1- 1- 1-) (4+ 1- 4+) [1 1 1] 0 3 0.0
+MatrixSetValues: 0 (1- 4+ 1-) (4+ 4+ 4+) [1 1 1] 0 4 0.0
+MatrixSetValues: 0 (1- 1- 1-) (4+ 4+ 1-) [1 1 1] 0 5 0.0
+MatrixSetValues: 0 (1- 1- 4+) (4+ 4+ 4+) [1 1 1] 0 6 0.0
 
 ###########################################################
 

--- a/src/test/sstruct.c
+++ b/src/test/sstruct.c
@@ -3536,7 +3536,7 @@ main( hypre_int argc,
       values_size = 1;
       values_size = hypre_max(values_size, data.fem_nvars * data.fem_nvars);
       values_size = hypre_max(values_size, data.max_boxsize);
-      values_size = hypre_max(values_size, data.fem_nsparse);
+      values_size = hypre_max(values_size, data.max_boxsize * data.fem_nsparse);
       for (part = 0; part < nparts; part++)
       {
          pdata = data.pdata[part];


### PR DESCRIPTION
This PR makes several fixes to the recmat regression tests and updates the saved files for the rhel9 tux compilers

* With the exception of three tests, the following all run cleanly: ij, sstruct, sstructmat, struct, structmat
* All of the passing tests in sstruct were run cleanly through valgrind as well
* Here are the sstruct tests that still need to be fixed
```
FAILED : TEST_sstruct/emptyProc.err  (1469)
FAILED : TEST_sstruct/io.err  (2940)
FAILED : TEST_sstruct/periodic.err  (4671)
```
