### PR TITLE
fix SEGV with petsc example src/mat/tests/ex225.c

### DIFF
--- a/src/IJ_mv/IJMatrix_parcsr.c
+++ b/src/IJ_mv/IJMatrix_parcsr.c
@@ -559,7 +559,7 @@ hypre_IJMatrixGetValuesParCSR( hypre_IJMatrix *matrix,
          {
             continue;
          }
-         indx = row_indexes[ii];
+         if (row_indexes) indx = row_indexes[ii]; else indx = 0;
          if (row >= row_partitioning[0] && row < row_partitioning[1])
          {
             row_local = (HYPRE_Int)(row - row_partitioning[0]);

--- a/src/IJ_mv/IJMatrix_parcsr.c
+++ b/src/IJ_mv/IJMatrix_parcsr.c
@@ -559,7 +559,7 @@ hypre_IJMatrixGetValuesParCSR( hypre_IJMatrix *matrix,
          {
             continue;
          }
-         if (row_indexes) indx = row_indexes[ii]; else indx = 0;
+         indx = (row_indexes) ? row_indexes[ii] : 0;
          if (row >= row_partitioning[0] && row < row_partitioning[1])
          {
             row_local = (HYPRE_Int)(row - row_partitioning[0]);


### PR DESCRIPTION
```
(gdb) run
Starting program: /home/balay/petsc/src/mat/tests/ex225

Program received signal SIGSEGV, Segmentation fault. hypre_IJMatrixGetValuesParCSR (matrix=0x47ca00, nrows=1, ncols=0x7fffffffd5d0, rows=0x523dd0, row_indexes=0x0, cols=0x7fffffffd890, values=0x5233b0, zero_out=0) at IJMatrix_parcsr.c:562
562              indx = row_indexes[ii];
(gdb) where
>0  hypre_IJMatrixGetValuesParCSR (matrix=0x47ca00, nrows=1, ncols=0x7fffffffd5d0, rows=0x523dd0, row_indexes=0x0, cols=0x7fffffffd890, values=0x5233b0, zero_out=0) at IJMatrix_parcsr.c:562
>1  0x00007ffff2c850d7 in HYPRE_IJMatrixGetValues (matrix=0x47ca00, nrows=1, ncols=0x7fffffffd5d0, rows=0x523dd0, cols=0x7fffffffd890, values=0x5233b0) at HYPRE_IJMatrix.c:874
>2  0x00007ffff4a69f64 in MatGetValues_HYPRE (A=0x4f3a70, m=20, idxm=0x523dd0, n=6, idxn=0x7fffffffd890, v=0x5233b0) at /home/balay/petsc/src/mat/impls/hypre/mhypre.c:2145
>3  0x00007ffff4f0ad4c in MatGetValues (mat=0x4f3a70, m=20, idxm=0x523dd0, n=6, idxn=0x7fffffffd890, v=0x5233b0) at /home/balay/petsc/src/mat/interface/matrix.c:2151
>4  0x0000000000406936 in main (argc=1, args=0x7fffffffde08) at ex225.c:129
```