### PR TITLE
expose HYPRE_FMANGLE etc. to CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,6 +147,15 @@ option(TPL_BLAS_LIBRARIES            "Optional list of absolute paths to BLAS li
 option(TPL_LAPACK_LIBRARIES          "Optional list of absolute paths to LAPACK libraries, otherwise use FindLAPACK to locate [].")
 option(TPL_FEI_INCLUDE_DIRS          "List of absolute paths to FEI include directories [].")
 
+set(HYPRE_FMANGLE 0 CACHE STRING "Set the HYPRE Fortran name mangling scheme")
+set_property(CACHE HYPRE_FMANGLE PROPERTY STRINGS 0 1 2 3 4)
+
+set(HYPRE_FMANGLE_BLAS 0 CACHE STRING "Set the BLAS name mangling scheme")
+set_property(CACHE HYPRE_FMANGLE_BLAS PROPERTY STRINGS 0 1 2 3 4)
+
+set(HYPRE_FMANGLE_LAPACK 0 CACHE STRING "Set the LAPACK name mangling scheme")
+set_property(CACHE HYPRE_FMANGLE_LAPACK PROPERTY STRINGS 0 1 2 3 4)
+
 # Set config name values
 if (HYPRE_ENABLE_SHARED)
   set(HYPRE_SHARED ON CACHE BOOL "" FORCE)

--- a/src/config/HYPRE_config.h.cmake.in
+++ b/src/config/HYPRE_config.h.cmake.in
@@ -165,13 +165,13 @@
  * 3 = two underscores
  * 4 = caps, no underscores
  * 5 = one underscore before and after */
-#define HYPRE_FMANGLE 0
+#define HYPRE_FMANGLE @HYPRE_FMANGLE@
 
 /* Define as in HYPRE_FMANGLE to set the BLAS name mangling scheme */
-#define HYPRE_FMANGLE_BLAS 0
+#define HYPRE_FMANGLE_BLAS @HYPRE_FMANGLE_BLAS@
 
 /* Define as in HYPRE_FMANGLE to set the LAPACK name mangling scheme */
-#define HYPRE_FMANGLE_LAPACK 0
+#define HYPRE_FMANGLE_LAPACK @HYPRE_FMANGLE_LAPACK@
 
 /* Define to a macro mangling the given C identifier (in lower and upper
  * case), which must not contain underscores, for linking with Fortran. */


### PR DESCRIPTION
`HYPRE_FMANGLE` controls how symbols for Fortran are mangled. This can be changed via the configure script, but could not be configured during a CMake build. This change adds 3 options to CMakeLists.txt exposing `HYPRE_FMANGLE`, `HYPRE_FMANGLE_BLAS`, and `HYPRE_FMANGLE_LAPACK` such that they can be configured during a CMake build.