### PR TITLE
Make HYPRE_StructVectorSetValues signature consistent

### DIFF
--- a/src/struct_mv/HYPRE_struct_mv.h
+++ b/src/struct_mv/HYPRE_struct_mv.h
@@ -420,7 +420,7 @@ HYPRE_Int HYPRE_StructVectorInitialize(HYPRE_StructVector vector);
  **/
 HYPRE_Int HYPRE_StructVectorSetValues(HYPRE_StructVector  vector,
                                       HYPRE_Int          *index,
-                                      HYPRE_Complex       value);
+                                      HYPRE_Complex      *values);
 
 /**
  * Add to vector coefficients index by index.

--- a/src/struct_mv/HYPRE_struct_vector.c
+++ b/src/struct_mv/HYPRE_struct_vector.c
@@ -54,7 +54,7 @@ HYPRE_StructVectorInitialize( HYPRE_StructVector vector )
 HYPRE_Int
 HYPRE_StructVectorSetValues( HYPRE_StructVector  vector,
                              HYPRE_Int          *grid_index,
-                             HYPRE_Complex       values )
+                             HYPRE_Complex      *values )
 {
    hypre_Index  new_grid_index;
 
@@ -66,7 +66,7 @@ HYPRE_StructVectorSetValues( HYPRE_StructVector  vector,
       hypre_IndexD(new_grid_index, d) = grid_index[d];
    }
 
-   hypre_StructVectorSetValues(vector, new_grid_index, &values, 0, -1, 0);
+   hypre_StructVectorSetValues(vector, new_grid_index, values, 0, -1, 0);
 
    return hypre_error_flag;
 }

--- a/src/struct_mv/_hypre_struct_mv.h
+++ b/src/struct_mv/_hypre_struct_mv.h
@@ -1553,7 +1553,7 @@ HYPRE_Int HYPRE_StructVectorCreate ( MPI_Comm comm, HYPRE_StructGrid grid,
 HYPRE_Int HYPRE_StructVectorDestroy ( HYPRE_StructVector struct_vector );
 HYPRE_Int HYPRE_StructVectorInitialize ( HYPRE_StructVector vector );
 HYPRE_Int HYPRE_StructVectorSetValues ( HYPRE_StructVector vector, HYPRE_Int *grid_index,
-                                        HYPRE_Complex values );
+                                        HYPRE_Complex *values );
 HYPRE_Int HYPRE_StructVectorSetBoxValues ( HYPRE_StructVector vector, HYPRE_Int *ilower,
                                            HYPRE_Int *iupper, HYPRE_Complex *values );
 HYPRE_Int HYPRE_StructVectorAddToValues ( HYPRE_StructVector vector, HYPRE_Int *grid_index,

--- a/src/struct_mv/protos.h
+++ b/src/struct_mv/protos.h
@@ -240,7 +240,7 @@ HYPRE_Int HYPRE_StructVectorCreate ( MPI_Comm comm, HYPRE_StructGrid grid,
 HYPRE_Int HYPRE_StructVectorDestroy ( HYPRE_StructVector struct_vector );
 HYPRE_Int HYPRE_StructVectorInitialize ( HYPRE_StructVector vector );
 HYPRE_Int HYPRE_StructVectorSetValues ( HYPRE_StructVector vector, HYPRE_Int *grid_index,
-                                        HYPRE_Complex values );
+                                        HYPRE_Complex *values );
 HYPRE_Int HYPRE_StructVectorSetBoxValues ( HYPRE_StructVector vector, HYPRE_Int *ilower,
                                            HYPRE_Int *iupper, HYPRE_Complex *values );
 HYPRE_Int HYPRE_StructVectorAddToValues ( HYPRE_StructVector vector, HYPRE_Int *grid_index,


### PR DESCRIPTION
HYPRE_StructVectorSetValues takes a "values" argument, but similar functions like HYPRE_StructVectorSetBoxValues, HYPRE_StructMatrixSetValues etc., take a pointer argument instead (*values). This becomes a problem when using HYPRE_StructVectorSetValues on GPUs, as internally, the function expects a pointer to device memory (otherwise an assert is triggered). We've encountered this problem when trying to integrate HYPRE with the GPU backend for ParFlow.

This PR fixes this by making the signature consistent with the other functions. Alternatively, if no changes to the API are desired in order to maintain backwards compatibility, we could have different function, e.g. HYPRE_StructVectorSetValuesPtr, with the new pointer argument.