### PR TITLE
Fix regression in C++ build

### DIFF
--- a/src/parcsr_mv/par_vector.c
+++ b/src/parcsr_mv/par_vector.c
@@ -884,7 +884,7 @@ hypre_VectorToParVector ( MPI_Comm      comm,
    global_size      = buffer[0];
    num_vectors      = (HYPRE_Int) buffer[1];
    global_vecstride = (HYPRE_Int) buffer[2];
-   memory_location  = (HYPRE_Int) buffer[3];
+   memory_location  = (HYPRE_MemoryLocation) buffer[3];
 
    if (num_vectors == 1)
    {


### PR DESCRIPTION
Fixes a build issue when compiling with C++

```
par_vector.c: In function ‘hypre_ParVector* hypre_VectorToParVector(MPI_Comm, hypre_Vector*, HYPRE_BigInt*)’:
par_vector.c:887:43: error: invalid conversion from ‘HYPRE_BigInt’ {aka ‘int’} to ‘HYPRE_MemoryLocation’ {aka ‘_HYPRE_MemoryLocation’} [-fpermissive]
  887 |    memory_location  = (HYPRE_Int) buffer[3];
      |                                   ~~~~~~~~^
      |                                           |
      |                                           HYPRE_BigInt {aka int}
```