### PR TITLE
Non-struct code refactoring and fixes

### DIFF
--- a/src/IJ_mv/HYPRE_IJMatrix.c
+++ b/src/IJ_mv/HYPRE_IJMatrix.c
@@ -1012,6 +1012,8 @@ HYPRE_IJMatrixGetValuesAndZeroOut( HYPRE_IJMatrix matrix,
    if (exec == HYPRE_EXEC_DEVICE)
    {
       /* TODO: add device implementation */
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "HYPRE_IJMatrixGetValuesAndZeroOut not implemented for GPUs!");
+
       if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
       {
          hypre_IJMatrixMigrateParCSR(ijmatrix, HYPRE_MEMORY_HOST);

--- a/src/IJ_mv/HYPRE_IJMatrix.c
+++ b/src/IJ_mv/HYPRE_IJMatrix.c
@@ -1011,7 +1011,14 @@ HYPRE_IJMatrixGetValuesAndZeroOut( HYPRE_IJMatrix matrix,
 
    if (exec == HYPRE_EXEC_DEVICE)
    {
-      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "HYPRE_IJMatrixGetValues not implemented for GPUs!");
+      /* TODO: add device implementation */
+      if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
+      {
+         hypre_IJMatrixMigrateParCSR(ijmatrix, HYPRE_MEMORY_HOST);
+         hypre_IJMatrixGetValuesParCSR(ijmatrix, nrows, ncols,
+                                       rows, row_indexes, cols, values, 1);
+         hypre_IJMatrixMigrateParCSR(ijmatrix, HYPRE_MEMORY_DEVICE);
+      }
    }
    else
 #endif

--- a/src/parcsr_mv/par_csr_matrix.c
+++ b/src/parcsr_mv/par_csr_matrix.c
@@ -423,7 +423,8 @@ hypre_ParCSRMatrixSetNumRownnz( hypre_ParCSRMatrix *matrix )
 
    HYPRE_BigInt      local_num_rownnz;
    HYPRE_BigInt      global_num_rownnz;
-   HYPRE_Int         i, j;
+   HYPRE_Int         i = num_rownnz_diag;
+   HYPRE_Int         j = num_rownnz_offd;
 
    if (!matrix)
    {
@@ -431,17 +432,25 @@ hypre_ParCSRMatrixSetNumRownnz( hypre_ParCSRMatrix *matrix )
       return hypre_error_flag;
    }
 
-   local_num_rownnz = i = j = 0;
-   while (i < num_rownnz_diag && j < num_rownnz_offd)
+   local_num_rownnz = 0;
+   if (rownnz_diag && !rownnz_offd)
    {
-      local_num_rownnz++;
-      if (rownnz_diag[i] < rownnz_offd[j])
+      local_num_rownnz = num_rownnz_diag;
+   }
+   else if (rownnz_diag && rownnz_offd)
+   {
+      i = j = 0;
+      while (i < num_rownnz_diag && j < num_rownnz_offd)
       {
-         i++;
-      }
-      else
-      {
-         j++;
+         local_num_rownnz++;
+         if (rownnz_diag[i] < rownnz_offd[j])
+         {
+            i++;
+         }
+         else
+         {
+            j++;
+         }
       }
    }
 

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -238,6 +238,14 @@ typedef double                 hypre_double;
 #define HYPRE_MAYBE_UNUSED_FUNC
 #endif
 
+/* Macro for marking fallthrough in switch statements */
+#if (defined(__GNUC__) && __GNUC__ >= 7) ||\
+    (defined(__clang__) && __clang_major__ >= 10)
+ #define HYPRE_FALLTHROUGH __attribute__ ((fallthrough))
+#else
+ #define HYPRE_FALLTHROUGH ((void)0)
+#endif
+
 /* Macro for silencing unused variable warning */
 #define HYPRE_UNUSED_VAR(var) ((void) var)
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -2487,6 +2487,20 @@ struct ReduceSum
       *this = other;
    }
 
+   /* copy assignment operator */
+   __host__ __device__
+   ReduceSum<T>& operator=(const ReduceSum<T>& other)
+   {
+      if (this != &other)
+      {
+         init = other.init;
+         __thread_sum = other.__thread_sum;
+         d_buf = other.d_buf;
+         nblocks = other.nblocks;
+      }
+      return *this;
+   }
+
    __host__ void
    Allocate2ndPhaseBuffer()
    {

--- a/src/utilities/device_reducer.h
+++ b/src/utilities/device_reducer.h
@@ -228,6 +228,20 @@ struct ReduceSum
       *this = other;
    }
 
+   /* copy assignment operator */
+   __host__ __device__
+   ReduceSum<T>& operator=(const ReduceSum<T>& other)
+   {
+      if (this != &other)
+      {
+         init = other.init;
+         __thread_sum = other.__thread_sum;
+         d_buf = other.d_buf;
+         nblocks = other.nblocks;
+      }
+      return *this;
+   }
+
    __host__ void
    Allocate2ndPhaseBuffer()
    {

--- a/src/utilities/general.h
+++ b/src/utilities/general.h
@@ -50,6 +50,14 @@ typedef double                 hypre_double;
 #define HYPRE_MAYBE_UNUSED_FUNC
 #endif
 
+/* Macro for marking fallthrough in switch statements */
+#if (defined(__GNUC__) && __GNUC__ >= 7) ||\
+    (defined(__clang__) && __clang_major__ >= 10)
+ #define HYPRE_FALLTHROUGH __attribute__ ((fallthrough))
+#else
+ #define HYPRE_FALLTHROUGH ((void)0)
+#endif
+
 /* Macro for silencing unused variable warning */
 #define HYPRE_UNUSED_VAR(var) ((void) var)
 


### PR DESCRIPTION
Non-struct code changes from #1251 

- Fix implementation of hypre_ParCSRMatrixSetNumRownnz
- Add copy assignment operator to ReduceSum struct
- Fix fallthrough compiler warnings
- Add temporary implementation for `HYPRE_IJMatrixGetValuesAndZeroOut`