### PR TITLE
GPU additions to IJ interface

### DIFF
--- a/src/IJ_mv/HYPRE_IJMatrix.c
+++ b/src/IJ_mv/HYPRE_IJMatrix.c
@@ -276,73 +276,6 @@ HYPRE_IJMatrixSetPrintLevel( HYPRE_IJMatrix matrix,
 }
 
 /*--------------------------------------------------------------------------
- * This is a helper routine to compute a prefix sum of integer values.
- *
- * The current implementation is okay for modest numbers of threads.
- *--------------------------------------------------------------------------*/
-
-HYPRE_Int
-hypre_PrefixSumInt(HYPRE_Int   nvals,
-                   HYPRE_Int  *vals,
-                   HYPRE_Int  *sums)
-{
-   HYPRE_Int  j, nthreads, bsize;
-
-   nthreads = hypre_NumThreads();
-   bsize = (nvals + nthreads - 1) / nthreads; /* This distributes the remainder */
-
-   if (nvals < nthreads || bsize == 1)
-   {
-      sums[0] = 0;
-      for (j = 1; j < nvals; j++)
-      {
-         sums[j] += sums[j - 1] + vals[j - 1];
-      }
-   }
-   else
-   {
-
-      /* Compute preliminary partial sums (in parallel) within each interval */
-#ifdef HYPRE_USING_OPENMP
-      #pragma omp parallel for private(j) HYPRE_SMP_SCHEDULE
-#endif
-      for (j = 0; j < nvals; j += bsize)
-      {
-         HYPRE_Int  i, n = hypre_min((j + bsize), nvals);
-
-         sums[j] = 0;
-         for (i = j + 1; i < n; i++)
-         {
-            sums[i] = sums[i - 1] + vals[i - 1];
-         }
-      }
-
-      /* Compute final partial sums (in serial) for the first entry of every interval */
-      for (j = bsize; j < nvals; j += bsize)
-      {
-         sums[j] = sums[j - bsize] + sums[j - 1] + vals[j - 1];
-      }
-
-      /* Compute final partial sums (in parallel) for the remaining entries */
-#ifdef HYPRE_USING_OPENMP
-      #pragma omp parallel for private(j) HYPRE_SMP_SCHEDULE
-#endif
-      for (j = bsize; j < nvals; j += bsize)
-      {
-         HYPRE_Int  i, n = hypre_min((j + bsize), nvals);
-
-         for (i = j + 1; i < n; i++)
-         {
-            sums[i] += sums[j];
-         }
-      }
-   }
-
-   return hypre_error_flag;
-}
-
-
-/*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
@@ -937,15 +870,16 @@ HYPRE_IJMatrixGetValues2( HYPRE_IJMatrix matrix,
 
    if (exec == HYPRE_EXEC_DEVICE)
    {
-      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "HYPRE_IJMatrixGetValues not implemented for GPUs!");
+      hypre_IJMatrixGetValuesParCSRDevice(ijmatrix, nrows, ncols, rows,
+                                          row_indexes, cols, values, 0);
    }
    else
 #endif
    {
       if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
       {
-         hypre_IJMatrixGetValuesParCSR( ijmatrix, nrows, ncols,
-                                        rows, row_indexes, cols, values, 0 );
+         hypre_IJMatrixGetValuesParCSR(ijmatrix, nrows, ncols, rows,
+                                       row_indexes, cols, values, 0);
       }
       else
       {
@@ -954,7 +888,6 @@ HYPRE_IJMatrixGetValues2( HYPRE_IJMatrix matrix,
    }
 
    return hypre_error_flag;
-
 }
 
 /*--------------------------------------------------------------------------
@@ -1011,25 +944,16 @@ HYPRE_IJMatrixGetValuesAndZeroOut( HYPRE_IJMatrix matrix,
 
    if (exec == HYPRE_EXEC_DEVICE)
    {
-      /* TODO: add device implementation */
-      hypre_error_w_msg(HYPRE_ERROR_GENERIC,
-                        "HYPRE_IJMatrixGetValuesAndZeroOut not implemented for GPUs!");
-
-      if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
-      {
-         hypre_IJMatrixMigrateParCSR(ijmatrix, HYPRE_MEMORY_HOST);
-         hypre_IJMatrixGetValuesParCSR(ijmatrix, nrows, ncols,
-                                       rows, row_indexes, cols, values, 1);
-         hypre_IJMatrixMigrateParCSR(ijmatrix, HYPRE_MEMORY_DEVICE);
-      }
+      hypre_IJMatrixGetValuesParCSRDevice(ijmatrix, nrows, ncols, rows,
+                                          row_indexes, cols, values, 1);
    }
    else
 #endif
    {
       if ( hypre_IJMatrixObjectType(ijmatrix) == HYPRE_PARCSR )
       {
-         hypre_IJMatrixGetValuesParCSR( ijmatrix, nrows, ncols,
-                                        rows, row_indexes, cols, values, 1 );
+         hypre_IJMatrixGetValuesParCSR(ijmatrix, nrows, ncols, rows,
+                                       row_indexes, cols, values, 1);
       }
       else
       {

--- a/src/IJ_mv/IJMatrix_parcsr_device.c
+++ b/src/IJ_mv/IJMatrix_parcsr_device.c
@@ -471,10 +471,12 @@ struct hypre_IJMatrixAssembleFunctor2 : public
 };
 #endif
 
-/* This helper routine is for combining new entries with existing CSR.
+/*--------------------------------------------------------------------------
+ * This helper routine is for combining new entries with existing CSR.
  * Opt = 2 for diag part to keep diagonal first
-       = 0 for offd part
- */
+ *     = 0 for offd part
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_IJMatrixAssembleSortAndReduce2(HYPRE_Int      *Nptr,
                                      HYPRE_Int     **Iptr,
@@ -538,7 +540,8 @@ hypre_IJMatrixAssembleSortAndReduce2(HYPRE_Int      *Nptr,
    return hypre_error_flag;
 }
 
-/* This is used on off-proc entries before sending them to other procs
+/*--------------------------------------------------------------------------
+ * This is used on off-proc entries before sending them to other procs
  * 1. StableSort
  * 2. Zero out all prior to the last set (including the set itself), since off-proc set is not allowed
  * 3. Reduce A (sum) by key (I, J).
@@ -548,7 +551,8 @@ hypre_IJMatrixAssembleSortAndReduce2(HYPRE_Int      *Nptr,
  *    Content of X0 is destroyed
  * Note:
  *    No need to reduce X, since all should be add
- */
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_IJMatrixAssembleSortAndReduce3(HYPRE_Int       N0,
                                      HYPRE_BigInt   *I0,
@@ -645,6 +649,9 @@ hypre_IJMatrixAssembleSortAndReduce3(HYPRE_Int       N0,
 
    return hypre_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_IJMatrixAssembleCommunicate(hypre_IJMatrix *matrix)
@@ -756,6 +763,9 @@ hypre_IJMatrixAssembleCommunicate(hypre_IJMatrix *matrix)
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
 HYPRE_Int
 hypre_IJMatrixAssembleCompressDevice(hypre_IJMatrix *matrix,
                                      HYPRE_Int       reduce_stack_size)
@@ -803,6 +813,9 @@ hypre_IJMatrixAssembleCompressDevice(hypre_IJMatrix *matrix,
 
    return hypre_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_IJMatrixAssembleParCSRDevice(hypre_IJMatrix *matrix)
@@ -1064,12 +1077,20 @@ hypre_IJMatrixAssembleParCSRDevice(hypre_IJMatrix *matrix)
       hypre_TFree(col_map_offd_new, HYPRE_MEMORY_DEVICE);
    } /* if (nelms) */
 
+   /* Generate nonzero rows in the diag and offd matrices */
+   hypre_CSRMatrixSetRownnz(hypre_ParCSRMatrixDiag(par_matrix));
+   hypre_CSRMatrixSetRownnz(hypre_ParCSRMatrixOffd(par_matrix));
+
+   /* Finalize */
    hypre_IJMatrixAssembleFlag(matrix) = 1;
    hypre_AuxParCSRMatrixDestroy(aux_matrix);
    hypre_IJMatrixTranslator(matrix) = NULL;
 
    return hypre_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_IJMatrixSetConstantValuesParCSRDevice( hypre_IJMatrix *matrix,
@@ -1085,6 +1106,230 @@ hypre_IJMatrixSetConstantValuesParCSRDevice( hypre_IJMatrix *matrix,
 
    hypreDevice_ComplexFilln( diag_data, nnz_diag, value );
    hypreDevice_ComplexFilln( offd_data, nnz_offd, value );
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_IJMatrixGetValuesParCSRDevice( hypre_IJMatrix *matrix,
+                                     HYPRE_Int       nrows,
+                                     HYPRE_Int      *ncols,
+                                     HYPRE_BigInt   *rows,
+                                     HYPRE_Int      *row_indexes,
+                                     HYPRE_BigInt   *cols,
+                                     HYPRE_Complex  *values,
+                                     HYPRE_Int       zero_out)
+{
+   hypre_ParCSRMatrix *par_matrix       = (hypre_ParCSRMatrix *) hypre_IJMatrixObject(matrix);
+   hypre_CSRMatrix    *diag             = hypre_ParCSRMatrixDiag(par_matrix);
+   hypre_CSRMatrix    *offd             = hypre_ParCSRMatrixOffd(par_matrix);
+
+   HYPRE_BigInt        row_start        = hypre_IJMatrixRowPartitioning(matrix)[0];
+   HYPRE_BigInt        row_end          = hypre_IJMatrixRowPartitioning(matrix)[1];
+   HYPRE_BigInt        col_start        = hypre_IJMatrixColPartitioning(matrix)[0];
+   HYPRE_BigInt        col_end          = hypre_IJMatrixColPartitioning(matrix)[1];
+
+   HYPRE_Int          *diag_i           = hypre_CSRMatrixI(diag);
+   HYPRE_Int          *diag_j           = hypre_CSRMatrixJ(diag);
+   HYPRE_Complex      *diag_data        = hypre_CSRMatrixData(diag);
+   HYPRE_Int          *offd_i           = hypre_CSRMatrixI(offd);
+   HYPRE_Int          *offd_j           = hypre_CSRMatrixJ(offd);
+   HYPRE_Complex      *offd_data        = hypre_CSRMatrixData(offd);
+   HYPRE_BigInt       *col_map_offd     = hypre_ParCSRMatrixDeviceColMapOffd(par_matrix);
+
+   hypre_ParCSRMatrix *h_parcsr;
+   HYPRE_IJMatrix      h_matrix;
+   HYPRE_Int          *h_ncols;
+   HYPRE_BigInt       *extended_rows;
+   HYPRE_BigInt       *extended_cols    = cols;
+   HYPRE_BigInt       *h_rows, *h_cols;
+   HYPRE_Complex      *h_values;
+   HYPRE_Int           i, num_nonzeros;
+
+   HYPRE_Int          *d_row_indexes    = row_indexes;
+   HYPRE_Int          *temp_row_indexes = NULL;
+   HYPRE_Int           num_get_rows;
+
+   hypre_GpuProfilingPushRange("IJMatrixGetValuesParCSR");
+
+   if (nrows > 0)
+   {
+      if (!d_row_indexes)
+      {
+         temp_row_indexes = hypre_TAlloc(HYPRE_Int, nrows + 1, HYPRE_MEMORY_DEVICE);
+         hypre_TMemcpy(temp_row_indexes + 1, ncols, HYPRE_Int, nrows, HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+         hypre_Memset(temp_row_indexes, 0, sizeof(HYPRE_Int), HYPRE_MEMORY_DEVICE);
+         hypreDevice_IntegerExclusiveScan(nrows + 1, temp_row_indexes);
+         d_row_indexes = temp_row_indexes;
+      }
+
+      hypre_TMemcpy(&num_nonzeros, d_row_indexes + nrows, HYPRE_Int, 1,
+                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+      extended_rows = hypre_TAlloc(HYPRE_BigInt, num_nonzeros, HYPRE_MEMORY_DEVICE);
+      extended_cols = hypre_TAlloc(HYPRE_BigInt, num_nonzeros, HYPRE_MEMORY_DEVICE);
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+      HYPRE_THRUST_CALL(for_each,
+                        thrust::make_counting_iterator(0),
+                        thrust::make_counting_iterator(nrows),
+      [=] __device__ (HYPRE_Int i)
+      {
+         for (HYPRE_Int j = d_row_indexes[i]; j < d_row_indexes[i + 1]; j++)
+         {
+            extended_rows[j] = rows[i];
+         }
+      });
+#elif defined(HYPRE_USING_SYCL)
+      HYPRE_ONEDPL_CALL(for_each,
+                        oneapi::dpl::make_counting_iterator<HYPRE_Int>(0),
+                        oneapi::dpl::make_counting_iterator<HYPRE_Int>(nrows),
+      [=] (HYPRE_Int i)
+      {
+         for (HYPRE_Int j = d_row_indexes[i]; j < d_row_indexes[i + 1]; j++)
+         {
+            extended_rows[j] = rows[i];
+         }
+      });
+#endif
+
+      hypreDevice_ComplexFilln(values, num_nonzeros, 0.0);
+
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+      HYPRE_THRUST_CALL(for_each,
+                        thrust::make_counting_iterator(0),
+                        thrust::make_counting_iterator(num_nonzeros),
+      [=] __device__ (HYPRE_Int k)
+      {
+         HYPRE_BigInt g_row = extended_rows[k];
+         HYPRE_BigInt g_col = extended_cols[k];
+
+         if (g_row >= row_start && g_row < row_end)
+         {
+            HYPRE_Int l_row = g_row - row_start;
+            if (g_col >= col_start && g_col < col_end)
+            {
+               HYPRE_Int        l_col   = g_col - col_start;
+               const HYPRE_Int *p_begin = diag_j + diag_i[l_row];
+               const HYPRE_Int *p_end   = diag_j + diag_i[l_row + 1];
+               const HYPRE_Int *p_found = thrust::lower_bound(thrust::seq, p_begin, p_end, l_col);
+               if (p_found < p_end && *p_found == l_col)
+               {
+                  HYPRE_Int offset = p_found - diag_j;
+                  values[k] = diag_data[offset];
+                  if (zero_out) diag_data[offset] = 0.0;
+               }
+            }
+            else
+            {
+               for (HYPRE_Int j = offd_i[l_row]; j < offd_i[l_row + 1]; j++)
+               {
+                  if (col_map_offd[offd_j[j]] == g_col)
+                  {
+                     values[k] = offd_data[j];
+                     if (zero_out) offd_data[j] = 0.0;
+                     break;
+                  }
+               }
+            }
+         }
+      });
+#elif defined(HYPRE_USING_SYCL)
+      HYPRE_ONEDPL_CALL(for_each,
+                        oneapi::dpl::make_counting_iterator<HYPRE_Int>(0),
+                        oneapi::dpl::make_counting_iterator<HYPRE_Int>(total_lookups),
+      [=] (HYPRE_Int k)
+      {
+         HYPRE_BigInt g_row = extended_rows[k];
+         HYPRE_BigInt g_col = extended_cols[k];
+
+         if (g_row >= row_start && g_row < row_end)
+         {
+            HYPRE_Int l_row = g_row - row_start;
+            if (g_col >= col_start && g_col < col_end)
+            {
+               HYPRE_Int        l_col   = g_col - col_start;
+               const HYPRE_Int *p_begin = diag_j + diag_i[l_row];
+               const HYPRE_Int *p_end   = diag_j + diag_i[l_row + 1];
+               const HYPRE_Int *p_found = std::lower_bound(p_begin, p_end, l_col);
+               if (p_found < p_end && *p_found == l_col)
+               {
+                  HYPRE_Int offset = p_found - diag_j;
+                  values[k] = diag_data[offset];
+                  if (zero_out) diag_data[offset] = 0.0;
+               }
+            }
+            else
+            {
+               for (HYPRE_Int j = offd_i[l_row]; j < offd_i[l_row + 1]; j++)
+               {
+                  if (col_map_offd[offd_j[j]] == g_col)
+                  {
+                     values[k] = offd_data[j];
+                     if (zero_out) offd_data[j] = 0.0;
+                     break;
+                  }
+               }
+            }
+         }
+      });
+#endif
+
+      hypre_TFree(extended_rows, HYPRE_MEMORY_DEVICE);
+      hypre_TFree(temp_row_indexes, HYPRE_MEMORY_DEVICE);
+   }
+   else
+   {
+      /* The host implementation for this case is inherently serial.
+         Fallback to host by copying data. */
+      num_get_rows = -nrows;
+
+      h_parcsr = hypre_ParCSRMatrixClone_v2(par_matrix, 1, HYPRE_MEMORY_HOST );
+      HYPRE_IJMatrixPartialClone(matrix, &h_matrix);
+      hypre_IJMatrixObject(h_matrix) = h_parcsr;
+
+      h_ncols = hypre_TAlloc(HYPRE_Int, num_get_rows, HYPRE_MEMORY_HOST);
+      h_rows  = hypre_TAlloc(HYPRE_BigInt, num_get_rows, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(h_ncols, ncols, HYPRE_Int, num_get_rows,
+                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+      hypre_TMemcpy(h_rows, rows, HYPRE_BigInt, num_get_rows,
+                    HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+
+      for (i = 0, num_nonzeros = 0; i < num_get_rows; i++)
+      {
+         num_nonzeros += h_ncols[i];
+      }
+
+      h_cols   = hypre_TAlloc(HYPRE_BigInt,  num_nonzeros, HYPRE_MEMORY_HOST);
+      h_values = hypre_TAlloc(HYPRE_Complex, num_nonzeros, HYPRE_MEMORY_HOST);
+
+      hypre_IJMatrixGetValuesParCSR(h_matrix, nrows, h_ncols, h_rows, NULL,
+                                    h_cols, h_values, zero_out);
+
+      hypre_TMemcpy(ncols, h_ncols, HYPRE_Int, num_get_rows,
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(cols, h_cols, HYPRE_BigInt, num_nonzeros,
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(values, h_values, HYPRE_Complex, num_nonzeros,
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+
+      if (zero_out)
+      {
+         /* If data was zeroed out on host, we need to copy the modified matrix back to device */
+         hypre_ParCSRMatrixDestroy(par_matrix);
+         hypre_IJMatrixObject(matrix) = hypre_ParCSRMatrixClone_v2(h_parcsr, 1, HYPRE_MEMORY_DEVICE);
+      }
+
+      hypre_TFree(h_ncols, HYPRE_MEMORY_HOST);
+      hypre_TFree(h_rows, HYPRE_MEMORY_HOST);
+      hypre_TFree(h_cols, HYPRE_MEMORY_HOST);
+      hypre_TFree(h_values, HYPRE_MEMORY_HOST);
+      HYPRE_IJMatrixDestroy(h_matrix);
+   }
+
+   hypre_GpuProfilingPopRange();
 
    return hypre_error_flag;
 }

--- a/src/IJ_mv/_hypre_IJ_mv.h
+++ b/src/IJ_mv/_hypre_IJ_mv.h
@@ -454,9 +454,6 @@ HYPRE_Int hypre_IJMatrixGetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrow
 HYPRE_Int hypre_IJMatrixSetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols,
                                           const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
                                           const HYPRE_Complex *values );
-HYPRE_Int hypre_IJMatrixSetAddValuesParCSRDevice ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
-                                                   HYPRE_Int *ncols, const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
-                                                   const HYPRE_Complex *values, const char *action );
 HYPRE_Int hypre_IJMatrixSetConstantValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Complex value );
 HYPRE_Int hypre_IJMatrixAddToValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
                                             HYPRE_Int *ncols, const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
@@ -481,15 +478,25 @@ HYPRE_Int hypre_IJMatrixSetValuesOMPParCSR ( hypre_IJMatrix *matrix, HYPRE_Int n
 HYPRE_Int hypre_IJMatrixAddToValuesOMPParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
                                                HYPRE_Int *ncols, const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
                                                const HYPRE_Complex *values );
-HYPRE_Int hypre_IJMatrixAssembleParCSRDevice(hypre_IJMatrix *matrix);
 HYPRE_Int hypre_IJMatrixInitializeParCSR_v2(hypre_IJMatrix *matrix,
                                             HYPRE_MemoryLocation memory_location);
-HYPRE_Int hypre_IJMatrixSetConstantValuesParCSRDevice( hypre_IJMatrix *matrix,
-                                                       HYPRE_Complex value );
 HYPRE_Int hypre_IJMatrixMigrateParCSR(hypre_IJMatrix *matrix, HYPRE_MemoryLocation memory_location);
 
 HYPRE_Int hypre_IJMatrixAssembleCommunicate(hypre_IJMatrix *matrix);
+
+/* IJMatrix_parcsr_device.c */
+HYPRE_Int hypre_IJMatrixSetConstantValuesParCSRDevice( hypre_IJMatrix *matrix,
+                                                       HYPRE_Complex value );
+HYPRE_Int hypre_IJMatrixSetAddValuesParCSRDevice ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
+                                                   HYPRE_Int *ncols, const HYPRE_BigInt *rows,
+                                                   const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
+                                                   const HYPRE_Complex *values, const char *action );
+HYPRE_Int hypre_IJMatrixGetValuesParCSRDevice( hypre_IJMatrix *matrix, HYPRE_Int nrows,
+                                               HYPRE_Int *ncols, HYPRE_BigInt *rows,
+                                               HYPRE_Int *row_indexes, HYPRE_BigInt *cols,
+                                               HYPRE_Complex *values, HYPRE_Int zero_out );
 HYPRE_Int hypre_IJMatrixAssembleCompressDevice(hypre_IJMatrix *matrix, HYPRE_Int reduce_stack_size);
+HYPRE_Int hypre_IJMatrixAssembleParCSRDevice(hypre_IJMatrix *matrix);
 
 /* IJMatrix_petsc.c */
 HYPRE_Int hypre_IJMatrixSetLocalSizePETSc ( hypre_IJMatrix *matrix, HYPRE_Int local_m,
@@ -547,12 +554,15 @@ HYPRE_Int hypre_IJVectorGetValuesPar ( hypre_IJVector *vector, HYPRE_Int num_val
 HYPRE_Int hypre_IJVectorAssembleOffProcValsPar ( hypre_IJVector *vector,
                                                  HYPRE_Int max_off_proc_elmts, HYPRE_Int current_num_elmts, HYPRE_MemoryLocation memory_location,
                                                  HYPRE_BigInt *off_proc_i, HYPRE_Complex *off_proc_data );
+HYPRE_Int hypre_IJVectorMigrateParCSR(hypre_IJVector *vector, HYPRE_MemoryLocation memory_location);
+
+/* IJVector_parcsr_device.c */
 HYPRE_Int hypre_IJVectorSetAddValuesParDevice(hypre_IJVector *vector, HYPRE_Int num_values,
                                               const HYPRE_BigInt *indices, const HYPRE_Complex *values, const char *action);
 HYPRE_Int hypre_IJVectorAssembleParDevice(hypre_IJVector *vector);
 HYPRE_Int hypre_IJVectorUpdateValuesDevice( hypre_IJVector *vector, HYPRE_Int num_values,
                                             const HYPRE_BigInt *indices, const HYPRE_Complex *values, HYPRE_Int action);
-HYPRE_Int hypre_IJVectorMigrateParCSR(hypre_IJVector *vector, HYPRE_MemoryLocation memory_location);
+
 
 /* HYPRE_IJMatrix.c */
 HYPRE_Int HYPRE_IJMatrixCreate ( MPI_Comm comm, HYPRE_BigInt ilower, HYPRE_BigInt iupper,

--- a/src/IJ_mv/protos.h
+++ b/src/IJ_mv/protos.h
@@ -82,9 +82,6 @@ HYPRE_Int hypre_IJMatrixGetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrow
 HYPRE_Int hypre_IJMatrixSetValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows, HYPRE_Int *ncols,
                                           const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
                                           const HYPRE_Complex *values );
-HYPRE_Int hypre_IJMatrixSetAddValuesParCSRDevice ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
-                                                   HYPRE_Int *ncols, const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
-                                                   const HYPRE_Complex *values, const char *action );
 HYPRE_Int hypre_IJMatrixSetConstantValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Complex value );
 HYPRE_Int hypre_IJMatrixAddToValuesParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
                                             HYPRE_Int *ncols, const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
@@ -109,15 +106,25 @@ HYPRE_Int hypre_IJMatrixSetValuesOMPParCSR ( hypre_IJMatrix *matrix, HYPRE_Int n
 HYPRE_Int hypre_IJMatrixAddToValuesOMPParCSR ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
                                                HYPRE_Int *ncols, const HYPRE_BigInt *rows, const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
                                                const HYPRE_Complex *values );
-HYPRE_Int hypre_IJMatrixAssembleParCSRDevice(hypre_IJMatrix *matrix);
 HYPRE_Int hypre_IJMatrixInitializeParCSR_v2(hypre_IJMatrix *matrix,
                                             HYPRE_MemoryLocation memory_location);
-HYPRE_Int hypre_IJMatrixSetConstantValuesParCSRDevice( hypre_IJMatrix *matrix,
-                                                       HYPRE_Complex value );
 HYPRE_Int hypre_IJMatrixMigrateParCSR(hypre_IJMatrix *matrix, HYPRE_MemoryLocation memory_location);
 
 HYPRE_Int hypre_IJMatrixAssembleCommunicate(hypre_IJMatrix *matrix);
+
+/* IJMatrix_parcsr_device.c */
+HYPRE_Int hypre_IJMatrixSetConstantValuesParCSRDevice( hypre_IJMatrix *matrix,
+                                                       HYPRE_Complex value );
+HYPRE_Int hypre_IJMatrixSetAddValuesParCSRDevice ( hypre_IJMatrix *matrix, HYPRE_Int nrows,
+                                                   HYPRE_Int *ncols, const HYPRE_BigInt *rows,
+                                                   const HYPRE_Int *row_indexes, const HYPRE_BigInt *cols,
+                                                   const HYPRE_Complex *values, const char *action );
+HYPRE_Int hypre_IJMatrixGetValuesParCSRDevice( hypre_IJMatrix *matrix, HYPRE_Int nrows,
+                                               HYPRE_Int *ncols, HYPRE_BigInt *rows,
+                                               HYPRE_Int *row_indexes, HYPRE_BigInt *cols,
+                                               HYPRE_Complex *values, HYPRE_Int zero_out );
 HYPRE_Int hypre_IJMatrixAssembleCompressDevice(hypre_IJMatrix *matrix, HYPRE_Int reduce_stack_size);
+HYPRE_Int hypre_IJMatrixAssembleParCSRDevice(hypre_IJMatrix *matrix);
 
 /* IJMatrix_petsc.c */
 HYPRE_Int hypre_IJMatrixSetLocalSizePETSc ( hypre_IJMatrix *matrix, HYPRE_Int local_m,
@@ -175,12 +182,15 @@ HYPRE_Int hypre_IJVectorGetValuesPar ( hypre_IJVector *vector, HYPRE_Int num_val
 HYPRE_Int hypre_IJVectorAssembleOffProcValsPar ( hypre_IJVector *vector,
                                                  HYPRE_Int max_off_proc_elmts, HYPRE_Int current_num_elmts, HYPRE_MemoryLocation memory_location,
                                                  HYPRE_BigInt *off_proc_i, HYPRE_Complex *off_proc_data );
+HYPRE_Int hypre_IJVectorMigrateParCSR(hypre_IJVector *vector, HYPRE_MemoryLocation memory_location);
+
+/* IJVector_parcsr_device.c */
 HYPRE_Int hypre_IJVectorSetAddValuesParDevice(hypre_IJVector *vector, HYPRE_Int num_values,
                                               const HYPRE_BigInt *indices, const HYPRE_Complex *values, const char *action);
 HYPRE_Int hypre_IJVectorAssembleParDevice(hypre_IJVector *vector);
 HYPRE_Int hypre_IJVectorUpdateValuesDevice( hypre_IJVector *vector, HYPRE_Int num_values,
                                             const HYPRE_BigInt *indices, const HYPRE_Complex *values, HYPRE_Int action);
-HYPRE_Int hypre_IJVectorMigrateParCSR(hypre_IJVector *vector, HYPRE_MemoryLocation memory_location);
+
 
 /* HYPRE_IJMatrix.c */
 HYPRE_Int HYPRE_IJMatrixCreate ( MPI_Comm comm, HYPRE_BigInt ilower, HYPRE_BigInt iupper,

--- a/src/krylov/pcg.c
+++ b/src/krylov/pcg.c
@@ -217,6 +217,7 @@ hypre_PCGSetup( void *pcg_vdata,
    void          *precond_data     = (pcg_data -> precond_data);
 
    HYPRE_ANNOTATE_FUNC_BEGIN;
+   hypre_GpuProfilingPushRange("PCG-Setup");
 
    (pcg_data -> A) = A;
 
@@ -291,6 +292,7 @@ hypre_PCGSetup( void *pcg_vdata,
                                                 pcg_functions, HYPRE_MEMORY_HOST );
    }
 
+   hypre_GpuProfilingPopRange();
    HYPRE_ANNOTATE_FUNC_END;
 
    return hypre_error_flag;
@@ -380,6 +382,7 @@ hypre_PCGSolve( void *pcg_vdata,
    HYPRE_Int       my_id, num_procs;
 
    HYPRE_ANNOTATE_FUNC_BEGIN;
+   hypre_GpuProfilingPushRange("PCG-Solve");
 
    (pcg_data -> converged) = 0;
 
@@ -439,6 +442,8 @@ hypre_PCGSolve( void *pcg_vdata,
          hypre_printf("ERROR detected by Hypre ...  END\n\n\n");
       }
       hypre_error(HYPRE_ERROR_GENERIC);
+
+      hypre_GpuProfilingPopRange();
       HYPRE_ANNOTATE_FUNC_END;
 
       return hypre_error_flag;
@@ -478,6 +483,7 @@ hypre_PCGSolve( void *pcg_vdata,
          norms[0]     = 0.0;
          rel_norms[i] = 0.0;
       }
+      hypre_GpuProfilingPopRange();
       HYPRE_ANNOTATE_FUNC_END;
 
       return hypre_error_flag;
@@ -517,6 +523,7 @@ hypre_PCGSolve( void *pcg_vdata,
          hypre_printf("ERROR detected by Hypre ...  END\n\n\n");
       }
       hypre_error(HYPRE_ERROR_GENERIC);
+      hypre_GpuProfilingPopRange();
       HYPRE_ANNOTATE_FUNC_END;
 
       return hypre_error_flag;
@@ -1002,6 +1009,7 @@ hypre_PCGSolve( void *pcg_vdata,
       (pcg_data -> rel_residual_norm) = 0.0;
    }
 
+   hypre_GpuProfilingPopRange();
    HYPRE_ANNOTATE_FUNC_END;
 
    return hypre_error_flag;

--- a/src/parcsr_ls/ads.c
+++ b/src/parcsr_ls/ads.c
@@ -1213,7 +1213,7 @@ hypre_ADSSetup(void *solver,
          {
             ads_data -> A_C = hypre_ParCSRMatrixRAPKT(ads_data -> C,
                                                       ads_data -> A,
-                                                      ads_data -> C, 1);
+                                                      ads_data -> C, 1, 1);
          }
          else
 #endif
@@ -1326,7 +1326,7 @@ hypre_ADSSetup(void *solver,
       {
          ads_data -> A_Pix = hypre_ParCSRMatrixRAPKT(ads_data -> Pix,
                                                      ads_data -> A,
-                                                     ads_data -> Pix, 1);
+                                                     ads_data -> Pix, 1, 1);
       }
       else
 #endif
@@ -1351,7 +1351,7 @@ hypre_ADSSetup(void *solver,
       {
          ads_data -> A_Piy = hypre_ParCSRMatrixRAPKT(ads_data -> Piy,
                                                      ads_data -> A,
-                                                     ads_data -> Piy, 1);
+                                                     ads_data -> Piy, 1, 1);
       }
       else
 #endif
@@ -1376,7 +1376,7 @@ hypre_ADSSetup(void *solver,
       {
          ads_data -> A_Piz = hypre_ParCSRMatrixRAPKT(ads_data -> Piz,
                                                      ads_data -> A,
-                                                     ads_data -> Piz, 1);
+                                                     ads_data -> Piz, 1, 1);
       }
       else
 #endif
@@ -1430,7 +1430,7 @@ hypre_ADSSetup(void *solver,
          {
             ads_data -> A_Pi = hypre_ParCSRMatrixRAPKT(ads_data -> Pi,
                                                        ads_data -> A,
-                                                       ads_data -> Pi, 1);
+                                                       ads_data -> Pi, 1, 1);
          }
          else
 #endif

--- a/src/parcsr_ls/ame.c
+++ b/src/parcsr_ls/ame.c
@@ -604,7 +604,7 @@ HYPRE_Int hypre_AMESetup(void *esolver)
 #if defined(HYPRE_USING_GPU)
       if (exec == HYPRE_EXEC_DEVICE)
       {
-         ame_data -> A_G = hypre_ParCSRMatrixRAPKT(ame_data -> G, ame_data -> M, ame_data -> G, 1);
+         ame_data -> A_G = hypre_ParCSRMatrixRAPKT(ame_data -> G, ame_data -> M, ame_data -> G, 1, 1);
       }
       else
 #endif

--- a/src/parcsr_ls/ams.c
+++ b/src/parcsr_ls/ams.c
@@ -3345,7 +3345,7 @@ hypre_AMSSetup(void *solver,
          {
             ams_data -> A_G = hypre_ParCSRMatrixRAPKT(ams_data -> G,
                                                       ams_data -> A,
-                                                      ams_data -> G, 1);
+                                                      ams_data -> G, 1, 1);
          }
          else
 #endif
@@ -3430,7 +3430,7 @@ hypre_AMSSetup(void *solver,
 #if defined(HYPRE_USING_GPU)
       if (exec == HYPRE_EXEC_DEVICE)
       {
-         ams_data -> A_Pix = hypre_ParCSRMatrixRAPKT(ams_data -> Pix, ams_data -> A, ams_data -> Pix, 1);
+         ams_data -> A_Pix = hypre_ParCSRMatrixRAPKT(ams_data -> Pix, ams_data -> A, ams_data -> Pix, 1, 1);
       }
       else
 #endif
@@ -3461,7 +3461,7 @@ hypre_AMSSetup(void *solver,
          {
             ams_data -> A_Piy = hypre_ParCSRMatrixRAPKT(ams_data -> Piy,
                                                         ams_data -> A,
-                                                        ams_data -> Piy, 1);
+                                                        ams_data -> Piy, 1, 1);
          }
          else
 #endif
@@ -3493,7 +3493,7 @@ hypre_AMSSetup(void *solver,
          {
             ams_data -> A_Piz = hypre_ParCSRMatrixRAPKT(ams_data -> Piz,
                                                         ams_data -> A,
-                                                        ams_data -> Piz, 1);
+                                                        ams_data -> Piz, 1, 1);
          }
          else
 #endif
@@ -3694,7 +3694,7 @@ hypre_AMSSetup(void *solver,
 #if defined(HYPRE_USING_GPU)
                if (exec == HYPRE_EXEC_DEVICE)
                {
-                  ams_data -> A_Pi = hypre_ParCSRMatrixRAPKT(ams_data -> Pi, ApGGt, ams_data -> Pi, 1);
+                  ams_data -> A_Pi = hypre_ParCSRMatrixRAPKT(ams_data -> Pi, ApGGt, ams_data -> Pi, 1, 1);
                }
                else
 #endif
@@ -3711,7 +3711,7 @@ hypre_AMSSetup(void *solver,
 #if defined(HYPRE_USING_GPU)
             if (exec == HYPRE_EXEC_DEVICE)
             {
-               ams_data -> A_Pi = hypre_ParCSRMatrixRAPKT(ams_data -> Pi, ams_data -> A, ams_data -> Pi, 1);
+               ams_data -> A_Pi = hypre_ParCSRMatrixRAPKT(ams_data -> Pi, ams_data -> A, ams_data -> Pi, 1, 1);
             }
             else
 #endif

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -2886,7 +2886,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
                   if (hypre_ParAMGDataModularizedMatMat(amg_data))
                   {
                      A_H = hypre_ParCSRMatrixRAPKT(P, A_array[level],
-                                                   P, keepTranspose);
+                                                   P, keepTranspose, 1);
                   }
                   else
                   {
@@ -3072,7 +3072,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
             if (hypre_ParAMGDataModularizedMatMat(amg_data))
             {
                A_H = hypre_ParCSRMatrixRAPKT(P_array[level], A_array[level],
-                                             P_array[level], keepTranspose);
+                                             P_array[level], keepTranspose, 1);
             }
             else
             {
@@ -4038,7 +4038,7 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
    }
 #endif
 
-   hypre_MemoryPrintUsage(comm, hypre_HandleLogLevel(hypre_handle()), "BoomerAMG setup end", 0);
+   hypre_MemoryPrintUsage(comm, hypre_HandleLogLevel(hypre_handle()), "BoomerAMG setup end  ", 0);
    hypre_GpuProfilingPopRange();
    HYPRE_ANNOTATE_FUNC_END;
 

--- a/src/parcsr_ls/par_mgr_rap.c
+++ b/src/parcsr_ls/par_mgr_rap.c
@@ -616,7 +616,7 @@ hypre_MGRBuildCoarseOperator(void                *mgr_vdata,
       }
       else if (RT)
       {
-         RAP = hypre_ParCSRMatrixRAPKT(RT, A, P, 1);
+         RAP = hypre_ParCSRMatrixRAPKT(RT, A, P, 1, 0);
       }
       else if (R)
       {

--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -1255,13 +1255,15 @@ hypre_ParCSRMatrix *hypre_ParCSRTMatMatKTDevice( hypre_ParCSRMatrix  *A, hypre_P
                                                  HYPRE_Int keep_transpose);
 hypre_ParCSRMatrix *hypre_ParCSRTMatMatKT( hypre_ParCSRMatrix  *A, hypre_ParCSRMatrix  *B,
                                            HYPRE_Int keep_transpose);
-hypre_ParCSRMatrix *hypre_ParCSRTMatMat( hypre_ParCSRMatrix  *A, hypre_ParCSRMatrix  *B);
-hypre_ParCSRMatrix *hypre_ParCSRMatrixRAPKT( hypre_ParCSRMatrix *R, hypre_ParCSRMatrix  *A,
-                                             hypre_ParCSRMatrix  *P, HYPRE_Int keepTranspose );
+hypre_ParCSRMatrix *hypre_ParCSRTMatMat( hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *B);
+hypre_ParCSRMatrix *hypre_ParCSRMatrixRAPKT( hypre_ParCSRMatrix *R, hypre_ParCSRMatrix *A,
+                                             hypre_ParCSRMatrix *P, HYPRE_Int keep_transpose,
+                                             HYPRE_Int has_diagonal );
 hypre_ParCSRMatrix *hypre_ParCSRMatrixRAP( hypre_ParCSRMatrix *R, hypre_ParCSRMatrix  *A,
-                                           hypre_ParCSRMatrix  *P );
+                                           hypre_ParCSRMatrix *P );
 hypre_ParCSRMatrix* hypre_ParCSRMatrixRAPKTDevice( hypre_ParCSRMatrix *R, hypre_ParCSRMatrix *A,
-                                                   hypre_ParCSRMatrix *P, HYPRE_Int keep_transpose );
+                                                   hypre_ParCSRMatrix *P, HYPRE_Int keep_transpose,
+                                                   HYPRE_Int has_diagonal );
 hypre_ParCSRMatrix* hypre_ParCSRMatrixRAPKTHost( hypre_ParCSRMatrix *R, hypre_ParCSRMatrix *A,
                                                  hypre_ParCSRMatrix *P, HYPRE_Int keep_transpose );
 

--- a/src/parcsr_mv/par_csr_triplemat_device.c
+++ b/src/parcsr_mv/par_csr_triplemat_device.c
@@ -60,7 +60,10 @@ struct RAP_functor
    }
 };
 
-/* C = A * B */
+/*--------------------------------------------------------------------------
+ * Computes C = A * B on the device
+ *--------------------------------------------------------------------------*/
+
 hypre_ParCSRMatrix*
 hypre_ParCSRMatMatDevice( hypre_ParCSRMatrix  *A,
                           hypre_ParCSRMatrix  *B )
@@ -310,7 +313,10 @@ hypre_ParCSRMatMatDevice( hypre_ParCSRMatrix  *A,
    return C;
 }
 
-/* C = A^T * B */
+/*--------------------------------------------------------------------------
+ * Computes C = A^T * B on the device
+ *--------------------------------------------------------------------------*/
+
 hypre_ParCSRMatrix*
 hypre_ParCSRTMatMatKTDevice( hypre_ParCSRMatrix  *A,
                              hypre_ParCSRMatrix  *B,
@@ -614,23 +620,30 @@ hypre_ParCSRTMatMatKTDevice( hypre_ParCSRMatrix  *A,
    return C;
 }
 
-/* C = R^{T} * A * P */
+/*--------------------------------------------------------------------------
+ * Computes C = R^{T} * A * P on the device.
+ *
+ * See hypre_ParCSRMatrixRAPKT for notes about the input arguments.
+ *--------------------------------------------------------------------------*/
+
 hypre_ParCSRMatrix*
 hypre_ParCSRMatrixRAPKTDevice( hypre_ParCSRMatrix *R,
                                hypre_ParCSRMatrix *A,
                                hypre_ParCSRMatrix *P,
-                               HYPRE_Int           keep_transpose )
+                               HYPRE_Int           keep_transpose,
+                               HYPRE_Int           has_diagonal )
 {
    MPI_Comm             comm   = hypre_ParCSRMatrixComm(A);
    hypre_CSRMatrix     *R_diag = hypre_ParCSRMatrixDiag(R);
    hypre_CSRMatrix     *R_offd = hypre_ParCSRMatrixOffd(R);
 
    hypre_ParCSRMatrix  *C;
-   hypre_CSRMatrix     *C_diag;
+   hypre_CSRMatrix     *C_diag, *C_diag_new;
    hypre_CSRMatrix     *C_offd;
+   hypre_CSRMatrix     *zero;
+
    HYPRE_Int            num_cols_offd_C = 0;
    HYPRE_BigInt        *col_map_offd_C = NULL;
-
    HYPRE_Int            num_procs;
 
    hypre_MPI_Comm_size(comm, &num_procs);
@@ -650,6 +663,8 @@ hypre_ParCSRMatrixRAPKTDevice( hypre_ParCSRMatrix *R,
       hypre_printf(" Error! Incompatible matrix local dimensions!\n");
       return NULL;
    }
+
+   hypre_GpuProfilingPushRange("ParCSRMatrixRAPKT");
 
    if (num_procs > 1)
    {
@@ -862,28 +877,35 @@ hypre_ParCSRMatrixRAPKTDevice( hypre_ParCSRMatrix *R,
    hypre_ParCSRMatrixCompressOffdMapDevice(C);
    hypre_ParCSRMatrixCopyColMapOffdToHost(C);
 
-   /* Ensure that the diagonal entries exist in the matrix structure (even if numerically zero) */
-   if (hypre_CSRMatrixCheckForMissingDiagonal(C_diag))
+   if (has_diagonal)
    {
-      hypre_CSRMatrix *zero = hypre_CSRMatrixIdentityDevice(hypre_CSRMatrixNumRows(C_diag), 0.0);
+      /* Ensure that the diagonal entries exist in the matrix structure
+         (even if numerically zero) */
+      if (hypre_CSRMatrixCheckForMissingDiagonal(C_diag))
+      {
+         zero = hypre_CSRMatrixIdentityDevice(hypre_CSRMatrixNumRows(C_diag), 0.0);
+         C_diag_new = hypre_CSRMatrixAddDevice(1.0, C_diag, 1.0, zero);
 
-      hypre_CSRMatrix *C_diag_new = hypre_CSRMatrixAddDevice(1.0, C_diag, 1.0, zero);
+         hypre_CSRMatrixDestroy(C_diag);
+         hypre_CSRMatrixDestroy(zero);
 
-      hypre_CSRMatrixDestroy(C_diag);
-      hypre_CSRMatrixDestroy(zero);
+         hypre_ParCSRMatrixDiag(C) = C_diag_new;
+      }
 
-      hypre_ParCSRMatrixDiag(C) = C_diag_new;
+      /* Move the diagonal entry to the first of each row */
+      hypre_CSRMatrixMoveDiagFirstDevice(hypre_ParCSRMatrixDiag(C));
+      hypre_assert(!hypre_CSRMatrixCheckDiagFirstDevice(hypre_ParCSRMatrixDiag(C)));
    }
-
-   /* Move the diagonal entry to the first of each row */
-   hypre_CSRMatrixMoveDiagFirstDevice(hypre_ParCSRMatrixDiag(C));
-
-   hypre_assert(!hypre_CSRMatrixCheckDiagFirstDevice(hypre_ParCSRMatrixDiag(C)));
 
    hypre_SyncComputeStream();
 
+   hypre_GpuProfilingPopRange();
+
    return C;
 }
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_ParCSRTMatMatPartialAddDevice( hypre_ParCSRCommPkg *comm_pkg,
@@ -913,7 +935,8 @@ hypre_ParCSRTMatMatPartialAddDevice( hypre_ParCSRCommPkg *comm_pkg,
    hypre_CSRMatrix *Cz;
 
    // local part of Cbar
-   hypre_CSRMatrix *Cbar_local = hypre_CSRMatrixCreate(num_rows, hypre_CSRMatrixNumCols(Cbar),
+   hypre_CSRMatrix *Cbar_local = hypre_CSRMatrixCreate(num_rows,
+                                                       hypre_CSRMatrixNumCols(Cbar),
                                                        local_nnz_Cbar);
    hypre_CSRMatrixI(Cbar_local) = hypre_CSRMatrixI(Cbar);
    hypre_CSRMatrixJ(Cbar_local) = hypre_CSRMatrixJ(Cbar);

--- a/src/parcsr_mv/protos.h
+++ b/src/parcsr_mv/protos.h
@@ -591,13 +591,15 @@ hypre_ParCSRMatrix *hypre_ParCSRTMatMatKTDevice( hypre_ParCSRMatrix  *A, hypre_P
                                                  HYPRE_Int keep_transpose);
 hypre_ParCSRMatrix *hypre_ParCSRTMatMatKT( hypre_ParCSRMatrix  *A, hypre_ParCSRMatrix  *B,
                                            HYPRE_Int keep_transpose);
-hypre_ParCSRMatrix *hypre_ParCSRTMatMat( hypre_ParCSRMatrix  *A, hypre_ParCSRMatrix  *B);
-hypre_ParCSRMatrix *hypre_ParCSRMatrixRAPKT( hypre_ParCSRMatrix *R, hypre_ParCSRMatrix  *A,
-                                             hypre_ParCSRMatrix  *P, HYPRE_Int keepTranspose );
+hypre_ParCSRMatrix *hypre_ParCSRTMatMat( hypre_ParCSRMatrix *A, hypre_ParCSRMatrix *B);
+hypre_ParCSRMatrix *hypre_ParCSRMatrixRAPKT( hypre_ParCSRMatrix *R, hypre_ParCSRMatrix *A,
+                                             hypre_ParCSRMatrix *P, HYPRE_Int keep_transpose,
+                                             HYPRE_Int has_diagonal );
 hypre_ParCSRMatrix *hypre_ParCSRMatrixRAP( hypre_ParCSRMatrix *R, hypre_ParCSRMatrix  *A,
-                                           hypre_ParCSRMatrix  *P );
+                                           hypre_ParCSRMatrix *P );
 hypre_ParCSRMatrix* hypre_ParCSRMatrixRAPKTDevice( hypre_ParCSRMatrix *R, hypre_ParCSRMatrix *A,
-                                                   hypre_ParCSRMatrix *P, HYPRE_Int keep_transpose );
+                                                   hypre_ParCSRMatrix *P, HYPRE_Int keep_transpose,
+                                                   HYPRE_Int has_diagonal );
 hypre_ParCSRMatrix* hypre_ParCSRMatrixRAPKTHost( hypre_ParCSRMatrix *R, hypre_ParCSRMatrix *A,
                                                  hypre_ParCSRMatrix *P, HYPRE_Int keep_transpose );
 

--- a/src/seq_mv/csr_matrix.c
+++ b/src/seq_mv/csr_matrix.c
@@ -356,6 +356,7 @@ hypre_CSRMatrixSetRownnzHost( hypre_CSRMatrix *matrix )
 
    HYPRE_Int             i, irownnz = 0;
 
+   /* Count the number of rows with nonzero entries */
    for (i = 0; i < num_rows; i++)
    {
       if ((A_i[i + 1] - A_i[i]) > 0)
@@ -366,7 +367,7 @@ hypre_CSRMatrixSetRownnzHost( hypre_CSRMatrix *matrix )
 
    hypre_CSRMatrixNumRownnz(matrix) = irownnz;
 
-   /* Free old rownnz pointer */
+   /* Free old rownnz array */
    hypre_TFree(Arownnz, memory_location);
 
    /* Set new rownnz pointer */
@@ -376,6 +377,7 @@ hypre_CSRMatrixSetRownnzHost( hypre_CSRMatrix *matrix )
    }
    else
    {
+      /* Compute new rownnz array */
       Arownnz = hypre_CTAlloc(HYPRE_Int, irownnz, memory_location);
       irownnz = 0;
       for (i = 0; i < num_rows; i++)
@@ -392,23 +394,26 @@ hypre_CSRMatrixSetRownnzHost( hypre_CSRMatrix *matrix )
 }
 
 /*--------------------------------------------------------------------------
- * hypre_CSRMatrixSetRownnz
- *
- * function to set the substructure rownnz and num_rowsnnz inside the CSRMatrix
- * it needs the A_i substructure of CSRMatrix to find the nonzero rows.
- * It runs after the create CSR and when A_i is known..It does not check for
- * the existence of A_i or of the CSR matrix.
+ * Function to set the array rownnz and num_rownnz inside the CSRMatrix.
+ *  - Needs the A_i array of CSRMatrix to find the nonzero rows.
+ *  - Does not check for the existence of A_i or of the CSR matrix.
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_CSRMatrixSetRownnz( hypre_CSRMatrix *matrix )
 {
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+   /* Return in case rownnz has been previously computed */
+   if (hypre_CSRMatrixRownnz(matrix))
+   {
+      return hypre_error_flag;
+   }
+
+#if defined(HYPRE_USING_GPU)
    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_CSRMatrixMemoryLocation(matrix) );
 
    if (exec == HYPRE_EXEC_DEVICE)
    {
-      // TODO RL: there's no need currently for having rownnz on GPUs
+      hypre_CSRMatrixSetRownnzDevice(matrix);
    }
    else
 #endif
@@ -922,8 +927,6 @@ hypre_CSRMatrixCopy( hypre_CSRMatrix *A, hypre_CSRMatrix *B, HYPRE_Int copy_data
  *
  * Migrates matrix row pointer, column indices and data to memory_location
  * if it is different to the current one.
- *
- * Note: Does not move rownnz array.
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -42,7 +42,7 @@ hypre_CSRMatrix * hypre_CSRMatrixAddPartial( hypre_CSRMatrix *A, hypre_CSRMatrix
                                              HYPRE_Int *row_nums);
 HYPRE_Int hypre_CSRMatrixComputeRowSum( hypre_CSRMatrix *A, HYPRE_Int *CF_i, HYPRE_Int *CF_j,
                                         HYPRE_Complex *row_sum, HYPRE_Int type, HYPRE_Complex scal,
-                                        const char *set_or_add );
+                                        const char *set_or_add);
 HYPRE_Int hypre_CSRMatrixComputeColSum( hypre_CSRMatrix *A, HYPRE_Complex *col_sum,
                                         HYPRE_Int type, HYPRE_Complex scal );
 HYPRE_Int hypre_CSRMatrixExtractDiagonal( hypre_CSRMatrix *A, HYPRE_Complex *d, HYPRE_Int type);
@@ -59,6 +59,7 @@ hypre_CSRMatrix *hypre_CSRMatrixAddDevice ( HYPRE_Complex alpha, hypre_CSRMatrix
 hypre_CSRMatrix *hypre_CSRMatrixMultiplyDevice ( hypre_CSRMatrix *A, hypre_CSRMatrix *B );
 hypre_CSRMatrix *hypre_CSRMatrixTripleMultiplyDevice ( hypre_CSRMatrix *A, hypre_CSRMatrix *B,
                                                        hypre_CSRMatrix *C );
+hypre_CSRMatrix *hypre_CSRMatrixDeleteZerosDevice ( hypre_CSRMatrix *A, HYPRE_Real tol );
 HYPRE_Int hypre_CSRMatrixMergeColMapOffd( HYPRE_Int num_cols_offd_B, HYPRE_BigInt *col_map_offd_B,
                                           HYPRE_Int B_ext_offd_nnz, HYPRE_BigInt *B_ext_offd_bigj, HYPRE_Int *num_cols_offd_C_ptr,
                                           HYPRE_BigInt **col_map_offd_C_ptr, HYPRE_Int **map_B_to_C_ptr );
@@ -74,6 +75,7 @@ HYPRE_Int hypre_CSRMatrixSplitDevice(hypre_CSRMatrix *B_ext, HYPRE_BigInt first_
                                      HYPRE_BigInt last_col_diag_B, HYPRE_Int num_cols_offd_B, HYPRE_BigInt *col_map_offd_B,
                                      HYPRE_Int **map_B_to_C_ptr, HYPRE_Int *num_cols_offd_C_ptr, HYPRE_BigInt **col_map_offd_C_ptr,
                                      hypre_CSRMatrix **B_ext_diag_ptr, hypre_CSRMatrix **B_ext_offd_ptr);
+HYPRE_Int hypre_CSRMatrixSetRownnzDevice( hypre_CSRMatrix *A );
 HYPRE_Int hypre_CSRMatrixTransposeDevice ( hypre_CSRMatrix *A, hypre_CSRMatrix **AT,
                                            HYPRE_Int data );
 hypre_CSRMatrix* hypre_CSRMatrixAddPartialDevice( hypre_CSRMatrix *A, hypre_CSRMatrix *B,

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -326,7 +326,7 @@ hypre_CSRMatrix * hypre_CSRMatrixAddPartial( hypre_CSRMatrix *A, hypre_CSRMatrix
                                              HYPRE_Int *row_nums);
 HYPRE_Int hypre_CSRMatrixComputeRowSum( hypre_CSRMatrix *A, HYPRE_Int *CF_i, HYPRE_Int *CF_j,
                                         HYPRE_Complex *row_sum, HYPRE_Int type, HYPRE_Complex scal,
-                                        const char *set_or_add );
+                                        const char *set_or_add);
 HYPRE_Int hypre_CSRMatrixComputeColSum( hypre_CSRMatrix *A, HYPRE_Complex *col_sum,
                                         HYPRE_Int type, HYPRE_Complex scal );
 HYPRE_Int hypre_CSRMatrixExtractDiagonal( hypre_CSRMatrix *A, HYPRE_Complex *d, HYPRE_Int type);
@@ -343,6 +343,7 @@ hypre_CSRMatrix *hypre_CSRMatrixAddDevice ( HYPRE_Complex alpha, hypre_CSRMatrix
 hypre_CSRMatrix *hypre_CSRMatrixMultiplyDevice ( hypre_CSRMatrix *A, hypre_CSRMatrix *B );
 hypre_CSRMatrix *hypre_CSRMatrixTripleMultiplyDevice ( hypre_CSRMatrix *A, hypre_CSRMatrix *B,
                                                        hypre_CSRMatrix *C );
+hypre_CSRMatrix *hypre_CSRMatrixDeleteZerosDevice ( hypre_CSRMatrix *A, HYPRE_Real tol );
 HYPRE_Int hypre_CSRMatrixMergeColMapOffd( HYPRE_Int num_cols_offd_B, HYPRE_BigInt *col_map_offd_B,
                                           HYPRE_Int B_ext_offd_nnz, HYPRE_BigInt *B_ext_offd_bigj, HYPRE_Int *num_cols_offd_C_ptr,
                                           HYPRE_BigInt **col_map_offd_C_ptr, HYPRE_Int **map_B_to_C_ptr );
@@ -358,6 +359,7 @@ HYPRE_Int hypre_CSRMatrixSplitDevice(hypre_CSRMatrix *B_ext, HYPRE_BigInt first_
                                      HYPRE_BigInt last_col_diag_B, HYPRE_Int num_cols_offd_B, HYPRE_BigInt *col_map_offd_B,
                                      HYPRE_Int **map_B_to_C_ptr, HYPRE_Int *num_cols_offd_C_ptr, HYPRE_BigInt **col_map_offd_C_ptr,
                                      hypre_CSRMatrix **B_ext_diag_ptr, hypre_CSRMatrix **B_ext_offd_ptr);
+HYPRE_Int hypre_CSRMatrixSetRownnzDevice( hypre_CSRMatrix *A );
 HYPRE_Int hypre_CSRMatrixTransposeDevice ( hypre_CSRMatrix *A, hypre_CSRMatrix **AT,
                                            HYPRE_Int data );
 hypre_CSRMatrix* hypre_CSRMatrixAddPartialDevice( hypre_CSRMatrix *A, hypre_CSRMatrix *B,

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -50,6 +50,7 @@ typedef void (*GPUMfreeFunc)(void *);
 typedef struct
 {
    HYPRE_Int              log_level;
+   HYPRE_Int              log_level_saved;
    HYPRE_Int              hypre_error;
    HYPRE_MemoryLocation   memory_location;
    HYPRE_ExecutionPolicy  default_exec_policy;
@@ -98,6 +99,7 @@ typedef struct
 
 /* accessor macros to hypre_Handle */
 #define hypre_HandleLogLevel(hypre_handle)                       ((hypre_handle) -> log_level)
+#define hypre_HandleLogLevelSaved(hypre_handle)                  ((hypre_handle) -> log_level_saved)
 #define hypre_HandleMemoryLocation(hypre_handle)                 ((hypre_handle) -> memory_location)
 #define hypre_HandleDefaultExecPolicy(hypre_handle)              ((hypre_handle) -> default_exec_policy)
 
@@ -2186,44 +2188,17 @@ HYPRE_Int hypre_DoubleQuickSplit ( HYPRE_Real *values, HYPRE_Int *indices, HYPRE
 /* HYPRE_CUDA_GLOBAL */ HYPRE_Real hypre_Rand ( void );
 
 /* prefix_sum.c */
-/**
- * Assumed to be called within an omp region.
- * Let x_i be the input of ith thread.
- * The output of ith thread y_i = x_0 + x_1 + ... + x_{i-1}
- * Additionally, sum = x_0 + x_1 + ... + x_{nthreads - 1}
- * Note that always y_0 = 0
- *
- * @param workspace at least with length (nthreads+1)
- *                  workspace[tid] will contain result for tid
- *                  workspace[nthreads] will contain sum
- */
-void hypre_prefix_sum(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int *workspace);
-/**
- * This version does prefix sum in pair.
- * Useful when we prefix sum of diag and offd in tandem.
- *
- * @param worksapce at least with length 2*(nthreads+1)
- *                  workspace[2*tid] and workspace[2*tid+1] will contain results for tid
- *                  workspace[3*nthreads] and workspace[3*nthreads + 1] will contain sums
- */
-void hypre_prefix_sum_pair(HYPRE_Int *in_out1, HYPRE_Int *sum1, HYPRE_Int *in_out2, HYPRE_Int *sum2,
-                           HYPRE_Int *workspace);
-/**
- * @param workspace at least with length 3*(nthreads+1)
- *                  workspace[3*tid:3*tid+3) will contain results for tid
- */
-void hypre_prefix_sum_triple(HYPRE_Int *in_out1, HYPRE_Int *sum1, HYPRE_Int *in_out2,
-                             HYPRE_Int *sum2, HYPRE_Int *in_out3, HYPRE_Int *sum3, HYPRE_Int *workspace);
-
-/**
- * n prefix-sums together.
- * workspace[n*tid:n*(tid+1)) will contain results for tid
- * workspace[nthreads*tid:nthreads*(tid+1)) will contain sums
- *
- * @param workspace at least with length n*(nthreads+1)
- */
-void hypre_prefix_sum_multiple(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int n,
-                               HYPRE_Int *workspace);
+HYPRE_Int hypre_PrefixSumInt(HYPRE_Int nvals, HYPRE_Int *vals, HYPRE_Int *sums);
+HYPRE_Int hypre_prefix_sum(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int *workspace);
+HYPRE_Int hypre_prefix_sum_pair(HYPRE_Int *in_out1, HYPRE_Int *sum1,
+                                HYPRE_Int *in_out2, HYPRE_Int *sum2,
+                                HYPRE_Int *workspace);
+HYPRE_Int hypre_prefix_sum_triple(HYPRE_Int *in_out1, HYPRE_Int *sum1,
+                                  HYPRE_Int *in_out2, HYPRE_Int *sum2,
+                                  HYPRE_Int *in_out3, HYPRE_Int *sum3,
+                                  HYPRE_Int *workspace);
+HYPRE_Int hypre_prefix_sum_multiple(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int n,
+                                    HYPRE_Int *workspace);
 
 /* hopscotch_hash.c */
 
@@ -2452,6 +2427,8 @@ HYPRE_Int hypre_GetSyncCudaCompute(HYPRE_Int *cuda_compute_stream_sync_ptr);
 
 /* handle.c */
 HYPRE_Int hypre_SetLogLevel( HYPRE_Int log_level );
+HYPRE_Int hypre_SetLogLevelSaved( HYPRE_Int log_level_saved );
+HYPRE_Int hypre_RestoreLogLevel( void );
 HYPRE_Int hypre_SetSpTransUseVendor( HYPRE_Int use_vendor );
 HYPRE_Int hypre_SetSpMVUseVendor( HYPRE_Int use_vendor );
 HYPRE_Int hypre_SetSpGemmUseVendor( HYPRE_Int use_vendor );

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -3513,4 +3513,3 @@ struct hypre_cub_CachingDeviceAllocator
 #endif
 
 #endif
-

--- a/src/utilities/general.c
+++ b/src/utilities/general.c
@@ -41,7 +41,8 @@ hypre_HandleCreate(void)
       avoid a segmentation fault when building with HYPRE_USING_UMPIRE_HOST */
    hypre_Handle *hypre_handle_ = (hypre_Handle*) calloc(1, sizeof(hypre_Handle));
 
-   hypre_HandleLogLevel(hypre_handle_) = 0;
+   hypre_HandleLogLevel(hypre_handle_)       = 0;
+   hypre_HandleLogLevelSaved(hypre_handle_)  = 0;
    hypre_HandleMemoryLocation(hypre_handle_) = HYPRE_MEMORY_DEVICE;
 
 #if defined(HYPRE_USING_GPU) || defined(HYPRE_USING_DEVICE_OPENMP)

--- a/src/utilities/handle.c
+++ b/src/utilities/handle.c
@@ -15,13 +15,38 @@
 #include "_hypre_utilities.hpp"
 
 /*--------------------------------------------------------------------------
- * hypre_SetLogLevel
+ * Set log level and update temporary log level with previous state
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
 hypre_SetLogLevel(HYPRE_Int log_level)
 {
+   hypre_HandleLogLevelSaved(hypre_handle()) = hypre_HandleLogLevel(hypre_handle());
    hypre_HandleLogLevel(hypre_handle()) = log_level;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * Set temporary variable for the log level
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_SetLogLevelSaved(HYPRE_Int log_level_saved)
+{
+   hypre_HandleLogLevelSaved(hypre_handle()) = log_level_saved;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * Restore log level value from the saved variable
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_RestoreLogLevel(void)
+{
+   hypre_HandleLogLevel(hypre_handle()) = hypre_HandleLogLevelSaved(hypre_handle());
 
    return hypre_error_flag;
 }

--- a/src/utilities/handle.h
+++ b/src/utilities/handle.h
@@ -34,6 +34,7 @@ typedef void (*GPUMfreeFunc)(void *);
 typedef struct
 {
    HYPRE_Int              log_level;
+   HYPRE_Int              log_level_saved;
    HYPRE_Int              hypre_error;
    HYPRE_MemoryLocation   memory_location;
    HYPRE_ExecutionPolicy  default_exec_policy;
@@ -82,6 +83,7 @@ typedef struct
 
 /* accessor macros to hypre_Handle */
 #define hypre_HandleLogLevel(hypre_handle)                       ((hypre_handle) -> log_level)
+#define hypre_HandleLogLevelSaved(hypre_handle)                  ((hypre_handle) -> log_level_saved)
 #define hypre_HandleMemoryLocation(hypre_handle)                 ((hypre_handle) -> memory_location)
 #define hypre_HandleDefaultExecPolicy(hypre_handle)              ((hypre_handle) -> default_exec_policy)
 

--- a/src/utilities/prefix_sum.c
+++ b/src/utilities/prefix_sum.c
@@ -7,7 +7,87 @@
 
 #include "_hypre_utilities.h"
 
-void hypre_prefix_sum(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int *workspace)
+/*--------------------------------------------------------------------------
+ * This is a helper routine to compute a prefix sum of integer values.
+ *
+ * The current implementation is okay for modest numbers of threads.
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_PrefixSumInt(HYPRE_Int   nvals,
+                   HYPRE_Int  *vals,
+                   HYPRE_Int  *sums)
+{
+   HYPRE_Int  j, nthreads, bsize;
+
+   nthreads = hypre_NumThreads();
+   bsize = (nvals + nthreads - 1) / nthreads; /* This distributes the remainder */
+
+   if (nvals < nthreads || bsize == 1)
+   {
+      sums[0] = 0;
+      for (j = 1; j < nvals; j++)
+      {
+         sums[j] += sums[j - 1] + vals[j - 1];
+      }
+   }
+   else
+   {
+      /* Compute preliminary partial sums (in parallel) within each interval */
+#ifdef HYPRE_USING_OPENMP
+      #pragma omp parallel for private(j) HYPRE_SMP_SCHEDULE
+#endif
+      for (j = 0; j < nvals; j += bsize)
+      {
+         HYPRE_Int  i, n = hypre_min((j + bsize), nvals);
+
+         sums[j] = 0;
+         for (i = j + 1; i < n; i++)
+         {
+            sums[i] = sums[i - 1] + vals[i - 1];
+         }
+      }
+
+      /* Compute final partial sums (in serial) for the first entry of every interval */
+      for (j = bsize; j < nvals; j += bsize)
+      {
+         sums[j] = sums[j - bsize] + sums[j - 1] + vals[j - 1];
+      }
+
+      /* Compute final partial sums (in parallel) for the remaining entries */
+#ifdef HYPRE_USING_OPENMP
+      #pragma omp parallel for private(j) HYPRE_SMP_SCHEDULE
+#endif
+      for (j = bsize; j < nvals; j += bsize)
+      {
+         HYPRE_Int  i, n = hypre_min((j + bsize), nvals);
+
+         for (i = j + 1; i < n; i++)
+         {
+            sums[i] += sums[j];
+         }
+      }
+   }
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * Assumed to be called within an omp region.
+ * Let x_i be the input of ith thread.
+ * The output of ith thread y_i = x_0 + x_1 + ... + x_{i-1}
+ * Additionally, sum = x_0 + x_1 + ... + x_{nthreads - 1}
+ * Note that always y_0 = 0
+ *
+ * @param workspace at least with length (nthreads+1)
+ *        workspace[tid] will contain result for tid
+ *        workspace[nthreads] will contain sum
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_prefix_sum( HYPRE_Int *in_out,
+                  HYPRE_Int *sum,
+                  HYPRE_Int *workspace )
 {
 #ifdef HYPRE_USING_OPENMP
    HYPRE_Int my_thread_num = hypre_GetThreadNum();
@@ -37,10 +117,25 @@ void hypre_prefix_sum(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int *workspace)
    workspace[0] = 0;
    workspace[1] = *sum;
 #endif /* !HYPRE_USING_OPENMP */
+
+   return hypre_error_flag;
 }
 
-void hypre_prefix_sum_pair(HYPRE_Int *in_out1, HYPRE_Int *sum1, HYPRE_Int *in_out2, HYPRE_Int *sum2,
-                           HYPRE_Int *workspace)
+/*--------------------------------------------------------------------------
+ * This version does prefix sum in pair.
+ * Useful when we prefix sum of diag and offd in tandem.
+ *
+ * @param worksapce at least with length 2*(nthreads+1)
+ *        workspace[2*tid] and workspace[2*tid+1] will contain results for tid
+ *        workspace[3*nthreads] and workspace[3*nthreads + 1] will contain sums
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_prefix_sum_pair( HYPRE_Int *in_out1,
+                       HYPRE_Int *sum1,
+                       HYPRE_Int *in_out2,
+                       HYPRE_Int *sum2,
+                       HYPRE_Int *workspace )
 {
 #ifdef HYPRE_USING_OPENMP
    HYPRE_Int my_thread_num = hypre_GetThreadNum();
@@ -80,10 +175,23 @@ void hypre_prefix_sum_pair(HYPRE_Int *in_out1, HYPRE_Int *sum1, HYPRE_Int *in_ou
    workspace[2] = *sum1;
    workspace[3] = *sum2;
 #endif /* !HYPRE_USING_OPENMP */
+
+   return hypre_error_flag;
 }
 
-void hypre_prefix_sum_triple(HYPRE_Int *in_out1, HYPRE_Int *sum1, HYPRE_Int *in_out2,
-                             HYPRE_Int *sum2, HYPRE_Int *in_out3, HYPRE_Int *sum3, HYPRE_Int *workspace)
+/*--------------------------------------------------------------------------
+ * @param workspace at least with length 3*(nthreads+1)
+ *        workspace[3*tid:3*tid+3) will contain results for tid
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_prefix_sum_triple( HYPRE_Int *in_out1,
+                         HYPRE_Int *sum1,
+                         HYPRE_Int *in_out2,
+                         HYPRE_Int *sum2,
+                         HYPRE_Int *in_out3,
+                         HYPRE_Int *sum3,
+                         HYPRE_Int *workspace )
 {
 #ifdef HYPRE_USING_OPENMP
    HYPRE_Int my_thread_num = hypre_GetThreadNum();
@@ -132,9 +240,23 @@ void hypre_prefix_sum_triple(HYPRE_Int *in_out1, HYPRE_Int *sum1, HYPRE_Int *in_
    workspace[4] = *sum2;
    workspace[5] = *sum3;
 #endif /* !HYPRE_USING_OPENMP */
+
+   return hypre_error_flag;
 }
 
-void hypre_prefix_sum_multiple(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int n, HYPRE_Int *workspace)
+/*--------------------------------------------------------------------------
+ * N prefix-sums together.
+ * workspace[n*tid:n*(tid+1)) will contain results for tid
+ * workspace[nthreads*tid:nthreads*(tid+1)) will contain sums
+ *
+ * @param workspace at least with length n*(nthreads+1)
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_prefix_sum_multiple( HYPRE_Int *in_out,
+                           HYPRE_Int *sum,
+                           HYPRE_Int  n,
+                           HYPRE_Int *workspace )
 {
    HYPRE_Int i;
 #ifdef HYPRE_USING_OPENMP
@@ -186,4 +308,6 @@ void hypre_prefix_sum_multiple(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int n, H
       workspace[n + i] = sum[i];
    }
 #endif /* !HYPRE_USING_OPENMP */
+
+   return hypre_error_flag;
 }

--- a/src/utilities/protos.h
+++ b/src/utilities/protos.h
@@ -118,44 +118,17 @@ HYPRE_Int hypre_DoubleQuickSplit ( HYPRE_Real *values, HYPRE_Int *indices, HYPRE
 /* HYPRE_CUDA_GLOBAL */ HYPRE_Real hypre_Rand ( void );
 
 /* prefix_sum.c */
-/**
- * Assumed to be called within an omp region.
- * Let x_i be the input of ith thread.
- * The output of ith thread y_i = x_0 + x_1 + ... + x_{i-1}
- * Additionally, sum = x_0 + x_1 + ... + x_{nthreads - 1}
- * Note that always y_0 = 0
- *
- * @param workspace at least with length (nthreads+1)
- *                  workspace[tid] will contain result for tid
- *                  workspace[nthreads] will contain sum
- */
-void hypre_prefix_sum(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int *workspace);
-/**
- * This version does prefix sum in pair.
- * Useful when we prefix sum of diag and offd in tandem.
- *
- * @param worksapce at least with length 2*(nthreads+1)
- *                  workspace[2*tid] and workspace[2*tid+1] will contain results for tid
- *                  workspace[3*nthreads] and workspace[3*nthreads + 1] will contain sums
- */
-void hypre_prefix_sum_pair(HYPRE_Int *in_out1, HYPRE_Int *sum1, HYPRE_Int *in_out2, HYPRE_Int *sum2,
-                           HYPRE_Int *workspace);
-/**
- * @param workspace at least with length 3*(nthreads+1)
- *                  workspace[3*tid:3*tid+3) will contain results for tid
- */
-void hypre_prefix_sum_triple(HYPRE_Int *in_out1, HYPRE_Int *sum1, HYPRE_Int *in_out2,
-                             HYPRE_Int *sum2, HYPRE_Int *in_out3, HYPRE_Int *sum3, HYPRE_Int *workspace);
-
-/**
- * n prefix-sums together.
- * workspace[n*tid:n*(tid+1)) will contain results for tid
- * workspace[nthreads*tid:nthreads*(tid+1)) will contain sums
- *
- * @param workspace at least with length n*(nthreads+1)
- */
-void hypre_prefix_sum_multiple(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int n,
-                               HYPRE_Int *workspace);
+HYPRE_Int hypre_PrefixSumInt(HYPRE_Int nvals, HYPRE_Int *vals, HYPRE_Int *sums);
+HYPRE_Int hypre_prefix_sum(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int *workspace);
+HYPRE_Int hypre_prefix_sum_pair(HYPRE_Int *in_out1, HYPRE_Int *sum1,
+                                HYPRE_Int *in_out2, HYPRE_Int *sum2,
+                                HYPRE_Int *workspace);
+HYPRE_Int hypre_prefix_sum_triple(HYPRE_Int *in_out1, HYPRE_Int *sum1,
+                                  HYPRE_Int *in_out2, HYPRE_Int *sum2,
+                                  HYPRE_Int *in_out3, HYPRE_Int *sum3,
+                                  HYPRE_Int *workspace);
+HYPRE_Int hypre_prefix_sum_multiple(HYPRE_Int *in_out, HYPRE_Int *sum, HYPRE_Int n,
+                                    HYPRE_Int *workspace);
 
 /* hopscotch_hash.c */
 
@@ -384,6 +357,8 @@ HYPRE_Int hypre_GetSyncCudaCompute(HYPRE_Int *cuda_compute_stream_sync_ptr);
 
 /* handle.c */
 HYPRE_Int hypre_SetLogLevel( HYPRE_Int log_level );
+HYPRE_Int hypre_SetLogLevelSaved( HYPRE_Int log_level_saved );
+HYPRE_Int hypre_RestoreLogLevel( void );
 HYPRE_Int hypre_SetSpTransUseVendor( HYPRE_Int use_vendor );
 HYPRE_Int hypre_SetSpMVUseVendor( HYPRE_Int use_vendor );
 HYPRE_Int hypre_SetSpGemmUseVendor( HYPRE_Int use_vendor );


### PR DESCRIPTION
This PR contains mainly improvements to GPU support in hypre. Details are given below:

- `hypre_IJMatrixGetValuesParCSRDevice`: Complete GPU implementation for retrieving values from ParCSR matrix
- `HYPRE_IJMatrixGetValues2()`: Now calls device implementation when execution policy is GPU
- `HYPRE_IJMatrixGetValuesAndZeroOut()`: Replaced error message with proper device implementation call
- Moved `hypre_PrefixSumInt()` implementation to `utilities`
- `hypre_CSRMatrixSetRownnzDevice()`: New device implementation for row non-zero counting
- Added GPU profiling range markers to key computational kernels
- Added flag to control addition of structural zeros in triple matrix multiplication algorithms for GPU execution
- Added `log_level_saved` in `hypre_handle` field for temporary log level storage
- Reorganized function declarations with clear separation between host and device implementations
- Added proper device function prototypes with complete parameter specifications
- Enhanced documentation comments for device-specific functions
- Enhanced test drivers with additional BoomerAMG configuration options:


