### PR TITLE
Recmat - fix for part boundary box coarsening and SSAMG convergence

### DIFF
--- a/src/sstruct_ls/_hypre_sstruct_ls.h
+++ b/src/sstruct_ls/_hypre_sstruct_ls.h
@@ -672,6 +672,11 @@ HYPRE_Int hypre_SStructKrylovMatvec ( void *matvec_data, HYPRE_Complex alpha, vo
                                       HYPRE_Complex beta, void *y );
 HYPRE_Int hypre_SStructKrylovMatvecDestroy ( void *matvec_data );
 HYPRE_Real hypre_SStructKrylovInnerProd ( void *x, void *y );
+HYPRE_Int
+hypre_SStructKrylovInnerProdTagged( void           *x,
+                                    void           *y,
+                                    HYPRE_Int      *num_tags_ptr,
+                                    HYPRE_Complex **iprod_ptr );
 HYPRE_Int hypre_SStructKrylovCopyVector ( void *x, void *y );
 HYPRE_Int hypre_SStructKrylovClearVector ( void *x );
 HYPRE_Int hypre_SStructKrylovScaleVector ( HYPRE_Complex alpha, void *x );

--- a/src/sstruct_ls/_hypre_sstruct_ls.h
+++ b/src/sstruct_ls/_hypre_sstruct_ls.h
@@ -672,8 +672,6 @@ HYPRE_Int hypre_SStructKrylovMatvec ( void *matvec_data, HYPRE_Complex alpha, vo
                                       HYPRE_Complex beta, void *y );
 HYPRE_Int hypre_SStructKrylovMatvecDestroy ( void *matvec_data );
 HYPRE_Real hypre_SStructKrylovInnerProd ( void *x, void *y );
-HYPRE_Int hypre_SStructKrylovInnerProdTagged ( void *x, void *y, HYPRE_Int *num_tags_ptr,
-                                               HYPRE_Complex **iprod_ptr );
 HYPRE_Int hypre_SStructKrylovCopyVector ( void *x, void *y );
 HYPRE_Int hypre_SStructKrylovClearVector ( void *x );
 HYPRE_Int hypre_SStructKrylovScaleVector ( HYPRE_Complex alpha, void *x );
@@ -969,3 +967,4 @@ HYPRE_Int hypre_SysSemiRestrictDestroy ( void *sys_restrict_vdata );
 #endif
 
 #endif
+

--- a/src/sstruct_ls/protos.h
+++ b/src/sstruct_ls/protos.h
@@ -413,6 +413,11 @@ HYPRE_Int hypre_SStructKrylovMatvec ( void *matvec_data, HYPRE_Complex alpha, vo
                                       HYPRE_Complex beta, void *y );
 HYPRE_Int hypre_SStructKrylovMatvecDestroy ( void *matvec_data );
 HYPRE_Real hypre_SStructKrylovInnerProd ( void *x, void *y );
+HYPRE_Int
+hypre_SStructKrylovInnerProdTagged( void           *x,
+                                    void           *y,
+                                    HYPRE_Int      *num_tags_ptr,
+                                    HYPRE_Complex **iprod_ptr );
 HYPRE_Int hypre_SStructKrylovCopyVector ( void *x, void *y );
 HYPRE_Int hypre_SStructKrylovClearVector ( void *x );
 HYPRE_Int hypre_SStructKrylovScaleVector ( HYPRE_Complex alpha, void *x );

--- a/src/sstruct_mv/sstruct_grid.c
+++ b/src/sstruct_mv/sstruct_grid.c
@@ -2935,9 +2935,9 @@ hypre_SStructGridCoarsen( hypre_SStructGrid   *fgrid,
          if (hypre_StructGridNumBoxes(scgrid))
          {
             fpbnd_boxaa = hypre_SStructPGridPBndBoxArrayArray(pfgrid, var);
-            hypre_CoarsenBoxArrayArrayNeg(fpbnd_boxaa,
-                                          hypre_StructGridBoxes(scgrid),
-                                          origin, strides[part], &cpbnd_boxaa);
+            hypre_CoarsenBoxArrayArrayOutward(fpbnd_boxaa,
+                                              hypre_StructGridBoxes(scgrid),
+                                              origin, strides[part], &cpbnd_boxaa);
             hypre_SStructPGridPBndBoxArrayArray(pcgrid, var) = cpbnd_boxaa;
          }
       }

--- a/src/sstruct_mv/sstruct_matmult.c
+++ b/src/sstruct_mv/sstruct_matmult.c
@@ -1066,7 +1066,7 @@ hypre_SStructMatmultComputeU( hypre_SStructMatmultData *mmdata,
    ijmatrix = hypre_SStructMatrixIJMatrix(matrices[m]);
    HYPRE_IJMatrixGetObject(ijmatrix, (void **) &parcsr_uP);
    num_nonzeros_uP = hypre_ParCSRMatrixNumNonzeros(parcsr_uP);
-#if 0
+#if 1
    // RDF Investigate: This produces faster code that isn't always correct.
    //
    // Comments from Wayne: In ssamg_setup.c, if you turn on the DEBUG_SETUP and
@@ -1093,6 +1093,7 @@ hypre_SStructMatmultComputeU( hypre_SStructMatmultData *mmdata,
 
       m = terms[2];
       hypre_SStructMatrixHaloToUMatrix(matrices[m], grid, &ij_tmp, 2);
+      //ij_tmp = hypre_SStructMatrixToUMatrix(matrices[m], 0);
       HYPRE_IJMatrixGetObject(ij_tmp, (void **) &parcsr_sP);
 
       if (!hypre_ParCSRMatrixCommPkg(parcsr_sP))

--- a/src/struct_mv/_hypre_struct_mv.h
+++ b/src/struct_mv/_hypre_struct_mv.h
@@ -2045,8 +2045,6 @@ hypre_ComputeCoarseOriginStride ( hypre_Index coarse_origin, hypre_Index coarse_
                                   hypre_IndexRef origin, hypre_Index stride, HYPRE_Int ndim );
 HYPRE_Int hypre_CoarsenBox ( hypre_Box *box, hypre_IndexRef origin, hypre_Index stride );
 HYPRE_Int hypre_RefineBox ( hypre_Box *box, hypre_IndexRef origin, hypre_Index stride );
-HYPRE_Int hypre_CoarsenBoxNeg ( hypre_Box *box, hypre_Box *refbox, hypre_IndexRef origin,
-                                hypre_Index stride );
 HYPRE_Int hypre_CoarsenBoxArray ( hypre_BoxArray *box_array, hypre_IndexRef origin,
                                   hypre_Index stride );
 HYPRE_Int hypre_RefineBoxArray ( hypre_BoxArray *box_array, hypre_IndexRef origin,
@@ -2055,8 +2053,12 @@ HYPRE_Int hypre_CoarsenBoxArrayArray ( hypre_BoxArrayArray *box_array_array, hyp
                                        hypre_Index stride );
 HYPRE_Int hypre_RefineBoxArrayArray ( hypre_BoxArrayArray *box_array_array, hypre_IndexRef origin,
                                       hypre_Index stride );
-HYPRE_Int hypre_CoarsenBoxArrayArrayNeg ( hypre_BoxArrayArray *boxaa, hypre_BoxArray *refboxa,
-                                          hypre_IndexRef origin, hypre_Index stride, hypre_BoxArrayArray **new_boxaa_ptr );
+HYPRE_Int
+hypre_CoarsenBoxArrayArrayOutward( hypre_BoxArrayArray   *boxaa,
+                                   hypre_BoxArray        *refboxa,
+                                   hypre_IndexRef         origin,
+                                   hypre_Index            stride,
+                                   hypre_BoxArrayArray  **new_boxaa_ptr );
 HYPRE_Int hypre_StructCoarsen ( hypre_StructGrid *fgrid, hypre_IndexRef origin, hypre_Index stride,
                                 HYPRE_Int prune, hypre_StructGrid **cgrid_ptr );
 

--- a/src/struct_mv/coarsen.c
+++ b/src/struct_mv/coarsen.c
@@ -336,10 +336,17 @@ hypre_CoarsenBoxArrayArrayNeg( hypre_BoxArrayArray   *boxaa,
    hypre_BoxArray        *new_boxa;
    hypre_BoxArrayArray   *new_boxaa;
 
+   hypre_Index            unit_index;
+   hypre_Index            grow_index;
+
    HYPRE_Int              count_box;
    HYPRE_Int              count_boxa;
    HYPRE_Int              box_id;
    HYPRE_Int              i, ii, j;
+
+   /* Set grow_index = stride - unit_index */
+   hypre_SetIndex(unit_index, 1);
+   hypre_SubtractIndexes(stride, unit_index, ndim, grow_index);
 
    /* Allocate box */
    box = hypre_BoxCreate(ndim);
@@ -358,7 +365,10 @@ hypre_CoarsenBoxArrayArrayNeg( hypre_BoxArrayArray   *boxaa,
       hypre_ForBoxI(j, boxa)
       {
          hypre_CopyBox(hypre_BoxArrayBox(boxa, j), box);
-         hypre_CoarsenBoxNeg(box, refbox, origin, stride);
+         //hypre_CoarsenBoxNeg(box, refbox, origin, stride);
+         hypre_BoxGrowByIndex(box, grow_index);
+         hypre_CoarsenBox(box, origin, stride);
+         hypre_IntersectBoxes(box, refbox, box);
          if (hypre_BoxVolume(box))
          {
             count_boxa++;
@@ -384,7 +394,10 @@ hypre_CoarsenBoxArrayArrayNeg( hypre_BoxArrayArray   *boxaa,
       hypre_ForBoxI(j, boxa)
       {
          hypre_CopyBox(hypre_BoxArrayBox(boxa, j), box);
-         hypre_CoarsenBoxNeg(box, refbox, origin, stride);
+         //hypre_CoarsenBoxNeg(box, refbox, origin, stride);
+         hypre_BoxGrowByIndex(box, grow_index);
+         hypre_CoarsenBox(box, origin, stride);
+         hypre_IntersectBoxes(box, refbox, box);
          if (hypre_BoxVolume(box))
          {
             count_box++;
@@ -400,7 +413,10 @@ hypre_CoarsenBoxArrayArrayNeg( hypre_BoxArrayArray   *boxaa,
          hypre_ForBoxI(j, boxa)
          {
             hypre_CopyBox(hypre_BoxArrayBox(boxa, j), box);
-            hypre_CoarsenBoxNeg(box, refbox, origin, stride);
+            //hypre_CoarsenBoxNeg(box, refbox, origin, stride);
+            hypre_BoxGrowByIndex(box, grow_index);
+            hypre_CoarsenBox(box, origin, stride);
+            hypre_IntersectBoxes(box, refbox, box);
             if (hypre_BoxVolume(box))
             {
                hypre_CopyBox(box, hypre_BoxArrayBox(new_boxa, count_box));

--- a/src/struct_mv/coarsen.c
+++ b/src/struct_mv/coarsen.c
@@ -308,7 +308,6 @@ hypre_CoarsenBoxArrayArrayOutward( hypre_BoxArrayArray   *boxaa,
       hypre_ForBoxI(j, boxa)
       {
          hypre_CopyBox(hypre_BoxArrayBox(boxa, j), box);
-         //hypre_CoarsenBoxNeg(box, refbox, origin, stride);
          hypre_BoxGrowByIndex(box, grow_index);
          hypre_CoarsenBox(box, origin, stride);
          hypre_IntersectBoxes(box, refbox, box);
@@ -337,7 +336,6 @@ hypre_CoarsenBoxArrayArrayOutward( hypre_BoxArrayArray   *boxaa,
       hypre_ForBoxI(j, boxa)
       {
          hypre_CopyBox(hypre_BoxArrayBox(boxa, j), box);
-         //hypre_CoarsenBoxNeg(box, refbox, origin, stride);
          hypre_BoxGrowByIndex(box, grow_index);
          hypre_CoarsenBox(box, origin, stride);
          hypre_IntersectBoxes(box, refbox, box);
@@ -356,7 +354,6 @@ hypre_CoarsenBoxArrayArrayOutward( hypre_BoxArrayArray   *boxaa,
          hypre_ForBoxI(j, boxa)
          {
             hypre_CopyBox(hypre_BoxArrayBox(boxa, j), box);
-            //hypre_CoarsenBoxNeg(box, refbox, origin, stride);
             hypre_BoxGrowByIndex(box, grow_index);
             hypre_CoarsenBox(box, origin, stride);
             hypre_IntersectBoxes(box, refbox, box);

--- a/src/struct_mv/protos.h
+++ b/src/struct_mv/protos.h
@@ -223,8 +223,6 @@ hypre_ComputeCoarseOriginStride ( hypre_Index coarse_origin, hypre_Index coarse_
                                   hypre_IndexRef origin, hypre_Index stride, HYPRE_Int ndim );
 HYPRE_Int hypre_CoarsenBox ( hypre_Box *box, hypre_IndexRef origin, hypre_Index stride );
 HYPRE_Int hypre_RefineBox ( hypre_Box *box, hypre_IndexRef origin, hypre_Index stride );
-HYPRE_Int hypre_CoarsenBoxNeg ( hypre_Box *box, hypre_Box *refbox, hypre_IndexRef origin,
-                                hypre_Index stride );
 HYPRE_Int hypre_CoarsenBoxArray ( hypre_BoxArray *box_array, hypre_IndexRef origin,
                                   hypre_Index stride );
 HYPRE_Int hypre_RefineBoxArray ( hypre_BoxArray *box_array, hypre_IndexRef origin,
@@ -233,8 +231,12 @@ HYPRE_Int hypre_CoarsenBoxArrayArray ( hypre_BoxArrayArray *box_array_array, hyp
                                        hypre_Index stride );
 HYPRE_Int hypre_RefineBoxArrayArray ( hypre_BoxArrayArray *box_array_array, hypre_IndexRef origin,
                                       hypre_Index stride );
-HYPRE_Int hypre_CoarsenBoxArrayArrayNeg ( hypre_BoxArrayArray *boxaa, hypre_BoxArray *refboxa,
-                                          hypre_IndexRef origin, hypre_Index stride, hypre_BoxArrayArray **new_boxaa_ptr );
+HYPRE_Int
+hypre_CoarsenBoxArrayArrayOutward( hypre_BoxArrayArray   *boxaa,
+                                   hypre_BoxArray        *refboxa,
+                                   hypre_IndexRef         origin,
+                                   hypre_Index            stride,
+                                   hypre_BoxArrayArray  **new_boxaa_ptr );
 HYPRE_Int hypre_StructCoarsen ( hypre_StructGrid *fgrid, hypre_IndexRef origin, hypre_Index stride,
                                 HYPRE_Int prune, hypre_StructGrid **cgrid_ptr );
 

--- a/src/test/TEST_sstruct/amr2d.saved
+++ b/src/test/TEST_sstruct/amr2d.saved
@@ -51,20 +51,20 @@ Iterations = 18
 Final Relative Residual Norm = 5.252407e-07
 
 # Output file: amr2d.out.14
-Iterations = 34
-Final Relative Residual Norm = 9.367235e-07
+Iterations = 37
+Final Relative Residual Norm = 8.428671e-07
 
 # Output file: amr2d.out.15
-Iterations = 34
-Final Relative Residual Norm = 9.367235e-07
+Iterations = 37
+Final Relative Residual Norm = 8.428671e-07
 
 # Output file: amr2d.out.16
 Iterations = 11
-Final Relative Residual Norm = 7.583217e-07
+Final Relative Residual Norm = 8.805905e-07
 
 # Output file: amr2d.out.17
 Iterations = 11
-Final Relative Residual Norm = 7.583217e-07
+Final Relative Residual Norm = 8.805905e-07
 
 # Output file: amr2d.out.18
 Iterations = 6

--- a/src/test/TEST_sstruct/amr3d.saved
+++ b/src/test/TEST_sstruct/amr3d.saved
@@ -1,18 +1,18 @@
 # Output file: amr3d.out.0
 Iterations = 21
-Final Relative Residual Norm = 6.746287e-07
+Final Relative Residual Norm = 6.233107e-07
 
 # Output file: amr3d.out.1
 Iterations = 21
-Final Relative Residual Norm = 6.746287e-07
+Final Relative Residual Norm = 6.233107e-07
 
 # Output file: amr3d.out.2
 Iterations = 10
-Final Relative Residual Norm = 3.726009e-07
+Final Relative Residual Norm = 3.378690e-07
 
 # Output file: amr3d.out.3
 Iterations = 10
-Final Relative Residual Norm = 3.726009e-07
+Final Relative Residual Norm = 3.378690e-07
 
 # Output file: amr3d.out.4
 Iterations = 6

--- a/src/test/TEST_sstruct/miller.saved
+++ b/src/test/TEST_sstruct/miller.saved
@@ -8,11 +8,11 @@ Final Relative Residual Norm = 9.625406e-08
 
 # Output file: miller.out.2
 Iterations = 19
-Final Relative Residual Norm = 6.262284e-07
+Final Relative Residual Norm = 6.039500e-07
 
 # Output file: miller.out.3
 Iterations = 9
-Final Relative Residual Norm = 2.271618e-07
+Final Relative Residual Norm = 2.316257e-07
 
 # Output file: miller.out.10
 Iterations = 15
@@ -24,11 +24,11 @@ Final Relative Residual Norm = 4.230245e-07
 
 # Output file: miller.out.12
 Iterations = 15
-Final Relative Residual Norm = 7.558636e-07
+Final Relative Residual Norm = 6.814768e-07
 
 # Output file: miller.out.13
-Iterations = 8
-Final Relative Residual Norm = 3.637652e-07
+Iterations = 7
+Final Relative Residual Norm = 6.188958e-07
 
 # Output file: miller.out.20
 Iterations = 18
@@ -39,12 +39,12 @@ Iterations = 6
 Final Relative Residual Norm = 8.758757e-08
 
 # Output file: miller.out.22
-Iterations = 19
-Final Relative Residual Norm = 9.371028e-07
+Iterations = 15
+Final Relative Residual Norm = 6.158164e-07
 
 # Output file: miller.out.23
 Iterations = 8
-Final Relative Residual Norm = 3.235898e-07
+Final Relative Residual Norm = 1.874655e-07
 
 # Output file: miller.out.30
 Iterations = 37
@@ -55,12 +55,12 @@ Iterations = 5
 Final Relative Residual Norm = 8.323418e-07
 
 # Output file: miller.out.32
-Iterations = 48
-Final Relative Residual Norm = 9.184883e-07
+Iterations = 33
+Final Relative Residual Norm = 9.319929e-07
 
 # Output file: miller.out.33
-Iterations = 12
-Final Relative Residual Norm = 2.123878e-07
+Iterations = 11
+Final Relative Residual Norm = 2.729486e-07
 
 # Output file: miller.out.40
 Iterations = 3

--- a/src/test/TEST_sstruct/solvers.saved
+++ b/src/test/TEST_sstruct/solvers.saved
@@ -127,24 +127,24 @@ Iterations = 15
 Final Relative Residual Norm = 6.735600e-07
 
 # Output file: solvers.out.36
-Iterations = 66
-Final Relative Residual Norm = 9.326551e-07
+Iterations = 33
+Final Relative Residual Norm = 9.815193e-07
 
 # Output file: solvers.out.37
-Iterations = 66
-Final Relative Residual Norm = 9.326551e-07
+Iterations = 33
+Final Relative Residual Norm = 9.815193e-07
 
 # Output file: solvers.out.38
 Iterations = 22
-Final Relative Residual Norm = 9.745370e-07
+Final Relative Residual Norm = 9.638458e-07
 
 # Output file: solvers.out.39
 Iterations = 22
-Final Relative Residual Norm = 9.745370e-07
+Final Relative Residual Norm = 9.638458e-07
 
 # Output file: solvers.out.40
 Iterations = 36
-Final Relative Residual Norm = 9.610187e-07
+Final Relative Residual Norm = 8.626187e-07
 
 # Output file: solvers.out.41
 Iterations = 17
@@ -271,28 +271,28 @@ Iterations = 8
 Final Relative Residual Norm = 3.862981e-07
 
 # Output file: solvers.out.135
-Iterations = 14
-Final Relative Residual Norm = 6.893755e-07
+Iterations = 11
+Final Relative Residual Norm = 5.085202e-07
 
 # Output file: solvers.out.136
-Iterations = 14
-Final Relative Residual Norm = 6.893755e-07
+Iterations = 11
+Final Relative Residual Norm = 5.085202e-07
 
 # Output file: solvers.out.137
-Iterations = 17
-Final Relative Residual Norm = 4.600898e-07
+Iterations = 14
+Final Relative Residual Norm = 4.469909e-07
 
 # Output file: solvers.out.138
 Iterations = 9
-Final Relative Residual Norm = 5.775868e-07
+Final Relative Residual Norm = 5.805179e-07
 
 # Output file: solvers.out.139
 Iterations = 9
-Final Relative Residual Norm = 5.775868e-07
+Final Relative Residual Norm = 5.805179e-07
 
 # Output file: solvers.out.140
 Iterations = 11
-Final Relative Residual Norm = 3.797903e-07
+Final Relative Residual Norm = 3.897422e-07
 
 # Output file: solvers.out.141
 Iterations = 8


### PR DESCRIPTION
This fixes an issue with the coarsening of the part boundary boxes.  Some notes:

- This PR is intended to first illustrate the changes needed and to support further discussion towards a final fix.
- The name of the function `hypre_CoarsenBoxArrayArrayNeg` is no longer appropriate and should be changed and possibly moved elsewhere since it is only needed in two places in the `sstruct_mv` directory.  It is pretty specific to the needs of the two calling routines: `hypre_SStructGridCoarsen` and `hypre_SStructPMatmultInitialize`.
- The function `hypre_CoarsenBoxNeg` is no longer used and can be removed.  It is only called by the function in the previous bullet (so maybe not generally useful) and it either has a bug in it or is not appropriate for coarsening the part boundary boxes.
- The ssamg regression tests in `amr2d` slow down slightly with these changes, `amr3d` stays the same, and the other ssamg tests (without a Krylov method) speed up considerably.
- The convergence of the `amr2d` problems is pretty slow overall (as a preconditioner it's fast), which is puzzling.
