### PR TITLE
Remove `ij_mv` driver from `CMakeLists.txt`

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -17,9 +17,7 @@ set(TEST_SRCS
   maxwell_unscaled.c
   struct_migrate.c
   sstruct_fac.c
-  ij_mv.c
   ij_assembly.c
 )
 
 add_hypre_executables(TEST_SRCS)
- 


### PR DESCRIPTION
Fixes regressions from 110124