### PR TITLE
[hypre 3.0] struct regression fixes on Tuolumne

### DIFF
--- a/src/sstruct_ls/node_relax.c
+++ b/src/sstruct_ls/node_relax.c
@@ -432,14 +432,14 @@ hypre_NodeRelaxSetup(  void                 *relax_vdata,
 
          if (vi == -1)
          {
-            hypre_ComputePkgCreate(compute_info,
+            hypre_ComputePkgCreate(memory_location, compute_info,
                                    hypre_StructVectorDataSpace(
                                       hypre_SStructPVectorSVector(x, 0)),
                                    1, sgrid, &compute_pkgs[p]);
          }
          else
          {
-            hypre_ComputePkgCreate(compute_info,
+            hypre_ComputePkgCreate(memory_location, compute_info,
                                    hypre_StructVectorDataSpace(
                                       hypre_SStructPVectorSVector(x, vi)),
                                    1, sgrid, &svec_compute_pkgs[p][vi]);

--- a/src/sstruct_ls/ssamg_relax.c
+++ b/src/sstruct_ls/ssamg_relax.c
@@ -8,8 +8,6 @@
 #include "_hypre_sstruct_ls.h"
 #include "_hypre_struct_mv.hpp"
 
-#define MAX_DEPTH 10
-
 typedef struct hypre_SSAMGRelaxData_struct
 {
    MPI_Comm                comm;
@@ -478,6 +476,7 @@ hypre_SSAMGRelaxSetup( void                *relax_vdata,
    HYPRE_Real             *weights         = (relax_data -> weights);
    HYPRE_Int               ndim            = hypre_SStructMatrixNDim(A);
    HYPRE_Int               nparts          = hypre_SStructMatrixNParts(A);
+   HYPRE_MemoryLocation    memory_location = hypre_SStructMatrixMemoryLocation(A);
 
    MPI_Comm                comm;
    hypre_SStructGrid      *grid;
@@ -770,14 +769,14 @@ hypre_SSAMGRelaxSetup( void                *relax_vdata,
                if (vi == -1)
                {
                   sx = hypre_SStructPVectorSVector(px, 0);
-                  hypre_ComputePkgCreate(compute_info,
+                  hypre_ComputePkgCreate(memory_location, compute_info,
                                          hypre_StructVectorDataSpace(sx),
                                          1, sgrid, &compute_pkgs[part][set]);
                }
                else
                {
                   sx = hypre_SStructPVectorSVector(px, vi);
-                  hypre_ComputePkgCreate(compute_info,
+                  hypre_ComputePkgCreate(memory_location, compute_info,
                                          hypre_StructVectorDataSpace(sx),
                                          1, sgrid, &svec_compute_pkgs[part][set][vi]);
                }

--- a/src/struct_ls/cyclic_reduction.c
+++ b/src/struct_ls/cyclic_reduction.c
@@ -660,10 +660,9 @@ hypre_CyclicReductionSetup( void               *cyc_red_vdata,
       hypre_ComputeInfoProjectSend(compute_info, findex, stride);
       hypre_ComputeInfoProjectRecv(compute_info, findex, stride);
       hypre_ComputeInfoProjectComp(compute_info, cindex, stride);
-      hypre_ComputePkgCreate(compute_info,
+      hypre_ComputePkgCreate(memory_location, compute_info,
                              hypre_StructVectorDataSpace(x_l[l]), 1,
                              grid_l[l], &down_compute_pkg_l[l]);
-      hypre_ComputePkgSetMemoryLocation(down_compute_pkg_l[l], memory_location);
 
       /* up-cycle */
       hypre_CreateComputeInfo(grid_l[l], ustride, hypre_StructMatrixStencil(A_l[l]),
@@ -671,10 +670,9 @@ hypre_CyclicReductionSetup( void               *cyc_red_vdata,
       hypre_ComputeInfoProjectSend(compute_info, cindex, stride);
       hypre_ComputeInfoProjectRecv(compute_info, cindex, stride);
       hypre_ComputeInfoProjectComp(compute_info, findex, stride);
-      hypre_ComputePkgCreate(compute_info,
+      hypre_ComputePkgCreate(memory_location, compute_info,
                              hypre_StructVectorDataSpace(x_l[l]), 1,
                              grid_l[l], &up_compute_pkg_l[l]);
-      hypre_ComputePkgSetMemoryLocation(up_compute_pkg_l[l], memory_location);
    }
 
    (cyc_red_data -> down_compute_pkg_l) = down_compute_pkg_l;

--- a/src/struct_ls/cyclic_reduction.c
+++ b/src/struct_ls/cyclic_reduction.c
@@ -488,6 +488,7 @@ hypre_CyclicReductionSetup( void               *cyc_red_vdata,
 
    hypre_CyclicReductionData *cyc_red_data = (hypre_CyclicReductionData *) cyc_red_vdata;
 
+   HYPRE_MemoryLocation    memory_location = hypre_StructMatrixMemoryLocation(A);
    MPI_Comm                comm        = (cyc_red_data -> comm);
    HYPRE_Int               cdir        = (cyc_red_data -> cdir);
    hypre_IndexRef          base_index  = (cyc_red_data -> base_index);
@@ -662,6 +663,7 @@ hypre_CyclicReductionSetup( void               *cyc_red_vdata,
       hypre_ComputePkgCreate(compute_info,
                              hypre_StructVectorDataSpace(x_l[l]), 1,
                              grid_l[l], &down_compute_pkg_l[l]);
+      hypre_ComputePkgSetMemoryLocation(down_compute_pkg_l[l], memory_location);
 
       /* up-cycle */
       hypre_CreateComputeInfo(grid_l[l], ustride, hypre_StructMatrixStencil(A_l[l]),
@@ -672,6 +674,7 @@ hypre_CyclicReductionSetup( void               *cyc_red_vdata,
       hypre_ComputePkgCreate(compute_info,
                              hypre_StructVectorDataSpace(x_l[l]), 1,
                              grid_l[l], &up_compute_pkg_l[l]);
+      hypre_ComputePkgSetMemoryLocation(up_compute_pkg_l[l], memory_location);
    }
 
    (cyc_red_data -> down_compute_pkg_l) = down_compute_pkg_l;

--- a/src/struct_ls/red_black_gs.c
+++ b/src/struct_ls/red_black_gs.c
@@ -74,6 +74,7 @@ hypre_RedBlackGSSetup( void               *relax_vdata,
                        hypre_StructVector *b,
                        hypre_StructVector *x )
 {
+   HYPRE_MemoryLocation   memory_location = hypre_StructMatrixMemoryLocation(A);
    hypre_RedBlackGSData  *relax_data = (hypre_RedBlackGSData *)relax_vdata;
    hypre_StructGrid      *grid       = hypre_StructMatrixGrid(A);
    hypre_StructStencil   *stencil    = hypre_StructMatrixStencil(A);
@@ -89,7 +90,8 @@ hypre_RedBlackGSSetup( void               *relax_vdata,
     *----------------------------------------------------------*/
 
    hypre_CreateComputeInfo(grid, ustride, stencil, &compute_info);
-   hypre_ComputePkgCreate(compute_info, hypre_StructVectorDataSpace(x), 1,
+   hypre_ComputePkgCreate(memory_location, compute_info,
+                          hypre_StructVectorDataSpace(x), 1,
                           grid, &compute_pkg);
 
    /*----------------------------------------------------------

--- a/src/struct_ls/semi_interp.c
+++ b/src/struct_ls/semi_interp.c
@@ -53,6 +53,7 @@ hypre_SemiInterpSetup( void               *interp_vdata,
 {
    HYPRE_UNUSED_VAR(xc);
 
+   HYPRE_MemoryLocation    memory_location = hypre_StructMatrixMemoryLocation(P);
    hypre_SemiInterpData   *interp_data = (hypre_SemiInterpData   *)interp_vdata;
 
    hypre_StructGrid       *grid;
@@ -77,7 +78,8 @@ hypre_SemiInterpSetup( void               *interp_vdata,
    hypre_ComputeInfoProjectSend(compute_info, cindex, stride);
    hypre_ComputeInfoProjectRecv(compute_info, cindex, stride);
    hypre_ComputeInfoProjectComp(compute_info, findex, stride);
-   hypre_ComputePkgCreate(compute_info, hypre_StructVectorDataSpace(e), 1,
+   hypre_ComputePkgCreate(memory_location, compute_info,
+                          hypre_StructVectorDataSpace(e), 1,
                           grid, &compute_pkg);
 
    /*----------------------------------------------------------

--- a/src/struct_ls/semi_restrict.c
+++ b/src/struct_ls/semi_restrict.c
@@ -53,6 +53,7 @@ hypre_SemiRestrictSetup( void               *restrict_vdata,
 {
    HYPRE_UNUSED_VAR(rc);
 
+   HYPRE_MemoryLocation    memory_location = hypre_StructMatrixMemoryLocation(R);
    hypre_SemiRestrictData *restrict_data = (hypre_SemiRestrictData *)restrict_vdata;
 
    hypre_StructGrid       *grid;
@@ -77,7 +78,8 @@ hypre_SemiRestrictSetup( void               *restrict_vdata,
    hypre_ComputeInfoProjectSend(compute_info, findex, stride);
    hypre_ComputeInfoProjectRecv(compute_info, findex, stride);
    hypre_ComputeInfoProjectComp(compute_info, cindex, stride);
-   hypre_ComputePkgCreate(compute_info, hypre_StructVectorDataSpace(r), 1,
+   hypre_ComputePkgCreate(memory_location, compute_info,
+                          hypre_StructVectorDataSpace(r), 1,
                           grid, &compute_pkg);
 
    /*----------------------------------------------------------

--- a/src/struct_ls/smg_residual.c
+++ b/src/struct_ls/smg_residual.c
@@ -57,6 +57,7 @@ hypre_SMGResidualSetup( void               *residual_vdata,
                         hypre_StructVector *b,
                         hypre_StructVector *r              )
 {
+   HYPRE_MemoryLocation    memory_location = hypre_StructMatrixMemoryLocation(A);
    hypre_SMGResidualData  *residual_data = (hypre_SMGResidualData  *)residual_vdata;
 
    hypre_IndexRef          base_index  = (residual_data -> base_index);
@@ -84,7 +85,8 @@ hypre_SMGResidualSetup( void               *residual_vdata,
 
    hypre_CreateComputeInfo(grid, ustride, stencil, &compute_info);
    hypre_ComputeInfoProjectComp(compute_info, base_index, base_stride);
-   hypre_ComputePkgCreate(compute_info, hypre_StructVectorDataSpace(x), 1,
+   hypre_ComputePkgCreate(memory_location, compute_info,
+                          hypre_StructVectorDataSpace(x), 1,
                           grid, &compute_pkg);
 
    /*----------------------------------------------------------
@@ -308,4 +310,3 @@ hypre_SMGResidualDestroy( void *residual_vdata )
 
    return hypre_error_flag;
 }
-

--- a/src/struct_ls/smg_setup_interp.c
+++ b/src/struct_ls/smg_setup_interp.c
@@ -78,6 +78,8 @@ hypre_SMGSetupInterpOp( void               *relax_data,
                         hypre_Index         findex,
                         hypre_Index         stride    )
 {
+   HYPRE_MemoryLocation  memory_location = hypre_StructMatrixMemoryLocation(A);
+
    hypre_StructMatrix   *A_mask;
 
    hypre_StructStencil  *A_stencil;
@@ -200,7 +202,8 @@ hypre_SMGSetupInterpOp( void               *relax_data,
       hypre_ComputeInfoProjectSend(compute_info, findex, stride);
       hypre_ComputeInfoProjectRecv(compute_info, findex, stride);
       hypre_ComputeInfoProjectComp(compute_info, cindex, stride);
-      hypre_ComputePkgCreate(compute_info, hypre_StructVectorDataSpace(x), 1,
+      hypre_ComputePkgCreate(memory_location, compute_info,
+                             hypre_StructVectorDataSpace(x), 1,
                              fgrid, &compute_pkg);
 
       /*-----------------------------------------------------
@@ -290,4 +293,3 @@ hypre_SMGSetupInterpOp( void               *relax_data,
 
    return hypre_error_flag;
 }
-

--- a/src/struct_mv/_hypre_struct_mv.h
+++ b/src/struct_mv/_hypre_struct_mv.h
@@ -2228,10 +2228,11 @@ hypre_CreateComputeInfo( hypre_StructGrid      *grid,
                          hypre_Index            stride,
                          hypre_StructStencil   *stencil,
                          hypre_ComputeInfo    **compute_info_ptr );
-HYPRE_Int hypre_ComputePkgCreate ( hypre_ComputeInfo *compute_info, hypre_BoxArray *data_space,
-                                   HYPRE_Int num_values, hypre_StructGrid *grid, hypre_ComputePkg **compute_pkg_ptr );
-HYPRE_Int hypre_ComputePkgSetMemoryLocation( hypre_ComputePkg *compute_pkg,
-                                             HYPRE_MemoryLocation memory_location );
+HYPRE_Int hypre_ComputePkgCreate ( HYPRE_MemoryLocation memory_location,
+                                   hypre_ComputeInfo *compute_info,
+                                   hypre_BoxArray *data_space,
+                                   HYPRE_Int num_values, hypre_StructGrid *grid,
+                                   hypre_ComputePkg **compute_pkg_ptr );
 HYPRE_Int hypre_ComputePkgDestroy ( hypre_ComputePkg *compute_pkg );
 HYPRE_Int hypre_InitializeIndtComputations ( hypre_ComputePkg *compute_pkg, HYPRE_Complex *data,
                                              hypre_CommHandle **comm_handle_ptr );

--- a/src/struct_mv/_hypre_struct_mv_mup.h
+++ b/src/struct_mv/_hypre_struct_mv_mup.h
@@ -973,11 +973,11 @@ HYPRE_Int
 hypre_ComputeInfoProjectSend_long_dbl( hypre_ComputeInfo *compute_info, hypre_Index index, hypre_Index stride );
 
 HYPRE_Int
-hypre_ComputePkgCreate_flt( hypre_ComputeInfo *compute_info, hypre_BoxArray *data_space, HYPRE_Int num_values, hypre_StructGrid *grid, hypre_ComputePkg **compute_pkg_ptr );
+hypre_ComputePkgCreate_flt( HYPRE_MemoryLocation memory_location, hypre_ComputeInfo *compute_info, hypre_BoxArray *data_space, HYPRE_Int num_values, hypre_StructGrid *grid, hypre_ComputePkg **compute_pkg_ptr );
 HYPRE_Int
-hypre_ComputePkgCreate_dbl( hypre_ComputeInfo *compute_info, hypre_BoxArray *data_space, HYPRE_Int num_values, hypre_StructGrid *grid, hypre_ComputePkg **compute_pkg_ptr );
+hypre_ComputePkgCreate_dbl( HYPRE_MemoryLocation memory_location, hypre_ComputeInfo *compute_info, hypre_BoxArray *data_space, HYPRE_Int num_values, hypre_StructGrid *grid, hypre_ComputePkg **compute_pkg_ptr );
 HYPRE_Int
-hypre_ComputePkgCreate_long_dbl( hypre_ComputeInfo *compute_info, hypre_BoxArray *data_space, HYPRE_Int num_values, hypre_StructGrid *grid, hypre_ComputePkg **compute_pkg_ptr );
+hypre_ComputePkgCreate_long_dbl( HYPRE_MemoryLocation memory_location, hypre_ComputeInfo *compute_info, hypre_BoxArray *data_space, HYPRE_Int num_values, hypre_StructGrid *grid, hypre_ComputePkg **compute_pkg_ptr );
 
 HYPRE_Int
 hypre_ComputePkgDestroy_flt( hypre_ComputePkg *compute_pkg );
@@ -985,13 +985,6 @@ HYPRE_Int
 hypre_ComputePkgDestroy_dbl( hypre_ComputePkg *compute_pkg );
 HYPRE_Int
 hypre_ComputePkgDestroy_long_dbl( hypre_ComputePkg *compute_pkg );
-
-HYPRE_Int
-hypre_ComputePkgSetMemoryLocation_flt( hypre_ComputePkg *compute_pkg, HYPRE_MemoryLocation memory_location );
-HYPRE_Int
-hypre_ComputePkgSetMemoryLocation_dbl( hypre_ComputePkg *compute_pkg, HYPRE_MemoryLocation memory_location );
-HYPRE_Int
-hypre_ComputePkgSetMemoryLocation_long_dbl( hypre_ComputePkg *compute_pkg, HYPRE_MemoryLocation memory_location );
 
 HYPRE_Int
 hypre_ConvertToCanonicalIndex_flt( hypre_Index index, hypre_Index stride, HYPRE_Int ndim );

--- a/src/struct_mv/_hypre_struct_mv_mup_def.h
+++ b/src/struct_mv/_hypre_struct_mv_mup_def.h
@@ -220,7 +220,6 @@
 #define hypre_ComputeInfoProjectSend HYPRE_FIXEDPRECISION_FUNC ( hypre_ComputeInfoProjectSend )
 #define hypre_ComputePkgCreate HYPRE_FIXEDPRECISION_FUNC ( hypre_ComputePkgCreate )
 #define hypre_ComputePkgDestroy HYPRE_FIXEDPRECISION_FUNC ( hypre_ComputePkgDestroy )
-#define hypre_ComputePkgSetMemoryLocation HYPRE_FIXEDPRECISION_FUNC ( hypre_ComputePkgSetMemoryLocation )
 #define hypre_ConvertToCanonicalIndex HYPRE_FIXEDPRECISION_FUNC ( hypre_ConvertToCanonicalIndex )
 #define hypre_CopyBox HYPRE_FIXEDPRECISION_FUNC ( hypre_CopyBox )
 #define hypre_CopyIndex HYPRE_FIXEDPRECISION_FUNC ( hypre_CopyIndex )

--- a/src/struct_mv/_hypre_struct_mv_mup_undef.h
+++ b/src/struct_mv/_hypre_struct_mv_mup_undef.h
@@ -217,7 +217,6 @@
 #undef hypre_ComputeInfoProjectSend
 #undef hypre_ComputePkgCreate
 #undef hypre_ComputePkgDestroy
-#undef hypre_ComputePkgSetMemoryLocation
 #undef hypre_ConvertToCanonicalIndex
 #undef hypre_CopyBox
 #undef hypre_CopyIndex

--- a/src/struct_mv/computation.c
+++ b/src/struct_mv/computation.c
@@ -277,7 +277,8 @@ hypre_CreateComputeInfo( hypre_StructGrid      *grid,
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_ComputePkgCreate( hypre_ComputeInfo     *compute_info,
+hypre_ComputePkgCreate( HYPRE_MemoryLocation   memory_location,
+                        hypre_ComputeInfo     *compute_info,
                         hypre_BoxArray        *data_space,
                         HYPRE_Int              num_values,
                         hypre_StructGrid      *grid,
@@ -291,7 +292,7 @@ hypre_ComputePkgCreate( hypre_ComputeInfo     *compute_info,
    hypre_CommPkgCreate(hypre_ComputeInfoCommInfo(compute_info),
                        data_space, data_space, num_values, NULL, 0,
                        hypre_StructGridComm(grid),
-                       HYPRE_MEMORY_HOST, &comm_pkg);
+                       memory_location, &comm_pkg);
    hypre_CommInfoDestroy(hypre_ComputeInfoCommInfo(compute_info));
    hypre_ComputePkgCommPkg(compute_pkg) = comm_pkg;
 
@@ -305,19 +306,6 @@ hypre_ComputePkgCreate( hypre_ComputeInfo     *compute_info,
    hypre_ComputeInfoDestroy(compute_info);
 
    *compute_pkg_ptr = compute_pkg;
-
-   return hypre_error_flag;
-}
-
-/*--------------------------------------------------------------------------
- * Set the memory location of the underlying communication package
- *--------------------------------------------------------------------------*/
-
-HYPRE_Int
-hypre_ComputePkgSetMemoryLocation( hypre_ComputePkg     *compute_pkg,
-                                   HYPRE_MemoryLocation  memory_location )
-{
-   hypre_ComputePkgMemoryLocation(compute_pkg) = memory_location;
 
    return hypre_error_flag;
 }

--- a/src/struct_mv/mup.fixed
+++ b/src/struct_mv/mup.fixed
@@ -136,7 +136,6 @@ hypre_ComputeInfoProjectRecv
 hypre_ComputeInfoProjectSend
 hypre_ComputePkgCreate
 hypre_ComputePkgDestroy
-hypre_ComputePkgSetMemoryLocation
 hypre_ConvertToCanonicalIndex
 hypre_CopyBox
 hypre_CopyIndex

--- a/src/struct_mv/mup_fixed.c
+++ b/src/struct_mv/mup_fixed.c
@@ -1105,9 +1105,9 @@ hypre_ComputeInfoProjectSend( hypre_ComputeInfo *compute_info, hypre_Index index
 /*--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_ComputePkgCreate( hypre_ComputeInfo *compute_info, hypre_BoxArray *data_space, HYPRE_Int num_values, hypre_StructGrid *grid, hypre_ComputePkg **compute_pkg_ptr )
+hypre_ComputePkgCreate( HYPRE_MemoryLocation memory_location, hypre_ComputeInfo *compute_info, hypre_BoxArray *data_space, HYPRE_Int num_values, hypre_StructGrid *grid, hypre_ComputePkg **compute_pkg_ptr )
 {
-   return HYPRE_CURRENTPRECISION_FUNC(hypre_ComputePkgCreate)( compute_info, data_space, num_values, grid, compute_pkg_ptr );
+   return HYPRE_CURRENTPRECISION_FUNC(hypre_ComputePkgCreate)( memory_location, compute_info, data_space, num_values, grid, compute_pkg_ptr );
 }
 
 /*--------------------------------------------------------------------------*/
@@ -1116,14 +1116,6 @@ HYPRE_Int
 hypre_ComputePkgDestroy( hypre_ComputePkg *compute_pkg )
 {
    return HYPRE_CURRENTPRECISION_FUNC(hypre_ComputePkgDestroy)( compute_pkg );
-}
-
-/*--------------------------------------------------------------------------*/
-
-HYPRE_Int
-hypre_ComputePkgSetMemoryLocation( hypre_ComputePkg *compute_pkg, HYPRE_MemoryLocation memory_location )
-{
-   return HYPRE_CURRENTPRECISION_FUNC(hypre_ComputePkgSetMemoryLocation)( compute_pkg, memory_location );
 }
 
 /*--------------------------------------------------------------------------*/

--- a/src/struct_mv/protos.h
+++ b/src/struct_mv/protos.h
@@ -310,10 +310,11 @@ hypre_CreateComputeInfo( hypre_StructGrid      *grid,
                          hypre_Index            stride,
                          hypre_StructStencil   *stencil,
                          hypre_ComputeInfo    **compute_info_ptr );
-HYPRE_Int hypre_ComputePkgCreate ( hypre_ComputeInfo *compute_info, hypre_BoxArray *data_space,
-                                   HYPRE_Int num_values, hypre_StructGrid *grid, hypre_ComputePkg **compute_pkg_ptr );
-HYPRE_Int hypre_ComputePkgSetMemoryLocation( hypre_ComputePkg *compute_pkg,
-                                             HYPRE_MemoryLocation memory_location );
+HYPRE_Int hypre_ComputePkgCreate ( HYPRE_MemoryLocation memory_location,
+                                   hypre_ComputeInfo *compute_info,
+                                   hypre_BoxArray *data_space,
+                                   HYPRE_Int num_values, hypre_StructGrid *grid,
+                                   hypre_ComputePkg **compute_pkg_ptr );
 HYPRE_Int hypre_ComputePkgDestroy ( hypre_ComputePkg *compute_pkg );
 HYPRE_Int hypre_InitializeIndtComputations ( hypre_ComputePkg *compute_pkg, HYPRE_Complex *data,
                                              hypre_CommHandle **comm_handle_ptr );

--- a/src/struct_mv/struct_matrix.c
+++ b/src/struct_mv/struct_matrix.c
@@ -2363,7 +2363,7 @@ hypre_StructMatrixReadData( FILE               *file,
    if (hypre_GetActualMemLocation(memory_location) != hypre_MEMORY_HOST)
    {
       vi = hypre_BoxArrayVolume(boxes) * num_values;
-      values = hypre_TAlloc(HYPRE_Complex, vi, HYPRE_MEMORY_DEVICE);
+      values = hypre_TAlloc(HYPRE_Complex, vi, memory_location);
       hypre_TMemcpy(values, h_values, HYPRE_Complex, vi,
                     memory_location, HYPRE_MEMORY_HOST);
       hypre_TFree(h_values, HYPRE_MEMORY_HOST);

--- a/src/struct_mv/struct_matvec.c
+++ b/src/struct_mv/struct_matvec.c
@@ -185,8 +185,7 @@ hypre_StructMatvecResize( hypre_StructMatvecData  *matvec_data,
       /* NOTE: Compute boxes will be appropriately projected in MatvecCompute */
       hypre_CommInfoRefine(hypre_ComputeInfoCommInfo(compute_info), NULL, xfstride);
       hypre_StructVectorMapCommInfo(x, hypre_ComputeInfoCommInfo(compute_info));
-      hypre_ComputePkgCreate(compute_info, data_space, 1, grid, &compute_pkg);
-      hypre_ComputePkgSetMemoryLocation(compute_pkg, memloc);
+      hypre_ComputePkgCreate(memloc, compute_info, data_space, 1, grid, &compute_pkg);
 
       /* Save compute_pkg */
       if ((matvec_data -> compute_pkg) != NULL)

--- a/src/struct_mv/struct_vector.c
+++ b/src/struct_mv/struct_vector.c
@@ -1586,7 +1586,7 @@ hypre_StructVectorReadData( FILE               *file,
    {
       vi = hypre_BoxArrayVolume(boxes) * num_values;
       values = hypre_TAlloc(HYPRE_Complex, vi, memory_location);
-      hypre_TMemcpy(values, h_values, HYPRE_Complex, num_values,
+      hypre_TMemcpy(values, h_values, HYPRE_Complex, vi,
                     memory_location, HYPRE_MEMORY_HOST);
       hypre_TFree(h_values, HYPRE_MEMORY_HOST);
    }


### PR DESCRIPTION
Fix regressions on Tuolumne. All the struct and sstruct regressions (except for ssamg) should be passing on both lassen and tuolumne now. Note that we need to generate some .saved files for Tuolumne, but I'm going to leave that for another PR focused on a larger revamp of what tests we do on that machine.