### PR TITLE
Fix logic for destroying filtered matrix

### DIFF
--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -3110,6 +3110,13 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
          fflush(NULL);
       }
 
+      /* Destroy filtered matrix */
+      if (!level && (A_tilde != A))
+      {
+         hypre_ParCSRMatrixDestroy(A_tilde);
+         A_array[0] = A;
+      }
+
       HYPRE_ANNOTATE_MGLEVEL_END(level);
       hypre_GpuProfilingPopRange();
       ++level;
@@ -3134,13 +3141,6 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
             hypre_ParCSRMatrixSetDNumNonzeros(A_H);
          }
          A_array[level] = A_H;
-      }
-
-      /* Destroy filtered matrix */
-      if (!level && (A_tilde != A))
-      {
-         hypre_ParCSRMatrixDestroy(A_tilde);
-         A_array[0] = A;
       }
 
 #if defined(HYPRE_USING_GPU)


### PR DESCRIPTION
Fix memory leak pointed out by the regression tests

```
$ mpirun -np 1 valgrind --leak-check=full ./ij -solver 1 -n 8 8 8 -sysL 3 -nf 3 -ff 1
==1395026== Memcheck, a memory error detector
==1395026== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==1395026== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==1395026== Command: ./ij -solver 1 -n 8 8 8 -sysL 3 -nf 3 -ff 1
==1395026== 
=============================================
Hypre init times:
=============================================
Hypre init:
  wall clock time = 0.000498 seconds
  wall MFLOPS     = 0.000000
  cpu clock time  = 0.000491 seconds
  cpu MFLOPS      = 0.000000


Using HYPRE_DEVELOP_STRING: v2.31.0-24-g3ac5e5a27 (branch fix-leak)

Running with these driver parameters:
  solver ID    = 1

  Laplacian:   num_fun = 3
    (nx, ny, nz) = (8, 8, 8)
    (Px, Py, Pz) = (1, 1, 1)
    (cx, cy, cz) = (1.000000, 1.000000, 1.000000)

=============================================
Generate Matrix:
=============================================
Spatial Operator:
  wall clock time = 0.011045 seconds
  wall MFLOPS     = 0.000000
  cpu clock time  = 0.011047 seconds
  cpu MFLOPS      = 0.000000

  Number of vector components: 1
  RHS vector has unit coefficients
  Initial guess is 0
=============================================
IJ Vector Setup:
=============================================
RHS and Initial Guess:
  wall clock time = 0.005859 seconds
  wall MFLOPS     = 0.000000
  cpu clock time  = 0.005860 seconds
  cpu MFLOPS      = 0.000000

 Number of functions = 3 
Solver: AMG-PCG
HYPRE_ParCSRPCGGetPrecond got good precond


 Num MPI tasks = 1

 Num OpenMP threads = 1


BoomerAMG SETUP PARAMETERS:

 Max levels = 25
 Num levels = 5

 Strength Threshold = 0.250000
 Interpolation Truncation Factor = 0.000000
 Maximum Row Sum Threshold for Dependency Weakening = 1.000000

 Coarsening Type = HMIS 
 measures are determined locally


 No global partition option chosen.

 Interpolation = extended+i interpolation
 Number of functions = 3
 Functions filtering is on

Operator Matrix Information:

             nonzero            entries/row          row sums
lev    rows  entries sparse   min  max     avg      min         max
======================================================================
  0    1536    28800  0.012    12   21    18.8   0.000e+00   1.200e+01
  1     768    10632  0.018     7   17    13.8   0.000e+00   8.000e+00
  2     147     3789  0.175    16   37    25.8   4.236e-01   1.055e+01
  3      21      147  0.333     7    7     7.0   1.089e+01   1.958e+01
  4       3        3  0.333     1    1     1.0   1.117e+01   1.117e+01


Interpolation Matrix Information:
                    entries/row        min        max            row sums
lev  rows x cols  min  max  avgW     weight      weight       min         max
================================================================================
  0  1536 x 768     1    4   4.0   1.667e-01   2.500e-01   5.000e-01   1.000e+00
  1   768 x 147     1    4   4.0   7.589e-03   3.504e-01   2.201e-01   1.000e+00
  2   147 x 21      1    4   3.9   1.863e-03   3.965e-01   3.772e-02   1.000e+00
  3    21 x 3       1    1   1.0   1.499e-03   1.264e-02   1.499e-03   1.000e+00


     Complexity:   grid = 1.611328
               operator = 1.505937
                 memory = 1.748437




BoomerAMG SOLVER PARAMETERS:

  Maximum number of cycles:         1 
  Stopping Tolerance:               0.000000e+00 
  Cycle type (1 = V, 2 = W, etc.):  1

  Relaxation Parameters:
   Visiting Grid:                     down   up  coarse
            Number of sweeps:            1    1     1 
   Type 0=Jac, 3=hGS, 6=hSGS, 9=GE:     13   14     9 
   Point types, partial sweeps (1=C, -1=F):
                  Pre-CG relaxation (down):   0
                   Post-CG relaxation (up):   0
                             Coarsest grid:   0

=============================================
Setup phase times:
=============================================
PCG Setup:
  wall clock time = 0.148277 seconds
  wall MFLOPS     = 0.000000
  cpu clock time  = 0.148271 seconds
  cpu MFLOPS      = 0.000000

<b,b>: 1.536000e+03


Iters       ||r||_2     conv.rate  ||r||_2/||b||_2
-----    ------------   ---------  ------------ 
    1    1.942408e+01    0.495616    4.956155e-01
    2    1.188837e+01    0.612043    3.033380e-01
    3    6.266748e+00    0.527133    1.598993e-01
    4    7.534064e-01    0.120223    1.922356e-02
    5    2.754693e-01    0.365632    7.028742e-03
    6    1.204778e-01    0.437355    3.074055e-03
    7    2.892130e-02    0.240055    7.379420e-04
    8    9.944496e-03    0.343847    2.537390e-04
    9    4.263218e-03    0.428701    1.087782e-04
   10    8.005592e-04    0.187783    2.042668e-05
   11    3.256304e-04    0.406754    8.308627e-06
   12    1.141148e-04    0.350443    2.911699e-06
   13    3.072199e-05    0.269220    7.838875e-07
   14    1.218086e-05    0.396487    3.108009e-07
   15    3.388496e-06    0.278182    8.645923e-08
   16    9.953930e-07    0.293757    2.539797e-08
   17    4.547667e-07    0.456871    1.160361e-08
   18    1.351498e-07    0.297185    3.448418e-09


=============================================
Solve phase times:
=============================================
PCG Solve:
  wall clock time = 0.113471 seconds
  wall MFLOPS     = 0.000000
  cpu clock time  = 0.113471 seconds
  cpu MFLOPS      = 0.000000


Iterations = 18
Final Relative Residual Norm = 3.448418e-09

==1395026== 
==1395026== HEAP SUMMARY:
==1395026==     in use at exit: 0 bytes in 0 blocks
==1395026==   total heap usage: 12,301 allocs, 12,301 frees, 22,243,930 bytes allocated
==1395026== 
==1395026== All heap blocks were freed -- no leaks are possible
==1395026== 
==1395026== For lists of detected and suppressed errors, rerun with: -s
==1395026== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```