### PR TITLE
Switch back to `hipMemcpy` for D2D

### DIFF
--- a/src/utilities/memory.c
+++ b/src/utilities/memory.c
@@ -663,10 +663,7 @@ hypre_Memcpy_core(void *dst, void *src, size_t size, hypre_MemoryLocation loc_ds
 #endif
 
 #if defined(HYPRE_USING_HIP)
-      // hipMemcpy(DtoD) causes a host-side synchronization, unlike cudaMemcpy(DtoD),
-      // use hipMemcpyAsync to get cuda's more performant behavior. For more info see:
-      // https://github.com/mfem/mfem/pull/2780
-      HYPRE_HIP_CALL( hipMemcpyAsync(dst, src, size, hipMemcpyDeviceToDevice) );
+      HYPRE_HIP_CALL( hipMemcpy(dst, src, size, hipMemcpyDeviceToDevice) );
 #endif
 
 #if defined(HYPRE_USING_SYCL)
@@ -794,10 +791,7 @@ hypre_Memcpy_core(void *dst, void *src, size_t size, hypre_MemoryLocation loc_ds
 #endif
 
 #if defined(HYPRE_USING_HIP)
-      // hipMemcpy(DtoD) causes a host-side synchronization, unlike cudaMemcpy(DtoD),
-      // use hipMemcpyAsync to get cuda's more performant behavior. For more info see:
-      // https://github.com/mfem/mfem/pull/2780
-      HYPRE_HIP_CALL( hipMemcpyAsync(dst, src, size, hipMemcpyDeviceToDevice) );
+      HYPRE_HIP_CALL( hipMemcpy(dst, src, size, hipMemcpyDeviceToDevice) );
 #endif
 
 #if defined(HYPRE_USING_SYCL)


### PR DESCRIPTION
Switch D2D memcpy back to `hipMemcpy` because the behavior was [fixed in 5.6.1](https://github.com/ROCm/ROCm/blob/docs/5.6.1/RELEASE.md)

We've done this in MFEM already as well: https://github.com/mfem/mfem/pull/4919