### PR TITLE
GPU fixes

### DIFF
--- a/src/IJ_mv/IJMatrix_parcsr_device.c
+++ b/src/IJ_mv/IJMatrix_parcsr_device.c
@@ -311,8 +311,7 @@ struct hypre_IJMatrixAssembleFunctor
 };
 #else
 template<typename T1, typename T2>
-struct hypre_IJMatrixAssembleFunctor : public
-   thrust::binary_function< thrust::tuple<T1, T2>, thrust::tuple<T1, T2>, thrust::tuple<T1, T2> >
+struct hypre_IJMatrixAssembleFunctor
 {
    typedef thrust::tuple<T1, T2> Tuple;
 
@@ -408,7 +407,7 @@ hypre_IJMatrixAssembleSortAndReduce1(HYPRE_Int      *Nptr,
       thrust::equal_to< thrust::tuple<HYPRE_BigInt, HYPRE_BigInt> >(),
       thrust::maximum<char>() );
 
-   HYPRE_THRUST_CALL(replace_if, A0, A0 + N0, X, thrust::identity<char>(), 0.0);
+   HYPRE_THRUST_CALL(replace_if, A0, A0 + N0, X, HYPRE_THRUST_IDENTITY(char), 0.0);
 
    auto new_end = HYPRE_THRUST_CALL(
                      reduce_by_key,
@@ -454,8 +453,7 @@ struct hypre_IJMatrixAssembleFunctor2
 };
 #else
 template<typename T1, typename T2>
-struct hypre_IJMatrixAssembleFunctor2 : public
-   thrust::binary_function< thrust::tuple<T1, T2>, thrust::tuple<T1, T2>, thrust::tuple<T1, T2> >
+struct hypre_IJMatrixAssembleFunctor2
 {
    typedef thrust::tuple<T1, T2> Tuple;
 
@@ -601,7 +599,7 @@ hypre_IJMatrixAssembleSortAndReduce3(HYPRE_Int       N0,
       thrust::equal_to< thrust::tuple<HYPRE_BigInt, HYPRE_BigInt> >(),
       thrust::maximum<char>() );
 
-   HYPRE_THRUST_CALL(replace_if, A0, A0 + N0, X0, thrust::identity<char>(), 0.0);
+   HYPRE_THRUST_CALL(replace_if, A0, A0 + N0, X0, HYPRE_THRUST_IDENTITY(char), 0.0);
 
    auto new_end = HYPRE_THRUST_CALL(
                      reduce_by_key,
@@ -632,7 +630,7 @@ hypre_IJMatrixAssembleSortAndReduce3(HYPRE_Int       N0,
                                       thrust::make_zip_iterator(thrust::make_tuple(I + Nt, J + Nt, A + Nt)),
                                       A,
                                       thrust::make_zip_iterator(thrust::make_tuple(I0, J0, A0)),
-                                      thrust::identity<HYPRE_Complex>() );
+                                      HYPRE_THRUST_IDENTITY(HYPRE_Complex) );
 
    *N1 = thrust::get<0>(new_end2.get_iterator_tuple()) - I0;
 #endif
@@ -718,7 +716,7 @@ hypre_IJMatrixAssembleCommunicate(hypre_IJMatrix *matrix)
                             is_on_proc,                                                         /* stencil */
                             thrust::make_zip_iterator(thrust::make_tuple(off_proc_i,      off_proc_j,      off_proc_data,
                                                                          off_proc_sora)),       /* result */
-                            thrust::not1(thrust::identity<char>()) );
+                            HYPRE_THRUST_NOT(HYPRE_THRUST_IDENTITY(char)) );
 
          hypre_assert(thrust::get<0>(new_end1.get_iterator_tuple()) - off_proc_i == nelms_off);
 
@@ -730,7 +728,7 @@ hypre_IJMatrixAssembleCommunicate(hypre_IJMatrix *matrix)
                             thrust::make_zip_iterator(thrust::make_tuple(stack_i + nelms, stack_j + nelms, stack_data + nelms,
                                                                          stack_sora + nelms)),  /* last */
                             is_on_proc,                                                         /* stencil */
-                            thrust::not1(thrust::identity<char>()) );
+                            HYPRE_THRUST_NOT(HYPRE_THRUST_IDENTITY(char)) );
 
          hypre_assert(thrust::get<0>(new_end2.get_iterator_tuple()) - stack_i == nelms_on);
 #endif

--- a/src/IJ_mv/IJVector_parcsr_device.c
+++ b/src/IJ_mv/IJVector_parcsr_device.c
@@ -21,32 +21,22 @@
  * hypre_IJVectorAssembleFunctor
  *--------------------------------------------------------------------*/
 
-#if defined(HYPRE_USING_SYCL)
 template<typename T1, typename T2>
 struct hypre_IJVectorAssembleFunctor
-{
-   typedef std::tuple<T1, T2> Tuple;
-
-   __device__ Tuple operator() (const Tuple& x, const Tuple& y ) const
-   {
-      return std::make_tuple( hypre_max(std::get<0>(x), std::get<0>(y)),
-                              std::get<1>(x) + std::get<1>(y) );
-   }
-};
-#else
-template<typename T1, typename T2>
-struct hypre_IJVectorAssembleFunctor : public
-   thrust::binary_function< thrust::tuple<T1, T2>, thrust::tuple<T1, T2>, thrust::tuple<T1, T2> >
 {
    typedef thrust::tuple<T1, T2> Tuple;
 
    __device__ Tuple operator() (const Tuple& x, const Tuple& y )
    {
+#if defined(HYPRE_USING_SYCL)
+      return std::make_tuple( hypre_max(std::get<0>(x), std::get<0>(y)),
+                              std::get<1>(x) + std::get<1>(y) );
+#else
       return thrust::make_tuple( hypre_max(thrust::get<0>(x), thrust::get<0>(y)),
                                  thrust::get<1>(x) + thrust::get<1>(y) );
+#endif
    }
 };
-#endif
 
 /*--------------------------------------------------------------------
  * hypre_IJVectorAssembleSortAndReduce1
@@ -125,7 +115,7 @@ hypre_IJVectorAssembleSortAndReduce1( HYPRE_Int       N0,
       thrust::equal_to<HYPRE_BigInt>(),
       thrust::maximum<char>() );
 
-   HYPRE_THRUST_CALL(replace_if, A0, A0 + N0, X, thrust::identity<char>(), 0.0);
+   HYPRE_THRUST_CALL(replace_if, A0, A0 + N0, X, HYPRE_THRUST_IDENTITY(char), 0.0);
 
    auto new_end = HYPRE_THRUST_CALL(
                      reduce_by_key,
@@ -207,7 +197,7 @@ hypre_IJVectorAssembleSortAndReduce3( HYPRE_Int      N0,
       thrust::equal_to<HYPRE_BigInt>(),
       thrust::maximum<char>() );
 
-   HYPRE_THRUST_CALL(replace_if, A0, A0 + N0, X0, thrust::identity<char>(), 0.0);
+   HYPRE_THRUST_CALL(replace_if, A0, A0 + N0, X0, HYPRE_THRUST_IDENTITY(char), 0.0);
 
    auto new_end = HYPRE_THRUST_CALL(
                      reduce_by_key,
@@ -237,7 +227,7 @@ hypre_IJVectorAssembleSortAndReduce3( HYPRE_Int      N0,
                                       thrust::make_zip_iterator(thrust::make_tuple(I, A)) + Nt,
                                       A,
                                       thrust::make_zip_iterator(thrust::make_tuple(I0, A0)),
-                                      thrust::identity<HYPRE_Complex>() );
+                                      HYPRE_THRUST_IDENTITY(HYPRE_Complex) );
 
    *N1 = thrust::get<0>(new_end2.get_iterator_tuple()) - I0;
 #endif
@@ -493,7 +483,7 @@ hypre_IJVectorAssembleParDevice(hypre_IJVector *vector)
                             is_on_proc,                                                         /* stencil */
                             thrust::make_zip_iterator(thrust::make_tuple(off_proc_i,      off_proc_data,
                                                                          off_proc_sora)),       /* result */
-                            HYPRE_THRUST_NOT(thrust::identity<char>()) );
+                            HYPRE_THRUST_NOT(HYPRE_THRUST_IDENTITY(char)) );
 
          hypre_assert(thrust::get<0>(new_end1.get_iterator_tuple()) - off_proc_i == nelms_off);
 
@@ -505,7 +495,7 @@ hypre_IJVectorAssembleParDevice(hypre_IJVector *vector)
                             thrust::make_zip_iterator(thrust::make_tuple(stack_i + nelms, stack_data + nelms,
                                                                          stack_sora + nelms)),  /* last */
                             is_on_proc,                                                         /* stencil */
-                            HYPRE_THRUST_NOT(thrust::identity<char>()) );
+                            HYPRE_THRUST_NOT(HYPRE_THRUST_IDENTITY(char)) );
 
          hypre_assert(thrust::get<0>(new_end2.get_iterator_tuple()) - stack_i == nelms_on);
 #endif

--- a/src/config/cmake/HYPRE_SetupCUDAToolkit.cmake
+++ b/src/config/cmake/HYPRE_SetupCUDAToolkit.cmake
@@ -60,13 +60,13 @@ endif()
 include(CheckLanguage)
 check_language(CUDA)
 if(DEFINED CMAKE_CUDA_COMPILER)
-   enable_language(CUDA)
+  enable_language(CUDA)
 else()
   message(FATAL_ERROR "CUDA language not found. Please check your CUDA installation.")
 endif()
 
 # Find the CUDA Toolkit
-find_package(CUDAToolkit REQUIRED)
+find_package(CUDAToolkit REQUIRED ${CUDA_DIR})
 
 # Add a dummy cuda target if it doesn't exist (avoid error when building with BLT dependencies)
 if(NOT TARGET cuda)
@@ -208,21 +208,14 @@ endfunction()
 # Handle CUDA libraries
 list(APPEND CUDA_LIBS CUDA::cudart) # Add cudart first since other CUDA libraries may depend on it
 find_and_add_cuda_library(cusparse HYPRE_ENABLE_CUSPARSE)
-find_and_add_cuda_library(curand HYPRE_ENABLE_CURAND)
-find_and_add_cuda_library(cublas HYPRE_ENABLE_CUBLAS)
+find_and_add_cuda_library(curand   HYPRE_ENABLE_CURAND)
+find_and_add_cuda_library(cublas   HYPRE_ENABLE_CUBLAS)
 find_and_add_cuda_library(cublasLt HYPRE_ENABLE_CUBLAS)
 find_and_add_cuda_library(cusolver HYPRE_ENABLE_CUSOLVER)
 
-# Handle GPU Profiling with nvToolsExt
+# Handle GPU Profiling with nvtx3
 if(HYPRE_ENABLE_GPU_PROFILING)
-  find_library(NVTX_LIBRARY nvToolsExt HINTS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib)
-  if(NVTX_LIBRARY)
-    message(STATUS "Found NVTX library")
-    set(HYPRE_USING_NVTX ON CACHE BOOL "" FORCE)
-    list(APPEND CUDA_LIBS ${NVTX_LIBRARY})
-  else()
-    message(FATAL_ERROR "NVTX library not found! Make sure CUDA is installed correctly.")
-  endif()
+  set(HYPRE_USING_NVTX ON CACHE BOOL "" FORCE)
 endif()
 
 # Add CUDA Toolkit include directories to the target

--- a/src/parcsr_ls/ame.c
+++ b/src/parcsr_ls/ame.c
@@ -699,7 +699,7 @@ HYPRE_Int hypre_AMESetup(void *esolver)
                                   data,
                                   data + ne,
                                   edge_bc,
-                                  thrust::identity<HYPRE_Int>(),
+                                  HYPRE_THRUST_IDENTITY(HYPRE_Int),
                                   0.0 );
 #endif
             }
@@ -707,10 +707,12 @@ HYPRE_Int hypre_AMESetup(void *esolver)
 #endif
             {
                for (j = 0; j < ne; j++)
+               {
                   if (edge_bc[j])
                   {
                      data[j] = 0.0;
                   }
+               }
             }
             hypre_AMEDiscrDivFreeComponent(esolver, vi);
          }

--- a/src/parcsr_ls/par_coarsen_device.c
+++ b/src/parcsr_ls/par_coarsen_device.c
@@ -218,7 +218,7 @@ hypre_BoomerAMGCoarsenPMISDevice( hypre_ParCSRMatrix    *S,
                                               graph_diag,
                                               graph_diag + graph_diag_size,
                                               diag_iwork,
-                                              thrust::identity<HYPRE_Int>() );
+                                              HYPRE_THRUST_IDENTITY(HYPRE_Int) );
 #endif
 
       graph_diag_size = new_end - graph_diag;
@@ -442,7 +442,7 @@ hypre_PMISCoarseningInitDevice( hypre_ParCSRMatrix  *S,               /* in */
                                 thrust::make_counting_iterator(num_rows_diag),
                                 CF_marker_diag,
                                 graph_diag,
-                                thrust::identity<HYPRE_Int>());
+                                HYPRE_THRUST_IDENTITY(HYPRE_Int));
 #endif
 
    *graph_diag_size = new_end - graph_diag;

--- a/src/parcsr_ls/par_ilu_setup_device.c
+++ b/src/parcsr_ls/par_ilu_setup_device.c
@@ -455,6 +455,9 @@ hypre_ILUSetupIterativeILU0Device(hypre_CSRMatrix  *A,
    rocsparse_datatype        data_type;
    size_t                    buffer_size;
    HYPRE_Int                 history_size;
+#if (ROCSPARSE_VERSION >= 300400)
+   HYPRE_Int                 num_free_iter = 10;
+#endif
 
    HYPRE_ANNOTATE_FUNC_BEGIN;
    hypre_GpuProfilingPushRange("CSRMatrixITILU0");
@@ -547,6 +550,9 @@ hypre_ILUSetupIterativeILU0Device(hypre_CSRMatrix  *A,
                                                           (rocsparse_itilu0_alg) type,
                                                           (rocsparse_int) option,
                                                           (rocsparse_int*) num_iter_ptr,
+#if (ROCSPARSE_VERSION >= 300400)
+                                                          (rocsparse_int) num_free_iter,
+#endif
                                                           tolerance,
                                                           (rocsparse_int) num_rows,
                                                           (rocsparse_int) num_nonzeros,

--- a/src/parcsr_ls/par_mgr_device.c
+++ b/src/parcsr_ls/par_mgr_device.c
@@ -19,11 +19,7 @@
 #if defined (HYPRE_USING_GPU)
 
 template<typename T>
-#if defined(HYPRE_USING_SYCL)
 struct functor
-#else
-struct functor : public thrust::binary_function<T, T, T>
-#endif
 {
    T scale;
 

--- a/src/parcsr_ls/par_mod_multi_interp_device.c
+++ b/src/parcsr_ls/par_mod_multi_interp_device.c
@@ -51,8 +51,7 @@ struct globalC_functor
 };
 #else
 template<typename T>
-struct tuple_plus : public
-   thrust::binary_function<thrust::tuple<T, T>, thrust::tuple<T, T>, thrust::tuple<T, T> >
+struct tuple_plus
 {
    __host__ __device__
    thrust::tuple<T, T> operator()( const thrust::tuple<T, T> & x1, const thrust::tuple<T, T> & x2)
@@ -63,8 +62,7 @@ struct tuple_plus : public
 };
 
 template<typename T>
-struct tuple_minus : public
-   thrust::binary_function<thrust::tuple<T, T>, thrust::tuple<T, T>, thrust::tuple<T, T> >
+struct tuple_minus
 {
    __host__ __device__
    thrust::tuple<T, T> operator()( const thrust::tuple<T, T> & x1, const thrust::tuple<T, T> & x2)
@@ -74,8 +72,7 @@ struct tuple_minus : public
    }
 };
 
-struct local_equal_plus_constant : public
-   thrust::binary_function<HYPRE_BigInt, HYPRE_BigInt, HYPRE_BigInt>
+struct local_equal_plus_constant
 {
    HYPRE_BigInt _value;
 
@@ -527,7 +524,7 @@ hypre_BoomerAMGBuildModMultipassDevice( hypre_ParCSRMatrix  *A,
                             thrust::make_permutation_iterator(pass_marker, points_left),
                             thrust::make_permutation_iterator(pass_marker, points_left + remaining),
                             diag_shifts,
-                            thrust::identity<HYPRE_Int>(),
+                            HYPRE_THRUST_IDENTITY(HYPRE_Int),
                             current_pass + 1 );
 
          hypre_TMemcpy(points_left_old, points_left, HYPRE_Int, remaining, HYPRE_MEMORY_DEVICE,
@@ -539,7 +536,7 @@ hypre_BoomerAMGBuildModMultipassDevice( hypre_ParCSRMatrix  *A,
                                       points_left_old + remaining,
                                       diag_shifts,
                                       pass_order + cnt_old,
-                                      thrust::identity<HYPRE_Int>() );
+                                      HYPRE_THRUST_IDENTITY(HYPRE_Int) );
 
          hypre_assert(new_end - pass_order == cnt);
 
@@ -548,7 +545,7 @@ hypre_BoomerAMGBuildModMultipassDevice( hypre_ParCSRMatrix  *A,
                                       points_left_old + remaining,
                                       diag_shifts,
                                       points_left,
-                                      HYPRE_THRUST_NOT(thrust::identity<HYPRE_Int>()) );
+                                      HYPRE_THRUST_NOT(HYPRE_THRUST_IDENTITY(HYPRE_Int)) );
 #endif
 
          hypre_assert(new_end - points_left == cnt_rem);

--- a/src/parcsr_mv/par_csr_fffc_device.c
+++ b/src/parcsr_mv/par_csr_fffc_device.c
@@ -87,9 +87,9 @@ struct FF_pred
 /* this predicate selects A^s_{FC} */
 template<typename T>
 #if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
-struct FC_pred
-#else
 struct FC_pred : public thrust::unary_function<Tuple, bool>
+#else
+struct FC_pred
 #endif
 {
    HYPRE_Int *row_CF_marker;
@@ -625,7 +625,7 @@ hypre_ParCSRMatrixGenerateFFFCDevice_core( hypre_ParCSRMatrix  *A,
                                                      thrust::make_transform_iterator(recv_buf, -_1 - 1) + num_cols_A_offd,
                                                      offd_mark,
                                                      col_map_offd_AFF,
-                                                     thrust::identity<HYPRE_Int>() );
+                                                     HYPRE_THRUST_IDENTITY(HYPRE_Int) );
       hypre_assert(tmp_end_big - col_map_offd_AFF == num_cols_AFF_offd);
 #endif
       hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
@@ -847,7 +847,7 @@ hypre_ParCSRMatrixGenerateFFFCDevice_core( hypre_ParCSRMatrix  *A,
                                                      recv_buf + num_cols_A_offd,
                                                      offd_mark,
                                                      col_map_offd_AFC,
-                                                     thrust::identity<HYPRE_Int>());
+                                                     HYPRE_THRUST_IDENTITY(HYPRE_Int));
 #endif
       hypre_assert(tmp_end_big - col_map_offd_AFC == num_cols_AFC_offd);
       hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
@@ -1075,7 +1075,7 @@ hypre_ParCSRMatrixGenerateFFFCDevice_core( hypre_ParCSRMatrix  *A,
                                                      thrust::make_transform_iterator(recv_buf, -_1 - 1) + num_cols_A_offd,
                                                      offd_mark,
                                                      col_map_offd_ACF,
-                                                     thrust::identity<HYPRE_Int>());
+                                                     HYPRE_THRUST_IDENTITY(HYPRE_Int));
 #endif
       hypre_assert(tmp_end_big - col_map_offd_ACF == num_cols_ACF_offd);
       hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
@@ -1299,7 +1299,7 @@ hypre_ParCSRMatrixGenerateFFFCDevice_core( hypre_ParCSRMatrix  *A,
                                                      recv_buf + num_cols_A_offd,
                                                      offd_mark,
                                                      col_map_offd_ACC,
-                                                     thrust::identity<HYPRE_Int>());
+                                                     HYPRE_THRUST_IDENTITY(HYPRE_Int));
 #endif
       hypre_assert(tmp_end_big - col_map_offd_ACC == num_cols_ACC_offd);
       hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
@@ -1785,7 +1785,7 @@ hypre_ParCSRMatrixGenerate1DCFDevice( hypre_ParCSRMatrix  *A,
                                                      col_map_offd_A + num_cols_A_offd,
                                                      offd_mark,
                                                      col_map_offd_ACX,
-                                                     thrust::identity<HYPRE_Int>());
+                                                     HYPRE_THRUST_IDENTITY(HYPRE_Int));
 #endif
       hypre_assert(tmp_end_big - col_map_offd_ACX == num_cols_ACX_offd);
       hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);
@@ -1984,7 +1984,7 @@ hypre_ParCSRMatrixGenerate1DCFDevice( hypre_ParCSRMatrix  *A,
                                                      recv_buf + num_cols_A_offd,
                                                      offd_mark,
                                                      col_map_offd_AXC,
-                                                     thrust::identity<HYPRE_Int>());
+                                                     HYPRE_THRUST_IDENTITY(HYPRE_Int));
 #endif
       hypre_assert(tmp_end_big - col_map_offd_AXC == num_cols_AXC_offd);
       hypre_TFree(tmp_j, HYPRE_MEMORY_DEVICE);

--- a/src/seq_mv/csr_spgemm_device_symbl.c
+++ b/src/seq_mv/csr_spgemm_device_symbl.c
@@ -144,7 +144,7 @@ hypreDevice_CSRSpGemmRownnzUpperbound( HYPRE_Int  m,
    *rownnz_exact_ptr = !HYPRE_THRUST_CALL( any_of,
                                            d_rf,
                                            d_rf + m,
-                                           thrust::identity<char>() );
+                                           HYPRE_THRUST_IDENTITY(char) );
 #endif
 
    hypre_TFree(d_rf, HYPRE_MEMORY_DEVICE);
@@ -231,7 +231,7 @@ hypreDevice_CSRSpGemmRownnzNoBin( HYPRE_Int  m,
                                thrust::make_counting_iterator(m),
                                d_rf,
                                d_rind,
-                               thrust::identity<char>() );
+                               HYPRE_THRUST_IDENTITY(char) );
 #endif
 
          hypre_assert(new_end - d_rind == num_failed_rows);
@@ -340,7 +340,7 @@ hypreDevice_CSRSpGemmRownnzBinned( HYPRE_Int  m,
                                thrust::make_counting_iterator(m),
                                d_rf,
                                d_rind,
-                               thrust::identity<char>() );
+                               HYPRE_THRUST_IDENTITY(char) );
 #endif
 
          hypre_assert(new_end - d_rind == num_failed_rows);

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SRCS
   ap.c
   log.c
   complex.c
+  device_markers.c
   device_utils.c
   error.c
   general.c
@@ -38,7 +39,6 @@ set(SRCS
   merge_sort.c
   mmio.c
   mpi_comm_f2c.c
-  nvtx.c
   omp_device.c
   prefix_sum.c
   printf.c
@@ -61,6 +61,7 @@ target_sources(${PROJECT_NAME}
 
 if (HYPRE_USING_GPU)
   set(GPU_SRCS
+    device_markers.c
     device_utils.c
     general.c
     handle.c

--- a/src/utilities/Makefile
+++ b/src/utilities/Makefile
@@ -70,13 +70,13 @@ FILES =\
  timing.c
 
 CUFILES=\
+ device_markers.c\
  device_utils.c\
  general.c\
  handle.c\
  int_array_device.c\
  memory.c\
  omp_device.c\
- nvtx.c\
  stl_ops.c
 
 COBJS = ${FILES:.c=.o}

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -385,6 +385,13 @@ using hypre_DeviceItem = void*;
 #define HYPRE_THRUST_NOT(pred) thrust::not_fn(pred)
 #endif
 
+/* Resolve deprecated warnings about thrust::identity */
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 200802)
+#define HYPRE_THRUST_IDENTITY(type) thrust::identity<type>()
+#elif defined(HYPRE_USING_CUDA)
+#define HYPRE_THRUST_IDENTITY(type) cuda::std::identity()
+#endif
+
 using namespace thrust::placeholders;
 #endif /* defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */
 
@@ -681,8 +688,13 @@ using hypre_DeviceItem = sycl::nd_item<3>;
 #define hypre_rocsparse_csrilu0_buffer_size    rocsparse_scsrilu0_buffer_size
 #define hypre_rocsparse_csrilu0_analysis       rocsparse_scsrilu0_analysis
 #define hypre_rocsparse_csrilu0                rocsparse_scsrilu0
-#define hypre_rocsparse_csritilu0_compute      rocsparse_scsritilu0_compute
 #define hypre_rocsparse_csritilu0_history      rocsparse_scsritilu0_history
+#if (ROCSPARSE_VERSION >= 300400)
+#define hypre_rocsparse_csritilu0_compute      rocsparse_scsritilu0_compute_ex
+#else
+#define hypre_rocsparse_csritilu0_compute      rocsparse_scsritilu0_compute
+#endif
+
 
 /* rocSOLVER */
 #define hypre_rocsolver_getrf_batched          rocsolver_sgetrf_batched
@@ -742,8 +754,13 @@ using hypre_DeviceItem = sycl::nd_item<3>;
 #define hypre_rocsparse_csrilu0_buffer_size    rocsparse_dcsrilu0_buffer_size
 #define hypre_rocsparse_csrilu0_analysis       rocsparse_dcsrilu0_analysis
 #define hypre_rocsparse_csrilu0                rocsparse_dcsrilu0
-#define hypre_rocsparse_csritilu0_compute      rocsparse_dcsritilu0_compute
 #define hypre_rocsparse_csritilu0_history      rocsparse_dcsritilu0_history
+#if (ROCSPARSE_VERSION >= 300400)
+#define hypre_rocsparse_csritilu0_compute      rocsparse_dcsritilu0_compute_ex
+#else
+#define hypre_rocsparse_csritilu0_compute      rocsparse_dcsritilu0_compute
+#endif
+
 
 /* rocSOLVER */
 #define hypre_rocsolver_getrf_batched          rocsolver_dgetrf_batched

--- a/src/utilities/device_markers.c
+++ b/src/utilities/device_markers.c
@@ -17,8 +17,7 @@
 #include <string>
 #include <algorithm>
 #include <vector>
-#include "nvToolsExt.h"
-#include "nvToolsExtCudaRt.h"
+#include "nvtx3/nvToolsExt.h"
 
 /* 16 named colors by HTML 4.01. Repalce white with Orange */
 typedef enum

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -189,6 +189,13 @@ using hypre_DeviceItem = void*;
 #define HYPRE_THRUST_NOT(pred) thrust::not_fn(pred)
 #endif
 
+/* Resolve deprecated warnings about thrust::identity */
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 200802)
+#define HYPRE_THRUST_IDENTITY(type) thrust::identity<type>()
+#elif defined(HYPRE_USING_CUDA)
+#define HYPRE_THRUST_IDENTITY(type) cuda::std::identity()
+#endif
+
 using namespace thrust::placeholders;
 #endif /* defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */
 
@@ -485,8 +492,13 @@ using hypre_DeviceItem = sycl::nd_item<3>;
 #define hypre_rocsparse_csrilu0_buffer_size    rocsparse_scsrilu0_buffer_size
 #define hypre_rocsparse_csrilu0_analysis       rocsparse_scsrilu0_analysis
 #define hypre_rocsparse_csrilu0                rocsparse_scsrilu0
-#define hypre_rocsparse_csritilu0_compute      rocsparse_scsritilu0_compute
 #define hypre_rocsparse_csritilu0_history      rocsparse_scsritilu0_history
+#if (ROCSPARSE_VERSION >= 300400)
+#define hypre_rocsparse_csritilu0_compute      rocsparse_scsritilu0_compute_ex
+#else
+#define hypre_rocsparse_csritilu0_compute      rocsparse_scsritilu0_compute
+#endif
+
 
 /* rocSOLVER */
 #define hypre_rocsolver_getrf_batched          rocsolver_sgetrf_batched
@@ -546,8 +558,13 @@ using hypre_DeviceItem = sycl::nd_item<3>;
 #define hypre_rocsparse_csrilu0_buffer_size    rocsparse_dcsrilu0_buffer_size
 #define hypre_rocsparse_csrilu0_analysis       rocsparse_dcsrilu0_analysis
 #define hypre_rocsparse_csrilu0                rocsparse_dcsrilu0
-#define hypre_rocsparse_csritilu0_compute      rocsparse_dcsritilu0_compute
 #define hypre_rocsparse_csritilu0_history      rocsparse_dcsritilu0_history
+#if (ROCSPARSE_VERSION >= 300400)
+#define hypre_rocsparse_csritilu0_compute      rocsparse_dcsritilu0_compute_ex
+#else
+#define hypre_rocsparse_csritilu0_compute      rocsparse_dcsritilu0_compute
+#endif
+
 
 /* rocSOLVER */
 #define hypre_rocsolver_getrf_batched          rocsolver_dgetrf_batched


### PR DESCRIPTION
This PR modernizes hypre's GPU compatibility by addressing deprecated API and eliminating compilation warnings with newer CUDA versions while maintaining backward compatibility. A detailed list of changes is given below:

- Removed deprecated `thrust::binary_function` inheritance from 6+ functor classes and introduced `HYPRE_THRUST_IDENTITY` macro for cross-version compatibility
- Improved CUDA detection with `${CUDA_DIR}` parameter and simplified NVTX setup using modern CMake handling
- Migrated from deprecated `nvToolsExt` to `nvtx3` library and renamed `nvtx.c` to `device_markers.c` for better semantics
- Added conditional compilation for ROCSPARSE 3.4.0+ features and enhanced iterative ILU0 with `num_free_iter` parameter support