### PR TITLE
Thrust usage refactor for cuda 11+

### DIFF
--- a/src/IJ_mv/IJVector_parcsr_device.c
+++ b/src/IJ_mv/IJVector_parcsr_device.c
@@ -493,7 +493,7 @@ hypre_IJVectorAssembleParDevice(hypre_IJVector *vector)
                             is_on_proc,                                                         /* stencil */
                             thrust::make_zip_iterator(thrust::make_tuple(off_proc_i,      off_proc_data,
                                                                          off_proc_sora)),       /* result */
-                            thrust::not1(thrust::identity<char>()) );
+                            HYPRE_THRUST_NOT(thrust::identity<char>()) );
 
          hypre_assert(thrust::get<0>(new_end1.get_iterator_tuple()) - off_proc_i == nelms_off);
 
@@ -505,7 +505,7 @@ hypre_IJVectorAssembleParDevice(hypre_IJVector *vector)
                             thrust::make_zip_iterator(thrust::make_tuple(stack_i + nelms, stack_data + nelms,
                                                                          stack_sora + nelms)),  /* last */
                             is_on_proc,                                                         /* stencil */
-                            thrust::not1(thrust::identity<char>()) );
+                            HYPRE_THRUST_NOT(thrust::identity<char>()) );
 
          hypre_assert(thrust::get<0>(new_end2.get_iterator_tuple()) - stack_i == nelms_on);
 #endif

--- a/src/parcsr_ls/ams.c
+++ b/src/parcsr_ls/ams.c
@@ -705,7 +705,7 @@ HYPRE_Int hypre_ParCSRComputeL1Norms(hypre_ParCSRMatrix  *A,
          1.0 );
 #else
          thrust::identity<HYPRE_Complex> identity;
-         HYPRE_THRUST_CALL( replace_if, l1_norm, l1_norm + num_rows, thrust::not1(identity), 1.0 );
+         HYPRE_THRUST_CALL( replace_if, l1_norm, l1_norm + num_rows, HYPRE_THRUST_NOT(identity), 1.0 );
 #endif
       }
       else
@@ -776,7 +776,6 @@ HYPRE_Int hypre_ParCSRComputeL1Norms(hypre_ParCSRMatrix  *A,
       HYPRE_THRUST_CALL( transform_if, l1_norm, l1_norm + num_rows, diag_tmp, l1_norm,
                          thrust::negate<HYPRE_Real>(),
                          is_negative<HYPRE_Real>() );
-      //bool any_zero = HYPRE_THRUST_CALL( any_of, l1_norm, l1_norm + num_rows, thrust::not1(thrust::identity<HYPRE_Complex>()) );
       bool any_zero = 0.0 == HYPRE_THRUST_CALL( reduce, l1_norm, l1_norm + num_rows, 1.0,
                                                 thrust::minimum<HYPRE_Real>() );
 #endif

--- a/src/parcsr_ls/par_lr_restr_device.c
+++ b/src/parcsr_ls/par_lr_restr_device.c
@@ -457,7 +457,11 @@ hypre_BoomerAMGBuildRestrNeumannAIR_assembleRdiag( hypre_DeviceItem    &item,
 }
 
 #if !defined(HYPRE_USING_SYCL)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct setTo1minus1 : public thrust::unary_function<HYPRE_Int, HYPRE_Int>
+#else
+struct setTo1minus1
+#endif
 {
    __host__ __device__ HYPRE_Int operator()(const HYPRE_Int &x) const
    {

--- a/src/parcsr_ls/par_mod_multi_interp_device.c
+++ b/src/parcsr_ls/par_mod_multi_interp_device.c
@@ -86,7 +86,11 @@ struct local_equal_plus_constant : public
 };
 
 /* transform from local C index to global C index */
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct globalC_functor : public thrust::unary_function<HYPRE_Int, HYPRE_BigInt>
+#else
+struct globalC_functor
+#endif
 {
    HYPRE_BigInt C_first;
 
@@ -330,7 +334,7 @@ hypre_BoomerAMGBuildModMultipassDevice( hypre_ParCSRMatrix  *A,
                                               thrust::make_counting_iterator(n_fine),
                                               CF_marker,
                                               points_left,
-                                              thrust::not1(equal<HYPRE_Int>(1)) );
+                                              HYPRE_THRUST_NOT(equal<HYPRE_Int>(1)) );
    remaining = points_end - points_left;
 
    /* Cpts; number of C pts */
@@ -544,7 +548,7 @@ hypre_BoomerAMGBuildModMultipassDevice( hypre_ParCSRMatrix  *A,
                                       points_left_old + remaining,
                                       diag_shifts,
                                       points_left,
-                                      thrust::not1(thrust::identity<HYPRE_Int>()) );
+                                      HYPRE_THRUST_NOT(thrust::identity<HYPRE_Int>()) );
 #endif
 
          hypre_assert(new_end - points_left == cnt_rem);
@@ -1613,7 +1617,7 @@ void hypre_modmp_init_fine_to_coarse( HYPRE_Int  n_fine,
                       fine_to_coarse,
                       fine_to_coarse + n_fine,
                       pass_marker,
-                      thrust::not1(equal<HYPRE_Int>(color)),
+                      HYPRE_THRUST_NOT(equal<HYPRE_Int>(color)),
                       -1 );
 #endif
 }

--- a/src/parcsr_mv/par_csr_fffc_device.c
+++ b/src/parcsr_mv/par_csr_fffc_device.c
@@ -21,10 +21,10 @@ typedef thrust::tuple<HYPRE_Int, HYPRE_Int> Tuple;
 /* transform from local F/C index to global F/C index,
  * where F index "x" are saved as "-x-1"
  */
-#if defined(HYPRE_USING_SYCL)
-struct FFFC_functor
-#else
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct FFFC_functor : public thrust::unary_function<Tuple, HYPRE_BigInt>
+#else
+struct FFFC_functor
 #endif
 {
    HYPRE_BigInt CF_first[2];
@@ -48,10 +48,10 @@ struct FFFC_functor : public thrust::unary_function<Tuple, HYPRE_BigInt>
 
 /* this predicate selects A^s_{FF} */
 template<typename T>
-#if defined(HYPRE_USING_SYCL)
-struct FF_pred
-#else
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct FF_pred : public thrust::unary_function<Tuple, bool>
+#else
+struct FF_pred
 #endif
 {
    HYPRE_Int  option;
@@ -86,7 +86,7 @@ struct FF_pred : public thrust::unary_function<Tuple, bool>
 
 /* this predicate selects A^s_{FC} */
 template<typename T>
-#if defined(HYPRE_USING_SYCL)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct FC_pred
 #else
 struct FC_pred : public thrust::unary_function<Tuple, bool>
@@ -113,10 +113,10 @@ struct FC_pred : public thrust::unary_function<Tuple, bool>
 
 /* this predicate selects A^s_{CF} */
 template<typename T>
-#if defined(HYPRE_USING_SYCL)
-struct CF_pred
-#else
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct CF_pred : public thrust::unary_function<Tuple, bool>
+#else
+struct CF_pred
 #endif
 {
    HYPRE_Int *row_CF_marker;
@@ -140,10 +140,10 @@ struct CF_pred : public thrust::unary_function<Tuple, bool>
 
 /* this predicate selects A^s_{CC} */
 template<typename T>
-#if defined(HYPRE_USING_SYCL)
-struct CC_pred
-#else
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct CC_pred : public thrust::unary_function<Tuple, bool>
+#else
+struct CC_pred
 #endif
 {
    HYPRE_Int *row_CF_marker;
@@ -166,10 +166,10 @@ struct CC_pred : public thrust::unary_function<Tuple, bool>
 };
 
 /* this predicate selects A^s_{C,:} */
-#if defined(HYPRE_USING_SYCL)
-struct CX_pred
-#else
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct CX_pred : public thrust::unary_function<Tuple, bool>
+#else
+struct CX_pred
 #endif
 {
    HYPRE_Int *row_CF_marker;
@@ -191,10 +191,10 @@ struct CX_pred : public thrust::unary_function<Tuple, bool>
 
 /* this predicate selects A^s_{:,C} */
 template<typename T>
-#if defined(HYPRE_USING_SYCL)
-struct XC_pred
-#else
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct XC_pred : public thrust::unary_function<Tuple, bool>
+#else
+struct XC_pred
 #endif
 {
    T         *col_CF_marker;

--- a/src/parcsr_mv/par_csr_triplemat_device.c
+++ b/src/parcsr_mv/par_csr_triplemat_device.c
@@ -17,10 +17,10 @@
  * option == 2, T = HYPRE_Int,
  */
 template<HYPRE_Int option, typename T>
-#if defined(HYPRE_USING_SYCL)
-struct RAP_functor
-#else
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct RAP_functor : public thrust::unary_function<HYPRE_Int, T>
+#else
+struct RAP_functor
 #endif
 {
    HYPRE_Int num_col;
@@ -233,7 +233,7 @@ hypre_ParCSRMatMatDevice( hypre_ParCSRMatrix  *A,
                                                                 hypre_CSRMatrixData(Cbar))) + hypre_CSRMatrixNumNonzeros(Cbar),
                    hypre_CSRMatrixJ(Cbar),
                    thrust::make_zip_iterator(thrust::make_tuple(C_offd_ii, C_offd_j, C_offd_a)),
-                   thrust::not1(pred) );
+                   HYPRE_THRUST_NOT(pred) );
       hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == C_offd_ii + nnz_C_offd );
 #endif
 
@@ -962,7 +962,7 @@ hypre_ParCSRTMatMatPartialAddDevice( hypre_ParCSRCommPkg *comm_pkg,
                                                                                      Cext_bigj)) + Cext_nnz,
                                         Cext_bigj,
                                         thrust::make_zip_iterator(thrust::make_tuple(work, big_work)),
-                                        thrust::not1(pred1) );
+                                        HYPRE_THRUST_NOT(pred1) );
 
       HYPRE_Int Cext_offd_nnz = thrust::get<0>(off_end.get_iterator_tuple()) - work;
 #endif
@@ -1224,7 +1224,7 @@ hypre_ParCSRTMatMatPartialAddDevice( hypre_ParCSRCommPkg *comm_pkg,
                                 thrust::make_zip_iterator(thrust::make_tuple(zmp_i, zmp_j, zmp_a)) + local_nnz_C,
                                 zmp_j,
                                 thrust::make_zip_iterator(thrust::make_tuple(C_offd_ii, C_offd_j, C_offd_a)),
-                                thrust::not1(pred) );
+                                HYPRE_THRUST_NOT(pred) );
    hypre_assert( thrust::get<0>(new_end.get_iterator_tuple()) == C_offd_ii + nnz_C_offd );
 #endif
    hypreDevice_CsrRowIndicesToPtrs_v2(hypre_CSRMatrixNumRows(C_offd), nnz_C_offd, C_offd_ii,

--- a/src/seq_mv/csr_spgemm_device.h
+++ b/src/seq_mv/csr_spgemm_device.h
@@ -356,10 +356,10 @@ HYPRE_Int HashFunc(HYPRE_Int key, HYPRE_Int i, HYPRE_Int prev)
 }
 
 template<typename T>
-#if defined(HYPRE_USING_SYCL)
-struct spgemm_bin_op
-#else
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct spgemm_bin_op : public thrust::unary_function<T, char>
+#else
+struct spgemm_bin_op
 #endif
 {
    char s, t, u; /* s: base size of bins; t: lowest bin; u: highest bin */
@@ -469,4 +469,3 @@ hypre_spgemm_get_num_groups_per_block()
 
 #endif /* defined(HYPRE_USING_GPU) */
 #endif /* #ifndef CSR_SPGEMM_DEVICE_H */
-

--- a/src/seq_mv/csr_spgemm_device_util.c
+++ b/src/seq_mv/csr_spgemm_device_util.c
@@ -11,10 +11,10 @@
 
 #if defined(HYPRE_USING_GPU)
 
-#if defined(HYPRE_USING_SYCL)
-struct row_size
-#else
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct row_size : public thrust::unary_function<HYPRE_Int, HYPRE_Int>
+#else
+struct row_size
 #endif
 {
    HYPRE_Int SHMEM_HASH_SIZE;
@@ -338,4 +338,3 @@ HYPRE_Int hypre_SpGemmCreateBins( HYPRE_Int  m,
 }
 
 #endif // #if defined(HYPRE_USING_GPU)
-

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -3946,3 +3946,4 @@ HYPRE_Int hypre_mm_read_mtx_crd_size(FILE *f, HYPRE_Int *M, HYPRE_Int *N, HYPRE_
 #endif
 
 #endif
+

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -378,7 +378,8 @@ using hypre_DeviceItem = void*;
 #include <thrust/version.h>
 
 /* VPM: this is needed to support cuda 10. not_fn is the correct replacement going forward. */
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#define THRUST_VERSION_NOTFN 200700
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 #define HYPRE_THRUST_NOT(pred) thrust::not1(pred)
 #else
 #define HYPRE_THRUST_NOT(pred) thrust::not_fn(pred)
@@ -1542,7 +1543,7 @@ T warp_allreduce_min(hypre_DeviceItem &item, T in)
 }
 
 template<typename T1, typename T2>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct type_cast : public thrust::unary_function<T1, T2>
 #else
 struct type_cast
@@ -1555,7 +1556,7 @@ struct type_cast
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct absolute_value : public thrust::unary_function<T, T>
 #else
 struct absolute_value
@@ -1610,7 +1611,7 @@ struct TupleComp3
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct is_negative : public thrust::unary_function<T, bool>
 #else
 struct is_negative
@@ -1623,7 +1624,7 @@ struct is_negative
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct is_positive : public thrust::unary_function<T, bool>
 #else
 struct is_positive
@@ -1636,7 +1637,7 @@ struct is_positive
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct is_nonnegative : public thrust::unary_function<T, bool>
 #else
 struct is_nonnegative
@@ -1649,7 +1650,7 @@ struct is_nonnegative
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct in_range : public thrust::unary_function<T, bool>
 #else
 struct in_range
@@ -1666,7 +1667,7 @@ struct in_range
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct out_of_range : public thrust::unary_function<T, bool>
 #else
 struct out_of_range
@@ -1683,7 +1684,7 @@ struct out_of_range
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct less_than : public thrust::unary_function<T, bool>
 #else
 struct less_than
@@ -1700,7 +1701,7 @@ struct less_than
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct modulo : public thrust::unary_function<T, T>
 #else
 struct modulo
@@ -1717,7 +1718,7 @@ struct modulo
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct equal : public thrust::unary_function<T, bool>
 #else
 struct equal

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -375,6 +375,14 @@ using hypre_DeviceItem = void*;
 #include <thrust/sequence.h>
 #include <thrust/for_each.h>
 #include <thrust/remove.h>
+#include <thrust/version.h>
+
+/* VPM: this is needed to support cuda 10. not_fn is the correct replacement going forward. */
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#define HYPRE_THRUST_NOT(pred) thrust::not1(pred)
+#else
+#define HYPRE_THRUST_NOT(pred) thrust::not_fn(pred)
+#endif
 
 using namespace thrust::placeholders;
 #endif /* defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */
@@ -1534,7 +1542,11 @@ T warp_allreduce_min(hypre_DeviceItem &item, T in)
 }
 
 template<typename T1, typename T2>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct type_cast : public thrust::unary_function<T1, T2>
+#else
+struct type_cast
+#endif
 {
    __host__ __device__ T2 operator()(const T1 &x) const
    {
@@ -1543,7 +1555,11 @@ struct type_cast : public thrust::unary_function<T1, T2>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct absolute_value : public thrust::unary_function<T, T>
+#else
+struct absolute_value
+#endif
 {
    __host__ __device__ T operator()(const T &x) const
    {
@@ -1594,7 +1610,11 @@ struct TupleComp3
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct is_negative : public thrust::unary_function<T, bool>
+#else
+struct is_negative
+#endif
 {
    __host__ __device__ bool operator()(const T &x)
    {
@@ -1603,7 +1623,11 @@ struct is_negative : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct is_positive : public thrust::unary_function<T, bool>
+#else
+struct is_positive
+#endif
 {
    __host__ __device__ bool operator()(const T &x)
    {
@@ -1612,7 +1636,11 @@ struct is_positive : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct is_nonnegative : public thrust::unary_function<T, bool>
+#else
+struct is_nonnegative
+#endif
 {
    __host__ __device__ bool operator()(const T &x)
    {
@@ -1621,7 +1649,11 @@ struct is_nonnegative : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct in_range : public thrust::unary_function<T, bool>
+#else
+struct in_range
+#endif
 {
    T low, up;
 
@@ -1634,7 +1666,11 @@ struct in_range : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct out_of_range : public thrust::unary_function<T, bool>
+#else
+struct out_of_range
+#endif
 {
    T low, up;
 
@@ -1647,7 +1683,11 @@ struct out_of_range : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct less_than : public thrust::unary_function<T, bool>
+#else
+struct less_than
+#endif
 {
    T val;
 
@@ -1660,7 +1700,11 @@ struct less_than : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct modulo : public thrust::unary_function<T, T>
+#else
+struct modulo
+#endif
 {
    T val;
 
@@ -1673,7 +1717,11 @@ struct modulo : public thrust::unary_function<T, T>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct equal : public thrust::unary_function<T, bool>
+#else
+struct equal
+#endif
 {
    T val;
 

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -182,7 +182,8 @@ using hypre_DeviceItem = void*;
 #include <thrust/version.h>
 
 /* VPM: this is needed to support cuda 10. not_fn is the correct replacement going forward. */
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#define THRUST_VERSION_NOTFN 200700
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 #define HYPRE_THRUST_NOT(pred) thrust::not1(pred)
 #else
 #define HYPRE_THRUST_NOT(pred) thrust::not_fn(pred)
@@ -1346,7 +1347,7 @@ T warp_allreduce_min(hypre_DeviceItem &item, T in)
 }
 
 template<typename T1, typename T2>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct type_cast : public thrust::unary_function<T1, T2>
 #else
 struct type_cast
@@ -1359,7 +1360,7 @@ struct type_cast
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct absolute_value : public thrust::unary_function<T, T>
 #else
 struct absolute_value
@@ -1414,7 +1415,7 @@ struct TupleComp3
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct is_negative : public thrust::unary_function<T, bool>
 #else
 struct is_negative
@@ -1427,7 +1428,7 @@ struct is_negative
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct is_positive : public thrust::unary_function<T, bool>
 #else
 struct is_positive
@@ -1440,7 +1441,7 @@ struct is_positive
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct is_nonnegative : public thrust::unary_function<T, bool>
 #else
 struct is_nonnegative
@@ -1453,7 +1454,7 @@ struct is_nonnegative
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct in_range : public thrust::unary_function<T, bool>
 #else
 struct in_range
@@ -1470,7 +1471,7 @@ struct in_range
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct out_of_range : public thrust::unary_function<T, bool>
 #else
 struct out_of_range
@@ -1487,7 +1488,7 @@ struct out_of_range
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct less_than : public thrust::unary_function<T, bool>
 #else
 struct less_than
@@ -1504,7 +1505,7 @@ struct less_than
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct modulo : public thrust::unary_function<T, T>
 #else
 struct modulo
@@ -1521,7 +1522,7 @@ struct modulo
 };
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct equal : public thrust::unary_function<T, bool>
 #else
 struct equal

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -179,6 +179,14 @@ using hypre_DeviceItem = void*;
 #include <thrust/sequence.h>
 #include <thrust/for_each.h>
 #include <thrust/remove.h>
+#include <thrust/version.h>
+
+/* VPM: this is needed to support cuda 10. not_fn is the correct replacement going forward. */
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#define HYPRE_THRUST_NOT(pred) thrust::not1(pred)
+#else
+#define HYPRE_THRUST_NOT(pred) thrust::not_fn(pred)
+#endif
 
 using namespace thrust::placeholders;
 #endif /* defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */
@@ -1338,7 +1346,11 @@ T warp_allreduce_min(hypre_DeviceItem &item, T in)
 }
 
 template<typename T1, typename T2>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct type_cast : public thrust::unary_function<T1, T2>
+#else
+struct type_cast
+#endif
 {
    __host__ __device__ T2 operator()(const T1 &x) const
    {
@@ -1347,7 +1359,11 @@ struct type_cast : public thrust::unary_function<T1, T2>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct absolute_value : public thrust::unary_function<T, T>
+#else
+struct absolute_value
+#endif
 {
    __host__ __device__ T operator()(const T &x) const
    {
@@ -1398,7 +1414,11 @@ struct TupleComp3
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct is_negative : public thrust::unary_function<T, bool>
+#else
+struct is_negative
+#endif
 {
    __host__ __device__ bool operator()(const T &x)
    {
@@ -1407,7 +1427,11 @@ struct is_negative : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct is_positive : public thrust::unary_function<T, bool>
+#else
+struct is_positive
+#endif
 {
    __host__ __device__ bool operator()(const T &x)
    {
@@ -1416,7 +1440,11 @@ struct is_positive : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct is_nonnegative : public thrust::unary_function<T, bool>
+#else
+struct is_nonnegative
+#endif
 {
    __host__ __device__ bool operator()(const T &x)
    {
@@ -1425,7 +1453,11 @@ struct is_nonnegative : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct in_range : public thrust::unary_function<T, bool>
+#else
+struct in_range
+#endif
 {
    T low, up;
 
@@ -1438,7 +1470,11 @@ struct in_range : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct out_of_range : public thrust::unary_function<T, bool>
+#else
+struct out_of_range
+#endif
 {
    T low, up;
 
@@ -1451,7 +1487,11 @@ struct out_of_range : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct less_than : public thrust::unary_function<T, bool>
+#else
+struct less_than
+#endif
 {
    T val;
 
@@ -1464,7 +1504,11 @@ struct less_than : public thrust::unary_function<T, bool>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct modulo : public thrust::unary_function<T, T>
+#else
+struct modulo
+#endif
 {
    T val;
 
@@ -1477,7 +1521,11 @@ struct modulo : public thrust::unary_function<T, T>
 };
 
 template<typename T>
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
 struct equal : public thrust::unary_function<T, bool>
+#else
+struct equal
+#endif
 {
    T val;
 


### PR DESCRIPTION
This PR includes several changes to improve compatibility with different versions of the Thrust library and to replace deprecated Thrust functions as of cuda 12.8.

The most important changes include modifying the usage of `thrust::not1` to `HYPRE_THRUST_NOT`, and updating functor structures to handle different Thrust versions.

These changes remains compatible with older versions of thrust, including the one distributed with cuda 10.