### PR TITLE
[hypre 3.0]: Fix MGR issues

### DIFF
--- a/src/parcsr_ls/par_mgr.c
+++ b/src/parcsr_ls/par_mgr.c
@@ -912,6 +912,8 @@ hypre_MGRSetReservedCoarseNodes(void      *mgr_vdata,
 
 /*--------------------------------------------------------------------------
  * Set CF marker array
+ *
+ * TODO: move to par_mgr_coarsen.c
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
@@ -923,11 +925,12 @@ hypre_MGRCoarsen(hypre_ParCSRMatrix *S,
                  hypre_IntArray **CF_marker_ptr,
                  HYPRE_Int cflag)
 {
-   HYPRE_Int   *CF_marker = NULL;
-   HYPRE_Int *cindexes = fixed_coarse_indexes;
-   HYPRE_Int    i, row, nc;
-   HYPRE_Int nloc =  hypre_ParCSRMatrixNumRows(A);
-   HYPRE_MemoryLocation memory_location;
+   HYPRE_Int            *CF_marker = NULL;
+   HYPRE_Int            *cindexes = fixed_coarse_indexes;
+   HYPRE_Int             i, row, nc;
+   HYPRE_Int             nloc            = hypre_ParCSRMatrixNumRows(A);
+   HYPRE_MemoryLocation  memory_location = hypre_ParCSRMatrixMemoryLocation(A);
+   HYPRE_ExecutionPolicy exec            = hypre_GetExecPolicy1(memory_location);
 
    /* If this is the last level, coarsen onto fixed coarse set */
    if (cflag)
@@ -939,7 +942,6 @@ hypre_MGRCoarsen(hypre_ParCSRMatrix *S,
       *CF_marker_ptr = hypre_IntArrayCreate(nloc);
       hypre_IntArrayInitialize(*CF_marker_ptr);
       hypre_IntArraySetConstantValues(*CF_marker_ptr, FMRK);
-      memory_location = hypre_IntArrayMemoryLocation(*CF_marker_ptr);
 
       if (hypre_GetActualMemLocation(memory_location) == hypre_MEMORY_DEVICE)
       {
@@ -969,8 +971,18 @@ hypre_MGRCoarsen(hypre_ParCSRMatrix *S,
        * but not necessarily the best option, compared to initializing
        * CF_marker first and then coarsening on subgraph which excludes
        * the initialized coarse nodes.
-      */
-      hypre_BoomerAMGCoarsen(S, A, 0, debug_flag, CF_marker_ptr);
+       */
+#if defined(HYPRE_USING_GPU)
+      if (exec == HYPRE_EXEC_DEVICE)
+      {
+         hypre_BoomerAMGCoarsenPMIS(S, A, 2, debug_flag, CF_marker_ptr);
+      }
+      else
+#endif
+      {
+         hypre_BoomerAMGCoarsen(S, A, 0, debug_flag, CF_marker_ptr);
+      }
+      hypre_IntArrayMigrate(*CF_marker_ptr, HYPRE_MEMORY_HOST);
       CF_marker = hypre_IntArrayData(*CF_marker_ptr);
 
       /* Update CF_marker to correct Cpoints marked as Fpoints. */
@@ -979,6 +991,7 @@ hypre_MGRCoarsen(hypre_ParCSRMatrix *S,
       {
          CF_marker[cindexes[i]] = CMRK;
       }
+
       /* set F-points to FMRK. This is necessary since the different coarsening schemes differentiate
        * between type of F-points (example Ruge coarsening). We do not need that distinction here.
       */
@@ -987,6 +1000,8 @@ hypre_MGRCoarsen(hypre_ParCSRMatrix *S,
          if (CF_marker[row] == CMRK) { continue; }
          CF_marker[row] = FMRK;
       }
+
+      hypre_IntArrayMigrate(*CF_marker_ptr, memory_location);
 #if 0
       /* IMPORTANT: Update coarse_indexes array to define the positions of the fixed coarse points
        * in the next level.

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -1735,9 +1735,11 @@ hypre_MGRSetup( void               *mgr_vdata,
 }
 
 /*--------------------------------------------------------------------------
- * hypre_MGRSetupFrelaxVcycleData
- *
  * Setup data for Frelax V-cycle
+ *
+ * TODO:
+ *  1) Revisit whether we should keep this function or not.
+ *  2) If kept, remove migrate calls from this function.
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
@@ -1751,6 +1753,9 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
    hypre_ParMGRData   *mgr_data = (hypre_ParMGRData*) mgr_vdata;
    hypre_ParAMGData    **FrelaxVcycleData = mgr_data -> FrelaxVcycleData;
    HYPRE_MemoryLocation memory_location = hypre_ParCSRMatrixMemoryLocation(A);
+/* #if defined(HYPRE_USING_GPU) */
+/*    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1(memory_location); */
+/* #endif */
 
    HYPRE_Int i, j, num_procs, my_id;
 
@@ -1782,7 +1787,6 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
 
    HYPRE_Int       old_num_levels = hypre_ParAMGDataNumLevels(FrelaxVcycleData[lev]);
    hypre_IntArray       **CF_marker_array_local = (FrelaxVcycleData[lev] -> CF_marker_array);
-   HYPRE_Int            *CF_marker_local = NULL;
    hypre_ParCSRMatrix   **A_array_local = (FrelaxVcycleData[lev] -> A_array);
    hypre_ParCSRMatrix   **P_array_local = (FrelaxVcycleData[lev] -> P_array);
    hypre_ParVector      **F_array_local = (FrelaxVcycleData[lev] -> F_array);
@@ -1889,19 +1893,13 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
    F_array_local[0] = f;
    U_array_local[0] = u;
 
-   for (i = 0; i < local_size; i++)
-   {
-      if (hypre_IntArrayData(CF_marker_array[lev])[i] == smrk_local)
-      {
-         num_fine_points++;
-      }
-   }
-   //hypre_printf("My_ID = %d, Size of A_FF matrix: %d \n", my_id, num_fine_points);
+   /* Count number of fine points */
+   hypre_IntArrayCount(CF_marker_array[lev], smrk_local, &num_fine_points);
 
    if (num_functions > 1 && dof_func == NULL)
    {
       dof_func = hypre_IntArrayCreate(num_fine_points);
-      hypre_IntArrayInitialize(dof_func);
+      hypre_IntArrayInitialize_v2(dof_func, HYPRE_MEMORY_HOST);
       indx = 0;
       tms = num_fine_points / num_functions;
       if (tms * num_functions + indx > num_fine_points) { tms--; }
@@ -1917,11 +1915,13 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
       {
          hypre_IntArrayData(dof_func)[indx++] = k++;
       }
+      hypre_IntArrayMigrate(dof_func, memory_location);
       FrelaxVcycleData[lev] -> dof_func = dof_func;
    }
    dof_func_array[0] = dof_func;
    hypre_ParAMGDataDofFuncArray(FrelaxVcycleData[lev]) = dof_func_array;
 
+   hypre_IntArrayMigrate(CF_marker_array[lev], HYPRE_MEMORY_HOST);
    while (not_finished)
    {
       local_size = hypre_ParCSRMatrixNumRows(A_array_local[lev_local]);
@@ -1935,12 +1935,15 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
       {
          /* use the CF_marker from the outer MGR cycle
             to create the strength connection matrix */
+         hypre_ParCSRMatrixMigrate(A_array_local[lev_local], HYPRE_MEMORY_HOST);
          hypre_BoomerAMGCreateSFromCFMarker(A_array_local[lev_local],
                                             strong_threshold,
                                             max_row_sum,
                                             hypre_IntArrayData(CF_marker_array[lev]),
                                             num_functions, dof_func_data,
                                             smrk_local, &S_local);
+         hypre_ParCSRMatrixMigrate(A_array_local[lev_local], memory_location);
+         hypre_ParCSRMatrixMigrate(S_local, memory_location);
       }
       else if (lev_local > 0)
       {
@@ -1951,7 +1954,6 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
 
       CF_marker_array_local[lev_local] = hypre_IntArrayCreate(local_size);
       hypre_IntArrayInitialize_v2(CF_marker_array_local[lev_local], memory_location);
-      CF_marker_local = hypre_IntArrayData(CF_marker_array_local[lev_local]);
 
       hypre_BoomerAMGCoarsenHMIS(S_local, A_array_local[lev_local], measure_type,
                                  coarsen_cut_factor, debug_flag,
@@ -1962,6 +1964,7 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
                                  CF_marker_array_local[lev_local],
                                  &coarse_dof_func_lvl, coarse_pnts_global_lvl);
 
+      hypre_IntArrayMigrate(CF_marker_array_local[lev_local], HYPRE_MEMORY_HOST);
       if (my_id == (num_procs - 1))
       {
          coarse_size = coarse_pnts_global_lvl[1];
@@ -1970,7 +1973,7 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
 
       if (coarse_size == 0) // stop coarsening
       {
-         if (S_local) { hypre_ParCSRMatrixDestroy(S_local); }
+         hypre_ParCSRMatrixDestroy(S_local);
          hypre_IntArrayDestroy(coarse_dof_func_lvl);
 
          if (lev_local == 0)
@@ -1984,7 +1987,7 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
                {
                   if (hypre_IntArrayData(CF_marker_array[lev])[i] == 1)
                   {
-                     CF_marker_local[i] = 0;
+                     hypre_IntArrayData(CF_marker_array_local[lev_local])[i] = 0;
                   }
                }
             }
@@ -1993,7 +1996,8 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
                /* Do lexicographic relaxation on F-points from outer CF-marker --DOK*/
                for (i = 0; i < local_size; i++)
                {
-                  CF_marker_local[i] = hypre_IntArrayData(CF_marker_array[lev])[i];
+                  hypre_IntArrayData(CF_marker_array_local[lev_local])[i] =
+                    hypre_IntArrayData(CF_marker_array[lev])[i];
                }
             }
          }
@@ -2005,13 +2009,14 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
          break;
       }
 
-      hypre_BoomerAMGBuildExtPIInterpHost(A_array_local[lev_local], CF_marker_local,
-                                          S_local, coarse_pnts_global_lvl, num_functions, dof_func_data,
-                                          debug_flag, trunc_factor, P_max_elmts, &P_local);
-
-      //    hypre_BoomerAMGBuildInterp(A_array_local[lev_local], CF_marker_local,
-      //                                   S_local, coarse_pnts_global_lvl, 1, NULL,
-      //                                   0, 0.0, 0, NULL, &P_local);
+      hypre_IntArrayMigrate(CF_marker_array_local[lev_local], memory_location);
+      hypre_BoomerAMGBuildExtPIInterp(A_array_local[lev_local],
+                                      hypre_IntArrayData(CF_marker_array_local[lev_local]),
+                                      S_local, coarse_pnts_global_lvl,
+                                      num_functions, dof_func_data,
+                                      debug_flag, trunc_factor,
+                                      P_max_elmts, &P_local);
+      hypre_IntArrayMigrate(CF_marker_array_local[lev_local], HYPRE_MEMORY_HOST);
 
       /* Save the CF_marker pointer. For lev_local = 0, save the cf_marker from outer MGR level (lev).
        * This is necessary to enable relaxations over the A_FF matrix during the solve phase. -- DOK
@@ -2025,7 +2030,7 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
             {
                if (hypre_IntArrayData(CF_marker_array[lev])[i] == 1)
                {
-                  CF_marker_local[i] = 0;
+                  hypre_IntArrayData(CF_marker_array_local[lev_local])[i] = 0;
                }
             }
          }
@@ -2034,10 +2039,13 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
             /* Do lexicographic relaxation on F-points from outer CF-marker --DOK */
             for (i = 0; i < local_size; i++)
             {
-               CF_marker_local[i] = hypre_IntArrayData(CF_marker_array[lev])[i];
+               hypre_IntArrayData(CF_marker_array_local[lev_local])[i] =
+                 hypre_IntArrayData(CF_marker_array[lev])[i];
             }
          }
       }
+      hypre_IntArrayMigrate(CF_marker_array_local[lev_local], memory_location);
+
       /* Save interpolation matrix pointer */
       P_array_local[lev_local] = P_local;
 
@@ -2047,17 +2055,18 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
       }
 
       /* build the coarse grid */
-      hypre_BoomerAMGBuildCoarseOperatorKT(P_local, A_array_local[lev_local],
-                                           P_local, 0, &RAP_local);
+      RAP_local = hypre_ParCSRMatrixRAPKT(P_local,
+                                          A_array_local[lev_local],
+                                          P_local, 0, 1);
       /*
           if (my_id == (num_procs -1)) coarse_size = coarse_pnts_global_lvl[1];
           hypre_MPI_Bcast(&coarse_size, 1, HYPRE_MPI_BIG_INT, num_procs-1, comm);
       */
       lev_local++;
 
-      if (S_local) { hypre_ParCSRMatrixDestroy(S_local); }
-      S_local = NULL;
-      if ( (lev_local == max_local_lvls - 1) || (coarse_size <= max_local_coarse_size) )
+      hypre_ParCSRMatrixDestroy(S_local); S_local = NULL;
+      if ((lev_local == max_local_lvls - 1) ||
+          (coarse_size <= max_local_coarse_size))
       {
          not_finished = 0;
       }
@@ -2066,13 +2075,14 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
       F_array_local[lev_local] = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(RAP_local),
                                                        hypre_ParCSRMatrixGlobalNumRows(RAP_local),
                                                        hypre_ParCSRMatrixRowStarts(RAP_local));
-      hypre_ParVectorInitialize(F_array_local[lev_local]);
+      hypre_ParVectorInitialize_v2(F_array_local[lev_local], memory_location);
 
       U_array_local[lev_local] = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(RAP_local),
                                                        hypre_ParCSRMatrixGlobalNumRows(RAP_local),
                                                        hypre_ParCSRMatrixRowStarts(RAP_local));
-      hypre_ParVectorInitialize(U_array_local[lev_local]);
+      hypre_ParVectorInitialize_v2(U_array_local[lev_local], memory_location);
    } // end while loop
+   hypre_IntArrayMigrate(CF_marker_array[lev], memory_location);
 
    // setup Vcycle data
    (FrelaxVcycleData[lev] -> A_array) = A_array_local;
@@ -2081,16 +2091,10 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
    (FrelaxVcycleData[lev] -> U_array) = U_array_local;
    (FrelaxVcycleData[lev] -> CF_marker_array) = CF_marker_array_local;
    (FrelaxVcycleData[lev] -> num_levels) = lev_local;
-   //if(lev == 1)
-   //{
-   //  for (i = 0; i < local_size; i++)
-   //  {
-   //    if(CF_marker_array_local[0][i] == 1)
-   //    hypre_printf("cfmarker[%d] = %d\n",i, CF_marker_array_local[0][i]);
-   //  }
-   //}
+
    /* setup GE for coarsest level (if small enough) */
-   if ((lev_local > 0) && (hypre_ParAMGDataUserCoarseRelaxType(FrelaxVcycleData[lev]) == 9))
+   if ((lev_local > 0) &&
+       (hypre_ParAMGDataUserCoarseRelaxType(FrelaxVcycleData[lev]) == 9))
    {
       if ((coarse_size <= max_local_coarse_size) && coarse_size > 0)
       {

--- a/src/parcsr_ls/par_mgr_solve.c
+++ b/src/parcsr_ls/par_mgr_solve.c
@@ -283,6 +283,7 @@ hypre_MGRFrelaxVcycle ( void            *Frelax_vdata,
    HYPRE_Int            local_size;
    HYPRE_Int            num_sweeps = 1;
    HYPRE_Int            relax_order = hypre_ParAMGDataRelaxOrder(Frelax_data);
+   HYPRE_Int            amg_relax_order;
    HYPRE_Int            relax_type = 3;
    HYPRE_Real           relax_weight = 1.0;
    HYPRE_Real           omega = 1.0;
@@ -308,6 +309,10 @@ hypre_MGRFrelaxVcycle ( void            *Frelax_vdata,
    HYPRE_Complex        fp_one = 1.0;
    HYPRE_Complex        fp_neg_one = - fp_one;
 
+#if defined(HYPRE_USING_GPU)
+   HYPRE_ExecutionPolicy  exec;
+#endif
+
    HYPRE_ANNOTATE_FUNC_BEGIN;
 
    F_array[0] = f;
@@ -317,6 +322,19 @@ hypre_MGRFrelaxVcycle ( void            *Frelax_vdata,
    if (CF_marker_array[0])
    {
       CF_marker = hypre_IntArrayData(CF_marker_array[0]);
+   }
+
+   /* Disable internal relax. order in AMG when running on GPUs */
+#if defined(HYPRE_USING_GPU)
+   exec = hypre_GetExecPolicy1(hypre_ParCSRMatrixMemoryLocation(A_array[0]));
+   if (exec == HYPRE_EXEC_DEVICE)
+   {
+      amg_relax_order = 0;
+   }
+   else
+#endif
+   {
+      amg_relax_order = relax_order;
    }
 
    /* (Re)set local_size for Vtemp */
@@ -335,7 +353,7 @@ hypre_MGRFrelaxVcycle ( void            *Frelax_vdata,
                                                  F_array[0],
                                                  CF_marker,
                                                  relax_type,
-                                                 relax_order,
+                                                 amg_relax_order,
                                                  1,
                                                  relax_weight,
                                                  omega,
@@ -353,7 +371,7 @@ hypre_MGRFrelaxVcycle ( void            *Frelax_vdata,
                                                F_array[0],
                                                CF_marker,
                                                relax_type,
-                                               -1,
+                                               amg_relax_order,
                                                relax_weight,
                                                omega,
                                                NULL,
@@ -381,8 +399,12 @@ hypre_MGRFrelaxVcycle ( void            *Frelax_vdata,
          hypre_ParVectorSetZeros(U_array[coarse_grid]);
 
          /* Avoid unnecessary copy using out-of-place version of SpMV */
-         hypre_ParCSRMatrixMatvecOutOfPlace(fp_neg_one, A_array[fine_grid], U_array[fine_grid],
-                                            fp_one, F_array[fine_grid], Vtemp);
+         hypre_ParCSRMatrixMatvecOutOfPlace(fp_neg_one,
+                                            A_array[fine_grid],
+                                            U_array[fine_grid],
+                                            fp_one,
+                                            F_array[fine_grid],
+                                            Vtemp);
 
          hypre_ParCSRMatrixMatvecT(fp_one, R_array[fine_grid], Vtemp,
                                    fp_zero, F_array[coarse_grid]);
@@ -418,7 +440,7 @@ hypre_MGRFrelaxVcycle ( void            *Frelax_vdata,
                                                        Aux_F,
                                                        CF_marker,
                                                        relax_type,
-                                                       relax_order,
+                                                       amg_relax_order,
                                                        cycle_param,
                                                        relax_weight,
                                                        omega,
@@ -448,7 +470,7 @@ hypre_MGRFrelaxVcycle ( void            *Frelax_vdata,
                                                        Aux_F,
                                                        CF_marker,
                                                        relax_type,
-                                                       relax_order,
+                                                       amg_relax_order,
                                                        cycle_param,
                                                        relax_weight,
                                                        omega,

--- a/src/test/TEST_ij/mgr.saved.lassen
+++ b/src/test/TEST_ij/mgr.saved.lassen
@@ -1,39 +1,55 @@
-# Output file: mgr.out.204
+# Output file: solvers.out.200
+MGR Iterations = 9
+Final Relative Residual Norm = 1.190910e-09
+
+# Output file: solvers.out.201
+MGR Iterations = 8
+Final Relative Residual Norm = 8.020893e-09
+
+# Output file: solvers.out.202
+MGR Iterations = 9
+Final Relative Residual Norm = 1.190910e-09
+
+# Output file: solvers.out.203
+MGR Iterations = 8
+Final Relative Residual Norm = 8.020893e-09
+
+# Output file: solvers.out.204
 MGR Iterations = 74
-Final Relative Residual Norm = 9.563442e-09
+Final Relative Residual Norm = 9.138946e-09
 
-# Output file: mgr.out.205
-MGR Iterations = 71
-Final Relative Residual Norm = 8.505703e-09
+# Output file: solvers.out.205
+MGR Iterations = 70
+Final Relative Residual Norm = 9.891106e-09
 
-# Output file: mgr.out.206
-MGR Iterations = 52
-Final Relative Residual Norm = 8.514201e-09
+# Output file: solvers.out.206
+MGR Iterations = 36
+Final Relative Residual Norm = 6.705837e-09
 
-# Output file: mgr.out.207
-MGR Iterations = 50
-Final Relative Residual Norm = 9.941525e-09
+# Output file: solvers.out.207
+MGR Iterations = 35
+Final Relative Residual Norm = 5.956428e-09
 
-# Output file: mgr.out.208
-MGR Iterations = 16
-Final Relative Residual Norm = 5.064272e-09
+# Output file: solvers.out.208
+MGR Iterations = 46
+Final Relative Residual Norm = 7.265172e-09
 
-# Output file: mgr.out.209
-MGR Iterations = 15
-Final Relative Residual Norm = 7.693914e-09
+# Output file: solvers.out.209
+MGR Iterations = 44
+Final Relative Residual Norm = 6.813070e-09
 
-# Output file: mgr.out.210
-MGR Iterations = 23
-Final Relative Residual Norm = 4.625304e-09
+# Output file: solvers.out.210
+MGR Iterations = 31
+Final Relative Residual Norm = 6.919435e-09
 
-# Output file: mgr.out.211
+# Output file: solvers.out.211
 MGR Iterations = 29
-Final Relative Residual Norm = 8.665192e-09
+Final Relative Residual Norm = 6.915185e-09
 
-# Output file: mgr.out.212
-Iterations = 11
-Final Relative Residual Norm = 3.738613e-09
+# Output file: solvers.out.212
+Iterations = 35
+Final Relative Residual Norm = 9.984248e-09
 
-# Output file: mgr.out.213
-Iterations = 29
-Final Relative Residual Norm = 5.268647e-09
+# Output file: solvers.out.213
+Iterations = 26
+Final Relative Residual Norm = 9.220161e-09

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -5737,6 +5737,7 @@ main( hypre_int argc,
             {
                HYPRE_BoomerAMGSetCycleRelaxType(amg_solver, relax_coarse, 3);
             }
+            HYPRE_BoomerAMGSetRelaxOrder(amg_solver, 1);
             HYPRE_BoomerAMGSetSmoothType(amg_solver, smooth_type);
             HYPRE_BoomerAMGSetSmoothNumSweeps(amg_solver, smooth_num_sweeps);
          }
@@ -5744,7 +5745,6 @@ main( hypre_int argc,
          HYPRE_BoomerAMGSetTol(amg_solver, 0.0);
          HYPRE_BoomerAMGSetPMaxElmts(amg_solver, 0);
          HYPRE_BoomerAMGSetNumSweeps(amg_solver, num_sweeps);
-         HYPRE_BoomerAMGSetRelaxOrder(amg_solver, 1);
          HYPRE_BoomerAMGSetMaxLevels(amg_solver, max_levels);
          HYPRE_BoomerAMGSetMaxIter(amg_solver, precon_cycles);
          HYPRE_BoomerAMGSetPrintLevel(amg_solver, 1);
@@ -9320,9 +9320,10 @@ main( hypre_int argc,
       HYPRE_BoomerAMGCreate(&amg_solver);
       if (hypre_GetExecPolicy1(memory_location) == HYPRE_EXEC_DEVICE)
       {
-         HYPRE_BoomerAMGSetInterpType(amg_solver, 18);
+         HYPRE_BoomerAMGSetInterpType(amg_solver, 6);
          HYPRE_BoomerAMGSetCoarsenType(amg_solver, 8);
-         HYPRE_BoomerAMGSetRelaxType(amg_solver, 3);
+         HYPRE_BoomerAMGSetRelaxType(amg_solver, 8);
+         HYPRE_BoomerAMGSetRelaxOrder(amg_solver, 0);
       }
       else
       {
@@ -9344,6 +9345,7 @@ main( hypre_int argc,
          {
             HYPRE_BoomerAMGSetCycleRelaxType(amg_solver, relax_coarse, 3);
          }
+         HYPRE_BoomerAMGSetRelaxOrder(amg_solver, 1);
          HYPRE_BoomerAMGSetSmoothType(amg_solver, smooth_type);
          HYPRE_BoomerAMGSetSmoothNumSweeps(amg_solver, smooth_num_sweeps);
       }
@@ -9351,7 +9353,6 @@ main( hypre_int argc,
       HYPRE_BoomerAMGSetTol(amg_solver, tol);
       HYPRE_BoomerAMGSetPMaxElmts(amg_solver, 0);
       HYPRE_BoomerAMGSetNumSweeps(amg_solver, num_sweeps);
-      HYPRE_BoomerAMGSetRelaxOrder(amg_solver, 1);
       HYPRE_BoomerAMGSetMaxLevels(amg_solver, max_levels);
       if (mgr_nlevels < 1 || mgr_bsize < 2)
       {

--- a/src/utilities/memory_tracker.c
+++ b/src/utilities/memory_tracker.c
@@ -419,7 +419,7 @@ hypre_PrintMemoryTracker( size_t     *totl_bytes_o,
                {
                   hypre_assert(p->ptr == entry->ptr);
                   entry->pair = p->index;
-                  hypre_assert(qf->data[p->index].pair == -1);
+                  //hypre_assert(qf->data[p->index].pair == -1); /* pair is an unsigned integer */
                   hypre_assert(qq[i].head - 1 == entry->index);
                   qf->data[p->index].pair = entry->index;
                   qf->data[p->index].nbytes = entry->nbytes;


### PR DESCRIPTION
Fix MGR regressions on lassen/tioga

A few tests were using a BoomerAMG relaxation method that is not GPU-enabled. This PR updates the default AMG relaxation in these tests to a GPU-enabled one.

Also, `hypre_MGRSetupFrelaxVcycleData` was relying on UVM to work. This PR makes it general to the non-UVM case.

@oseikuffuor1 I would like to revisit this internal function in MGR. Now that we can specify the `A_FF` solver as an object outside MGR, it seems we don't need `hypre_MGRSetupFrelaxVcycleData` anymore