### PR TITLE
Updating the nonmixedint tests to use the new emptyProc input file

### DIFF
--- a/src/test/TEST_sstruct/nonmixedint.jobs
+++ b/src/test/TEST_sstruct/nonmixedint.jobs
@@ -18,13 +18,16 @@
 # 16: emptyProc.out.120
 #=============================================================================
 
+# solvers.jobs tests
 mpirun -np 2  ./sstruct -P 1 1 2 -solver 21 > nonmixedint.out.0
 mpirun -np 2  ./sstruct -P 1 1 2 -solver 22 > nonmixedint.out.1
 mpirun -np 2  ./sstruct -P 1 1 2 -solver 41 > nonmixedint.out.2
 mpirun -np 2  ./sstruct -P 1 1 2 -solver 42 > nonmixedint.out.3
-mpirun -np 2  ./sstruct -in sstruct.in.emptyProc1 -rhsone -solver 22 > nonmixedint.out.4
-mpirun -np 2  ./sstruct -in sstruct.in.emptyProc3 -rhsone -solver 22 > nonmixedint.out.14
-mpirun -np 2  ./sstruct -in sstruct.in.emptyProc1 -rhsone -solver 42 > nonmixedint.out.5
-mpirun -np 2  ./sstruct -in sstruct.in.emptyProc3 -rhsone -solver 42 > nonmixedint.out.15
-mpirun -np 2  ./sstruct -in sstruct.in.emptyProc1 -rhsone -solver 62 > nonmixedint.out.6
-mpirun -np 2  ./sstruct -in sstruct.in.emptyProc3 -rhsone -solver 62 > nonmixedint.out.16
+
+# emptyProc.jobs tests
+mpirun -np 1  ./sstruct -in sstruct.in.emptyProc -rhsone -solver 22 > nonmixedint.out.4
+mpirun -np 2  ./sstruct -in sstruct.in.emptyProc -rhsone -solver 22 > nonmixedint.out.14
+mpirun -np 1  ./sstruct -in sstruct.in.emptyProc -rhsone -solver 42 > nonmixedint.out.5
+mpirun -np 2  ./sstruct -in sstruct.in.emptyProc -rhsone -solver 42 > nonmixedint.out.15
+mpirun -np 1  ./sstruct -in sstruct.in.emptyProc -rhsone -solver 62 > nonmixedint.out.6
+mpirun -np 2  ./sstruct -in sstruct.in.emptyProc -rhsone -solver 62 > nonmixedint.out.16

--- a/src/test/TEST_sstruct/nonmixedint.saved
+++ b/src/test/TEST_sstruct/nonmixedint.saved
@@ -25,3 +25,4 @@ Final Relative Residual Norm = 6.043891e-07
 # Output file: nonmixedint.out.6
 Iterations = 8
 Final Relative Residual Norm = 7.771825e-07
+


### PR DESCRIPTION
I didn't realize that some of the emptyProc tests were in the nonmixedint jobs file so they were still using the old input files.
