### PR TITLE
Don't free data if we don't own it

### DIFF
--- a/src/seq_mv/csr_matrix.c
+++ b/src/seq_mv/csr_matrix.c
@@ -926,6 +926,7 @@ hypre_CSRMatrixMigrate( hypre_CSRMatrix     *A,
    HYPRE_Int      *A_j          = hypre_CSRMatrixJ(A);
    HYPRE_BigInt   *A_big_j      = hypre_CSRMatrixBigJ(A);
    HYPRE_Complex  *A_data       = hypre_CSRMatrixData(A);
+   HYPRE_Int       owns_data    = hypre_CSRMatrixOwnsData(A);
 
    HYPRE_MemoryLocation old_memory_location = hypre_CSRMatrixMemoryLocation(A);
 
@@ -992,7 +993,10 @@ hypre_CSRMatrixMigrate( hypre_CSRMatrix     *A,
          B_data = hypre_TAlloc(HYPRE_Complex, num_nonzeros, memory_location);
          hypre_TMemcpy(B_data, A_data, HYPRE_Complex, num_nonzeros,
                        memory_location, old_memory_location);
-         hypre_TFree(A_data, old_memory_location);
+         if (owns_data)
+         {
+            hypre_TFree(A_data, old_memory_location);
+         }
          hypre_CSRMatrixData(A) = B_data;
       }
    }


### PR DESCRIPTION
I ran into this in PETSc where we have hypre alias some other internal PETSc matrix's memory. When trying to do a cudaMemcpy from that PETSc matrix I got an invalid argument and found that the device pointer had been unregistered by this free