### PR TITLE
[hypre-3.0]: Fix regressions with rocm 5.4.3

### DIFF
--- a/src/seq_mv/csr_matop_device.c
+++ b/src/seq_mv/csr_matop_device.c
@@ -349,7 +349,7 @@ hypre_CSRMatrixDeleteZerosDevice( hypre_CSRMatrix *A,
                                         thrust::make_zip_iterator(thrust::make_tuple(A_data + num_nonzeros, A_j + num_nonzeros)),
                                         A_data,
                                         thrust::make_zip_iterator(thrust::make_tuple(B_data, B_j)),
-      [ = ] __device__ (HYPRE_Complex v) { return hypre_cabs(v) > tol; } );
+					hypreFunctor_NonzeroAboveTol(tol));
       hypre_assert(thrust::get<0>(new_end.get_iterator_tuple()) - B_data == num_nonzeros_B);
 #elif defined(HYPRE_USING_SYCL)
       auto new_end = HYPRE_ONEDPL_CALL( copy_if,
@@ -394,7 +394,7 @@ hypre_CSRMatrixDeleteZerosDevice( hypre_CSRMatrix *A,
                          row_indices + num_nonzeros,
                          A_data,
                          B_row_indices,
-      [ = ] __device__ (HYPRE_Complex v) { return hypre_cabs(v) > tol; } );
+			 hypreFunctor_NonzeroAboveTol(tol));
 #elif defined(HYPRE_USING_SYCL)
       hypreSycl_copy_if( row_indices,
                          row_indices + num_nonzeros,

--- a/src/sstruct_mv/sstruct_grid.c
+++ b/src/sstruct_mv/sstruct_grid.c
@@ -2895,6 +2895,8 @@ hypre_SStructGridCoarsen( hypre_SStructGrid   *fgrid,
                           hypre_Index         *periodic, // periodic data for each part
                           hypre_SStructGrid  **cgrid_ptr )
 {
+   HYPRE_UNUSED_VAR(periodic);
+
    MPI_Comm                 comm    = hypre_SStructGridComm(fgrid);
    HYPRE_Int                ndim    = hypre_SStructGridNDim(fgrid);
    HYPRE_Int                nparts  = hypre_SStructGridNParts(fgrid);

--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -2675,7 +2675,7 @@ hypre_SStructMatrixBoxesToUMatrix( hypre_SStructMatrix   *A,
    HYPRE_Int             *num_ghost;
    HYPRE_Int              nSentries;
 #if !defined(HYPRE_USING_GPU)
-   HYPRE_Int              m = 0
+   HYPRE_Int              m = 0;
    hypre_Index            loop_size;
    hypre_IndexRef         start;
 #endif

--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -2671,12 +2671,11 @@ hypre_SStructMatrixBoxesToUMatrix( hypre_SStructMatrix   *A,
    HYPRE_BigInt           sizes[4];
    HYPRE_Int              entry, part, var, nvars;
    HYPRE_Int              nnzrow;
-   HYPRE_Int              nvalues, i, j, m;
+   HYPRE_Int              nvalues, i, j;
    HYPRE_Int             *num_ghost;
    HYPRE_Int              nSentries;
-#if defined(HYPRE_USING_GPU)
-   HYPRE_ExecutionPolicy  exec = hypre_GetExecPolicy1(memory_location);
-#else
+#if !defined(HYPRE_USING_GPU)
+   HYPRE_Int              m = 0
    hypre_Index            loop_size;
    hypre_IndexRef         start;
 #endif
@@ -2695,7 +2694,7 @@ hypre_SStructMatrixBoxesToUMatrix( hypre_SStructMatrix   *A,
 
    /* Set row sizes */
    HYPRE_ANNOTATE_REGION_BEGIN("%s", "Set rowsizes");
-   nvalues = 0; m = 0;
+   nvalues = 0;
    hypre_SetIndex(stride, 1);
 #if !defined(HYPRE_USING_GPU)
    if (!*ij_Ahat_ptr)
@@ -2747,8 +2746,9 @@ hypre_SStructMatrixBoxesToUMatrix( hypre_SStructMatrix   *A,
                nvalues = hypre_max(nvalues, nnzrow * hypre_BoxVolume(convert_box));
             } /* Loop over convert_boxa[part][var] */
 
+#if !defined(HYPRE_USING_GPU)
             m += hypre_BoxVolume(ghost_box);
-
+#endif
          } /* Loop over grid_boxes */
       } /* Loop over vars */
    } /* Loop over parts */

--- a/src/struct_ls/pfmg_coarsen.c
+++ b/src/struct_ls/pfmg_coarsen.c
@@ -733,11 +733,6 @@ hypre_PFMGComputeCxyz( hypre_StructMatrix *A,
    HYPRE_Int              vsi[HYPRE_MAXDIM][stencil_size];
    HYPRE_Int              diag_is_constant;
 
-#if defined(HYPRE_USING_GPU)
-   HYPRE_MemoryLocation   memory_location = hypre_StructMatrixMemoryLocation(A);
-   HYPRE_ExecutionPolicy  exec_policy     = hypre_GetExecPolicy1(memory_location);
-#endif
-
    HYPRE_ANNOTATE_FUNC_BEGIN;
    hypre_GpuProfilingPushRange("PFMGComputeCxyz");
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -118,7 +118,7 @@ struct hypreFunctor_NonzeroAboveTol
 {
    HYPRE_Real tol;
 
-   hypreFunctor_NonzeroAboveTol(double tol_) : tol(tol_) {}
+   hypreFunctor_NonzeroAboveTol(HYPRE_Real tol_) : tol(tol_) {}
 
    __host__ __device__
    bool operator()(const HYPRE_Complex& x) const

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -110,6 +110,23 @@ struct hypreFunctor_IndexCycle
    }
 };
 
+/*--------------------------------------------------------------------------
+ * Functor to check: |x| > tol
+ *--------------------------------------------------------------------------*/
+
+struct hypreFunctor_NonzeroAboveTol
+{
+   HYPRE_Real tol;
+
+   hypreFunctor_NonzeroAboveTol(double tol_) : tol(tol_) {}
+
+   __host__ __device__
+   bool operator()(const HYPRE_Complex& x) const
+   {
+      return hypre_cabs(x) > tol;
+   }
+};
+
 #endif /* if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */
 #endif /* ifndef HYPRE_FUNCTORS_H */
 /******************************************************************************

--- a/src/utilities/functors.h
+++ b/src/utilities/functors.h
@@ -96,5 +96,22 @@ struct hypreFunctor_IndexCycle
    }
 };
 
+/*--------------------------------------------------------------------------
+ * Functor to check: |x| > tol
+ *--------------------------------------------------------------------------*/
+
+struct hypreFunctor_NonzeroAboveTol
+{
+   HYPRE_Real tol;
+
+   hypreFunctor_NonzeroAboveTol(double tol_) : tol(tol_) {}
+
+   __host__ __device__
+   bool operator()(const HYPRE_Complex& x) const
+   {
+      return hypre_cabs(x) > tol;
+   }
+};
+
 #endif /* if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) */
 #endif /* ifndef HYPRE_FUNCTORS_H */

--- a/src/utilities/functors.h
+++ b/src/utilities/functors.h
@@ -104,7 +104,7 @@ struct hypreFunctor_NonzeroAboveTol
 {
    HYPRE_Real tol;
 
-   hypreFunctor_NonzeroAboveTol(double tol_) : tol(tol_) {}
+   hypreFunctor_NonzeroAboveTol(HYPRE_Real tol_) : tol(tol_) {}
 
    __host__ __device__
    bool operator()(const HYPRE_Complex& x) const


### PR DESCRIPTION
See https://github.com/hypre-space/hypre/pull/1316#issuecomment-3237530935

Fixes also a few compilation warnings:

```
sstruct_matrix.c:2674:42: warning: variable 'm' set but not used [-Wunused-but-set-variable]
   HYPRE_Int              nvalues, i, j, m;
                                         ^
sstruct_matrix.c:2678:27: warning: unused variable 'exec' [-Wunused-variable]
   HYPRE_ExecutionPolicy  exec = hypre_GetExecPolicy1(memory_location);
                          ^

pfmg_coarsen.c:738:27: warning: unused variable 'exec_policy' [-Wunused-variable]
   HYPRE_ExecutionPolicy  exec_policy     = hypre_GetExecPolicy1(memory_location);
                          ^

```