### PR TITLE
Fix for hypre_BoxArrayCreateFromIndices()

### DIFF
--- a/src/struct_mv/box.c
+++ b/src/struct_mv/box.c
@@ -909,7 +909,9 @@ hypre_BoxArrayCreateFromIndices( HYPRE_Int         ndim,
    }
 
    /* Set defaults */
-   box_minvol = (HYPRE_Real) hypre_pow2(ndim);
+   /* WM: what's the reason for box_minvol? */
+   box_minvol = 1;
+   /* box_minvol = (HYPRE_Real) hypre_pow2(ndim); */
 
    /* Compute bounding box */
    bbox = hypre_BoxCreate(ndim);
@@ -1095,7 +1097,7 @@ hypre_BoxArrayCreateFromIndices( HYPRE_Int         ndim,
             }
 
             /* Look for largest sign change among all directions */
-            dir = 0;
+            dir = -1;
             for (d = 1; d < ndim; d++)
             {
                if (hypre_IndexD(sign, dir) < hypre_IndexD(sign, d))
@@ -1107,6 +1109,22 @@ hypre_BoxArrayCreateFromIndices( HYPRE_Int         ndim,
             /* Set cut direction and coordinate */
             hypre_IndexD(cut, dir) = hypre_IndexD(signcoord, dir);
             splitdir = dir;
+
+            /* If no change of sign in the Laplacian was found, just cut the longest dim in half */
+            if (dir < 0)
+            {
+               change = 0;
+               for (d = 0; d < ndim; d++)
+               {
+                  if (change < hypre_BoxSizeD(box, d))
+                  {
+                     change = hypre_BoxSizeD(box, d);
+                     dir = d;
+                  }
+               }
+               hypre_IndexD(cut, dir) = (hypre_BoxIMinD(box, dir) + hypre_BoxIMaxD(box, dir)) / 2;
+               splitdir = dir;
+            }
          }
          hypre_assert((splitdir >= 0) && (splitdir < ndim));
 

--- a/src/struct_mv/box.c
+++ b/src/struct_mv/box.c
@@ -909,9 +909,7 @@ hypre_BoxArrayCreateFromIndices( HYPRE_Int         ndim,
    }
 
    /* Set defaults */
-   /* WM: what's the reason for box_minvol? */
    box_minvol = 1;
-   /* box_minvol = (HYPRE_Real) hypre_pow2(ndim); */
 
    /* Compute bounding box */
    bbox = hypre_BoxCreate(ndim);


### PR DESCRIPTION
There are cases where the algorithm implemented in hypre_BoxArrayCreateFromIndices() does not find a change in sign in the computed Laplacian. In these cases, the cut dimension defaults to 0, which may not be a valid direction (e.g. if all points lie in the same plane in that dim). This PR addresses this case by selecting the cut dimension to be the box's longest dimension.