### PR TITLE
Recmat device updates

### DIFF
--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -820,6 +820,9 @@ hypre_SStructPMatrixGetDiagonal( hypre_SStructPMatrix  *pmatrix,
  *==========================================================================*/
 
 /*--------------------------------------------------------------------------
+ * hypre_SStructUMatrixInitialize
+ *
+ * TODO (VPM): check row_sizes usage in device runs.
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
@@ -853,6 +856,13 @@ hypre_SStructUMatrixInitialize( hypre_SStructMatrix *matrix )
    HYPRE_Int              *row_sizes;
    HYPRE_Int               max_size;
 
+   /* TODO (VPM): memory_location should be an input argument or
+                  already set in the SStructMatrix object */
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+   HYPRE_MemoryLocation    memory_location = HYPRE_MEMORY_DEVICE;
+   HYPRE_ExecutionPolicy   exec            = hypre_GetExecPolicy1(memory_location);
+#endif
+
    HYPRE_IJMatrixSetObjectType(ijmatrix, HYPRE_PARCSR);
    if (matrix_type == HYPRE_SSTRUCT || matrix_type == HYPRE_STRUCT)
    {
@@ -865,86 +875,96 @@ hypre_SStructUMatrixInitialize( hypre_SStructMatrix *matrix )
       nrows    = hypre_SStructGridLocalSize(grid);
    }
 
-   /* set row sizes */
-   max_size  = m = 0;
-   ghost_box = hypre_BoxCreate(ndim);
-   row_sizes = hypre_CTAlloc(HYPRE_Int, nrows, HYPRE_MEMORY_HOST);
-   hypre_SetIndex(stride, 1);
-   for (part = 0; part < nparts; part++)
+   /* Set row sizes */
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+   if (exec == HYPRE_EXEC_DEVICE)
    {
-      pgrid = hypre_SStructGridPGrid(grid, part);
-      nvars = hypre_SStructPGridNVars(pgrid);
-
-      /* This part is active in the range grid */
-      for (var = 0; var < nvars; var++)
-      {
-         sgrid = hypre_SStructPGridSGrid(pgrid, var);
-
-         stencil = stencils[part][var];
-         split = hypre_SStructMatrixSplit(matrix, part, var);
-         nnzs = 0;
-         for (entry = 0; entry < hypre_SStructStencilSize(stencil); entry++)
-         {
-            if (split[entry] == -1)
-            {
-               nnzs++;
-            }
-         }
-#if 0
-         /* TODO: For now, assume stencil is full/complete */
-         if (hypre_SStructMatrixSymmetric(matrix))
-         {
-            nnzs = 2 * nnzs - 1;
-         }
-#endif
-         boxes = hypre_StructGridBoxes(sgrid);
-         hypre_ForBoxI(b, boxes)
-         {
-            box = hypre_BoxArrayBox(boxes, b);
-            hypre_CopyBox(box, ghost_box);
-            if (matrix_type == HYPRE_SSTRUCT || matrix_type == HYPRE_STRUCT)
-            {
-               hypre_BoxGrowByArray(ghost_box, hypre_StructGridNumGhost(sgrid));
-            }
-
-            start = hypre_BoxIMin(box);
-            hypre_BoxGetSize(box, loop_size);
-            hypre_BoxLoop1Begin(ndim, loop_size, ghost_box, start, stride, mi);
-            {
-               row_sizes[m + mi] = nnzs;
-            }
-            hypre_BoxLoop1End(mi);
-
-            m += hypre_BoxVolume(ghost_box);
-         }
-
-         max_size = hypre_max(max_size, nnzs);
-         if (nvneighbors[part][var])
-         {
-            max_size = hypre_max(max_size, hypre_SStructStencilSize(stencil));
-         }
-      } /* loop on variables */
-   } /* loop on parts */
-   hypre_BoxDestroy(ghost_box);
-
-   /* GEC0902 essentially for each UVentry we figure out how many
-    * extra columns we need to add to the rowsizes */
-
-   /* RDF: THREAD? */
-   for (entry = 0; entry < nUventries; entry++)
-   {
-      mi = iUventries[entry];
-      m = hypre_SStructUVEntryRank(Uventries[mi]) - rowstart;
-      if ((m > -1) && (m < nrows))
-      {
-         row_sizes[m] += hypre_SStructUVEntryNUEntries(Uventries[mi]);
-         max_size = hypre_max(max_size, row_sizes[m]);
-      }
+      row_sizes = NULL;
+      max_size  = 0;
    }
+   else
+#endif
+   {
+      m = 0;
+      ghost_box = hypre_BoxCreate(ndim);
+      row_sizes = hypre_CTAlloc(HYPRE_Int, nrows, HYPRE_MEMORY_HOST);
+      hypre_SetIndex(stride, 1);
+      for (part = 0; part < nparts; part++)
+      {
+         pgrid = hypre_SStructGridPGrid(grid, part);
+         nvars = hypre_SStructPGridNVars(pgrid);
 
-   /* ZTODO: Update row_sizes based on neighbor off-part couplings */
-   HYPRE_IJMatrixSetRowSizes(ijmatrix, (const HYPRE_Int *) row_sizes);
-   hypre_TFree(row_sizes, HYPRE_MEMORY_HOST);
+         /* This part is active in the range grid */
+         for (var = 0; var < nvars; var++)
+         {
+            sgrid = hypre_SStructPGridSGrid(pgrid, var);
+
+            stencil = stencils[part][var];
+            split = hypre_SStructMatrixSplit(matrix, part, var);
+            nnzs = 0;
+            for (entry = 0; entry < hypre_SStructStencilSize(stencil); entry++)
+            {
+               if (split[entry] == -1)
+               {
+                  nnzs++;
+               }
+            }
+#if 0
+            /* TODO: For now, assume stencil is full/complete */
+            if (hypre_SStructMatrixSymmetric(matrix))
+            {
+               nnzs = 2 * nnzs - 1;
+            }
+#endif
+            boxes = hypre_StructGridBoxes(sgrid);
+            hypre_ForBoxI(b, boxes)
+            {
+               box = hypre_BoxArrayBox(boxes, b);
+               hypre_CopyBox(box, ghost_box);
+               if (matrix_type == HYPRE_SSTRUCT || matrix_type == HYPRE_STRUCT)
+               {
+                  hypre_BoxGrowByArray(ghost_box, hypre_StructGridNumGhost(sgrid));
+               }
+
+               start = hypre_BoxIMin(box);
+               hypre_BoxGetSize(box, loop_size);
+               hypre_BoxLoop1BeginHost(ndim, loop_size, ghost_box, start, stride, mi);
+               {
+                  row_sizes[m + mi] = nnzs;
+               }
+               hypre_BoxLoop1EndHost(mi);
+
+               m += hypre_BoxVolume(ghost_box);
+            }
+
+            max_size = hypre_max(max_size, nnzs);
+            if (nvneighbors[part][var])
+            {
+               max_size = hypre_max(max_size, hypre_SStructStencilSize(stencil));
+            }
+         } /* loop on variables */
+      } /* loop on parts */
+      hypre_BoxDestroy(ghost_box);
+
+      /* GEC0902 essentially for each UVentry we figure out how many
+       * extra columns we need to add to the rowsizes */
+
+      /* RDF: THREAD? */
+      for (entry = 0; entry < nUventries; entry++)
+      {
+         mi = iUventries[entry];
+         m = hypre_SStructUVEntryRank(Uventries[mi]) - rowstart;
+         if ((m > -1) && (m < nrows))
+         {
+            row_sizes[m] += hypre_SStructUVEntryNUEntries(Uventries[mi]);
+            max_size = hypre_max(max_size, row_sizes[m]);
+         }
+      }
+
+      /* ZTODO: Update row_sizes based on neighbor off-part couplings */
+      HYPRE_IJMatrixSetRowSizes(ijmatrix, (const HYPRE_Int *) row_sizes);
+      hypre_TFree(row_sizes, HYPRE_MEMORY_HOST);
+   }
 
    hypre_SStructMatrixTmpSize(matrix)            = max_size;
    hypre_SStructMatrixTmpRowCoords(matrix)       = hypre_CTAlloc(HYPRE_BigInt,  max_size,
@@ -1247,8 +1267,8 @@ hypre_SStructUMatrixSetBoxValuesHelper( hypre_SStructMatrix *matrix,
    HYPRE_Int             nboxman_entries;
    hypre_BoxManEntry   **boxman_to_entries;
    HYPRE_Int             nboxman_to_entries;
-   HYPRE_Int             nrows;
-   HYPRE_Int            *ncols, *row_indexes;;
+   HYPRE_Int             nrows, num_nonzeros;
+   HYPRE_Int            *ncols, *row_indexes;
    HYPRE_BigInt         *rows, *cols;
    HYPRE_Complex        *ijvalues;
    HYPRE_Int            *values_map;
@@ -1257,12 +1277,17 @@ hypre_SStructUMatrixSetBoxValuesHelper( hypre_SStructMatrix *matrix,
    hypre_Box            *map_box;
    hypre_Box            *int_box;
    hypre_Box            *map_vbox;
-   hypre_Index           index, stride, loop_size;
+   hypre_Index           index;
+   hypre_Index           unit_stride;
+   hypre_Index           loop_size;
    hypre_Index           mstart;
    hypre_IndexRef        vstart;
    hypre_Index           rs, cs;
    HYPRE_BigInt          row_base, col_base;
    HYPRE_Int             ei, entry, i, ii, jj;
+#if defined(HYPRE_USING_GPU)
+   HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1(memory_location);
+#endif
 
    HYPRE_ANNOTATE_FUNC_BEGIN;
 
@@ -1270,6 +1295,7 @@ hypre_SStructUMatrixSetBoxValuesHelper( hypre_SStructMatrix *matrix,
     * all stencil entries
     *------------------------------------------*/
 
+   hypre_SetIndex(unit_stride, 1);
    if (entries[0] < size)
    {
       box      = hypre_BoxCreate(ndim);
@@ -1278,19 +1304,32 @@ hypre_SStructUMatrixSetBoxValuesHelper( hypre_SStructMatrix *matrix,
       int_box  = hypre_BoxCreate(ndim);
       map_vbox = hypre_BoxCreate(ndim);
 
-      nrows       = hypre_BoxVolume(set_box);
-      ncols       = hypre_CTAlloc(HYPRE_Int,     nrows,            memory_location);
-      rows        = hypre_CTAlloc(HYPRE_BigInt,  nrows,            memory_location);
-      row_indexes = hypre_CTAlloc(HYPRE_Int,     nrows,            memory_location);
-      cols        = hypre_CTAlloc(HYPRE_BigInt,  nrows * nentries, memory_location);
-      ijvalues    = hypre_CTAlloc(HYPRE_Complex, nrows * nentries, memory_location);
-      values_map  = hypre_CTAlloc(HYPRE_Int,     nrows * nentries, memory_location);
-      for (i = 0; i < nrows * nentries; i++)
-      {
-         values_map[i] = -1;
-      }
+      nrows        = hypre_BoxVolume(set_box);
+      num_nonzeros = nrows * nentries;
+      ncols        = hypre_CTAlloc(HYPRE_Int,     nrows,        memory_location);
+      rows         = hypre_CTAlloc(HYPRE_BigInt,  nrows,        memory_location);
+      row_indexes  = hypre_CTAlloc(HYPRE_Int,     nrows,        memory_location);
+      cols         = hypre_CTAlloc(HYPRE_BigInt,  num_nonzeros, memory_location);
+      ijvalues     = hypre_TAlloc(HYPRE_Complex,  num_nonzeros, memory_location);
+      values_map   = hypre_TAlloc(HYPRE_Int,      num_nonzeros, memory_location);
 
-      hypre_SetIndex(stride, 1);
+      /* TODO (VPM): We could wrap this into a separate function */
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+      if (exec == HYPRE_EXEC_DEVICE)
+      {
+         hypreDevice_IntFilln(values_map, num_nonzeros, -1);
+      }
+      else
+#endif
+      {
+#ifdef HYPRE_USING_OPENMP
+         #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+         for (i = 0; i < num_nonzeros; i++)
+         {
+            values_map[i] = -1;
+         }
+      }
 
       hypre_SStructGridIntersect(grid, part, var, set_box, -1,
                                  &boxman_entries, &nboxman_entries);
@@ -1308,22 +1347,34 @@ hypre_SStructUMatrixSetBoxValuesHelper( hypre_SStructMatrix *matrix,
          /* For each index in 'box', compute a row of length <= nentries and
           * insert it into an nentries-length segment of 'cols' and 'ijvalues'.
           * This may result in gaps, but IJSetValues2() is designed for that. */
-
          nrows = hypre_BoxVolume(box);
 
-         /* TODO (VPM): extend to GPUs */
-#ifdef HYPRE_USING_OPENMP
-         #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
-#endif
-         for (i = 0; i < nrows; i++)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+         if (exec == HYPRE_EXEC_DEVICE)
          {
-            ncols[i] = 0;
-            row_indexes[i] = i * nentries;
+            hypreDevice_IntFilln(ncols, num_nonzeros, 0);
+            HYPRE_THRUST_CALL( transform,
+                               thrust::counting_iterator<HYPRE_Int>(0),
+                               thrust::counting_iterator<HYPRE_Int>(nrows),
+                               row_indexes,
+                                _1 * nentries );
+         }
+         else
+#endif
+         {
+#ifdef HYPRE_USING_OPENMP
+            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+#endif
+            for (i = 0; i < nrows; i++)
+            {
+               ncols[i] = 0;
+               row_indexes[i] = i * nentries;
+            }
          }
 
          for (ei = 0; ei < nentries; ei++)
          {
-            entry = entries[ei];
+            entry  = entries[ei];
             offset = shape[entry];
 
             hypre_CopyBox(box, to_box);
@@ -1390,7 +1441,7 @@ hypre_SStructUMatrixSetBoxValuesHelper( hypre_SStructMatrix *matrix,
 #define DEVICE_VAR is_device_ptr(ncols,rows,cols,ijvalues,values)
                   hypre_BoxLoop2Begin(ndim, loop_size,
                                       box, mstart, dom_stride, mi,
-                                      map_vbox, vstart, stride, vi);
+                                      map_vbox, vstart, unit_stride, vi);
                   {
                      hypre_Index loop_index;
                      HYPRE_Int   ci;
@@ -1432,7 +1483,7 @@ hypre_SStructUMatrixSetBoxValuesHelper( hypre_SStructMatrix *matrix,
                {
                   hypre_BoxLoop2Begin(ndim, loop_size,
                                       box, mstart, dom_stride, mi,
-                                      map_vbox, vstart, stride, vi);
+                                      map_vbox, vstart, unit_stride, vi);
                   {
                      hypre_Index loop_index;
                      HYPRE_Int   ci, d;
@@ -1483,11 +1534,13 @@ hypre_SStructUMatrixSetBoxValuesHelper( hypre_SStructMatrix *matrix,
             if (action == -2)
             {
                /* Zero out entries gotten */
-               HYPRE_IJMatrixGetValuesAndZeroOut(ijmatrix, nrows, ncols, rows, row_indexes, cols, ijvalues);
+               HYPRE_IJMatrixGetValuesAndZeroOut(ijmatrix, nrows, ncols,
+                                                 rows, row_indexes, cols, ijvalues);
             }
             else
             {
-               HYPRE_IJMatrixGetValues2(ijmatrix, nrows, ncols, rows, row_indexes, cols, ijvalues);
+               HYPRE_IJMatrixGetValues2(ijmatrix, nrows, ncols,
+                                        rows, row_indexes, cols, ijvalues);
             }
          }
 
@@ -1842,6 +1895,7 @@ hypre_SStructMatrixSetInterPartValues( HYPRE_SStructMatrix  matrix,
                                        HYPRE_Int            action )
 {
    HYPRE_Int                ndim       = hypre_SStructMatrixNDim(matrix);
+   hypre_IJMatrix          *ij_matrix  = hypre_SStructMatrixIJMatrix(matrix);
    hypre_SStructGraph      *graph      = hypre_SStructMatrixGraph(matrix);
    hypre_SStructGrid       *grid       = hypre_SStructGraphGrid(graph);
    hypre_SStructPMatrix    *pmatrix    = hypre_SStructMatrixPMatrix(matrix, part);
@@ -1852,6 +1906,7 @@ hypre_SStructMatrixSetInterPartValues( HYPRE_SStructMatrix  matrix,
    hypre_SStructStencil    *stencil    = hypre_SStructPMatrixStencil(pmatrix, var);
    hypre_Index             *shape      = hypre_SStructStencilShape(stencil);
    HYPRE_Int               *vars       = hypre_SStructStencilVars(stencil);
+   HYPRE_MemoryLocation     memloc     = hypre_IJMatrixMemoryLocation(ij_matrix);
 
    hypre_SStructVariable    tovartype;
    hypre_StructMatrix      *smatrix;
@@ -1859,7 +1914,7 @@ hypre_SStructMatrixSetInterPartValues( HYPRE_SStructMatrix  matrix,
    hypre_BoxArray          *pbnd_boxa;
    hypre_BoxArray          *grid_boxes;
    hypre_Box               *grid_box, *box, *ibox0, *ibox1, *ibox2, *tobox, *frbox;
-   hypre_Index              stride, loop_size;
+   hypre_Index              unit_stride, loop_size;
    hypre_IndexRef           offset, start;
    hypre_BoxManEntry      **frentries, **toentries;
    hypre_SStructBoxManInfo *frinfo, *toinfo;
@@ -1868,8 +1923,6 @@ hypre_SStructMatrixSetInterPartValues( HYPRE_SStructMatrix  matrix,
    HYPRE_Int                nfrentries, ntoentries, frpart, topart;
    HYPRE_Int                entry, sentry, ei, fri, toi, i;
    HYPRE_Int                tvalues_size, tvalues_new_size;
-   HYPRE_MemoryLocation     memory_location = hypre_IJMatrixMemoryLocation(
-                                                 hypre_SStructMatrixIJMatrix(matrix));
 
    box   = hypre_BoxCreate(ndim);
    ibox0 = hypre_BoxCreate(ndim);
@@ -1878,7 +1931,7 @@ hypre_SStructMatrixSetInterPartValues( HYPRE_SStructMatrix  matrix,
    tobox = hypre_BoxCreate(ndim);
    frbox = hypre_BoxCreate(ndim);
 
-   hypre_SetIndex(stride, 1);
+   hypre_SetIndex(unit_stride, 1);
    for (ei = 0; ei < nentries; ei++)
    {
       entry  = entries[ei];
@@ -1948,7 +2001,7 @@ hypre_SStructMatrixSetInterPartValues( HYPRE_SStructMatrix  matrix,
                {
                   tvalues_new_size = hypre_BoxVolume(ibox1);
                   tvalues = hypre_TReAlloc_v2(tvalues, HYPRE_Complex, tvalues_size,
-                                              HYPRE_Complex, tvalues_new_size, memory_location);
+                                              HYPRE_Complex, tvalues_new_size, memloc);
                   tvalues_size = tvalues_new_size;
 
                   if (action >= 0)
@@ -1969,34 +2022,32 @@ hypre_SStructMatrixSetInterPartValues( HYPRE_SStructMatrix  matrix,
                      start = hypre_BoxIMin(ibox1);
                      hypre_BoxGetSize(ibox1, loop_size);
                      hypre_BoxLoop2Begin(ndim, loop_size,
-                                         ibox1, start, stride, mi,
-                                         value_box,  start, stride, vi);
+                                         ibox1, start, unit_stride, mi,
+                                         value_box, start, unit_stride, vi);
                      {
                         tvalues[mi] = values[ei + vi * nentries];
                      }
                      hypre_BoxLoop2End(mi, vi);
 
                      /* put values into UMatrix */
-                     hypre_SStructUMatrixSetBoxValues(
-                        matrix, part, ibox1, var, 1, &entry, ibox1, tvalues, action);
+                     hypre_SStructUMatrixSetBoxValues(matrix, part, ibox1, var, 1,
+                                                      &entry, ibox1, tvalues, action);
+
                      /* zero out values in PMatrix (possibly in ghost) */
-                     hypre_StructMatrixClearBoxValues(
-                        smatrix, ibox1, 1, &sentry, -1, 1);
+                     hypre_StructMatrixClearBoxValues(smatrix, ibox1, 1, &sentry, -1, 1);
                   }
                   else
                   {
-                     /* get */
-
                      /* get values from UMatrix */
-                     hypre_SStructUMatrixSetBoxValues(
-                        matrix, part, ibox1, var, 1, &entry, ibox1, tvalues, action);
+                     hypre_SStructUMatrixSetBoxValues(matrix, part, ibox1, var, 1,
+                                                      &entry, ibox1, tvalues, action);
 
                      /* copy tvalues into values */
                      start = hypre_BoxIMin(ibox1);
                      hypre_BoxGetSize(ibox1, loop_size);
                      hypre_BoxLoop2Begin(ndim, loop_size,
-                                         ibox1, start, stride, mi,
-                                         value_box,  start, stride, vi);
+                                         ibox1, start, unit_stride, mi,
+                                         value_box, start, unit_stride, vi);
                      {
                         values[ei + vi * nentries] = tvalues[mi];
                      }
@@ -2005,9 +2056,11 @@ hypre_SStructMatrixSetInterPartValues( HYPRE_SStructMatrix  matrix,
                   } /* end if action */
                } /* end if nonzero ibox1 */
             } /* end of "from" boxman entries loop */
+
             hypre_TFree(frentries, HYPRE_MEMORY_HOST);
          } /* end if nonzero ibox0 */
       } /* end of "to" boxman entries loop */
+
       hypre_TFree(toentries, HYPRE_MEMORY_HOST);
    } /* end of entries loop */
 
@@ -2017,7 +2070,7 @@ hypre_SStructMatrixSetInterPartValues( HYPRE_SStructMatrix  matrix,
    hypre_BoxDestroy(ibox2);
    hypre_BoxDestroy(tobox);
    hypre_BoxDestroy(frbox);
-   hypre_TFree(tvalues, memory_location);
+   hypre_TFree(tvalues, memloc);
 
    return hypre_error_flag;
 }
@@ -2221,8 +2274,8 @@ hypre_SStructMatrixCompressUToS( HYPRE_SStructMatrix A,
             {
                if (hypre_CSRMatrixI(A_ud)[offset + ii + 1] -
                    hypre_CSRMatrixI(A_ud)[offset + ii] +
-                   hypre_CSRMatrixI(A_uo)[offset + ii + 1]
-                   - hypre_CSRMatrixI(A_uo)[offset + ii] > 0)
+                   hypre_CSRMatrixI(A_uo)[offset + ii + 1] -
+                   hypre_CSRMatrixI(A_uo)[offset + ii] > 0)
                {
                   hypre_Index index;
                   hypre_BoxLoopGetIndex(index);
@@ -2457,6 +2510,7 @@ hypre_SStructMatrixBoxesToUMatrix( hypre_SStructMatrix   *A,
    HYPRE_Int              nparts   = hypre_SStructMatrixNParts(A);
    HYPRE_Int             *Sentries = hypre_SStructMatrixSEntries(A);
    HYPRE_IJMatrix         ij_A     = hypre_SStructMatrixIJMatrix(A);
+   HYPRE_MemoryLocation   memory_location = hypre_IJMatrixMemoryLocation(ij_A);
    hypre_SStructPGrid    *pgrid;
    hypre_StructGrid      *sgrid;
    hypre_SStructStencil  *stencil;
@@ -2487,8 +2541,9 @@ hypre_SStructMatrixBoxesToUMatrix( hypre_SStructMatrix   *A,
    HYPRE_Int              nvalues, i, j, m;
    HYPRE_Int             *num_ghost;
    HYPRE_Int              nSentries;
-
-   HYPRE_ANNOTATE_FUNC_BEGIN;
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+   HYPRE_ExecutionPolicy  exec            = hypre_GetExecPolicy1(memory_location);
+#endif
 
 #if defined(HYPRE_DEBUG) && defined(DEBUG_MATCONV)
    MPI_Comm  comm = hypre_SStructMatrixComm(A);
@@ -2497,61 +2552,73 @@ hypre_SStructMatrixBoxesToUMatrix( hypre_SStructMatrix   *A,
    hypre_MPI_Comm_rank(comm, &myid);
 #endif
 
+   HYPRE_ANNOTATE_FUNC_BEGIN;
+
    /* Get row and column ranges */
    HYPRE_IJMatrixGetLocalRange(ij_A, &sizes[0], &sizes[1], &sizes[2], &sizes[3]);
    nrows = (HYPRE_Int) (sizes[1] - sizes[0] + 1);
    ncols = (HYPRE_Int) (sizes[3] - sizes[2] + 1);
 
-   /* Set row sizes */
-   HYPRE_ANNOTATE_REGION_BEGIN("%s", "Set rowsizes");
-   nvalues = 0; m = 0;
-   hypre_SetIndex(stride, 1);
-   row_sizes = hypre_CTAlloc(HYPRE_Int, nrows, HYPRE_MEMORY_HOST);
-   for (part = 0; part < nparts; part++)
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+   if (exec == HYPRE_EXEC_DEVICE)
    {
-      pA    = hypre_SStructMatrixPMatrix(A, part);
-      pgrid = hypre_SStructGridPGrid(grid, part);
-      nvars = hypre_SStructPMatrixNVars(pA);
-
-      for (var = 0; var < nvars; var++)
+      row_sizes = NULL;
+   }
+   else
+#endif
+   {
+      /* Set row sizes */
+      HYPRE_ANNOTATE_REGION_BEGIN("%s", "Set rowsizes");
+      nvalues = 0; m = 0;
+      hypre_SetIndex(stride, 1);
+      row_sizes = hypre_CTAlloc(HYPRE_Int, nrows, HYPRE_MEMORY_HOST);
+      for (part = 0; part < nparts; part++)
       {
-         sgrid   = hypre_SStructPGridSGrid(pgrid, var);
-         split   = hypre_SStructMatrixSplit(A, part, var);
-         stencil = hypre_SStructPMatrixStencil(pA, var);
-         grid_boxes = hypre_StructGridBoxes(sgrid);
-         num_ghost  = hypre_StructGridNumGhost(sgrid);
+         pA    = hypre_SStructMatrixPMatrix(A, part);
+         pgrid = hypre_SStructGridPGrid(grid, part);
+         nvars = hypre_SStructPMatrixNVars(pA);
 
-         nnzs = hypre_SStructStencilSize(stencil);
-
-         hypre_ForBoxI(i, grid_boxes)
+         for (var = 0; var < nvars; var++)
          {
-            grid_box = hypre_BoxArrayBox(grid_boxes, i);
-            hypre_CopyBox(grid_box, ghost_box);
-            hypre_BoxGrowByArray(ghost_box, num_ghost);
+            sgrid   = hypre_SStructPGridSGrid(pgrid, var);
+            split   = hypre_SStructMatrixSplit(A, part, var);
+            stencil = hypre_SStructPMatrixStencil(pA, var);
+            grid_boxes = hypre_StructGridBoxes(sgrid);
+            num_ghost  = hypre_StructGridNumGhost(sgrid);
 
-            hypre_ForBoxI(j, convert_boxa[part][var])
+            nnzs = hypre_SStructStencilSize(stencil);
+
+            hypre_ForBoxI(i, grid_boxes)
             {
-               convert_box = hypre_BoxArrayBox(convert_boxa[part][var], j);
-               hypre_IntersectBoxes(grid_box, convert_box, box);
-               start = hypre_BoxIMin(box);
-               hypre_BoxGetSize(box, loop_size);
-               /* WM: do I need to check whether there is a non-trivial intersection, or is that handled automatically? */
-               hypre_BoxLoop1Begin(ndim, loop_size, ghost_box, start, stride, mi);
+               grid_box = hypre_BoxArrayBox(grid_boxes, i);
+               hypre_CopyBox(grid_box, ghost_box);
+               hypre_BoxGrowByArray(ghost_box, num_ghost);
+
+               hypre_ForBoxI(j, convert_boxa[part][var])
                {
-                  row_sizes[m + mi] = nnzs;
-               }
-               hypre_BoxLoop1End(mi);
-               nvalues = hypre_max(nvalues, nnzs * hypre_BoxVolume(convert_box));
-            } /* Loop over convert_boxa[part][var] */
+                  convert_box = hypre_BoxArrayBox(convert_boxa[part][var], j);
+                  hypre_IntersectBoxes(grid_box, convert_box, box);
+                  start = hypre_BoxIMin(box);
+                  hypre_BoxGetSize(box, loop_size);
+                  /* WM: do I need to check whether there is a non-trivial
+                         intersection, or is that handled automatically? */
+                  hypre_BoxLoop1Begin(ndim, loop_size, ghost_box, start, stride, mi);
+                  {
+                     row_sizes[m + mi] = nnzs;
+                  }
+                  hypre_BoxLoop1End(mi);
+                  nvalues = hypre_max(nvalues, nnzs * hypre_BoxVolume(convert_box));
+               } /* Loop over convert_boxa[part][var] */
 
-            m += hypre_BoxVolume(ghost_box);
+               m += hypre_BoxVolume(ghost_box);
 
-         } /* Loop over grid_boxes */
-      } /* Loop over vars */
-   } /* Loop over parts */
-   hypre_BoxDestroy(box);
-   hypre_BoxDestroy(ghost_box);
-   HYPRE_ANNOTATE_REGION_END("%s", "Set rowsizes");
+            } /* Loop over grid_boxes */
+         } /* Loop over vars */
+      } /* Loop over parts */
+      hypre_BoxDestroy(box);
+      hypre_BoxDestroy(ghost_box);
+      HYPRE_ANNOTATE_REGION_END("%s", "Set rowsizes");
+   }
 
    /* Create and initialize ij_Ahat */
    if (*ij_Ahat_ptr)
@@ -2562,14 +2629,17 @@ hypre_SStructMatrixBoxesToUMatrix( hypre_SStructMatrix   *A,
    {
       HYPRE_ANNOTATE_REGION_BEGIN("%s", "Create Matrix");
       HYPRE_IJMatrixPartialClone(ij_A, &ij_Ahat);
-      hypre_AuxParCSRMatrixCreate(&aux_matrix, nrows, ncols, row_sizes);
-      hypre_IJMatrixTranslator(ij_Ahat) = aux_matrix;
+      if (row_sizes)
+      {
+         hypre_AuxParCSRMatrixCreate(&aux_matrix, nrows, ncols, row_sizes);
+         hypre_IJMatrixTranslator(ij_Ahat) = aux_matrix;
+      }
       HYPRE_IJMatrixInitialize(ij_Ahat);
       HYPRE_ANNOTATE_REGION_END("%s", "Create Matrix");
    }
 
    /* Allocate memory */
-   values = hypre_CTAlloc(HYPRE_Complex, nvalues, HYPRE_MEMORY_HOST);
+   values = hypre_CTAlloc(HYPRE_Complex, nvalues, memory_location);
 
    /* Set entries of ij_Ahat */
    for (part = 0; part < nparts; part++)
@@ -2635,7 +2705,7 @@ hypre_SStructMatrixBoxesToUMatrix( hypre_SStructMatrix   *A,
          } /* Loop over convert_boxa */
       } /* Loop over vars */
    } /* Loop over parts */
-   hypre_TFree(values, HYPRE_MEMORY_HOST);
+   hypre_TFree(values, memory_location);
 
 #if defined(HYPRE_DEBUG) && defined(DEBUG_MATCONV)
    if (!myid)

--- a/src/struct_mv/struct_data.c
+++ b/src/struct_mv/struct_data.c
@@ -44,6 +44,8 @@ hypre_StructDataCopy( HYPRE_Complex   *fr_data,        /* from */
       return hypre_error_flag;
    }
 
+   HYPRE_ANNOTATE_FUNC_BEGIN;
+
    hypre_SetIndex(stride, 1);
    int_box = hypre_BoxCreate(ndim);
 
@@ -93,6 +95,8 @@ hypre_StructDataCopy( HYPRE_Complex   *fr_data,        /* from */
    }
 
    hypre_BoxDestroy(int_box);
+
+   HYPRE_ANNOTATE_FUNC_END;
 
    return hypre_error_flag;
 }

--- a/src/test/sstruct.c
+++ b/src/test/sstruct.c
@@ -4037,7 +4037,9 @@ main( hypre_int argc,
                            hypre_TMemcpy(d_values, values, HYPRE_Real, size,
                                          memory_location, HYPRE_MEMORY_HOST);
 
-                           HYPRE_SStructVectorSetBoxValues(x, part, ilower, iupper, var, values);
+                           HYPRE_SStructVectorSetBoxValues(x, part,
+                                                           ilower, iupper,
+                                                           var, d_values);
                         }
                      }
                   }

--- a/src/test/sstruct_helpers.c
+++ b/src/test/sstruct_helpers.c
@@ -2598,7 +2598,7 @@ BuildVector( MPI_Comm             comm,
                                             pdata.iuppers[box],
                                             ilower, iupper);
             HYPRE_SStructVectorSetBoxValues(vec, part, ilower, iupper,
-                                            var, values);
+                                            var, d_values);
          }
       }
    }

--- a/src/test/sstructmat.c
+++ b/src/test/sstructmat.c
@@ -104,7 +104,8 @@ main( hypre_int  argc,
    hypre_bind_device(myid, nprocs, comm);
 
    /* Initialize hypre */
-   HYPRE_Init();
+   HYPRE_Initialize();
+   HYPRE_DeviceInitialize();
 
    /* Initialize some input parameters */
    nmatrices = 1;


### PR DESCRIPTION
- Updates memory location for data member in various places
- Turns off computation of row_sizes when running on GPUs
- Add device initialization to `sstructmat` driver