### PR TITLE
Add `HYPRE_ENABLE_FORTRAN` option to CMake build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,7 @@ set_hypre_option(BASE HYPRE_ENABLE_SINGLE               "Use float for HYPRE_Rea
 set_hypre_option(BASE HYPRE_ENABLE_LONG_DOUBLE          "Use long double for HYPRE_Real" OFF)
 set_hypre_option(BASE HYPRE_ENABLE_COMPLEX              "Use complex values" OFF)
 set_hypre_option(BASE HYPRE_ENABLE_MIXED_PRECISION      "Enable mixed precision support" OFF)
+set_hypre_option(BASE HYPRE_ENABLE_FORTRAN              "Enable Fortran drivers (examples/tests)" OFF)
 set_hypre_option(BASE HYPRE_ENABLE_HYPRE_BLAS           "Use internal BLAS library" ON)
 set_hypre_option(BASE HYPRE_ENABLE_HYPRE_LAPACK         "Use internal LAPACK library" ON)
 set_hypre_option(BASE HYPRE_ENABLE_PERSISTENT_COMM      "Use persistent communication" OFF)
@@ -181,6 +182,7 @@ set_hypre_option(HIP  HYPRE_ENABLE_ROCSOLVER            "Use rocSOLVER" ON)
 set_hypre_option(SYCL HYPRE_ENABLE_ONEMKLSPARSE         "Use oneMKL sparse" ON)
 set_hypre_option(SYCL HYPRE_ENABLE_ONEMKLBLAS           "Use oneMKL blas" ON)
 set_hypre_option(SYCL HYPRE_ENABLE_ONEMKLRAND           "Use oneMKL rand" ON)
+
 # TPL options
 set_hypre_option(TPL  HYPRE_ENABLE_UMPIRE               "Use Umpire Allocator for device and unified memory" OFF)
 set_hypre_option(TPL  HYPRE_ENABLE_UMPIRE_HOST          "Use Umpire Allocator for host memory" OFF)
@@ -223,6 +225,14 @@ endforeach()
 process_fmangling_scheme(FMANGLE "name")
 process_fmangling_scheme(FMANGLE_BLAS "BLAS")
 process_fmangling_scheme(FMANGLE_LAPACK "LAPACK")
+
+# Enable Fortran language when requested (for examples/tests only)
+if (HYPRE_ENABLE_FORTRAN)
+  enable_language(Fortran)
+  if (HYPRE_ENABLE_MPI)
+    find_package(MPI REQUIRED COMPONENTS Fortran)
+  endif()
+endif()
 
 # Set config name values
 set_internal_hypre_option("" BIGINT)

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -38,3 +38,20 @@ endif()
 
 add_hypre_executables(EXAMPLE_SRCS)
 
+if(HYPRE_ENABLE_FORTRAN)
+  # Pure Fortran-enabled examples: ex5f and ex12f
+  # Note: CUDA/Fortran (cudaf.f, ex5f_cptr.f, ex12f_cptr.f)
+  #       paths are handled by GPU toolchains (skipped here)
+  add_executable(ex5f ex5f.f)
+  target_link_libraries(ex5f PUBLIC HYPRE)
+  if(HYPRE_ENABLE_MPI)
+    find_package(MPI REQUIRED COMPONENTS Fortran)
+    target_link_libraries(ex5f PUBLIC MPI::MPI_Fortran)
+  endif()
+
+  add_executable(ex12f ex12f.f)
+  target_link_libraries(ex12f PUBLIC HYPRE)
+  if(HYPRE_ENABLE_MPI)
+    target_link_libraries(ex12f PUBLIC MPI::MPI_Fortran)
+  endif()
+endif()

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -171,3 +171,37 @@ if(BUILD_TESTING)
     FAIL_REGULAR_EXPRESSION "Failed"
   )
 endif()
+
+# Optional Fortran-based drivers
+if(HYPRE_ENABLE_FORTRAN)
+  # Build Fortran wrapper object libraries to be linked into C drivers
+  add_library(hypre_fstruct_wrappers OBJECT fstruct_mv.f fstruct_ls.f)
+  add_library(hypre_fsstruct_wrappers OBJECT fsstruct_mv.f fsstruct_ls.f)
+  add_library(hypre_fparcsr_wrappers OBJECT fparcsr_mv.f fparcsr_ls.f)
+  add_library(hypre_fij_wrappers OBJECT fij_mv.f)
+
+  # Common include dirs for mixed-language linking
+  foreach(wlib IN ITEMS hypre_fstruct_wrappers hypre_fsstruct_wrappers hypre_fparcsr_wrappers hypre_fij_wrappers)
+    target_include_directories(${wlib} PRIVATE
+      ${CMAKE_SOURCE_DIR}
+      ${CMAKE_BINARY_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    if(HYPRE_ENABLE_MPI)
+      target_link_libraries(${wlib} PRIVATE MPI::MPI_Fortran)
+    endif()
+  endforeach()
+
+  # Pure Fortran test drivers
+  add_executable(f77_ij f77_ij.f)
+  target_link_libraries(f77_ij PUBLIC HYPRE)
+  if(HYPRE_ENABLE_MPI)
+    target_link_libraries(f77_ij PUBLIC MPI::MPI_Fortran)
+  endif()
+
+  add_executable(f77_struct f77_struct.f)
+  target_link_libraries(f77_struct PUBLIC HYPRE)
+  if(HYPRE_ENABLE_MPI)
+    target_link_libraries(f77_struct PUBLIC MPI::MPI_Fortran)
+  endif()
+endif()

--- a/src/test/fstruct_mv.f
+++ b/src/test/fstruct_mv.f
@@ -174,7 +174,7 @@
 !******************************************
 !      fhypre_structmatrixcreate
 !******************************************
-      subroutine fhypre_structmatrixcreate(fcomm, fgrid, fstencil, 
+      subroutine fhypre_structmatrixcreate(fcomm, fgrid, fstencil,
      1                                     fmatrix)
       integer ierr
       integer fcomm
@@ -224,7 +224,7 @@
 !******************************************
 !      fhypre_structmatrixsetvalues
 !******************************************
-      subroutine fhypre_structmatrixsetvalues(fmatrix, fgridindx, 
+      subroutine fhypre_structmatrixsetvalues(fmatrix, fgridindx,
      1                                        fnumsindx, fsindx, fvals)
       integer ierr
       integer fgridindx(*)
@@ -233,7 +233,7 @@
       double precision fvals(*)
       integer*8 fmatrix
 
-      call HYPRE_StructMatrixSetValues(fmatrix, fgridindx, fnumsindx, 
+      call HYPRE_StructMatrixSetValues(fmatrix, fgridindx, fnumsindx,
      1                                 fsindx, fvals, ierr)
       if (ierr .ne. 0) then
          print *, 'fhypre_structmatrixsetvalues: error = ', ierr
@@ -321,7 +321,7 @@
       double precision fvals(*)
       integer*8 fmatrix
 
-      call HYPRE_StructMatrixSetConstantVa(fmatrix, fnumsindx, 
+      call HYPRE_StructMatrixSetConstantVa(fmatrix, fnumsindx,
      1                                         fsindx, fvals, ierr)
       if (ierr .ne. 0) then
          print *, 'fhypre_structmatrixsetconstantvalues: error = ', ierr
@@ -388,7 +388,7 @@
       double precision fvals(*)
       integer*8 fmatrix
 
-      call HYPRE_StructMatrixSetConstantVa(fmatrix, fnumsindx, 
+      call HYPRE_StructMatrixAddToConstant(fmatrix, fnumsindx,
      1                                         fsindx, fvals, ierr)
       if (ierr .ne. 0) then
          print *, 'fhypre_structmatrixaddtoconstantvalues: error = ',
@@ -624,7 +624,7 @@
 !******************************************
 !      fhypre_structvectoraddtoboxvalues
 !******************************************
-      subroutine fhypre_structvectoraddtoboxvalu(fvector, flower, 
+      subroutine fhypre_structvectoraddtoboxvalu(fvector, flower,
      1                                             fupper, fvals)
       integer ierr
       integer flower(*)
@@ -678,7 +678,7 @@
 !******************************************
 !      fhypre_structvectorgetboxvalues
 !******************************************
-      subroutine fhypre_structvectorgetboxvalues(fvector, flower, 
+      subroutine fhypre_structvectorgetboxvalues(fvector, flower,
      1                                           fupper, fvals)
       integer ierr
       integer flower(*)
@@ -745,7 +745,7 @@
 !******************************************
 !      fhypre_structvectorgetmigratecommpkg
 !******************************************
-      subroutine fhypre_structvectorgetmigrateco(ffromvec, ftovec, 
+      subroutine fhypre_structvectorgetmigrateco(ffromvec, ftovec,
      1                                                fcommpkg)
       integer ierr
       integer*8 ffromvec


### PR DESCRIPTION
We talk about it in the documentation, but it was not implemented yet.

This option is mainly for enabling Fortran tests and examples. There's no code that gets compiled with Fortran and added to the library.

cc @helloworld922 