### PR TITLE
Fix memory leak affecting ext+e interpolation in AMG

### DIFF
--- a/AUTOTEST/machine-aurora.sh
+++ b/AUTOTEST/machine-aurora.sh
@@ -57,14 +57,14 @@ save="aurora"
 
 # SYCL with UM in debug mode [ij, struct]
 # WM: I suppress all warnings for sycl files for now
-co="--enable-debug --with-sycl --enable-unified-memory CC=mpicc CXX=mpicxx --disable-fortran --with-extra-CFLAGS=\\'-Wno-unused-but-set-variable -Wno-unused-variable -Wno-builtin-macro-redefined -Rno-debug-disables-optimization\\' --with-extra-CUFLAGS=\\'-w\\' --with-MPI-include=${MPI_ROOT}/include --with-MPI-libs=mpi --with-MPI-lib-dirs=${MPI_ROOT}/lib"
+co="--enable-debug --with-sycl --enable-unified-memory --with-extra-CFLAGS=\\'-Wno-unused-but-set-variable -Wno-unused-variable -Wno-builtin-macro-redefined -Rno-debug-disables-optimization\\' --with-extra-CUFLAGS=\\'-w\\'"
 ro="-ij-gpu -struct -rt -save ${save} -script gpu_tile_compact.sh -rtol ${rtol} -atol ${atol}"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ro
 ./renametest.sh basic $output_dir/basic-sycl-um
 
 # SYCL with bigint (compile only)
 # WM: I suppress all warnings for sycl files for now
-co="--enable-bigint --with-sycl --enable-unified-memory CC=mpicc CXX=mpicxx --disable-fortran --with-extra-CFLAGS=\\'-Wno-unused-but-set-variable -Wno-unused-variable -Wno-builtin-macro-redefined -Rno-debug-disables-optimization\\' --with-extra-CUFLAGS=\\'-w\\' --with-MPI-include=${MPI_ROOT}/include --with-MPI-libs=mpi --with-MPI-lib-dirs=${MPI_ROOT}/lib"
+co="--enable-bigint --with-sycl --enable-unified-memory --with-extra-CFLAGS=\\'-Wno-unused-but-set-variable -Wno-unused-variable -Wno-builtin-macro-redefined -Rno-debug-disables-optimization\\' --with-extra-CUFLAGS=\\'-w\\'"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo
 ./renametest.sh basic $output_dir/basic-sycl-bigint
 

--- a/src/parcsr_ls/par_mod_lr_interp.c
+++ b/src/parcsr_ls/par_mod_lr_interp.c
@@ -1840,6 +1840,7 @@ hypre_BoomerAMGBuildModExtPEInterpHost(hypre_ParCSRMatrix   *A,
    hypre_TFree(start_array, HYPRE_MEMORY_HOST);
    hypre_TFree(startf_array, HYPRE_MEMORY_HOST);
    hypre_TFree(buf_data, HYPRE_MEMORY_HOST);
+   hypre_TFree(dof_func_offd, HYPRE_MEMORY_HOST);
    hypre_ParCSRMatrixDestroy(As_FF);
    hypre_ParCSRMatrixDestroy(As_FC);
    hypre_ParCSRMatrixDestroy(W);

--- a/src/test/TEST_ij/interp.jobs
+++ b/src/test/TEST_ij/interp.jobs
@@ -44,4 +44,14 @@ mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -interptype 16 -Pmx 12 \
 mpirun -np 4  ./ij -rhsrand -n 15 15 10 -P 2 2 1 -interptype 17 \
  > interp.out.8
 
+mpirun -np 4 ./ij -rhsrand -n 8 8 8 -sysL 2 -nf 2 -interptype 15 \
+ > interp.out.9
 
+mpirun -np 4 ./ij -rhsrand -n 8 8 8 -sysL 2 -nf 2 -interptype 16 \
+ > interp.out.10
+
+mpirun -np 4 ./ij -rhsrand -n 8 8 8 -sysL 2 -nf 2 -interptype 17 \
+ > interp.out.11
+
+mpirun -np 4 ./ij -rhsrand -n 8 8 8 -sysL 2 -nf 2 -interptype 18 \
+ > interp.out.12

--- a/src/test/TEST_ij/interp.saved
+++ b/src/test/TEST_ij/interp.saved
@@ -61,3 +61,30 @@
                 operator = 2.681224
                    cycle = 5.360748
 
+# Output file: interp.out.9
+ Average Convergence Factor = 0.522598
+
+     Complexity:    grid = 1.489258
+                operator = 2.126953
+                   cycle = 4.251953
+
+# Output file: interp.out.10
+ Average Convergence Factor = 0.467057
+
+     Complexity:    grid = 1.474609
+                operator = 2.478906
+                   cycle = 4.957109
+
+# Output file: interp.out.11
+ Average Convergence Factor = 0.423068
+
+     Complexity:    grid = 1.478516
+                operator = 2.503750
+                   cycle = 5.005547
+
+# Output file: interp.out.12
+ Average Convergence Factor = 0.428721
+
+     Complexity:    grid = 1.479492
+                operator = 2.506016
+                   cycle = 5.010078

--- a/src/test/TEST_ij/interp.saved.aurora
+++ b/src/test/TEST_ij/interp.saved.aurora
@@ -61,3 +61,31 @@
                 operator = 2.566327
                    cycle = 5.131565
 
+# Output file: interp.out.9
+ Average Convergence Factor = 0.795761
+
+     Complexity:    grid = 1.460938
+                operator = 2.152031
+                   cycle = 4.303359
+
+# Output file: interp.out.10
+ Average Convergence Factor = 0.795949
+
+     Complexity:    grid = 1.447266
+                operator = 2.585625
+                   cycle = 5.170547
+
+# Output file: interp.out.11
+ Average Convergence Factor = 0.764146
+
+     Complexity:    grid = 1.429688
+                operator = 2.505000
+                   cycle = 5.005000
+
+# Output file: interp.out.12
+ Average Convergence Factor = 0.764224
+
+     Complexity:    grid = 1.429688
+                operator = 2.502813
+                   cycle = 5.000625
+

--- a/src/test/TEST_ij/interp.saved.lassen
+++ b/src/test/TEST_ij/interp.saved.lassen
@@ -61,3 +61,30 @@
                 operator = 2.556327
                    cycle = 5.110952
 
+# Output file: interp.out.9
+ Average Convergence Factor = 0.790196
+
+     Complexity:    grid = 1.487305
+                operator = 2.181797
+                   cycle = 4.363281
+
+# Output file: interp.out.10
+ Average Convergence Factor = 0.797378
+
+     Complexity:    grid = 1.471680
+                operator = 2.534453
+                   cycle = 5.068203
+
+# Output file: interp.out.11
+ Average Convergence Factor = 0.767811
+
+     Complexity:    grid = 1.469727
+                operator = 2.535234
+                   cycle = 5.070156
+
+# Output file: interp.out.12
+ Average Convergence Factor = 0.767716
+
+     Complexity:    grid = 1.465820
+                operator = 2.527891
+                   cycle = 5.049453

--- a/src/test/TEST_ij/interp.saved.lassen_cpu
+++ b/src/test/TEST_ij/interp.saved.lassen_cpu
@@ -61,3 +61,30 @@
                 operator = 2.681224
                    cycle = 5.360748
 
+# Output file: interp.out.9
+ Average Convergence Factor = 0.522598
+
+     Complexity:    grid = 1.489258
+                operator = 2.126953
+                   cycle = 4.251953
+
+# Output file: interp.out.10
+ Average Convergence Factor = 0.467547
+
+     Complexity:    grid = 1.472656
+                operator = 2.464844
+                   cycle = 4.928984
+
+# Output file: interp.out.11
+ Average Convergence Factor = 0.423068
+
+     Complexity:    grid = 1.478516
+                operator = 2.503750
+                   cycle = 5.005547
+
+# Output file: interp.out.12
+ Average Convergence Factor = 0.428721
+
+     Complexity:    grid = 1.479492
+                operator = 2.506016
+                   cycle = 5.010078

--- a/src/test/TEST_ij/interp.sh
+++ b/src/test/TEST_ij/interp.sh
@@ -22,6 +22,10 @@ FILES="\
  ${TNAME}.out.6\
  ${TNAME}.out.7\
  ${TNAME}.out.8\
+ ${TNAME}.out.9\
+ ${TNAME}.out.10\
+ ${TNAME}.out.11\
+ ${TNAME}.out.12\
 "
 
 for i in $FILES


### PR DESCRIPTION
This PR includes a memory leak fix to the `hypre_BoomerAMGBuildModExtPEInterpHost` function. The change adds a call to free the `dof_func_offd` memory.
