### PR TITLE
Added new struct to hold convergence parameters for the Krylov solvers.

### DIFF
--- a/src/krylov/conv_params.h
+++ b/src/krylov/conv_params.h
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright (c) 1998 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ ******************************************************************************/
+
+/******************************************************************************
+ *
+ * Krylov convergence parameters header
+ *
+ *****************************************************************************/
+
+#ifndef hypre_CONV_PARAMS_HEADER
+#define hypre_CONV_PARAMS_HEADER
+
+
+/**
+ * The {\tt hypre\_conv\_params} object ...
+ **/
+
+/*
+ Summary of Parameters to Control Stopping Test:
+ - tol = relative error tolerance, as above
+ -a_tol = absolute convergence tolerance (default is 0.0)
+   If one desires the convergence test to check the absolute
+   convergence tolerance *only*, then set the relative convergence
+   tolerance to 0.0.  (The default convergence test is  <C*r,r> <=
+   max(relative_tolerance^2 * <C*b, b>, absolute_tolerance^2)
+- cf_tol = convergence factor tolerance; if >0 used for special test
+  for slow convergence
+ - atolf = absolute error tolerance factor to be used _together_ with the
+ relative error tolerance, |delta-residual| / ( atolf + |right-hand-side| ) < tol
+  (To BE PHASED OUT)
+*/
+
+typedef struct
+{
+   HYPRE_Real   tol;
+   HYPRE_Real   atolf;
+   HYPRE_Real   cf_tol;
+   HYPRE_Real   a_tol;
+   HYPRE_Real   rtol;
+
+   HYPRE_Real   rel_residual_norm;
+
+} hypre_conv_params;
+
+#endif

--- a/src/krylov/krylov.h
+++ b/src/krylov/krylov.h
@@ -27,6 +27,49 @@ extern "C" {
 
 /******************************************************************************
  *
+ * Krylov convergence parameters header
+ *
+ *****************************************************************************/
+
+#ifndef hypre_CONV_PARAMS_HEADER
+#define hypre_CONV_PARAMS_HEADER
+
+
+/**
+ * The {\tt hypre\_conv\_params} object ...
+ **/
+
+/*
+ Summary of Parameters to Control Stopping Test:
+ - tol = relative error tolerance, as above
+ -a_tol = absolute convergence tolerance (default is 0.0)
+   If one desires the convergence test to check the absolute
+   convergence tolerance *only*, then set the relative convergence
+   tolerance to 0.0.  (The default convergence test is  <C*r,r> <=
+   max(relative_tolerance^2 * <C*b, b>, absolute_tolerance^2)
+- cf_tol = convergence factor tolerance; if >0 used for special test
+  for slow convergence
+ - atolf = absolute error tolerance factor to be used _together_ with the
+ relative error tolerance, |delta-residual| / ( atolf + |right-hand-side| ) < tol
+  (To BE PHASED OUT)
+*/
+
+typedef struct
+{
+   HYPRE_Real   tol;
+   HYPRE_Real   atolf;
+   HYPRE_Real   cf_tol;
+   HYPRE_Real   a_tol;
+   HYPRE_Real   rtol;
+
+   HYPRE_Real   rel_residual_norm;
+
+} hypre_conv_params;
+
+#endif
+
+/******************************************************************************
+ *
  * BiCGSTAB bicgstab
  *
  *****************************************************************************/
@@ -1109,11 +1152,8 @@ typedef struct
 
 typedef struct
 {
-   HYPRE_Real   tol;
-   HYPRE_Real   atolf;
-   HYPRE_Real   cf_tol;
-   HYPRE_Real   a_tol;
-   HYPRE_Real   rtol;
+   void        *conv_params;
+
    HYPRE_Int      max_iter;
    HYPRE_Int      two_norm;
    HYPRE_Int      rel_change;

--- a/src/krylov/pcg.h
+++ b/src/krylov/pcg.h
@@ -107,11 +107,7 @@ typedef struct
 
 typedef struct
 {
-   HYPRE_Real   tol;
-   HYPRE_Real   atolf;
-   HYPRE_Real   cf_tol;
-   HYPRE_Real   a_tol;
-   HYPRE_Real   rtol;
+   void        *conv_params;
    HYPRE_Int    max_iter;
    HYPRE_Int    two_norm;
    HYPRE_Int    rel_change;
@@ -139,7 +135,7 @@ typedef struct
 
    /* log info (always logged) */
    HYPRE_Int    num_iterations;
-   HYPRE_Real   rel_residual_norm;
+//   HYPRE_Real   rel_residual_norm;
 
    HYPRE_Int    print_level; /* printing when print_level>0 */
    HYPRE_Int    logging;  /* extra computations for logging when logging>0 */


### PR DESCRIPTION
This PR adds a new struct in the krylov directory to hold convergence parameters for the krylov solvers. This changes how we access these parameters. We will now access the tolerances and residual norm via this new struct member of the Krylov solver data, rather than directly through the solver data. This makes it convenient to define different precisions of these parameters without changing the solver data, which is favorable to mixed-precision algorithm development.

 