### PR TITLE
Fix rocm 5.4.3 build

### DIFF
--- a/src/parcsr_ls/par_lr_restr_device.c
+++ b/src/parcsr_ls/par_lr_restr_device.c
@@ -457,7 +457,7 @@ hypre_BoomerAMGBuildRestrNeumannAIR_assembleRdiag( hypre_DeviceItem    &item,
 }
 
 #if !defined(HYPRE_USING_SYCL)
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct setTo1minus1 : public thrust::unary_function<HYPRE_Int, HYPRE_Int>
 #else
 struct setTo1minus1

--- a/src/parcsr_ls/par_mod_multi_interp_device.c
+++ b/src/parcsr_ls/par_mod_multi_interp_device.c
@@ -86,7 +86,7 @@ struct local_equal_plus_constant : public
 };
 
 /* transform from local C index to global C index */
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct globalC_functor : public thrust::unary_function<HYPRE_Int, HYPRE_BigInt>
 #else
 struct globalC_functor

--- a/src/parcsr_mv/par_csr_fffc_device.c
+++ b/src/parcsr_mv/par_csr_fffc_device.c
@@ -21,7 +21,7 @@ typedef thrust::tuple<HYPRE_Int, HYPRE_Int> Tuple;
 /* transform from local F/C index to global F/C index,
  * where F index "x" are saved as "-x-1"
  */
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct FFFC_functor : public thrust::unary_function<Tuple, HYPRE_BigInt>
 #else
 struct FFFC_functor
@@ -48,7 +48,7 @@ struct FFFC_functor
 
 /* this predicate selects A^s_{FF} */
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct FF_pred : public thrust::unary_function<Tuple, bool>
 #else
 struct FF_pred
@@ -86,7 +86,7 @@ struct FF_pred
 
 /* this predicate selects A^s_{FC} */
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct FC_pred
 #else
 struct FC_pred : public thrust::unary_function<Tuple, bool>
@@ -113,7 +113,7 @@ struct FC_pred : public thrust::unary_function<Tuple, bool>
 
 /* this predicate selects A^s_{CF} */
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct CF_pred : public thrust::unary_function<Tuple, bool>
 #else
 struct CF_pred
@@ -140,7 +140,7 @@ struct CF_pred
 
 /* this predicate selects A^s_{CC} */
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct CC_pred : public thrust::unary_function<Tuple, bool>
 #else
 struct CC_pred
@@ -166,7 +166,7 @@ struct CC_pred
 };
 
 /* this predicate selects A^s_{C,:} */
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct CX_pred : public thrust::unary_function<Tuple, bool>
 #else
 struct CX_pred
@@ -191,7 +191,7 @@ struct CX_pred
 
 /* this predicate selects A^s_{:,C} */
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct XC_pred : public thrust::unary_function<Tuple, bool>
 #else
 struct XC_pred

--- a/src/parcsr_mv/par_csr_triplemat_device.c
+++ b/src/parcsr_mv/par_csr_triplemat_device.c
@@ -17,7 +17,7 @@
  * option == 2, T = HYPRE_Int,
  */
 template<HYPRE_Int option, typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct RAP_functor : public thrust::unary_function<HYPRE_Int, T>
 #else
 struct RAP_functor

--- a/src/seq_mv/csr_matop_device.c
+++ b/src/seq_mv/csr_matop_device.c
@@ -1868,7 +1868,7 @@ struct Int2Unequal
 };
 #else
 typedef thrust::tuple<HYPRE_Int, HYPRE_Int> Int2;
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct Int2Unequal : public thrust::unary_function<Int2, bool>
 #else
 struct Int2Unequal
@@ -2093,7 +2093,7 @@ struct cabsfirst_greaterthan_second_pred
    }
 };
 #else
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct cabsfirst_greaterthan_second_pred : public
    thrust::unary_function<thrust::tuple<HYPRE_Complex, HYPRE_Real>, bool>
 #else
@@ -2357,7 +2357,7 @@ hypre_CSRMatrixDiagMatrixFromMatrixDevice(hypre_CSRMatrix *A, HYPRE_Int type)
  * adj_functor (Used in hypre_CSRMatrixPermuteDevice)
  *--------------------------------------------------------------------------*/
 
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct adj_functor : public thrust::unary_function<HYPRE_Int, HYPRE_Int>
 #else
 struct adj_functor

--- a/src/seq_mv/csr_spgemm_device.h
+++ b/src/seq_mv/csr_spgemm_device.h
@@ -356,7 +356,7 @@ HYPRE_Int HashFunc(HYPRE_Int key, HYPRE_Int i, HYPRE_Int prev)
 }
 
 template<typename T>
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct spgemm_bin_op : public thrust::unary_function<T, char>
 #else
 struct spgemm_bin_op

--- a/src/seq_mv/csr_spgemm_device_util.c
+++ b/src/seq_mv/csr_spgemm_device_util.c
@@ -11,7 +11,7 @@
 
 #if defined(HYPRE_USING_GPU)
 
-#if (defined(THRUST_VERSION) && THRUST_VERSION < 101000)
+#if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 struct row_size : public thrust::unary_function<HYPRE_Int, HYPRE_Int>
 #else
 struct row_size


### PR DESCRIPTION
Fixes build issue with rocm 5.4.3 reported by the PETSc team:

```
/opt/rocm-5.4.3/include/thrust/iterator/detail/transform_iterator.inl:44:8: error: no type named 'type' in 'thrust::detail::ia_dflt_help<thrust::use_default, thrust::detail::result_of_adaptable_function<row_size (int)>>'
    >::type reference;
    ~~~^~~~
/opt/rocm-5.4.3/include/thrust/iterator/transform_iterator.h:190:22: note: in instantiation of template class 'thrust::detail::transform_iterator_base<row_size, int *, thrust::use_default, thrust::use_default>' requested here
    : public detail::transform_iterator_base<AdaptableUnaryFunction, Iterator, Reference, Value>::type
                     ^
csr_spgemm_device_util.c:153:26: note: in instantiation of template class 'thrust::transform_iterator<row_size, int *>' requested here
                         thrust::make_transform_iterator(d_c, row_size(SHMEM_HASH_SIZE)),
                         ^
csr_spgemm_device_util.c:154:90: error: invalid operands to binary expression ('transform_iterator<row_size, int *>' and 'HYPRE_Int' (aka 'int'))
                         thrust::make_transform_iterator(d_c, row_size(SHMEM_HASH_SIZE)) + m,
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~
./../utilities/_hypre_utilities.hpp:848:131: note: expanded from macro 'HYPRE_THRUST_CALL'
   thrust::func_name(thrust::hip::par(hypre_HandleDeviceAllocator(hypre_handle())).on(hypre_HandleComputeStream(hypre_handle())), __VA_ARGS__);
                                                                                                                                  ^~~~~~~~~~~
/opt/rocm-5.4.3/include/hip/hip_bfloat16.h:188:41: note: candidate function not viable: no known conversion from 'transform_iterator<row_size, int *>' to 'hip_bfloat16' for 1st argument
inline __host__ __device__ hip_bfloat16 operator+(hip_bfloat16 a, hip_bfloat16 b)
                                        ^
/opt/rocm-5.4.3/include/hip/amd_detail/amd_hip_vector_types.h:956:27: note: candidate template ignored: could not match 'HIP_vector_type' against 'transform_iterator'
    HIP_vector_type<T, n> operator+(
                          ^
/opt/rocm-5.4.3/include/hip/amd_detail/amd_hip_vector_types.h:965:27: note: candidate template ignored: could not match 'HIP_vector_type' against 'transform_iterator'
    HIP_vector_type<T, n> operator+(
                          ^
/opt/rocm-5.4.3/include/hip/amd_detail/amd_hip_vector_types.h:974:27: note: candidate template ignored: could not match 'HIP_vector_type<T, n>' against 'HYPRE_Int' (aka 'int')
    HIP_vector_type<T, n> operator+(
                          ^
/opt/rocm-5.4.3/include/thrust/iterator/iterator_facade.h:516:9: note: candidate template ignored: could not match 'iterator_facade' against 'transform_iterator'
Derived operator+ (iterator_facade<Derived,Value,System,Traversal,Reference,Difference> const& i,
        ^
/opt/rocm-5.4.3/include/thrust/iterator/iterator_facade.h:525:9: note: candidate template ignored: could not match 'iterator_facade<Derived, Value, System, Traversal, Reference, Difference>' against 'HYPRE_Int' (aka 'int')
Derived operator+ (typename Derived::difference_type n,
        ^
/opt/rocm-5.4.3/include/hip/hip_bfloat16.h:179:41: note: candidate function not viable: requires single argument 'a', but 2 arguments were provided
inline __host__ __device__ hip_bfloat16 operator+(hip_bfloat16 a)
                                        ^
In file included from csr_spgemm_device_util.c:10:
In file included from ./csr_spgemm_device.h:11:
In file included from ./../utilities/_hypre_utilities.hpp:352:
In file included from /opt/rocm-5.4.3/include/thrust/execution_policy.h:33:
In file included from /opt/rocm-5.4.3/include/thrust/system/cpp/execution_policy.h:64:
In file included from /opt/rocm-5.4.3/include/thrust/system/cpp/detail/sort.h:22:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/sequential/sort.h:62:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/sequential/sort.inl:25:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/sequential/stable_merge_sort.h:58:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/sequential/stable_merge_sort.inl:24:
In file included from /opt/rocm-5.4.3/include/thrust/merge.h:677:
In file included from /opt/rocm-5.4.3/include/thrust/detail/merge.inl:25:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/adl/merge.h:44:
In file included from /opt/rocm-5.4.3/include/thrust/system/hip/detail/merge.h:39:
In file included from /opt/rocm-5.4.3/include/thrust/extrema.h:800:
In file included from /opt/rocm-5.4.3/include/thrust/detail/extrema.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/extrema.h:87:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/extrema.inl:29:
In file included from /opt/rocm-5.4.3/include/thrust/reduce.h:781:
In file included from /opt/rocm-5.4.3/include/thrust/detail/reduce.inl:26:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/adl/reduce.h:44:
In file included from /opt/rocm-5.4.3/include/thrust/system/hip/detail/reduce.h:41:
In file included from /opt/rocm-5.4.3/include/thrust/device_vector.h:26:
In file included from /opt/rocm-5.4.3/include/thrust/detail/vector_base.h:586:
In file included from /opt/rocm-5.4.3/include/thrust/detail/vector_base.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/equal.h:235:
In file included from /opt/rocm-5.4.3/include/thrust/detail/equal.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/equal.h:46:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/equal.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/mismatch.h:257:
In file included from /opt/rocm-5.4.3/include/thrust/detail/mismatch.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/mismatch.h:56:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/mismatch.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/find.h:381:
In file included from /opt/rocm-5.4.3/include/thrust/detail/find.inl:22:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/find.h:61:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/find.inl:26:
/opt/rocm-5.4.3/include/thrust/iterator/transform_iterator.h:221:9: error: type 'thrust::transform_iterator<row_size, thrust::permutation_iterator<int *, int *>>::super_t' (aka 'iterator_adaptor<transform_iterator<row_size, thrust::permutation_iterator<int *, int *>, thrust::use_default, thrust::use_default>, thrust::permutation_iterator<int *, int *>, int, thrust::use_default, std::random_access_iterator_tag, int>') is not a direct or virtual base of 'thrust::transform_iterator<row_size, thrust::permutation_iterator<int *, int *>>'
      : super_t(x), m_f(f) {
        ^~~~~~~
/opt/rocm-5.4.3/include/thrust/iterator/transform_iterator.h:345:10: note: in instantiation of member function 'thrust::transform_iterator<row_size, thrust::permutation_iterator<int *, int *>>::transform_iterator' requested here
  return transform_iterator<AdaptableUnaryFunction, Iterator>(it, fun);
         ^
csr_spgemm_device_util.c:144:34: note: in instantiation of function template specialization 'thrust::make_transform_iterator<row_size, thrust::permutation_iterator<int *, int *>>' requested here
                         thrust::make_transform_iterator(thrust::make_permutation_iterator(d_c, row_id),
                                 ^
In file included from csr_spgemm_device_util.c:10:
In file included from ./csr_spgemm_device.h:11:
In file included from ./../utilities/_hypre_utilities.hpp:352:
In file included from /opt/rocm-5.4.3/include/thrust/execution_policy.h:33:
In file included from /opt/rocm-5.4.3/include/thrust/system/cpp/execution_policy.h:64:
In file included from /opt/rocm-5.4.3/include/thrust/system/cpp/detail/sort.h:22:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/sequential/sort.h:62:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/sequential/sort.inl:25:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/sequential/stable_merge_sort.h:58:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/sequential/stable_merge_sort.inl:24:
In file included from /opt/rocm-5.4.3/include/thrust/merge.h:677:
In file included from /opt/rocm-5.4.3/include/thrust/detail/merge.inl:25:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/adl/merge.h:44:
In file included from /opt/rocm-5.4.3/include/thrust/system/hip/detail/merge.h:39:
In file included from /opt/rocm-5.4.3/include/thrust/extrema.h:800:
In file included from /opt/rocm-5.4.3/include/thrust/detail/extrema.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/extrema.h:87:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/extrema.inl:29:
In file included from /opt/rocm-5.4.3/include/thrust/reduce.h:781:
In file included from /opt/rocm-5.4.3/include/thrust/detail/reduce.inl:26:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/adl/reduce.h:44:
In file included from /opt/rocm-5.4.3/include/thrust/system/hip/detail/reduce.h:41:
In file included from /opt/rocm-5.4.3/include/thrust/device_vector.h:26:
In file included from /opt/rocm-5.4.3/include/thrust/detail/vector_base.h:586:
In file included from /opt/rocm-5.4.3/include/thrust/detail/vector_base.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/equal.h:235:
In file included from /opt/rocm-5.4.3/include/thrust/detail/equal.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/equal.h:46:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/equal.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/mismatch.h:257:
In file included from /opt/rocm-5.4.3/include/thrust/detail/mismatch.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/mismatch.h:56:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/mismatch.inl:23:
In file included from /opt/rocm-5.4.3/include/thrust/find.h:381:
In file included from /opt/rocm-5.4.3/include/thrust/detail/find.inl:22:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/find.h:61:
In file included from /opt/rocm-5.4.3/include/thrust/system/detail/generic/find.inl:26:
/opt/rocm-5.4.3/include/thrust/iterator/transform_iterator.h:221:9: error: type 'thrust::transform_iterator<row_size, int *>::super_t' (aka 'iterator_adaptor<transform_iterator<row_size, int *, thrust::use_default, thrust::use_default>, int *, int, thrust::use_default, std::random_access_iterator_tag, int>') is not a direct or virtual base of 'thrust::transform_iterator<row_size, int *>'
      : super_t(x), m_f(f) {
        ^~~~~~~
/opt/rocm-5.4.3/include/thrust/iterator/transform_iterator.h:345:10: note: in instantiation of member function 'thrust::transform_iterator<row_size, int *>::transform_iterator' requested here
  return transform_iterator<AdaptableUnaryFunction, Iterator>(it, fun);
         ^
csr_spgemm_device_util.c:153:34: note: in instantiation of function template specialization 'thrust::make_transform_iterator<row_size, int *>' requested here
                         thrust::make_transform_iterator(d_c, row_size(SHMEM_HASH_SIZE)),
                                 ^
6 errors generated when compiling for gfx90a.
make[2]: *** [../config/Makefile.config:66: csr_spgemm_device_util.obj] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:92: all] Error 2
make: *** [Makefile:91: all] Error 1
                    Error running make; make install on HYPRE: Could not execute "['/nfs/gce/projects/petsc/soft/u22.04/make-4.4/bin/make -j24 -l131.2  ']":
Making blas ...
make[1]: Entering directory '/scratch/svcpetsc/glci-builds/AbTGp5-t/0/petsc/petsc/arch-ci-linux-hip-double/externalpackages/git.hypre/src/blas'
mpicc -fPIC -Wno-lto-type-mismatch -Wno-stringop-overflow -g -O  -fPIC -DHAVE_CONFIG_H   -I/opt/
 .... more output .....
tch/svcpetsc/glci-builds/AbTGp5-t/0/petsc/petsc/arch-ci-linux-hip-double/externalpackages/git.hypre/src/seq_mv'
make[1]: Leaving directory '/scratch/svcpetsc/glci-builds/AbTGp5-t/0/petsc/petsc/arch-ci-linux-hip-double/externalpackages/git.hypre/src/seq_mv'In file included from csr_spgemm_device_util.c:10:
In file included from ./csr_spgemm_device.h:11:
In file included from ./../utilities/_hypre_utilities.hpp:352:
In file included from /opt/rocm-5.4.3/include/thrust/execution_policy.h:26:
In file included f
 .... more error .....
      ^
6 errors generated when compiling for gfx90a.
make[2]: *** [../config/Makefile.config:66: csr_spgemm_device_util.obj] Error 1
```

cc @prj- 