### PR TITLE
Fix complex build

### DIFF
--- a/src/multivector/interpreter.h
+++ b/src/multivector/interpreter.h
@@ -38,8 +38,8 @@ typedef struct
    void   (*CopyMultiVector)    ( void *x, void *y );
    void   (*ClearMultiVector)   ( void *x );
    void   (*SetRandomVectors)   ( void *x, HYPRE_Int seed );
-   void   (*MultiInnerProd)     ( void *x, void *y, HYPRE_BigInt, HYPRE_Int, HYPRE_Int, HYPRE_Real* );
-   void   (*MultiInnerProdDiag) ( void *x, void *y, HYPRE_Int*, HYPRE_Int, HYPRE_Real* );
+   void   (*MultiInnerProd)     ( void *x, void *y, HYPRE_BigInt, HYPRE_Int, HYPRE_Int, HYPRE_Complex* );
+   void   (*MultiInnerProdDiag) ( void *x, void *y, HYPRE_Int*, HYPRE_Int, HYPRE_Complex* );
    void   (*MultiVecMat)        ( void *x, HYPRE_BigInt, HYPRE_Int, HYPRE_Int, HYPRE_Complex*,
                                   void *y );
    void   (*MultiVecMatDiag)    ( void *x, HYPRE_Int*, HYPRE_Int, HYPRE_Complex*, void *y );

--- a/src/parcsr_ls/par_mgr_interp.c
+++ b/src/parcsr_ls/par_mgr_interp.c
@@ -749,6 +749,8 @@ hypre_MGRBuildPHost( hypre_ParCSRMatrix   *A,
    HYPRE_Int            num_rows_AFF = hypre_ParCSRMatrixNumRows(A_FF);
    HYPRE_Int            num_procs, my_id;
 
+   HYPRE_Real           zero      = 0.0;
+   HYPRE_Real           one       = 1.0;
    HYPRE_Complex        scal      = 1.0;
    hypre_CSRMatrix     *A_FF_diag = hypre_ParCSRMatrixDiag(A_FF);
    hypre_CSRMatrix     *A_FC_diag = hypre_ParCSRMatrixDiag(A_FC);
@@ -786,7 +788,8 @@ hypre_MGRBuildPHost( hypre_ParCSRMatrix   *A,
          for (i = 0; i < num_rows_AFF; i++)
          {
             dsum = diag[i] + scal * (diag_FF[i] - hypre_cabs(diag[i]));
-            diag[i] = (dsum > 0.0 || dsum < 0.0) ? (1.0 / dsum) : 1.0;
+            diag[i] = (hypre_cabs(dsum) > zero || hypre_cabs(dsum) < zero) ?
+                      (one / dsum) : one;
          }
          hypre_TFree(diag_FF, memory_location_P);
       }


### PR DESCRIPTION
Fix compilation errors for build with complex numbers support: `./configure --enable-complex --enable-maxdim=4`

Example `ex18comp` now runs successfully 