### PR TITLE
[hypre 3.0]: CUDA 13 support

### DIFF
--- a/src/config/cmake/HYPRE_SetupGPUToolkit.cmake
+++ b/src/config/cmake/HYPRE_SetupGPUToolkit.cmake
@@ -6,21 +6,10 @@
 # Enable CXX language
 enable_language(CXX)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-if(HYPRE_ENABLE_SYCL)
-  # We enforce the use of Intel's oneAPI DPC++/C++ Compiler
-  if(NOT CMAKE_CXX_COMPILER MATCHES "dpcpp|icpx")
-    message(FATAL_ERROR "SYCL requires DPC++ or Intel C++ compiler")
-  endif()
 
-  # Enforce C++17 at least for SYCL
-  if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 17)
-    set(CMAKE_CXX_STANDARD 17)
-  endif()
-else()
-  # Enforce C++14 at least for CUDA and HIP
-  if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 14)
-    set(CMAKE_CXX_STANDARD 14)
-  endif()
+# Enforce C++17 at least
+if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 17)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 # Set C++ standard for HYPRE

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -197,7 +197,7 @@ hypre_using_memory_tracker=no
 
 hypre_test_using_host=no
 
-hypre_cxxstd=11
+hypre_cxxstd=17
 
 dnl *********************************************************************
 dnl * Initialize hypre-MAGMA variables
@@ -2699,7 +2699,7 @@ AS_IF([test x"$hypre_using_hip" == x"yes"],
         dnl interprets as C and therefore invokes the C compiler rather than the HIP part
         dnl of clang. Put HIPCXXFLAGS at the end so the user can override from
         dnl from the configure line.
-        HIPCXXFLAGS="-x hip -fPIE -std=c++14 ${HIPCXXFLAGS}"
+        HIPCXXFLAGS="-x hip -fPIE -std=c++${hypre_cxxstd} ${HIPCXXFLAGS}"
 
         dnl If not in debug mode, at least -O2, but the user can override with
         dnl with HIPCXXFLAGS on the configure line. If in debug mode, -O0 -Wall

--- a/src/configure
+++ b/src/configure
@@ -3378,7 +3378,7 @@ hypre_using_memory_tracker=no
 
 hypre_test_using_host=no
 
-hypre_cxxstd=11
+hypre_cxxstd=17
 
 hypre_using_magma=no
 hypre_user_gave_magma_inc=no
@@ -10927,7 +10927,7 @@ printf "%s\n" "#define HYPRE_USING_HIP 1" >>confdefs.h
            HYPRE_CUDA_GENCODE="`echo ${HYPRE_CUDA_GENCODE}|sed 's/,$//'`"
         fi
 
-                                        HIPCXXFLAGS="-x hip -fPIE -std=c++14 ${HIPCXXFLAGS}"
+                                        HIPCXXFLAGS="-x hip -fPIE -std=c++${hypre_cxxstd} ${HIPCXXFLAGS}"
 
                                 if test x"$hypre_using_debug" == x"yes"
 then :

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -264,10 +264,6 @@ using hypre_DeviceItem = void*;
 #define CUB_IGNORE_DEPRECATED_CPP_DIALECT
 #endif
 
-#if CUDART_VERSION >= 13000
-#define cudaMemPrefetchAsync(a0, a1, a2, a3) cudaMemPrefetchAsync(a0, a1, a2, 0, a3)
-#endif
-
 #ifndef CUSPARSE_VERSION
 #if defined(CUSPARSE_VER_MAJOR) && defined(CUSPARSE_VER_MINOR) && defined(CUSPARSE_VER_PATCH)
 #define CUSPARSE_VERSION (CUSPARSE_VER_MAJOR * 1000 + CUSPARSE_VER_MINOR *  100 + CUSPARSE_VER_PATCH)
@@ -316,6 +312,31 @@ using hypre_DeviceItem = void*;
 #define HYPRE_THRUST_EXECUTION thrust::cuda::par_nosync
 #else
 #define HYPRE_THRUST_EXECUTION thrust::cuda::par
+#endif
+
+#if CUDART_VERSION >= 13000
+// Macro for device memory prefetching (CUDART 13.0+)
+#define HYPRE_MEM_PREFETCH_DEVICE(ptr, size, stream) \
+   do { \
+      cudaMemLocation loc = {cudaMemLocationTypeDevice, hypre_HandleDevice(hypre_handle())}; \
+      HYPRE_CUDA_CALL(cudaMemPrefetchAsync(ptr, size, loc, 0, stream)); \
+   } while (0)
+
+// Macro for host memory prefetching (CUDART 13.0+)
+#define HYPRE_MEM_PREFETCH_HOST(ptr, size, stream) \
+   do { \
+      cudaMemLocation loc = {cudaMemLocationTypeHost, cudaCpuDeviceId}; \
+      HYPRE_CUDA_CALL(cudaMemPrefetchAsync(ptr, size, loc, 0, stream)); \
+   } while (0)
+
+#else
+// Macro for device memory prefetching (< CUDART 13.0)
+#define HYPRE_MEM_PREFETCH_DEVICE(ptr, size, stream) \
+   HYPRE_CUDA_CALL(cudaMemPrefetchAsync(ptr, size, hypre_HandleDevice(hypre_handle()), stream))
+
+// Macro for host memory prefetching (< CUDART 13.0)
+#define HYPRE_MEM_PREFETCH_HOST(ptr, size, stream) \
+   HYPRE_CUDA_CALL(cudaMemPrefetchAsync(ptr, size, cudaCpuDeviceId, stream))
 #endif
 
 #endif /* defined(HYPRE_USING_CUDA) */

--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -196,13 +196,11 @@ hypre_UnifiedMemPrefetch(void *ptr, size_t size, hypre_MemoryLocation location)
 #if defined(HYPRE_USING_CUDA)
    if (location == hypre_MEMORY_DEVICE)
    {
-      HYPRE_CUDA_CALL( cudaMemPrefetchAsync(ptr, size, hypre_HandleDevice(hypre_handle()),
-                                            hypre_HandleComputeStream(hypre_handle())) );
+      HYPRE_MEM_PREFETCH_DEVICE(ptr, size, hypre_HandleComputeStream(hypre_handle()));
    }
    else if (location == hypre_MEMORY_HOST)
    {
-      HYPRE_CUDA_CALL( cudaMemPrefetchAsync(ptr, size, cudaCpuDeviceId,
-                                            hypre_HandleComputeStream(hypre_handle())) );
+      HYPRE_MEM_PREFETCH_HOST(ptr, size, hypre_HandleComputeStream(hypre_handle()));
    }
 
 #elif defined(HYPRE_USING_HIP)


### PR DESCRIPTION
Fixes a couple of issues involving CUDA 13 support. See https://github.com/hypre-space/hypre/pull/1324#issuecomment-3239392950

CUDA 13 and rocm 7.0 both require C++17. This PR bumps our minimum C++ standard to 17

Closes #1326 