### PR TITLE
Fix incompatible pointer warnings

### DIFF
--- a/src/distributed_ls/Euclid/getRow_dh.c
+++ b/src/distributed_ls/Euclid/getRow_dh.c
@@ -18,12 +18,12 @@
 
 #undef __FUNC__
 #define __FUNC__ "EuclidGetRow (HYPRE_GET_ROW)"
-void EuclidGetRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val) 
+void EuclidGetRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val)
 {
   START_FUNC_DH
   HYPRE_Int ierr;
   HYPRE_ParCSRMatrix mat = (HYPRE_ParCSRMatrix) A;
-  ierr = HYPRE_ParCSRMatrixGetRow(mat, row, len, ind, val); 
+  ierr = HYPRE_ParCSRMatrixGetRow(mat, row, len, (HYPRE_BigInt **) ind, val);
   if (ierr) {
     hypre_sprintf(msgBuf_dh, "HYPRE_ParCSRMatrixRestoreRow(row= %i) returned %i", row+1, ierr);
     SET_V_ERROR(msgBuf_dh);
@@ -33,12 +33,12 @@ void EuclidGetRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE
 
 #undef __FUNC__
 #define __FUNC__ "EuclidRestoreRow (HYPRE_GET_ROW)"
-void EuclidRestoreRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val) 
+void EuclidRestoreRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val)
 {
   START_FUNC_DH
   HYPRE_Int ierr;
   HYPRE_ParCSRMatrix mat = (HYPRE_ParCSRMatrix) A;
-  ierr = HYPRE_ParCSRMatrixRestoreRow(mat, row, len, ind, val); 
+  ierr = HYPRE_ParCSRMatrixRestoreRow(mat, row, len, (HYPRE_BigInt **) ind, val);
   if (ierr) {
     hypre_sprintf(msgBuf_dh, "HYPRE_ParCSRMatrixRestoreRow(row= %i) returned %i", row+1, ierr);
     SET_V_ERROR(msgBuf_dh);
@@ -51,8 +51,8 @@ void EuclidRestoreRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, H
 void EuclidGetDimensions(void *A, HYPRE_Int *beg_row, HYPRE_Int *rowsLocal, HYPRE_Int *rowsGlobal)
 {
   START_FUNC_DH
-  HYPRE_Int ierr, m, n;
-  HYPRE_Int row_start, row_end, col_start, col_end;
+  HYPRE_Int ierr;
+  HYPRE_BigInt m, n, row_start, row_end, col_start, col_end;
   HYPRE_ParCSRMatrix mat = (HYPRE_ParCSRMatrix) A;
 
   ierr = HYPRE_ParCSRMatrixGetDims(mat, &m, &n);
@@ -61,8 +61,8 @@ void EuclidGetDimensions(void *A, HYPRE_Int *beg_row, HYPRE_Int *rowsLocal, HYPR
     SET_V_ERROR(msgBuf_dh);
   }
 
-  ierr = HYPRE_ParCSRMatrixGetLocalRange(mat, &row_start, &row_end, 
-                                       &col_start, &col_end);
+  ierr = HYPRE_ParCSRMatrixGetLocalRange(mat, &row_start, &row_end,
+                                         &col_start, &col_end);
   if (ierr) {
     hypre_sprintf(msgBuf_dh, "HYPRE_ParCSRMatrixGetLocalRange() returned %i", ierr);
     SET_V_ERROR(msgBuf_dh);
@@ -98,14 +98,14 @@ HYPRE_Int EuclidReadLocalNz(void *A)
 
 #undef __FUNC__
 #define __FUNC__ "EuclidGetRow (PETSC_GET_ROW)"
-void EuclidGetRow(void *Ain, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val) 
+void EuclidGetRow(void *Ain, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val)
 {
   START_FUNC_DH
   Mat A = Ain;
   HYPRE_Int ierr;
 
   ierr = MatGetRow(A, row, len, ind, val);
-  if (ierr) { 
+  if (ierr) {
     hypre_sprintf(msgBuf_dh, "PETSc's MatGetRow bombed for row= %i", row);
     SET_V_ERROR(msgBuf_dh);
   }
@@ -115,7 +115,7 @@ void EuclidGetRow(void *Ain, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYP
 
 #undef __FUNC__
 #define __FUNC__ "EuclidRestoreRow (PETSC_GET_ROW)"
-void EuclidRestoreRow(void *Ain, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val) 
+void EuclidRestoreRow(void *Ain, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val)
 {
   START_FUNC_DH
   Mat A = (Mat)Ain;
@@ -143,7 +143,7 @@ void EuclidGetDimensions(void *Ain, HYPRE_Int *beg_row, HYPRE_Int *rowsLocal, HY
     hypre_sprintf(msgBuf_dh, "PETSc's MatGetOwnershipRange failed");
     SET_V_ERROR(msgBuf_dh);
   }
-  ierr = MatGetSize(A, &rows, &cols); 
+  ierr = MatGetSize(A, &rows, &cols);
   if (ierr) {
     hypre_sprintf(msgBuf_dh, "PETSc'MatGetSize failed");
     SET_V_ERROR(msgBuf_dh);
@@ -167,7 +167,7 @@ HYPRE_Int EuclidReadLocalNz(void *Ain)
   Mat A = (Mat)Ain;
   HYPRE_Int m, n, ierr;
 
-  ierr = MatGetLocalSize(Ain, &m, &n); 
+  ierr = MatGetLocalSize(Ain, &m, &n);
   if (ierr) SET_ERROR(-1, "PETSc::MatGetLocalSize failed!\n");
   END_FUNC_VAL(m)
 }
@@ -175,17 +175,17 @@ HYPRE_Int EuclidReadLocalNz(void *Ain)
 
 
 /*-------------------------------------------------------------------
- *  Euclid  
+ *  Euclid
  *-------------------------------------------------------------------*/
 #elif defined(EUCLID_GET_ROW)
 
 
 #undef __FUNC__
 #define __FUNC__ "EuclidGetRow (EUCLID_GET_ROW)"
-void EuclidGetRow(void *A, HYPRE_Int globalRow, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val) 
+void EuclidGetRow(void *A, HYPRE_Int globalRow, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val)
 {
   START_FUNC_DH
-  Mat_dh B = (Mat_dh)A;  
+  Mat_dh B = (Mat_dh)A;
   HYPRE_Int row = globalRow - B->beg_row;
   if (row > B->m) {
     hypre_sprintf(msgBuf_dh, "requested globalRow= %i, which is local row= %i, but only have %i rows!",
@@ -193,14 +193,14 @@ void EuclidGetRow(void *A, HYPRE_Int globalRow, HYPRE_Int *len, HYPRE_Int **ind,
     SET_V_ERROR(msgBuf_dh);
   }
   *len = B->rp[row+1] - B->rp[row];
-  if (ind != NULL) *ind = B->cval + B->rp[row]; 
-  if (val != NULL) *val = B->aval + B->rp[row]; 
+  if (ind != NULL) *ind = B->cval + B->rp[row];
+  if (val != NULL) *val = B->aval + B->rp[row];
   END_FUNC_DH
 }
 
 #undef __FUNC__
 #define __FUNC__ "EuclidRestoreRow (EUCLID_GET_ROW)"
-void EuclidRestoreRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val) 
+void EuclidRestoreRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val)
 {
   START_FUNC_DH
   END_FUNC_DH
@@ -211,7 +211,7 @@ void EuclidRestoreRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, H
 void EuclidGetDimensions(void *A, HYPRE_Int *beg_row, HYPRE_Int *rowsLocal, HYPRE_Int *rowsGlobal)
 {
   START_FUNC_DH
-  Mat_dh B = (Mat_dh)A;  
+  Mat_dh B = (Mat_dh)A;
   *beg_row = B->beg_row;
   *rowsLocal = B->m;
   *rowsGlobal = B->n;
@@ -223,7 +223,7 @@ void EuclidGetDimensions(void *A, HYPRE_Int *beg_row, HYPRE_Int *rowsLocal, HYPR
 HYPRE_Int EuclidReadLocalNz(void *A)
 {
   START_FUNC_DH
-  Mat_dh B = (Mat_dh)A;  
+  Mat_dh B = (Mat_dh)A;
   HYPRE_Int nz = B->rp[B->m];
   END_FUNC_VAL(nz)
 }
@@ -235,7 +235,7 @@ HYPRE_Int EuclidReadLocalNz(void *A)
 
 #undef __FUNC__
 #define __FUNC__ "EuclidGetRow (ERROR)"
-void EuclidGetRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val) 
+void EuclidGetRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val)
 {
   START_FUNC_DH
   SET_ERROR(EUCLID_ERROR, "Oops; missing XXX_GET_ROW definition!");
@@ -244,7 +244,7 @@ void EuclidGetRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE
 
 #undef __FUNC__
 #define __FUNC__ "EuclidRestoreRow (ERROR)"
-void EuclidRestoreRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val) 
+void EuclidRestoreRow(void *A, HYPRE_Int row, HYPRE_Int *len, HYPRE_Int **ind, HYPRE_Real **val)
 {
   START_FUNC_DH
   SET_ERROR(EUCLID_ERROR, "Oops; missing XXX_GET_ROW definition!");
@@ -321,7 +321,7 @@ void PrintMatUsingGetRow(void* A, HYPRE_Int beg_row, HYPRE_Int m,
           newRow = n2o_row[i] + beg_row;
           EuclidGetRow(A, newRow, &len, &cval, &aval); CHECK_V_ERROR;
           for (j=0; j<len; ++j) {
-            newCol = o2n_col[cval[j]-beg_row] + beg_row; 
+            newCol = o2n_col[cval[j]-beg_row] + beg_row;
             hypre_fprintf(fp, "%i %i %g\n", i+1, newCol, aval[j]);
           }
           EuclidRestoreRow(A, i, &len, &cval, &aval); CHECK_V_ERROR;
@@ -347,8 +347,7 @@ void PrintMatUsingGetRow(void* A, HYPRE_Int beg_row, HYPRE_Int m,
 void Euclid_dhInputHypreMat(Euclid_dh ctx, HYPRE_ParCSRMatrix A)
 {
   START_FUNC_DH
-  HYPRE_Int M, N;
-  HYPRE_Int beg_row, end_row, junk;
+  HYPRE_BigInt M, N, beg_row, end_row, junk;
 
   /* get dimension and ownership information */
   HYPRE_ParCSRMatrixGetDims(A, &M , &N);

--- a/src/distributed_ls/ParaSails/hypre_ParaSails.c
+++ b/src/distributed_ls/ParaSails/hypre_ParaSails.c
@@ -31,7 +31,7 @@ typedef struct
    hypre_ParaSails_struct;
 
 /*--------------------------------------------------------------------------
- * balance_info - Dump out information about the partitioning of the 
+ * balance_info - Dump out information about the partitioning of the
  * matrix, which affects load balance
  *--------------------------------------------------------------------------*/
 
@@ -120,7 +120,7 @@ static void matvec_timing(MPI_Comm comm, Matrix *mat)
 
    hypre_MPI_Comm_rank(comm, &mype);
    if (mype == 0)
-      hypre_printf("Timings: %f %f %f Serial: %f %f %f\n", 
+      hypre_printf("Timings: %f %f %f Serial: %f %f %f\n",
                    trial1, trial2, trial3, trial4, trial5, trial6);
 
    fflush(stdout);
@@ -131,14 +131,16 @@ static void matvec_timing(MPI_Comm comm, Matrix *mat)
 #endif
 
 /*--------------------------------------------------------------------------
- * convert_matrix - Create and convert distributed matrix to native 
+ * convert_matrix - Create and convert distributed matrix to native
  * data structure of ParaSails
  *--------------------------------------------------------------------------*/
 
 static Matrix *convert_matrix(MPI_Comm comm, HYPRE_DistributedMatrix distmat)
 {
-   HYPRE_Int beg_row, end_row, row, dummy;
-   HYPRE_Int len, *ind;
+   HYPRE_Int row;
+   HYPRE_BigInt beg_row, end_row, dummy;
+   HYPRE_Int len;
+   HYPRE_BigInt *ind;
    HYPRE_Real *val;
    Matrix *mat;
 
@@ -150,7 +152,7 @@ static Matrix *convert_matrix(MPI_Comm comm, HYPRE_DistributedMatrix distmat)
    for (row=beg_row; row<=end_row; row++)
    {
       HYPRE_DistributedMatrixGetRow(distmat, row, &len, &ind, &val);
-      MatrixSetRow(mat, row, len, ind, val);
+      MatrixSetRow(mat, row, len, (HYPRE_Int*) ind, val);
       HYPRE_DistributedMatrixRestoreRow(distmat, row, &len, &ind, &val);
    }
 
@@ -216,7 +218,7 @@ HYPRE_Int hypre_ParaSailsSetup(hypre_ParaSails obj,
 
    ParaSailsDestroy(internal->ps);
 
-   internal->ps = ParaSailsCreate(internal->comm, 
+   internal->ps = ParaSailsCreate(internal->comm,
                                   mat->beg_row, mat->end_row, sym);
 
    ParaSailsSetupPattern(internal->ps, mat, thresh, nlevels);
@@ -256,7 +258,7 @@ HYPRE_Int hypre_ParaSailsSetupPattern(hypre_ParaSails obj,
 
    ParaSailsDestroy(internal->ps);
 
-   internal->ps = ParaSailsCreate(internal->comm, 
+   internal->ps = ParaSailsCreate(internal->comm,
                                   mat->beg_row, mat->end_row, sym);
 
    ParaSailsSetupPattern(internal->ps, mat, thresh, nlevels);
@@ -301,7 +303,7 @@ HYPRE_Int hypre_ParaSailsSetupValues(hypre_ParaSails obj,
 }
 
 /*--------------------------------------------------------------------------
- * hypre_ParaSailsApply - Apply the ParaSails preconditioner to an array 
+ * hypre_ParaSailsApply - Apply the ParaSails preconditioner to an array
  * "u", and return the result in the array "v".
  *--------------------------------------------------------------------------*/
 
@@ -341,9 +343,9 @@ hypre_ParaSailsBuildIJMatrix(hypre_ParaSails obj, HYPRE_IJMatrix *pij_A)
    ParaSails *ps = internal->ps;
    Matrix *mat = internal->ps->M;
 
-   HYPRE_Int *diag_sizes, *offdiag_sizes, local_row, i, j;
+   HYPRE_Int *col_inds, *diag_sizes, *offdiag_sizes, local_row, j;
+   HYPRE_BigInt i;
    HYPRE_Int size;
-   HYPRE_Int *col_inds;
    HYPRE_Real *values;
 
    HYPRE_IJMatrixCreate( ps->comm, ps->beg_row, ps->end_row,
@@ -382,7 +384,8 @@ hypre_ParaSailsBuildIJMatrix(hypre_ParaSails obj, HYPRE_IJMatrix *pij_A)
    {
       MatrixGetRow(mat, local_row, &size, &col_inds, &values);
 
-      HYPRE_IJMatrixSetValues( *pij_A, 1, &size, &i, (const HYPRE_Int *) col_inds,
+      HYPRE_IJMatrixSetValues( *pij_A, 1, &size, &i,
+                               (const HYPRE_BigInt *) col_inds,
                                (const HYPRE_Real *) values );
 
       NumberingGlobalToLocal(ps->numb, size, col_inds, col_inds);

--- a/src/distributed_ls/pilut/HYPRE_DistributedMatrixPilutSolver.c
+++ b/src/distributed_ls/pilut/HYPRE_DistributedMatrixPilutSolver.c
@@ -337,7 +337,8 @@ HYPRE_Int HYPRE_DistributedMatrixPilutSolverSetLogging(
 
 HYPRE_Int HYPRE_DistributedMatrixPilutSolverSetup( HYPRE_DistributedMatrixPilutSolver in_ptr )
 {
-   HYPRE_Int m, n, nprocs, start, end, *rowdist, col0, coln, ierr;
+   HYPRE_Int nprocs, *rowdist, ierr;
+   HYPRE_BigInt m, n, start, end, col0, coln;
    hypre_DistributedMatrixPilutSolver *solver =
       (hypre_DistributedMatrixPilutSolver *) in_ptr;
    hypre_PilutSolverGlobals *globals = hypre_DistributedMatrixPilutSolverGlobals(solver);

--- a/src/distributed_ls/pilut/serilut.c
+++ b/src/distributed_ls/pilut/serilut.c
@@ -45,7 +45,8 @@ HYPRE_Int hypre_SerILUT(DataDistType *ddist, HYPRE_DistributedMatrix matrix,
   HYPRE_Int i, ii, j, k, kk, l, m, ierr, diag_present;
   HYPRE_Int *perm, *iperm,
           *usrowptr, *uerowptr, *ucolind;
-  HYPRE_Int row_size, *col_ind;
+  HYPRE_Int row_size;
+  HYPRE_BigInt *col_ind;
   HYPRE_Real *values, *uvalues, *dvalues, *nrm2s;
   HYPRE_Int nlocal, nbnd;
   HYPRE_Real mult, rtol;
@@ -356,7 +357,8 @@ HYPRE_Int hypre_SelectInterior( HYPRE_Int local_num_rows,
 {
   HYPRE_Int nbnd, nlocal, i, j;
   HYPRE_Int break_loop; /* marks finding an element making this row exterior. -AC */
-  HYPRE_Int row_size, *col_ind;
+  HYPRE_Int row_size;
+  HYPRE_BigInt *col_ind;
   HYPRE_Real *values;
 
   /* Determine which vertices are in the boundary,
@@ -412,7 +414,8 @@ HYPRE_Int hypre_FindStructuralUnion( HYPRE_DistributedMatrix matrix,
                     HYPRE_Int **structural_union,
                     hypre_PilutSolverGlobals *globals )
 {
-  HYPRE_Int ierr=0, i, j, row_size, *col_ind;
+  HYPRE_Int ierr=0, i, j, row_size;
+  HYPRE_BigInt *col_ind;
 
   /* Allocate and clear structural_union vector */
   *structural_union = hypre_CTAlloc( HYPRE_Int,  nrows , HYPRE_MEMORY_HOST);


### PR DESCRIPTION
Fix incompatible pointer warnings arising in the build with HIP and mixedint enabled. For example:

```bash
hypre-path/src/distributed_ls/Euclid/getRow_dh.c:26:50: warning: incompatible pointer types passing 'HYPRE_Int **' (aka 'int **') to parameter of type 'HYPRE_BigInt **' (aka 'long long **') [-Wincompatible-pointer-types]
   26 |   ierr = HYPRE_ParCSRMatrixGetRow(mat, row, len, (HYPRE_Int **) ind, val);
      |                                                  ^~~~~~~~~~~~~~~~~~
hypre-path/src/parcsr_mv/HYPRE_parcsr_mv.h:56:52: note: passing argument to parameter 'col_ind' here
   56 |                                     HYPRE_BigInt **col_ind, HYPRE_Complex **values );
      |                                                    ^
```