### PR TITLE
Unused variable fix

### DIFF
--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -1446,6 +1446,9 @@ hypre_MemoryPrintUsage(MPI_Comm    comm,
    /* Get umpire memory info */
 #if defined(HYPRE_USING_UMPIRE)
    hypre_UmpireMemoryGetUsage(&lmem[6 + offset]);
+
+#elif !defined(HYPRE_USING_GPU)
+   HYPRE_UNUSED_VAR(offset);
 #endif
 
    /* Gather memory info to rank 0 */


### PR DESCRIPTION
Fix the following:

```
memory.c:1388:17: warning: unused variable 'offset' [-Wunused-variable]
 1388 |    HYPRE_Int    offset = 0;
      |                 ^~~~~~
```