### PR TITLE
[Doc] Add note on the product of matrices C and G needed for ADS

### DIFF
--- a/src/docs/usr-manual/solvers-ads.rst
+++ b/src/docs/usr-manual/solvers-ads.rst
@@ -65,6 +65,8 @@ additional user input:
 #. Vectors :math:`x`, :math:`y`, and :math:`z` representing the coordinates of
    the vertices of the mesh.
 
+When debugging an implementation, it might be useful to note that by construction,
+:math:`CG`, the product of the discrete curl and gradient matrices is the zero matrix.
 Internally, ADS proceeds with the construction of the following additional objects:
 
 * :math:`A_C` -- the curl-curl matrix :math:`C^{\,T} {\mathbf A} C`.

--- a/src/docs/usr-manual/solvers-boomeramg.rst
+++ b/src/docs/usr-manual/solvers-boomeramg.rst
@@ -171,7 +171,7 @@ Special AMG Cycles
 ------------------------------------------------------------------------------
 
 The default cycle is a V(1,1)-cycle, however it is possible to change the number
-of sweeps of the up- and down-cycle as well as the coare grid. One can also
+of sweeps of the up- and down-cycle as well as the coarse grid. One can also
 choose a W-cycle, however for parallel processing this is not recommended, since
 it is not scalable.
 


### PR DESCRIPTION
Hi,

I noticed this while implementing ADS preconditioning functionality, and thought it could be useful to others.

Cheers,
-Nuno