### PR TITLE
Fix nvhpc warnings

### DIFF
--- a/src/config/cmake/HYPRE_SetupCUDAToolkit.cmake
+++ b/src/config/cmake/HYPRE_SetupCUDAToolkit.cmake
@@ -215,9 +215,14 @@ find_and_add_cuda_library(cusolver HYPRE_ENABLE_CUSOLVER)
 
 # Handle GPU Profiling with nvToolsExt
 if(HYPRE_ENABLE_GPU_PROFILING)
-  find_package(nvToolsExt REQUIRED)
-  set(HYPRE_USING_NVTX ON CACHE BOOL "" FORCE)
-  list(APPEND CUDA_LIBS CUDA::nvToolsExt)
+  find_library(NVTX_LIBRARY nvToolsExt HINTS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib)
+  if(NVTX_LIBRARY)
+    message(STATUS "Found NVTX library")
+    set(HYPRE_USING_NVTX ON CACHE BOOL "" FORCE)
+    list(APPEND CUDA_LIBS ${NVTX_LIBRARY})
+  else()
+    message(FATAL_ERROR "NVTX library not found! Make sure CUDA is installed correctly.")
+  endif()
 endif()
 
 # Add CUDA Toolkit include directories to the target

--- a/src/parcsr_ls/par_ilu_setup.c
+++ b/src/parcsr_ls/par_ilu_setup.c
@@ -39,7 +39,9 @@ hypre_ILUSetup( void               *ilu_vdata,
 
    /* Pointers to device data, note that they are not NULL only when needed */
 #if defined(HYPRE_USING_GPU)
+#if defined(HYPRE_USING_UNIFIED_MEMORY)
    HYPRE_Int             test_opt            = hypre_ParILUDataTestOption(ilu_data);
+#endif
    hypre_ParCSRMatrix   *Aperm               = hypre_ParILUDataAperm(ilu_data);
    hypre_ParCSRMatrix   *R                   = hypre_ParILUDataR(ilu_data);
    hypre_ParCSRMatrix   *P                   = hypre_ParILUDataP(ilu_data);

--- a/src/parcsr_ls/par_ilu_setup.c
+++ b/src/parcsr_ls/par_ilu_setup.c
@@ -427,11 +427,11 @@ hypre_ILUSetup( void               *ilu_vdata,
             hypre_error_w_msg(HYPRE_ERROR_GENERIC,
                               "GMRES+ILU0-RAP setup on device runs requires unified memory!");
             return hypre_error_flag;
-#endif
-
+#else
             hypre_ILUSetupRAPILU0Device(matA, perm, n, nLU,
                                         &Aperm, &matS, &matALU_d, &matBLU_d,
                                         &matSLU_d, &matE_d, &matF_d, test_opt);
+#endif
          }
          else
 #endif

--- a/src/parcsr_mv/par_csr_matrix.c
+++ b/src/parcsr_mv/par_csr_matrix.c
@@ -1762,12 +1762,12 @@ hypre_ParCSRMatrixGetRow( hypre_ParCSRMatrix  *mat,
 
    if (exec == HYPRE_EXEC_DEVICE)
    {
-      return hypre_ParCSRMatrixGetRowDevice(mat, row, size, col_ind, values);
+      hypre_ParCSRMatrixGetRowDevice(mat, row, size, col_ind, values);
    }
    else
 #endif
    {
-      return hypre_ParCSRMatrixGetRowHost(mat, row, size, col_ind, values);
+      hypre_ParCSRMatrixGetRowHost(mat, row, size, col_ind, values);
    }
 
    return hypre_error_flag;

--- a/src/seq_mv/csr_spgemm_device_numer.c
+++ b/src/seq_mv/csr_spgemm_device_numer.c
@@ -32,9 +32,9 @@ hypreDevice_CSRSpGemmNumerWithRownnzUpperboundNoBin( HYPRE_Int       m,
                                                      HYPRE_Complex **d_c_out,
                                                      HYPRE_Int      *nnzC_out )
 {
-   constexpr HYPRE_Int SHMEM_HASH_SIZE = NUMER_HASH_SIZE[HYPRE_SPGEMM_DEFAULT_BIN];
-   constexpr HYPRE_Int GROUP_SIZE = T_GROUP_SIZE[HYPRE_SPGEMM_DEFAULT_BIN];
-   const HYPRE_Int BIN = HYPRE_SPGEMM_DEFAULT_BIN;
+   static constexpr HYPRE_Int SHMEM_HASH_SIZE = NUMER_HASH_SIZE[HYPRE_SPGEMM_DEFAULT_BIN];
+   static constexpr HYPRE_Int GROUP_SIZE = T_GROUP_SIZE[HYPRE_SPGEMM_DEFAULT_BIN];
+   static constexpr HYPRE_Int BIN = HYPRE_SPGEMM_DEFAULT_BIN;
 
 #ifdef HYPRE_SPGEMM_PRINTF
 #if defined(HYPRE_USING_SYCL)

--- a/src/seq_mv/csr_spgemm_device_rowest.c
+++ b/src/seq_mv/csr_spgemm_device_rowest.c
@@ -440,8 +440,8 @@ hypreDevice_CSRSpGemmRownnzEstimate( HYPRE_Int  m,
    HYPRE_Real t1 = hypre_MPI_Wtime();
 #endif
 
+   static constexpr HYPRE_Int shmem_size_per_warp = 128;
    const HYPRE_Int num_warps_per_block =  16;
-   const HYPRE_Int shmem_size_per_warp = 128;
    const HYPRE_Int BDIMX               =   2;
    const HYPRE_Int BDIMY               = HYPRE_WARP_SIZE / BDIMX;
 
@@ -528,4 +528,3 @@ hypreDevice_CSRSpGemmRownnzEstimate( HYPRE_Int  m,
 }
 
 #endif /* defined(HYPRE_USING_GPU) */
-

--- a/src/seq_mv/csr_spgemm_device_symbl.c
+++ b/src/seq_mv/csr_spgemm_device_symbl.c
@@ -36,9 +36,9 @@ hypreDevice_CSRSpGemmRownnzUpperboundNoBin( HYPRE_Int  m,
                                             HYPRE_Int *d_rc,
                                             char      *d_rf )
 {
-   constexpr HYPRE_Int SHMEM_HASH_SIZE = SYMBL_HASH_SIZE[5];
-   constexpr HYPRE_Int GROUP_SIZE = T_GROUP_SIZE[5];
-   const HYPRE_Int BIN = 5;
+   static constexpr HYPRE_Int SHMEM_HASH_SIZE = SYMBL_HASH_SIZE[5];
+   static constexpr HYPRE_Int GROUP_SIZE = T_GROUP_SIZE[5];
+   static constexpr HYPRE_Int BIN = 5;
 
    const bool need_ghash = in_rc > 0;
    const bool can_fail = in_rc < 2;

--- a/src/seq_mv/csr_spgemm_device_symbl.c
+++ b/src/seq_mv/csr_spgemm_device_symbl.c
@@ -181,9 +181,9 @@ hypreDevice_CSRSpGemmRownnzNoBin( HYPRE_Int  m,
                                   HYPRE_Int  in_rc,
                                   HYPRE_Int *d_rc )
 {
-   constexpr HYPRE_Int SHMEM_HASH_SIZE = SYMBL_HASH_SIZE[5];
-   constexpr HYPRE_Int GROUP_SIZE = T_GROUP_SIZE[5];
-   const HYPRE_Int BIN = 5;
+   static constexpr HYPRE_Int SHMEM_HASH_SIZE = SYMBL_HASH_SIZE[5];
+   static constexpr HYPRE_Int GROUP_SIZE = T_GROUP_SIZE[5];
+   static constexpr HYPRE_Int BIN = 5;
 
    const bool need_ghash = in_rc > 0;
    const bool can_fail = in_rc < 2;


### PR DESCRIPTION
Fix build warnings when compiling hypre with NVHPC:

```bash
"path-to-hypre/src/seq_mv/csr_spgemm_device_numer.c", line 35: warning: variable "SHMEM_HASH_SIZE" was declared but never referenced [declared_but_not_referenced]
  constexpr HYPRE_Int SHMEM_HASH_SIZE = (NUMER_HASH_SIZE[5]); 
                      ^
Remark: individual warnings can be suppressed with "--diag_suppress <warning-name>"

"path-to-hypre/src/seq_mv/csr_spgemm_device_numer.c", line 36: warning: variable "GROUP_SIZE" was declared but never referenced [declared_but_not_referenced]
  constexpr HYPRE_Int GROUP_SIZE = (T_GROUP_SIZE[5]); 
                      ^
"path-to-hypre/src/seq_mv/csr_spgemm_device_numer.c", line 37: warning: variable "BIN" was declared but never referenced [declared_but_not_referenced]
  const HYPRE_Int BIN = 5; 
                  ^
"path-to-hypre/src/seq_mv/csr_spgemm_device_rowest.c", line 444: warning: variable "shmem_size_per_warp" was declared but never referenced [declared_but_not_referenced]
  const HYPRE_Int shmem_size_per_warp = 128; 
                  ^
Remark: individual warnings can be suppressed with "--diag_suppress <warning-name>"

"path-to-hypre/src/seq_mv/csr_spgemm_device_symbl.c", line 39: warning: variable "SHMEM_HASH_SIZE" was declared but never referenced [declared_but_not_referenced]
  constexpr HYPRE_Int SHMEM_HASH_SIZE = (SYMBL_HASH_SIZE[5]); 
                      ^

Remark: individual warnings can be suppressed with "--diag_suppress <warning-name>"

"path-to-hypre/src/seq_mv/csr_spgemm_device_symbl.c", line 40: warning: variable "GROUP_SIZE" was declared but never referenced [declared_but_not_referenced]
  constexpr HYPRE_Int GROUP_SIZE = (T_GROUP_SIZE[5]); 
                      ^
"path-to-hypre/src/seq_mv/csr_spgemm_device_symbl.c", line 41: warning: variable "BIN" was declared but never referenced [declared_but_not_referenced]
  const HYPRE_Int BIN = 5; 
                  ^
"path-to-hypre/src/seq_mv/csr_spgemm_device_symbl.c", line 184: warning: variable "SHMEM_HASH_SIZE" was declared but never referenced [declared_but_not_referenced]
  constexpr HYPRE_Int SHMEM_HASH_SIZE = (SYMBL_HASH_SIZE[5]); 
                      ^
"path-to-hypre/src/seq_mv/csr_spgemm_device_symbl.c", line 185: warning: variable "GROUP_SIZE" was declared but never referenced [declared_but_not_referenced]
  constexpr HYPRE_Int GROUP_SIZE = (T_GROUP_SIZE[5]); 
                      ^
"path-to-hypre/src/seq_mv/csr_spgemm_device_symbl.c", line 186: warning: variable "BIN" was declared but never referenced [declared_but_not_referenced]
  const HYPRE_Int BIN = 5; 
                  ^

```