### PR TITLE
Recmat structmat

### DIFF
--- a/src/sstruct_ls/maxwell_semi_interp.c
+++ b/src/sstruct_ls/maxwell_semi_interp.c
@@ -18,6 +18,26 @@
 #include "_hypre_sstruct_ls.h"
 
 /*--------------------------------------------------------------------------
+ * Adding a local FineToCoarse function to fix --with-print-errors issues
+ * when using the hypre_StructMapFineToCoarse() function
+ *--------------------------------------------------------------------------*/
+HYPRE_Int
+maxwell_MapFineToCoarse( hypre_Index findex,
+                         hypre_Index index,
+                         hypre_Index stride,
+                         hypre_Index cindex )
+{
+   hypre_IndexX(cindex) =
+      (hypre_IndexX(findex) - hypre_IndexX(index)) / hypre_IndexX(stride);
+   hypre_IndexY(cindex) =
+      (hypre_IndexY(findex) - hypre_IndexY(index)) / hypre_IndexY(stride);
+   hypre_IndexZ(cindex) =
+      (hypre_IndexZ(findex) - hypre_IndexZ(index)) / hypre_IndexZ(stride);
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
  * hypre_Maxwell_Interp.c
  *--------------------------------------------------------------------------*/
 HYPRE_Int
@@ -407,10 +427,10 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
          fbox = hypre_BoxArrayBox(fboxes, j);
          hypre_CopyBox(fbox, &copy_box);
          hypre_ProjectBox(&copy_box, zero_index, rfactor);
-         hypre_StructMapFineToCoarse(hypre_BoxIMin(&copy_box), zero_index,
-                                     rfactor, hypre_BoxIMin(&copy_box));
-         hypre_StructMapFineToCoarse(hypre_BoxIMax(&copy_box), zero_index,
-                                     rfactor, hypre_BoxIMax(&copy_box));
+         maxwell_MapFineToCoarse(hypre_BoxIMin(&copy_box), zero_index,
+                                 rfactor, hypre_BoxIMin(&copy_box));
+         maxwell_MapFineToCoarse(hypre_BoxIMax(&copy_box), zero_index,
+                                 rfactor, hypre_BoxIMax(&copy_box));
 
          /* since the ordering of the cboxes was determined by the fbox
             ordering, we only have to check if the first cbox in the
@@ -462,8 +482,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
          /* record the cstarts of the cbox */
          hypre_ProjectBox(cbox, zero_index, rfactor);
          hypre_CopyIndex(hypre_BoxIMin(cbox), Edge_cstarts[i][j]);
-         hypre_StructMapFineToCoarse(Edge_cstarts[i][j], zero_index, rfactor,
-                                     Edge_cstarts[i][j]);
+         maxwell_MapFineToCoarse(Edge_cstarts[i][j], zero_index, rfactor,
+                                 Edge_cstarts[i][j]);
 
          hypre_BoxDestroy(cbox);
       }
@@ -2311,8 +2331,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
             }
 
             hypre_BoxGetSize(&copy_box, loop_size);
-            hypre_StructMapFineToCoarse(loop_size, zero_index, stride,
-                                        loop_size);
+            maxwell_MapFineToCoarse(loop_size, zero_index, stride,
+                                    loop_size);
 
             /* extend the loop_size so that upper boundary of the box are reached. */
             hypre_AddIndexes(loop_size, hi_index, 3, loop_size);
@@ -2435,8 +2455,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
 
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
@@ -2512,8 +2532,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
 
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
                      loop_size[1]++;
@@ -2611,8 +2631,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
 
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
@@ -2687,8 +2707,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
 
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
@@ -2786,8 +2806,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
 
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
@@ -2866,8 +2886,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                      loop_size[1]++;
@@ -2960,8 +2980,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                         hypre_BoxIMin(&copy_box));
 
                   hypre_BoxGetSize(&copy_box, loop_size);
-                  hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                              loop_size);
+                  maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                          loop_size);
                   hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                   hypre_SerialBoxLoop1Begin(ndim, loop_size,
@@ -3016,8 +3036,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                         hypre_BoxIMin(&copy_box));
 
                   hypre_BoxGetSize(&copy_box, loop_size);
-                  hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                              loop_size);
+                  maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                          loop_size);
                   hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                   hypre_SerialBoxLoop1Begin(ndim, loop_size,
@@ -3073,8 +3093,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                         hypre_BoxIMin(&copy_box));
 
                   hypre_BoxGetSize(&copy_box, loop_size);
-                  hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                              loop_size);
+                  maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                          loop_size);
                   hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                   hypre_SerialBoxLoop1Begin(ndim, loop_size,
@@ -3140,8 +3160,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                         hypre_BoxIMin(&copy_box));
 
                   hypre_BoxGetSize(&copy_box, loop_size);
-                  hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                              loop_size);
+                  maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                          loop_size);
                   hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                   hypre_SerialBoxLoop1Begin(ndim, loop_size,
@@ -3208,8 +3228,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                         hypre_BoxIMin(&copy_box));
 
                   hypre_BoxGetSize(&copy_box, loop_size);
-                  hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                              loop_size);
+                  maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                          loop_size);
                   hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                   hypre_SerialBoxLoop1Begin(ndim, loop_size,
@@ -3442,15 +3462,15 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
 
                   /* also modify cstart */
                   hypre_AddIndexes(boxoffset[j], one_index, 3, boxoffset[j]);
-                  hypre_StructMapFineToCoarse(boxoffset[j], zero_index, rfactor,
-                                              boxoffset[j]);
+                  maxwell_MapFineToCoarse(boxoffset[j], zero_index, rfactor,
+                                          boxoffset[j]);
                   hypre_AddIndexes(cstart, boxoffset[j], 3, cstart);
                }
             }
 
             hypre_BoxGetSize(&copy_box, loop_size);
-            hypre_StructMapFineToCoarse(loop_size, zero_index, stride,
-                                        loop_size);
+            maxwell_MapFineToCoarse(loop_size, zero_index, stride,
+                                    loop_size);
 
             /* extend the loop_size so that upper boundary of the box are reached. */
             hypre_AddIndexes(loop_size, hi_index, 3, loop_size);
@@ -3481,8 +3501,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                   hypre_SubtractIndexes(findex, start, 3, findex);
 
                   /* determine where the edge lies- coarsening required. */
-                  hypre_StructMapFineToCoarse(findex, zero_index, rfactor,
-                                              cindex);
+                  maxwell_MapFineToCoarse(findex, zero_index, rfactor,
+                                          cindex);
                   hypre_AddIndexes(cindex, cstart, 3, cindex);
                   hypre_AddIndexes(findex, start, 3, findex);
 
@@ -3605,8 +3625,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                      /* increase the loop_size by one in the Z plane direction */
@@ -3744,8 +3764,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                      loop_size[1]++;
@@ -3907,8 +3927,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                      /* increase the loop_size by one in the Z plane direction */
@@ -4041,8 +4061,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                      loop_size[0]++;
@@ -4203,8 +4223,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
 
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
@@ -4337,8 +4357,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                            hypre_BoxIMin(&copy_box));
 
                      hypre_BoxGetSize(&copy_box, loop_size);
-                     hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                                 loop_size);
+                     maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                             loop_size);
                      hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                      loop_size[1]++;
@@ -4499,8 +4519,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                         hypre_BoxIMin(&copy_box));
 
                   hypre_BoxGetSize(&copy_box, loop_size);
-                  hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                              loop_size);
+                  maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                          loop_size);
                   hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                   hypre_SerialBoxLoop1Begin(ndim, loop_size,
@@ -4582,8 +4602,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                         hypre_BoxIMin(&copy_box));
 
                   hypre_BoxGetSize(&copy_box, loop_size);
-                  hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                              loop_size);
+                  maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                          loop_size);
                   hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                   hypre_SerialBoxLoop1Begin(ndim, loop_size,
@@ -4665,8 +4685,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                         hypre_BoxIMin(&copy_box));
 
                   hypre_BoxGetSize(&copy_box, loop_size);
-                  hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                              loop_size);
+                  maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                          loop_size);
                   hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                   hypre_SerialBoxLoop1Begin(ndim, loop_size,
@@ -4819,8 +4839,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                         hypre_BoxIMin(&copy_box));
 
                   hypre_BoxGetSize(&copy_box, loop_size);
-                  hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                              loop_size);
+                  maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                          loop_size);
                   hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                   hypre_SerialBoxLoop1Begin(ndim, loop_size,
@@ -4974,8 +4994,8 @@ hypre_Maxwell_PTopology(  hypre_SStructGrid    *fgrid_edge,
                                         hypre_BoxIMin(&copy_box));
 
                   hypre_BoxGetSize(&copy_box, loop_size);
-                  hypre_StructMapFineToCoarse(loop_size, zero_index, rfactor,
-                                              loop_size);
+                  maxwell_MapFineToCoarse(loop_size, zero_index, rfactor,
+                                          loop_size);
                   hypre_CopyIndex(hypre_BoxIMin(&copy_box), start);
 
                   hypre_SerialBoxLoop1Begin(ndim, loop_size,

--- a/src/sstruct_mv/sstruct_matmult.c
+++ b/src/sstruct_mv/sstruct_matmult.c
@@ -226,7 +226,9 @@ hypre_SStructPMatmultSetup( hypre_SStructPMatmultData  *pmmdata,
             hypre_StructMatrixDestroy(sM);
 
             /* This sets up the grid and stencil of the (vi,vj)-block of the PMatrix */
-            hypre_StructMatmultSetup(smmdata[vi][vj], &sM);
+            /* NOTE: Do not assemble the sM grid here.  Assemble the grids later
+             * in HYPRE_SStructGridAssemble(Mgrid) to reduce box manager overhead. */
+            hypre_StructMatmultSetup(smmdata[vi][vj], 0, &sM);
             hypre_SStructPMatrixSMatrix(pM, vi, vj) = sM;
 
             /* Update struct stencil of the (vi,vj)-block with actual stencils */

--- a/src/struct_mv/_hypre_struct_mv.h
+++ b/src/struct_mv/_hypre_struct_mv.h
@@ -2135,8 +2135,8 @@ HYPRE_Int hypre_StructMatmultCreate ( HYPRE_Int nmatrices_in, hypre_StructMatrix
                                       HYPRE_Int nterms, HYPRE_Int *terms_in, HYPRE_Int *transposes_in,
                                       hypre_StructMatmultData **mmdata_ptr );
 HYPRE_Int hypre_StructMatmultDestroy ( hypre_StructMatmultData *mmdata );
-HYPRE_Int hypre_StructMatmultSetup ( hypre_StructMatmultData  *mmdata, hypre_StructMatrix **M_ptr );
-HYPRE_Int hypre_StructMatmultCommunicate ( hypre_StructMatmultData *mmdata, hypre_StructMatrix *M );
+HYPRE_Int hypre_StructMatmultSetup ( hypre_StructMatmultData  *mmdata, HYPRE_Int assemble_grid, hypre_StructMatrix **M_ptr );
+HYPRE_Int hypre_StructMatmultCommunicate ( hypre_StructMatmultData *mmdata );
 HYPRE_Int hypre_StructMatmultCompute ( hypre_StructMatmultData *mmdata, hypre_StructMatrix *M );
 HYPRE_Int hypre_StructMatmultCompute_core_double ( hypre_StructMatmultHelper *a, HYPRE_Int na,
                                                    HYPRE_Int ndim, hypre_Index loop_size, HYPRE_Int stencil_size, hypre_Box *fdbox,

--- a/src/struct_mv/protos.h
+++ b/src/struct_mv/protos.h
@@ -357,8 +357,8 @@ HYPRE_Int hypre_StructMatmultCreate ( HYPRE_Int nmatrices_in, hypre_StructMatrix
                                       HYPRE_Int nterms, HYPRE_Int *terms_in, HYPRE_Int *transposes_in,
                                       hypre_StructMatmultData **mmdata_ptr );
 HYPRE_Int hypre_StructMatmultDestroy ( hypre_StructMatmultData *mmdata );
-HYPRE_Int hypre_StructMatmultSetup ( hypre_StructMatmultData  *mmdata, hypre_StructMatrix **M_ptr );
-HYPRE_Int hypre_StructMatmultCommunicate ( hypre_StructMatmultData *mmdata, hypre_StructMatrix *M );
+HYPRE_Int hypre_StructMatmultSetup ( hypre_StructMatmultData  *mmdata, HYPRE_Int assemble_grid, hypre_StructMatrix **M_ptr );
+HYPRE_Int hypre_StructMatmultCommunicate ( hypre_StructMatmultData *mmdata );
 HYPRE_Int hypre_StructMatmultCompute ( hypre_StructMatmultData *mmdata, hypre_StructMatrix *M );
 HYPRE_Int hypre_StructMatmultCompute_core_double ( hypre_StructMatmultHelper *a, HYPRE_Int na,
                                                    HYPRE_Int ndim, hypre_Index loop_size, HYPRE_Int stencil_size, hypre_Box *fdbox,

--- a/src/struct_mv/struct_matmult.c
+++ b/src/struct_mv/struct_matmult.c
@@ -397,6 +397,10 @@ hypre_StructMatmultSetup( hypre_StructMatmultData  *mmdata,
       hypre_StructCoarsen(grid, NULL, coarsen_stride, 1, &Mgrid);
       hypre_MapToCoarseIndex(Mran_stride, NULL, coarsen_stride, ndim);
       hypre_MapToCoarseIndex(Mdom_stride, NULL, coarsen_stride, ndim);
+      /* Assemble the grid. Note: StructGridGlobalSize is updated to zero so that
+       * its computation is triggered in hypre_StructGridAssemble */
+      hypre_StructGridGlobalSize(grid) = 0;
+      hypre_StructGridAssemble(grid);
    }
    else
    {
@@ -887,10 +891,13 @@ hypre_StructMatmultCommunicate( hypre_StructMatmultData  *mmdata,
    hypre_CommHandle   *comm_handle;
    HYPRE_Int           i, j, nb;
 
+#if 0
+   /* Moved this to hypre_StructMatmultSetup */
    /* Assemble the grid. Note: StructGridGlobalSize is updated to zero so that
     * its computation is triggered in hypre_StructGridAssemble */
    hypre_StructGridGlobalSize(grid) = 0;
    hypre_StructGridAssemble(grid);
+#endif
 
    /* If all constant coefficients, return */
    if (mmdata -> na == 0)

--- a/src/struct_mv/struct_matmult.c
+++ b/src/struct_mv/struct_matmult.c
@@ -399,8 +399,8 @@ hypre_StructMatmultSetup( hypre_StructMatmultData  *mmdata,
       hypre_MapToCoarseIndex(Mdom_stride, NULL, coarsen_stride, ndim);
       /* Assemble the grid. Note: StructGridGlobalSize is updated to zero so that
        * its computation is triggered in hypre_StructGridAssemble */
-      hypre_StructGridGlobalSize(grid) = 0;
-      hypre_StructGridAssemble(grid);
+      hypre_StructGridGlobalSize(Mgrid) = 0;
+      hypre_StructGridAssemble(Mgrid);
    }
    else
    {
@@ -879,7 +879,7 @@ HYPRE_Int
 hypre_StructMatmultCommunicate( hypre_StructMatmultData  *mmdata,
                                 hypre_StructMatrix       *M )
 {
-   hypre_StructGrid   *grid = hypre_StructMatrixGrid(M);
+//   hypre_StructGrid   *grid = hypre_StructMatrixGrid(M);
 
    hypre_CommPkg      *comm_pkg        = (mmdata -> comm_pkg);
    HYPRE_Complex     **comm_data       = (mmdata -> comm_data);

--- a/src/struct_mv/struct_matmult.c
+++ b/src/struct_mv/struct_matmult.c
@@ -240,6 +240,7 @@ hypre_StructMatmultDestroy( hypre_StructMatmultData *mmdata )
 
 HYPRE_Int
 hypre_StructMatmultSetup( hypre_StructMatmultData  *mmdata,
+                          HYPRE_Int                 assemble_grid,
                           hypre_StructMatrix      **M_ptr )
 {
    HYPRE_Int                  nterms       = (mmdata -> nterms);
@@ -397,10 +398,13 @@ hypre_StructMatmultSetup( hypre_StructMatmultData  *mmdata,
       hypre_StructCoarsen(grid, NULL, coarsen_stride, 1, &Mgrid);
       hypre_MapToCoarseIndex(Mran_stride, NULL, coarsen_stride, ndim);
       hypre_MapToCoarseIndex(Mdom_stride, NULL, coarsen_stride, ndim);
-      /* Assemble the grid. Note: StructGridGlobalSize is updated to zero so that
-       * its computation is triggered in hypre_StructGridAssemble */
-      hypre_StructGridGlobalSize(Mgrid) = 0;
-      hypre_StructGridAssemble(Mgrid);
+      if (assemble_grid)
+      {
+         /* Assemble the grid. Note: StructGridGlobalSize is updated to zero so that
+          * its computation is triggered in hypre_StructGridAssemble */
+         hypre_StructGridGlobalSize(Mgrid) = 0;
+         hypre_StructGridAssemble(Mgrid);
+      }
    }
    else
    {
@@ -876,11 +880,8 @@ hypre_StructMatmultSetup( hypre_StructMatmultData  *mmdata,
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_StructMatmultCommunicate( hypre_StructMatmultData  *mmdata,
-                                hypre_StructMatrix       *M )
+hypre_StructMatmultCommunicate( hypre_StructMatmultData  *mmdata )
 {
-//   hypre_StructGrid   *grid = hypre_StructMatrixGrid(M);
-
    hypre_CommPkg      *comm_pkg        = (mmdata -> comm_pkg);
    HYPRE_Complex     **comm_data       = (mmdata -> comm_data);
    hypre_CommPkg     **comm_pkg_a      = (mmdata -> comm_pkg_a);
@@ -890,14 +891,6 @@ hypre_StructMatmultCommunicate( hypre_StructMatmultData  *mmdata,
 
    hypre_CommHandle   *comm_handle;
    HYPRE_Int           i, j, nb;
-
-#if 0
-   /* Moved this to hypre_StructMatmultSetup */
-   /* Assemble the grid. Note: StructGridGlobalSize is updated to zero so that
-    * its computation is triggered in hypre_StructGridAssemble */
-   hypre_StructGridGlobalSize(grid) = 0;
-   hypre_StructGridAssemble(grid);
-#endif
 
    /* If all constant coefficients, return */
    if (mmdata -> na == 0)
@@ -4374,8 +4367,8 @@ hypre_StructMatmult( HYPRE_Int            nmatrices,
    hypre_StructMatmultData *mmdata;
 
    hypre_StructMatmultCreate(nmatrices, matrices, nterms, terms, trans, &mmdata);
-   hypre_StructMatmultSetup(mmdata, M_ptr);
-   hypre_StructMatmultCommunicate(mmdata, *M_ptr);
+   hypre_StructMatmultSetup(mmdata, 1, M_ptr);
+   hypre_StructMatmultCommunicate(mmdata);
    hypre_StructMatmultCompute(mmdata, *M_ptr);
    HYPRE_StructMatrixAssemble(*M_ptr);
    hypre_StructMatmultDestroy(mmdata);
@@ -4404,8 +4397,8 @@ hypre_StructMatmat( hypre_StructMatrix  *A,
 
    /* Compute resulting matrix M */
    hypre_StructMatmultCreate(nmatrices, matrices, nterms, terms, trans, &mmdata);
-   hypre_StructMatmultSetup(mmdata, M_ptr);
-   hypre_StructMatmultCommunicate(mmdata, *M_ptr);
+   hypre_StructMatmultSetup(mmdata, 1, M_ptr);
+   hypre_StructMatmultCommunicate(mmdata);
    hypre_StructMatmultCompute(mmdata, *M_ptr);
    hypre_StructMatmultDestroy(mmdata);
 
@@ -4436,8 +4429,8 @@ hypre_StructMatrixPtAP( hypre_StructMatrix  *A,
 
    /* Compute resulting matrix M */
    hypre_StructMatmultCreate(nmatrices, matrices, nterms, terms, trans, &mmdata);
-   hypre_StructMatmultSetup(mmdata, M_ptr);
-   hypre_StructMatmultCommunicate(mmdata, *M_ptr);
+   hypre_StructMatmultSetup(mmdata, 1, M_ptr);
+   hypre_StructMatmultCommunicate(mmdata);
    hypre_StructMatmultCompute(mmdata, *M_ptr);
    hypre_StructMatmultDestroy(mmdata);
 
@@ -4469,8 +4462,8 @@ hypre_StructMatrixRAP( hypre_StructMatrix  *R,
 
    /* Compute resulting matrix M */
    hypre_StructMatmultCreate(nmatrices, matrices, nterms, terms, trans, &mmdata);
-   hypre_StructMatmultSetup(mmdata, M_ptr);
-   hypre_StructMatmultCommunicate(mmdata, *M_ptr);
+   hypre_StructMatmultSetup(mmdata, 1, M_ptr);
+   hypre_StructMatmultCommunicate(mmdata);
    hypre_StructMatmultCompute(mmdata, *M_ptr);
    hypre_StructMatmultDestroy(mmdata);
 
@@ -4502,8 +4495,8 @@ hypre_StructMatrixRTtAP( hypre_StructMatrix  *RT,
 
    /* Compute resulting matrix M */
    hypre_StructMatmultCreate(nmatrices, matrices, nterms, terms, trans, &mmdata);
-   hypre_StructMatmultSetup(mmdata, M_ptr);
-   hypre_StructMatmultCommunicate(mmdata, *M_ptr);
+   hypre_StructMatmultSetup(mmdata, 1, M_ptr);
+   hypre_StructMatmultCommunicate(mmdata);
    hypre_StructMatmultCompute(mmdata, *M_ptr);
    hypre_StructMatmultDestroy(mmdata);
 

--- a/src/test/TEST_longdouble/solvers_struct.saved
+++ b/src/test/TEST_longdouble/solvers_struct.saved
@@ -12,11 +12,11 @@ Final Relative Residual Norm = 7.177049e-17
 
 # Output file: solvers_struct.out.3
 Iterations = 34
-Final Relative Residual Norm = 3.265691e-18
+Final Relative Residual Norm = 3.283145e-18
 
 # Output file: solvers_struct.out.4
 Iterations = 34
-Final Relative Residual Norm = 3.219688e-18
+Final Relative Residual Norm = 3.220144e-18
 
 # Output file: solvers_struct.out.10.lobpcg
 Iterations = 9
@@ -24,7 +24,7 @@ Final Relative Residual Norm = 8.224720e-17
 
 # Output file: solvers_struct.out.10.lobpcg.1
 Eigenvalue lambda   1.84366453091756e-01
-Residual   6.51777159501743e-08
+Residual   6.51777159501458e-08
 
 # Output file: solvers_struct.out.10.lobpcg.5
 Eigenvalue lambda   1.84366453091754e-01
@@ -32,11 +32,11 @@ Eigenvalue lambda   2.50882493969729e-01
 Eigenvalue lambda   3.60090369737174e-01
 Eigenvalue lambda   4.20845334658399e-01
 Eigenvalue lambda   4.20845334658517e-01
-Residual   3.01898591710117e-08
-Residual   4.55422767371506e-08
-Residual   3.17971068849731e-07
-Residual   1.36018481189308e-07
-Residual   3.39522268990133e-07
+Residual   3.01898591710165e-08
+Residual   4.55422767371611e-08
+Residual   3.17971068849217e-07
+Residual   1.36018499807955e-07
+Residual   3.39522271917928e-07
 
 # Output file: solvers_struct.out.11.lobpcg
 Iterations = 20
@@ -44,7 +44,7 @@ Final Relative Residual Norm = 4.957736e-17
 
 # Output file: solvers_struct.out.11.lobpcg.1
 Eigenvalue lambda   1.84366453091756e-01
-Residual   5.90808378148877e-08
+Residual   5.90808378148828e-08
 
 # Output file: solvers_struct.out.11.lobpcg.5
 Eigenvalue lambda   1.84366453091753e-01
@@ -52,11 +52,11 @@ Eigenvalue lambda   2.50882493969729e-01
 Eigenvalue lambda   3.60090369737179e-01
 Eigenvalue lambda   4.20845334658427e-01
 Eigenvalue lambda   4.20845334658489e-01
-Residual   3.21720429474187e-08
-Residual   6.44224703497146e-08
-Residual   2.42812454193411e-07
-Residual   3.37502154312378e-07
-Residual   3.28950912831126e-07
+Residual   3.21720429474025e-08
+Residual   6.44224703493958e-08
+Residual   2.42812454193480e-07
+Residual   3.37502138632775e-07
+Residual   3.28950713040786e-07
 
 # Output file: solvers_struct.out.17.lobpcg
 Iterations = 34
@@ -64,7 +64,7 @@ Final Relative Residual Norm = 4.087402e-17
 
 # Output file: solvers_struct.out.17.lobpcg.1
 Eigenvalue lambda   1.84366453091770e-01
-Residual   1.03034775753859e-07
+Residual   1.03034775753639e-07
 
 # Output file: solvers_struct.out.17.lobpcg.5
 Eigenvalue lambda   1.84366453091753e-01
@@ -72,31 +72,31 @@ Eigenvalue lambda   2.50882493969729e-01
 Eigenvalue lambda   3.60090369737173e-01
 Eigenvalue lambda   4.20845334658410e-01
 Eigenvalue lambda   4.20845334658418e-01
-Residual   2.01876274958806e-08
-Residual   2.36598865456373e-07
-Residual   1.80211166022567e-07
-Residual   1.64172205059144e-07
-Residual   1.88447274083737e-07
+Residual   2.01876274958973e-08
+Residual   2.36598865456431e-07
+Residual   1.80211166018897e-07
+Residual   1.64172413298106e-07
+Residual   1.88446276369215e-07
 
 # Output file: solvers_struct.out.18.lobpcg
 Iterations = 59
-Final Relative Residual Norm = 5.038238e-17
+Final Relative Residual Norm = 5.065856e-17
 
 # Output file: solvers_struct.out.18.lobpcg.1
 Eigenvalue lambda   1.84366453091755e-01
-Residual   8.10727379998635e-08
+Residual   8.10727379997399e-08
 
 # Output file: solvers_struct.out.18.lobpcg.5
 Eigenvalue lambda   1.84366453091753e-01
-Eigenvalue lambda   2.50882493969729e-01
+Eigenvalue lambda   2.50882493969730e-01
 Eigenvalue lambda   3.60090369737172e-01
 Eigenvalue lambda   4.20845334658451e-01
 Eigenvalue lambda   4.20845334658495e-01
-Residual   9.97341733992902e-08
-Residual   1.68228046062857e-07
-Residual   1.17106600356615e-07
-Residual   3.61346668971189e-07
-Residual   3.12170077450817e-07
+Residual   9.97341733991806e-08
+Residual   1.68228046059353e-07
+Residual   1.17106600340711e-07
+Residual   3.61346542614735e-07
+Residual   3.12202039435436e-07
 
 # Output file: solvers_struct.out.19.lobpcg
 Iterations = 32
@@ -104,17 +104,17 @@ Final Relative Residual Norm = 8.259590e-07
 
 # Output file: solvers_struct.out.19.lobpcg.1
 Eigenvalue lambda   1.84366453091755e-01
-Residual   8.10727379998105e-08
+Residual   8.10727379996446e-08
 
 # Output file: solvers_struct.out.19.lobpcg.5
 Eigenvalue lambda   1.84366453091753e-01
-Eigenvalue lambda   2.50882493969730e-01
+Eigenvalue lambda   2.50882493969729e-01
 Eigenvalue lambda   3.60090369737172e-01
 Eigenvalue lambda   4.20845334658451e-01
 Eigenvalue lambda   4.20845334658495e-01
-Residual   9.97341733991334e-08
-Residual   1.68228046056442e-07
-Residual   1.17106600356972e-07
-Residual   3.61346507824777e-07
-Residual   3.12150570425402e-07
+Residual   9.97341733995603e-08
+Residual   1.68228046063164e-07
+Residual   1.17106600294191e-07
+Residual   3.61345787304609e-07
+Residual   3.12211423409527e-07
 

--- a/src/test/TEST_single/solvers_struct.saved
+++ b/src/test/TEST_single/solvers_struct.saved
@@ -1,120 +1,120 @@
 # Output file: solvers_struct.out.0
 Iterations = 3
-Final Relative Residual Norm = 3.246673e-05
+Final Relative Residual Norm = 3.246699e-05
 
 # Output file: solvers_struct.out.1
 Iterations = 6
-Final Relative Residual Norm = 2.055850e-05
+Final Relative Residual Norm = 2.055853e-05
 
 # Output file: solvers_struct.out.2
 Iterations = 16
-Final Relative Residual Norm = 5.377689e-05
+Final Relative Residual Norm = 5.377659e-05
 
 # Output file: solvers_struct.out.3
 Iterations = 16
-Final Relative Residual Norm = 3.726248e-05
+Final Relative Residual Norm = 3.728096e-05
 
 # Output file: solvers_struct.out.4
 Iterations = 16
-Final Relative Residual Norm = 3.718718e-05
+Final Relative Residual Norm = 3.718455e-05
 
 # Output file: solvers_struct.out.10.lobpcg
 Iterations = 3
-Final Relative Residual Norm = 6.275783e-06
+Final Relative Residual Norm = 6.275819e-06
 
 # Output file: solvers_struct.out.10.lobpcg.1
-Eigenvalue lambda   1.84366211295128e-01
-Residual   2.48430933424970e-05
+Eigenvalue lambda   1.84366166591644e-01
+Residual   2.46475228777854e-05
 
 # Output file: solvers_struct.out.10.lobpcg.3
-Iteration 10 	bsize 2 	maxres   4.35155990999192e-04
-Iteration 11 	bsize 1 	maxres   2.05302669201046e-04
-Iteration 12 	bsize 1 	maxres   8.52039884193800e-05
+Iteration 10 	bsize 2 	maxres   4.33441076893359e-04
+Iteration 11 	bsize 1 	maxres   2.04675059649162e-04
+Iteration 12 	bsize 1 	maxres   8.52896992000751e-05
 
-Eigenvalue lambda   1.84366419911385e-01
-Eigenvalue lambda   2.50882804393768e-01
-Eigenvalue lambda   3.60089868307114e-01
-Residual   7.40827381378040e-05
-Residual   4.10445172747131e-05
-Residual   8.52039884193800e-05
+Eigenvalue lambda   1.84366330504417e-01
+Eigenvalue lambda   2.50882118940353e-01
+Eigenvalue lambda   3.60088735818863e-01
+Residual   7.39786846679635e-05
+Residual   4.10001339332666e-05
+Residual   8.52896992000751e-05
 
 # Output file: solvers_struct.out.11.lobpcg
 Iterations = 6
-Final Relative Residual Norm = 2.112817e-05
+Final Relative Residual Norm = 2.112820e-05
 
 # Output file: solvers_struct.out.11.lobpcg.1
-Eigenvalue lambda   1.84366181492805e-01
-Residual   3.16434197884519e-05
+Eigenvalue lambda   1.84366494417191e-01
+Residual   3.15583383780904e-05
 
 # Output file: solvers_struct.out.11.lobpcg.3
-Iteration 11 	bsize 2 	maxres   6.89531618263572e-04
-Iteration 12 	bsize 2 	maxres   2.52014782745391e-04
-Iteration 13 	bsize 1 	maxres   7.00048913131468e-05
+Iteration 11 	bsize 2 	maxres   6.89460255671293e-04
+Iteration 12 	bsize 2 	maxres   2.51991732511669e-04
+Iteration 13 	bsize 1 	maxres   7.00520104146563e-05
 
-Eigenvalue lambda   1.84366345405579e-01
-Eigenvalue lambda   2.50880867242813e-01
-Eigenvalue lambda   3.60090494155884e-01
-Residual   5.61281849513762e-05
-Residual   2.61230034084292e-05
-Residual   7.00048913131468e-05
+Eigenvalue lambda   1.84366449713707e-01
+Eigenvalue lambda   2.50883340835571e-01
+Eigenvalue lambda   3.60090821981430e-01
+Residual   5.58525280212052e-05
+Residual   2.58278087130748e-05
+Residual   7.00520104146563e-05
 
 # Output file: solvers_struct.out.17.lobpcg
-Iterations = 20
-Final Relative Residual Norm = 4.194806e-07
+Iterations = 17
+Final Relative Residual Norm = 9.315891e-07
 
 # Output file: solvers_struct.out.17.lobpcg.1
-Eigenvalue lambda   1.84366390109062e-01
-Residual   1.95900083781453e-05
+Eigenvalue lambda   1.84366405010223e-01
+Residual   1.96240998775465e-05
 
 # Output file: solvers_struct.out.17.lobpcg.3
-Iteration 10 	bsize 2 	maxres   3.62457707524300e-04
-Iteration 11 	bsize 1 	maxres   1.69860562891699e-04
-Iteration 12 	bsize 1 	maxres   7.12833571014926e-05
+Iteration 10 	bsize 2 	maxres   3.61716025508940e-04
+Iteration 11 	bsize 1 	maxres   1.69966908288188e-04
+Iteration 12 	bsize 1 	maxres   7.13053086656146e-05
 
-Eigenvalue lambda   1.84366583824158e-01
-Eigenvalue lambda   2.50883996486664e-01
-Eigenvalue lambda   3.60090583562851e-01
-Residual   5.53683385078330e-05
-Residual   3.08582348225173e-05
-Residual   7.12833571014926e-05
+Eigenvalue lambda   1.84366419911385e-01
+Eigenvalue lambda   2.50881373882294e-01
+Eigenvalue lambda   3.60090196132660e-01
+Residual   5.55491933482699e-05
+Residual   3.06540605379269e-05
+Residual   7.13053086656146e-05
 
 # Output file: solvers_struct.out.18.lobpcg
 Iterations = 33
-Final Relative Residual Norm = 8.027236e-07
+Final Relative Residual Norm = 7.695794e-07
 
 # Output file: solvers_struct.out.18.lobpcg.1
-Eigenvalue lambda   1.84366077184677e-01
-Residual   4.44860852439888e-05
+Eigenvalue lambda   1.84366717934608e-01
+Residual   4.44324978161603e-05
 
 # Output file: solvers_struct.out.18.lobpcg.3
-Iteration 10 	bsize 2 	maxres   5.79534214921296e-04
-Iteration 11 	bsize 1 	maxres   1.98537352844141e-04
-Iteration 12 	bsize 1 	maxres   9.26745269680396e-05
+Iteration 10 	bsize 2 	maxres   5.81631611566991e-04
+Iteration 11 	bsize 1 	maxres   1.99548783712089e-04
+Iteration 12 	bsize 1 	maxres   9.25178101169877e-05
 
-Eigenvalue lambda   1.84366509318352e-01
-Eigenvalue lambda   2.50894546508789e-01
-Eigenvalue lambda   3.60091388225555e-01
-Residual   9.26745269680396e-05
-Residual   8.93285541678779e-05
-Residual   5.54441285203211e-05
+Eigenvalue lambda   1.84366375207901e-01
+Eigenvalue lambda   2.50890493392944e-01
+Eigenvalue lambda   3.60092371702194e-01
+Residual   9.25178101169877e-05
+Residual   8.82172535057180e-05
+Residual   5.55432416149415e-05
 
 # Output file: solvers_struct.out.19.lobpcg
 Iterations = 25
-Final Relative Residual Norm = 7.712499e-05
+Final Relative Residual Norm = 7.712633e-05
 
 # Output file: solvers_struct.out.19.lobpcg.1
-Eigenvalue lambda   1.84366524219513e-01
-Residual   4.43533899670001e-05
+Eigenvalue lambda   1.84366270899773e-01
+Residual   4.44394063379150e-05
 
 # Output file: solvers_struct.out.19.lobpcg.3
-Iteration 10 	bsize 2 	maxres   5.82181091886014e-04
-Iteration 11 	bsize 1 	maxres   1.99127141968347e-04
-Iteration 12 	bsize 1 	maxres   9.26545544643886e-05
+Iteration 10 	bsize 2 	maxres   5.82931446842849e-04
+Iteration 11 	bsize 1 	maxres   1.99493268155493e-04
+Iteration 12 	bsize 1 	maxres   9.26577413338237e-05
 
-Eigenvalue lambda   1.84366345405579e-01
-Eigenvalue lambda   2.50889092683792e-01
-Eigenvalue lambda   3.60089659690857e-01
-Residual   9.26545544643886e-05
-Residual   8.75688710948452e-05
-Residual   5.51430639461614e-05
+Eigenvalue lambda   1.84366598725319e-01
+Eigenvalue lambda   2.50893682241440e-01
+Eigenvalue lambda   3.60090702772141e-01
+Residual   9.26577413338237e-05
+Residual   8.91809468157589e-05
+Residual   5.48030657228082e-05
 


### PR DESCRIPTION
This fixes some regression test issues with structmat and sstructmat.  It's difficult to explain what the problem was, but it had to do with calling BoxManAssemble more than once.  There is an effort in the code to minimize the calls to this routine, but it leads to rather confusing code.  I ultimately had to add an argument to hypre_StructMatmultSetup to tell it when it should and should not assemble the grid for the product matrix.  I still think there is a potential issue with this that we will have to work through in the future.
