### PR TITLE
Add `HYPRE_IJMatrixGetGlobalInfo`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ src/TAGS
 hypre/
 cmbuild/
 install/
-test/
 AUTOTEST/*.dir
 .vscode
 

--- a/src/IJ_mv/HYPRE_IJMatrix.c
+++ b/src/IJ_mv/HYPRE_IJMatrix.c
@@ -1104,6 +1104,48 @@ HYPRE_IJMatrixGetLocalRange( HYPRE_IJMatrix  matrix,
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
 
+HYPRE_Int
+HYPRE_IJMatrixGetGlobalInfo( HYPRE_IJMatrix matrix,
+                             HYPRE_BigInt  *global_num_rows,
+                             HYPRE_BigInt  *global_num_cols,
+                             HYPRE_BigInt  *global_num_nonzeros )
+{
+   hypre_IJMatrix *ijmatrix = (hypre_IJMatrix *) matrix;
+
+   if (!ijmatrix)
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+
+   *global_num_rows = hypre_IJMatrixGlobalNumRows(ijmatrix);
+   *global_num_cols = hypre_IJMatrixGlobalNumCols(ijmatrix);
+
+   if (hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR)
+   {
+      hypre_ParCSRMatrix *par_matrix = (hypre_ParCSRMatrix *) hypre_IJMatrixObject(ijmatrix);
+
+      if (!par_matrix)
+      {
+         hypre_error_in_arg(1);
+         return hypre_error_flag;
+      }
+
+      hypre_ParCSRMatrixSetNumNonzeros(par_matrix);
+      *global_num_nonzeros = hypre_ParCSRMatrixNumNonzeros(par_matrix);
+   }
+   else
+   {
+      hypre_error_in_arg(1);
+      return hypre_error_flag;
+   }
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
 /**
    Returns a pointer to an underlying ijmatrix type used to implement IJMatrix.
    Assumes that the implementation has an underlying matrix, so it would not

--- a/src/IJ_mv/HYPRE_IJMatrix.c
+++ b/src/IJ_mv/HYPRE_IJMatrix.c
@@ -1318,6 +1318,8 @@ HYPRE_Int
 HYPRE_IJMatrixPrint( HYPRE_IJMatrix  matrix,
                      const char     *filename )
 {
+   void   *object;
+
    if (!matrix)
    {
       hypre_error_in_arg(1);
@@ -1330,11 +1332,8 @@ HYPRE_IJMatrixPrint( HYPRE_IJMatrix  matrix,
       return hypre_error_flag;
    }
 
-   void *object;
    HYPRE_IJMatrixGetObject(matrix, &object);
-   hypre_ParCSRMatrix *par_csr = (hypre_ParCSRMatrix*) object;
-
-   hypre_ParCSRMatrixPrintIJ(par_csr, 0, 0, filename);
+   hypre_ParCSRMatrixPrintIJ((hypre_ParCSRMatrix*) object, 0, 0, filename);
 
    return hypre_error_flag;
 }

--- a/src/IJ_mv/HYPRE_IJ_mv.h
+++ b/src/IJ_mv/HYPRE_IJ_mv.h
@@ -281,6 +281,24 @@ HYPRE_Int HYPRE_IJMatrixGetLocalRange(HYPRE_IJMatrix  matrix,
                                       HYPRE_BigInt   *jupper);
 
 /**
+ * Gets global information about the matrix, including the total number of rows,
+ * columns, and nonzero elements across all processes.
+ *
+ * @param matrix The IJMatrix object to query.
+ * @param global_num_rows Pointer to store the total number of rows in the matrix.
+ * @param global_num_cols Pointer to store the total number of columns in the matrix.
+ * @param global_num_nonzeros Pointer to store the total number of nonzero elements in the matrix.
+ *
+ * @return HYPRE_Int Error code.
+ *
+ * Collective (must be called by all processes).
+ **/
+HYPRE_Int HYPRE_IJMatrixGetGlobalInfo(HYPRE_IJMatrix  matrix,
+                                      HYPRE_BigInt   *global_num_rows,
+                                      HYPRE_BigInt   *global_num_cols,
+                                      HYPRE_BigInt   *global_num_nonzeros);
+
+/**
  * Get a reference to the constructed matrix object.
  *
  * @see HYPRE_IJMatrixSetObjectType

--- a/src/parcsr_ls/par_nongalerkin.c
+++ b/src/parcsr_ls/par_nongalerkin.c
@@ -1019,6 +1019,8 @@ hypre_NonGalerkinSparsityPattern(hypre_ParCSRMatrix *R_IAP,
    HYPRE_Int           i, j, Cpt, row_start, row_end;
    HYPRE_BigInt        global_row, global_col;
 
+   HYPRE_ANNOTATE_FUNC_BEGIN;
+
    /* Other Setup */
    if (num_cols_RAP_offd)
    {
@@ -1233,6 +1235,8 @@ hypre_NonGalerkinSparsityPattern(hypre_ParCSRMatrix *R_IAP,
       hypre_TFree(ijbuf_sym_numcols, memory_location_RAP);
    }
 
+   HYPRE_ANNOTATE_FUNC_END;
+
    return Pattern_CSR;
 }
 
@@ -1367,6 +1371,8 @@ hypre_BoomerAMGBuildNonGalerkinCoarseOperator( hypre_ParCSRMatrix **RAP_ptr,
    HYPRE_Real          *ijbuf_sym_data;
    HYPRE_BigInt        *ijbuf_sym_cols, *ijbuf_sym_rownums;
    HYPRE_Int           *ijbuf_sym_numcols;
+
+   HYPRE_ANNOTATE_FUNC_BEGIN;
 
    /* Further Initializations */
    if (num_cols_RAP_offd)
@@ -2351,6 +2357,8 @@ hypre_BoomerAMGBuildNonGalerkinCoarseOperator( hypre_ParCSRMatrix **RAP_ptr,
    hypre_ParCSRMatrixDestroy(S);
    HYPRE_IJMatrixSetObjectType(ijmatrix, -1);
    HYPRE_IJMatrixDestroy(ijmatrix);
+
+   HYPRE_ANNOTATE_FUNC_END;
 
    return hypre_error_flag;
 }

--- a/src/parcsr_mv/par_csr_filter.c
+++ b/src/parcsr_mv/par_csr_filter.c
@@ -199,6 +199,8 @@ hypre_ParCSRMatrixBlkFilter( hypre_ParCSRMatrix  *A,
                              HYPRE_Int            block_size,
                              hypre_ParCSRMatrix **B_ptr )
 {
+   HYPRE_ANNOTATE_FUNC_BEGIN;
+
 #if defined(HYPRE_USING_GPU)
    if (hypre_GetExecPolicy1(hypre_ParCSRMatrixMemoryLocation(A)) == HYPRE_EXEC_DEVICE)
    {
@@ -209,6 +211,8 @@ hypre_ParCSRMatrixBlkFilter( hypre_ParCSRMatrix  *A,
    {
       hypre_ParCSRMatrixBlkFilterHost(A, block_size, B_ptr);
    }
+
+   HYPRE_ANNOTATE_FUNC_END;
 
    return hypre_error_flag;
 }

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -3370,9 +3370,9 @@ main( hypre_int argc,
       if (myid == 0)
       {
          hypre_printf("  Matrix Information:\n");
-         hypre_printf("    Global number of rows:     %lld\n", global_num_rows);
-         hypre_printf("    Global number of columns:  %lld\n", global_num_cols);
-         hypre_printf("    Global number of nonzeros: %lld\n", global_num_nonzeros);
+         hypre_printf("    Global number of rows:     %b\n", global_num_rows);
+         hypre_printf("    Global number of columns:  %b\n", global_num_cols);
+         hypre_printf("    Global number of nonzeros: %b\n", global_num_nonzeros);
       }
    }
 
@@ -4429,6 +4429,8 @@ main( hypre_int argc,
 
    if (solver_id == 0 || solver_id == 90)
    {
+      HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-1");
+
       if (solver_id == 0)
       {
          if (myid == 0) { hypre_printf("Solver:  AMG\n"); }
@@ -4682,9 +4684,11 @@ main( hypre_int argc,
       hypre_PrintTiming("Solve phase times", hypre_MPI_COMM_WORLD);
       hypre_FinalizeTiming(time_index);
       hypre_ClearTiming();
+      HYPRE_ANNOTATE_REGION_END("%s", "Run-1");
 
       if (second_time)
       {
+         HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-2");
          HYPRE_SetExecutionPolicy(exec2_policy);
 
          /* run a second time [for timings, to check for memory leaks] */
@@ -4740,6 +4744,7 @@ main( hypre_int argc,
          hypre_FinalizeTiming(time_index);
          hypre_ClearTiming();
 
+         HYPRE_ANNOTATE_REGION_END("%s", "Run-2");
 #if defined(HYPRE_USING_CUDA)
          cudaProfilerStop();
 #endif
@@ -4994,6 +4999,7 @@ main( hypre_int argc,
                        solver_id == 43 || solver_id == 71))
       /*end lobpcg */
    {
+      HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-1");
       time_index = hypre_InitializeTiming("PCG Setup");
       hypre_BeginTiming(time_index);
 
@@ -5547,9 +5553,11 @@ main( hypre_int argc,
       hypre_PrintTiming("Solve phase times", hypre_MPI_COMM_WORLD);
       hypre_FinalizeTiming(time_index);
       hypre_ClearTiming();
+      HYPRE_ANNOTATE_REGION_END("%s", "Run-1");
 
       if (second_time)
       {
+         HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-2");
          HYPRE_SetExecutionPolicy(exec2_policy);
 
          /* run a second time [for timings, to check for memory leaks] */
@@ -5593,6 +5601,7 @@ main( hypre_int argc,
          hypre_FinalizeTiming(time_index);
          hypre_ClearTiming();
 
+         HYPRE_ANNOTATE_REGION_END("%s", "Run-2");
 #if defined(HYPRE_USING_CUDA)
          cudaProfilerStop();
 #endif
@@ -6692,6 +6701,7 @@ main( hypre_int argc,
        solver_id == 15 || solver_id == 18 || solver_id == 44 ||
        solver_id == 81 || solver_id == 91)
    {
+      HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-1");
       time_index = hypre_InitializeTiming("GMRES Setup");
       hypre_BeginTiming(time_index);
 
@@ -7246,9 +7256,11 @@ main( hypre_int argc,
          hypre_TFree(indices_d, memory_location);
          hypre_TFree(values_d, memory_location);
       }
+      HYPRE_ANNOTATE_REGION_END("%s", "Run-1");
 
       if (second_time)
       {
+         HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-2");
          /* run a second time [for timings, to check for memory leaks] */
          HYPRE_ParVectorSetRandomValues(x, 775);
 #if defined(HYPRE_USING_CURAND) || defined(HYPRE_USING_ROCRAND)
@@ -7256,10 +7268,15 @@ main( hypre_int argc,
 #endif
          hypre_ParVectorCopy(x0_save, x);
 
-         HYPRE_GMRESSetup(pcg_solver, (HYPRE_Matrix)parcsr_M, (HYPRE_Vector)b,
-                          (HYPRE_Vector)x);
-         HYPRE_GMRESSolve(pcg_solver, (HYPRE_Matrix)parcsr_A, (HYPRE_Vector)b,
-                          (HYPRE_Vector)x);
+         HYPRE_GMRESSetup(pcg_solver,
+                          (HYPRE_Matrix) parcsr_M,
+                          (HYPRE_Vector) b,
+                          (HYPRE_Vector) x);
+         HYPRE_GMRESSolve(pcg_solver,
+                          (HYPRE_Matrix) parcsr_A,
+                          (HYPRE_Vector) b,
+                          (HYPRE_Vector) x);
+         HYPRE_ANNOTATE_REGION_END("%s", "Run-2");
       }
 
       HYPRE_GMRESGetNumIterations(pcg_solver, &num_iterations);
@@ -7310,6 +7327,7 @@ main( hypre_int argc,
 
    if (solver_id == 50 || solver_id == 51 )
    {
+      HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-1");
       time_index = hypre_InitializeTiming("LGMRES Setup");
       hypre_BeginTiming(time_index);
 
@@ -7527,6 +7545,7 @@ main( hypre_int argc,
          hypre_printf("Final LGMRES Relative Residual Norm = %e\n", final_res_norm);
          hypre_printf("\n");
       }
+      HYPRE_ANNOTATE_REGION_END("%s", "Run-1");
    }
 
    /*-----------------------------------------------------------
@@ -7535,6 +7554,7 @@ main( hypre_int argc,
 
    if (solver_id == 60 || solver_id == 61 || solver_id == 72 || solver_id == 82 || solver_id == 47)
    {
+      HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-1");
       time_index = hypre_InitializeTiming("FlexGMRES Setup");
       hypre_BeginTiming(time_index);
 
@@ -7962,6 +7982,7 @@ main( hypre_int argc,
          hypre_printf("Final FlexGMRES Relative Residual Norm = %e\n", final_res_norm);
          hypre_printf("\n");
       }
+      HYPRE_ANNOTATE_REGION_END("%s", "Run-1");
    }
 
    /*-----------------------------------------------------------
@@ -7970,6 +7991,7 @@ main( hypre_int argc,
 
    if (solver_id == 9 || solver_id == 10 || solver_id == 11 || solver_id == 45 || solver_id == 73)
    {
+      HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-1");
       time_index = hypre_InitializeTiming("BiCGSTAB Setup");
       hypre_BeginTiming(time_index);
 
@@ -8307,20 +8329,27 @@ main( hypre_int argc,
       hypre_PrintTiming("Solve phase times", hypre_MPI_COMM_WORLD);
       hypre_FinalizeTiming(time_index);
       hypre_ClearTiming();
+      HYPRE_ANNOTATE_REGION_END("%s", "Run-1");
 
       if (second_time)
       {
          /* run a second time [for timings, to check for memory leaks] */
+         HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-2");
          HYPRE_ParVectorSetRandomValues(x, 775);
 #if defined(HYPRE_USING_CURAND) || defined(HYPRE_USING_ROCRAND)
          hypre_ResetDeviceRandGenerator(1234ULL, 0ULL);
 #endif
          hypre_ParVectorCopy(x0_save, x);
 
-         HYPRE_BiCGSTABSetup(pcg_solver, (HYPRE_Matrix) parcsr_M,
-                             (HYPRE_Vector) b, (HYPRE_Vector) x);
-         HYPRE_BiCGSTABSolve(pcg_solver, (HYPRE_Matrix) parcsr_A,
-                             (HYPRE_Vector) b, (HYPRE_Vector) x);
+         HYPRE_BiCGSTABSetup(pcg_solver,
+                             (HYPRE_Matrix) parcsr_M,
+                             (HYPRE_Vector) b,
+                             (HYPRE_Vector) x);
+         HYPRE_BiCGSTABSolve(pcg_solver,
+                             (HYPRE_Matrix) parcsr_A,
+                             (HYPRE_Vector) b,
+                             (HYPRE_Vector) x);
+         HYPRE_ANNOTATE_REGION_END("%s", "Run-2");
       }
 
       HYPRE_BiCGSTABGetNumIterations(pcg_solver, &num_iterations);
@@ -8386,6 +8415,7 @@ main( hypre_int argc,
 
    if (solver_id == 16 || solver_id == 17 || solver_id == 46 || solver_id == 74)
    {
+      HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-1");
       time_index = hypre_InitializeTiming("COGMRES Setup");
       hypre_BeginTiming(time_index);
 
@@ -8685,20 +8715,27 @@ main( hypre_int argc,
       hypre_PrintTiming("Solve phase times", hypre_MPI_COMM_WORLD);
       hypre_FinalizeTiming(time_index);
       hypre_ClearTiming();
+      HYPRE_ANNOTATE_REGION_END("%s", "Run-1");
 
       if (second_time)
       {
          /* run a second time [for timings, to check for memory leaks] */
+         HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-2");
          HYPRE_ParVectorSetRandomValues(x, 775);
 #if defined(HYPRE_USING_CURAND) || defined(HYPRE_USING_ROCRAND)
          hypre_ResetDeviceRandGenerator(1234ULL, 0ULL);
 #endif
          hypre_ParVectorCopy(x0_save, x);
 
-         HYPRE_COGMRESSetup(pcg_solver, (HYPRE_Matrix) parcsr_M,
-                            (HYPRE_Vector) b, (HYPRE_Vector) x);
-         HYPRE_COGMRESSolve(pcg_solver, (HYPRE_Matrix) parcsr_A,
-                            (HYPRE_Vector) b, (HYPRE_Vector) x);
+         HYPRE_COGMRESSetup(pcg_solver,
+                            (HYPRE_Matrix) parcsr_M,
+                            (HYPRE_Vector) b,
+                            (HYPRE_Vector) x);
+         HYPRE_COGMRESSolve(pcg_solver,
+                            (HYPRE_Matrix) parcsr_A,
+                            (HYPRE_Vector) b,
+                            (HYPRE_Vector) x);
+         HYPRE_ANNOTATE_REGION_END("%s", "Run-2");
       }
 
       HYPRE_COGMRESGetNumIterations(pcg_solver, &num_iterations);
@@ -8759,6 +8796,7 @@ main( hypre_int argc,
 
    if (solver_id == 5 || solver_id == 6)
    {
+      HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-1");
       time_index = hypre_InitializeTiming("CGNR Setup");
       hypre_BeginTiming(time_index);
 
@@ -8921,20 +8959,27 @@ main( hypre_int argc,
       hypre_PrintTiming("Solve phase times", hypre_MPI_COMM_WORLD);
       hypre_FinalizeTiming(time_index);
       hypre_ClearTiming();
+      HYPRE_ANNOTATE_REGION_END("%s", "Run-1");
 
       if (second_time)
       {
          /* run a second time [for timings, to check for memory leaks] */
+         HYPRE_ANNOTATE_REGION_BEGIN("%s", "Run-2");
          HYPRE_ParVectorSetRandomValues(x, 775);
 #if defined(HYPRE_USING_CURAND) || defined(HYPRE_USING_ROCRAND)
          hypre_ResetDeviceRandGenerator(1234ULL, 0ULL);
 #endif
          hypre_ParVectorCopy(x0_save, x);
 
-         HYPRE_CGNRSetup(pcg_solver, (HYPRE_Matrix) parcsr_M,
-                         (HYPRE_Vector) b, (HYPRE_Vector) x);
-         HYPRE_CGNRSolve(pcg_solver, (HYPRE_Matrix) parcsr_A,
-                         (HYPRE_Vector) b, (HYPRE_Vector) x);
+         HYPRE_CGNRSetup(pcg_solver,
+                         (HYPRE_Matrix) parcsr_M,
+                         (HYPRE_Vector) b,
+                         (HYPRE_Vector) x);
+         HYPRE_CGNRSolve(pcg_solver,
+                         (HYPRE_Matrix) parcsr_A,
+                         (HYPRE_Vector) b,
+                         (HYPRE_Vector) x);
+         HYPRE_ANNOTATE_REGION_END("%s", "Run-2");
       }
 
       HYPRE_CGNRGetNumIterations(pcg_solver, &num_iterations);


### PR DESCRIPTION
Add function to get the global number of rows, columns, and nonzeros of an IJMatrix.

Respective calls for StructMatrix and SStructMatrix will be added on the recmat branch

Usage example implemented in the IJ driver:

```
$ mpirun -np 4 ./ij -n 48 56 18 -27pt -P 2 2 1 -mat-info
=============================================
Hypre init times:
=============================================
Hypre init:
  wall clock time = 0.000000 seconds
  wall MFLOPS     = 0.000000
  cpu clock time  = 0.000001 seconds
  cpu MFLOPS      = 0.000000


Using HYPRE_DEVELOP_STRING: v2.31.0-28-gdbb1f8c70 (branch mat-info; not the develop branch)

Running with these driver parameters:
  solver ID    = 0

  Laplacian_27pt:
    (nx, ny, nz) = (48, 56, 18)
    (Px, Py, Pz) = (2, 2, 1)

=============================================
Generate Matrix:
=============================================
Spatial Operator:
  wall clock time = 0.001652 seconds
  wall MFLOPS     = 0.000000
  cpu clock time  = 0.001652 seconds
  cpu MFLOPS      = 0.000000

  Matrix Information:
    Global number of rows:     48384
    Global number of columns:  48384
    Global number of nonzeros: 1225744
  Number of vector components: 1
  RHS vector has unit coefficients
  Initial guess is 0
```
