### PR TITLE
Extract raw pointer from accessor in SYCL build

### DIFF
--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -522,10 +522,11 @@ using hypre_DeviceItem = sycl::nd_item<3>;
       hypre_HandleComputeStream(hypre_handle())->submit([&] (sycl::handler& cgh) {           \
          sycl::range<1> shmem_range(shmem_size);                                             \
          sycl::local_accessor<char, 1> shmem_accessor(shmem_range, cgh);                     \
-         auto shmem_ptr = shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get();\
          cgh.parallel_for(sycl::nd_range<3>(gridsize*blocksize, blocksize),                  \
             [=] (hypre_DeviceItem item) [[intel::reqd_sub_group_size(HYPRE_WARP_SIZE)]]      \
-               { (kernel_name)(item, shmem_ptr, __VA_ARGS__); });                            \
+               { (kernel_name)(item,                                                         \
+                  shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get(),        \
+                  __VA_ARGS__); });                                                          \
       }).wait_and_throw();                                                                   \
    }                                                                                         \
 }
@@ -565,10 +566,11 @@ using hypre_DeviceItem = sycl::nd_item<3>;
          sycl::range<1> shmem_range(shmem_size);                                             \
          sycl::accessor<char, 1, sycl::access_mode::read_write,                              \
             sycl::target::local> shmem_accessor(shmem_range, cgh);                           \
-         auto shmem_ptr = shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get();\
          cgh.parallel_for(sycl::nd_range<3>(gridsize*blocksize, blocksize),                  \
             [=] (hypre_DeviceItem item) [[intel::reqd_sub_group_size(HYPRE_WARP_SIZE)]]      \
-               { (kernel_name)(item, shmem_ptr, __VA_ARGS__); });                            \
+               { (kernel_name)(item,                                                         \
+                  shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get(),        \
+                  __VA_ARGS__); });                                                          \
       }).wait_and_throw();                                                                   \
    }                                                                                         \
 }

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -522,11 +522,10 @@ using hypre_DeviceItem = sycl::nd_item<3>;
       hypre_HandleComputeStream(hypre_handle())->submit([&] (sycl::handler& cgh) {           \
          sycl::range<1> shmem_range(shmem_size);                                             \
          sycl::local_accessor<char, 1> shmem_accessor(shmem_range, cgh);                     \
+         auto shmem_ptr = shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get();\
          cgh.parallel_for(sycl::nd_range<3>(gridsize*blocksize, blocksize),                  \
             [=] (hypre_DeviceItem item) [[intel::reqd_sub_group_size(HYPRE_WARP_SIZE)]]      \
-               { (kernel_name)(item,                                                         \
-                  shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>(), __VA_ARGS__);\
-         });                                                                                 \
+               { (kernel_name)(item, shmem_ptr, __VA_ARGS__); });                            \
       }).wait_and_throw();                                                                   \
    }                                                                                         \
 }
@@ -566,11 +565,10 @@ using hypre_DeviceItem = sycl::nd_item<3>;
          sycl::range<1> shmem_range(shmem_size);                                             \
          sycl::accessor<char, 1, sycl::access_mode::read_write,                              \
             sycl::target::local> shmem_accessor(shmem_range, cgh);                           \
+         auto shmem_ptr = shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get();\
          cgh.parallel_for(sycl::nd_range<3>(gridsize*blocksize, blocksize),                  \
             [=] (hypre_DeviceItem item) [[intel::reqd_sub_group_size(HYPRE_WARP_SIZE)]]      \
-               { (kernel_name)(item, debug_stream,                                           \
-                  shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>(), __VA_ARGS__);\
-         });                                                                                 \
+               { (kernel_name)(item, shmem_ptr, __VA_ARGS__); });                            \
       }).wait_and_throw();                                                                   \
    }                                                                                         \
 }

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -326,10 +326,11 @@ using hypre_DeviceItem = sycl::nd_item<3>;
       hypre_HandleComputeStream(hypre_handle())->submit([&] (sycl::handler& cgh) {           \
          sycl::range<1> shmem_range(shmem_size);                                             \
          sycl::local_accessor<char, 1> shmem_accessor(shmem_range, cgh);                     \
-         auto shmem_ptr = shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get();\
          cgh.parallel_for(sycl::nd_range<3>(gridsize*blocksize, blocksize),                  \
             [=] (hypre_DeviceItem item) [[intel::reqd_sub_group_size(HYPRE_WARP_SIZE)]]      \
-               { (kernel_name)(item, shmem_ptr, __VA_ARGS__); });                            \
+               { (kernel_name)(item,                                                         \
+                  shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get(),        \
+                  __VA_ARGS__); });                                                          \
       }).wait_and_throw();                                                                   \
    }                                                                                         \
 }
@@ -369,10 +370,11 @@ using hypre_DeviceItem = sycl::nd_item<3>;
          sycl::range<1> shmem_range(shmem_size);                                             \
          sycl::accessor<char, 1, sycl::access_mode::read_write,                              \
             sycl::target::local> shmem_accessor(shmem_range, cgh);                           \
-         auto shmem_ptr = shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get();\
          cgh.parallel_for(sycl::nd_range<3>(gridsize*blocksize, blocksize),                  \
             [=] (hypre_DeviceItem item) [[intel::reqd_sub_group_size(HYPRE_WARP_SIZE)]]      \
-               { (kernel_name)(item, shmem_ptr, __VA_ARGS__); });                            \
+               { (kernel_name)(item,                                                         \
+                  shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get(),        \
+                  __VA_ARGS__); });                                                          \
       }).wait_and_throw();                                                                   \
    }                                                                                         \
 }

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -326,11 +326,10 @@ using hypre_DeviceItem = sycl::nd_item<3>;
       hypre_HandleComputeStream(hypre_handle())->submit([&] (sycl::handler& cgh) {           \
          sycl::range<1> shmem_range(shmem_size);                                             \
          sycl::local_accessor<char, 1> shmem_accessor(shmem_range, cgh);                     \
+         auto shmem_ptr = shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get();\
          cgh.parallel_for(sycl::nd_range<3>(gridsize*blocksize, blocksize),                  \
             [=] (hypre_DeviceItem item) [[intel::reqd_sub_group_size(HYPRE_WARP_SIZE)]]      \
-               { (kernel_name)(item,                                                         \
-                  shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>(), __VA_ARGS__);\
-         });                                                                                 \
+               { (kernel_name)(item, shmem_ptr, __VA_ARGS__); });                            \
       }).wait_and_throw();                                                                   \
    }                                                                                         \
 }
@@ -370,11 +369,10 @@ using hypre_DeviceItem = sycl::nd_item<3>;
          sycl::range<1> shmem_range(shmem_size);                                             \
          sycl::accessor<char, 1, sycl::access_mode::read_write,                              \
             sycl::target::local> shmem_accessor(shmem_range, cgh);                           \
+         auto shmem_ptr = shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>().get();\
          cgh.parallel_for(sycl::nd_range<3>(gridsize*blocksize, blocksize),                  \
             [=] (hypre_DeviceItem item) [[intel::reqd_sub_group_size(HYPRE_WARP_SIZE)]]      \
-               { (kernel_name)(item, debug_stream,                                           \
-                  shmem_accessor.get_multi_ptr<sycl::access::decorated::yes>(), __VA_ARGS__);\
-         });                                                                                 \
+               { (kernel_name)(item, shmem_ptr, __VA_ARGS__); });                            \
       }).wait_and_throw();                                                                   \
    }                                                                                         \
 }


### PR DESCRIPTION
This PR modifies the `HYPRE_GPU_LAUNCH2` macro to explicitly extract the raw pointer from the SYCL local memory accessor before passing it to the kernel. This change prevents the following deprecated conversion warning in SYCL 2020:

```
warning: 'operator __local char *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.
```