### PR TITLE
Fix regressions from 100825

### DIFF
--- a/src/IJ_mv/HYPRE_IJMatrix.c
+++ b/src/IJ_mv/HYPRE_IJMatrix.c
@@ -1075,7 +1075,7 @@ HYPRE_IJMatrixSetMaxOffProcElmts( HYPRE_IJMatrix matrix,
       return hypre_error_flag;
    }
 
-   hypre_IJMatrixSetMaxOffProcElmtsParCSR(ijmatrix,max_off_proc_elmts);
+   hypre_IJMatrixSetMaxOffProcElmtsParCSR(ijmatrix, max_off_proc_elmts);
 
    return hypre_error_flag;
 }

--- a/src/IJ_mv/IJMatrix_parcsr_device.c
+++ b/src/IJ_mv/IJMatrix_parcsr_device.c
@@ -314,7 +314,7 @@ struct hypre_IJMatrixAssembleFunctor
       using namespace thrust;
 #endif
       return make_tuple( hypre_max(get<0>(x), get<0>(y)),
-                                 get<1>(x) + get<1>(y) );
+                         get<1>(x) + get<1>(y) );
    }
 };
 

--- a/src/IJ_mv/IJVector_parcsr_device.c
+++ b/src/IJ_mv/IJVector_parcsr_device.c
@@ -39,7 +39,7 @@ struct hypre_IJVectorAssembleFunctor
       using namespace thrust;
 #endif
       return make_tuple( hypre_max(get<0>(x), get<0>(y)),
-                                   get<1>(x) + get<1>(y) );
+                         get<1>(x) + get<1>(y) );
    }
 };
 

--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -2097,8 +2097,10 @@ HYPRE_Int hypre_Bisection ( HYPRE_Int n, HYPRE_Real *diag, HYPRE_Real *offd, HYP
 /* par_cheby.c */
 hypre_ParChebyData * hypre_ParChebyCreate( void );
 HYPRE_Int hypre_ParChebyDestroy( hypre_ParChebyData *cheby_data );
-HYPRE_Int hypre_ParChebySetMaxIterations( hypre_ParChebyData *cheby_data, HYPRE_Int max_iterations );
-HYPRE_Int hypre_ParChebyGetMaxIterations( hypre_ParChebyData *cheby_data, HYPRE_Int *max_iterations );
+HYPRE_Int hypre_ParChebySetMaxIterations( hypre_ParChebyData *cheby_data,
+                                          HYPRE_Int max_iterations );
+HYPRE_Int hypre_ParChebyGetMaxIterations( hypre_ParChebyData *cheby_data,
+                                          HYPRE_Int *max_iterations );
 HYPRE_Int hypre_ParChebySetZeroGuess( hypre_ParChebyData *cheby_data, HYPRE_Int zero_guess );
 HYPRE_Int hypre_ParChebyGetZeroGuess( hypre_ParChebyData *cheby_data, HYPRE_Int *zero_guess );
 HYPRE_Int hypre_ParChebySetTolerance( hypre_ParChebyData *cheby_data, HYPRE_Real tol );

--- a/src/parcsr_ls/ams.c
+++ b/src/parcsr_ls/ams.c
@@ -692,7 +692,7 @@ HYPRE_Int hypre_ParCSRComputeL1Norms(hypre_ParCSRMatrix  *A,
       {
 #if defined(HYPRE_USING_SYCL)
          HYPRE_ONEDPL_CALL( std::replace_if, l1_norm, l1_norm + num_rows,
-                            [] (const auto & x) {return !x;}, 1.0 );
+         [] (const auto & x) {return !x;}, 1.0 );
 #else
          HYPRE_THRUST_CALL(replace_if, l1_norm, l1_norm + num_rows,
                            HYPRE_THRUST_NOT(HYPRE_THRUST_IDENTITY(HYPRE_Complex)), 1.0 );

--- a/src/parcsr_ls/par_cheby_setup.c
+++ b/src/parcsr_ls/par_cheby_setup.c
@@ -180,8 +180,8 @@ hypre_ParCSRRelax_Cheby_Setup(hypre_ParCSRMatrix *A,
 
    if (variant == 1)
    {
-     /* These are the corresponding cheby polynomials: u = u_o + s(A) r_0
-        So order is one less than  resid poly: r(t) = 1 - t*s(t) */
+      /* These are the corresponding cheby polynomials: u = u_o + s(A) r_0
+         So order is one less than  resid poly: r(t) = 1 - t*s(t) */
       switch (cheby_order)
       {
          case 0:

--- a/src/parcsr_ls/par_cheby_solve.c
+++ b/src/parcsr_ls/par_cheby_solve.c
@@ -211,8 +211,8 @@ hypre_ParCSRRelax_Cheby_SolveHost(hypre_ParCSRMatrix *A,
    HYPRE_Real      *f_data   = hypre_ParVectorLocalData(f);
    HYPRE_Real      *v_data   = hypre_ParVectorLocalData(v);
    HYPRE_Real      *r_data   = hypre_ParVectorLocalData(r);
-   HYPRE_Real      *tmp_data = hypre_ParVectorLocalData(tmp_vec);
    HYPRE_Int        num_rows = hypre_CSRMatrixNumRows(A_diag);
+   HYPRE_Real      *tmp_data;
 
    HYPRE_Int        i, j;
    HYPRE_Int        cheby_order;
@@ -274,6 +274,8 @@ hypre_ParCSRRelax_Cheby_SolveHost(hypre_ParCSRMatrix *A,
    }
    else /* with scaling */
    {
+      tmp_data = hypre_ParVectorLocalData(tmp_vec);
+
       /* Compute scaled residual: r = D^(-1/2) f - D^(-1/2) A*u */
       /* tmp = -A*u */
       hypre_ParCSRMatrixMatvec(-1.0, A, u, 0.0, tmp_vec);

--- a/src/parcsr_ls/par_cycle.c
+++ b/src/parcsr_ls/par_cycle.c
@@ -289,6 +289,9 @@ hypre_BoomerAMGCycle( void              *amg_vdata,
       {
          local_size = hypre_VectorSize(hypre_ParVectorLocalVector(F_array[level]));
          hypre_ParVectorSetLocalSize(Vtemp, local_size);
+         if (Ztemp) { hypre_ParVectorSetLocalSize(Ztemp, local_size); }
+         if (Rtemp) { hypre_ParVectorSetLocalSize(Rtemp, local_size); }
+         if (Ptemp) { hypre_ParVectorSetLocalSize(Ptemp, local_size); }
 
          if (smooth_num_levels <= level)
          {
@@ -299,10 +302,6 @@ hypre_BoomerAMGCycle( void              *amg_vdata,
          }
          else if (smooth_type > 9)
          {
-            hypre_ParVectorSetLocalSize(Ztemp, local_size);
-            hypre_ParVectorSetLocalSize(Rtemp, local_size);
-            hypre_ParVectorSetLocalSize(Ptemp, local_size);
-
             Ztemp_data = hypre_VectorData(hypre_ParVectorLocalVector(Ztemp));
             Ptemp_data = hypre_VectorData(hypre_ParVectorLocalVector(Ptemp));
             hypre_ParVectorSetConstantValues(Ztemp, 0.0);

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -1753,9 +1753,9 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
    hypre_ParMGRData   *mgr_data = (hypre_ParMGRData*) mgr_vdata;
    hypre_ParAMGData    **FrelaxVcycleData = mgr_data -> FrelaxVcycleData;
    HYPRE_MemoryLocation memory_location = hypre_ParCSRMatrixMemoryLocation(A);
-/* #if defined(HYPRE_USING_GPU) */
-/*    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1(memory_location); */
-/* #endif */
+   /* #if defined(HYPRE_USING_GPU) */
+   /*    HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1(memory_location); */
+   /* #endif */
 
    HYPRE_Int i, j, num_procs, my_id;
 
@@ -1997,7 +1997,7 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
                for (i = 0; i < local_size; i++)
                {
                   hypre_IntArrayData(CF_marker_array_local[lev_local])[i] =
-                    hypre_IntArrayData(CF_marker_array[lev])[i];
+                     hypre_IntArrayData(CF_marker_array[lev])[i];
                }
             }
          }
@@ -2040,7 +2040,7 @@ hypre_MGRSetupFrelaxVcycleData( void               *mgr_vdata,
             for (i = 0; i < local_size; i++)
             {
                hypre_IntArrayData(CF_marker_array_local[lev_local])[i] =
-                 hypre_IntArrayData(CF_marker_array[lev])[i];
+                  hypre_IntArrayData(CF_marker_array[lev])[i];
             }
          }
       }

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -555,8 +555,10 @@ HYPRE_Int hypre_Bisection ( HYPRE_Int n, HYPRE_Real *diag, HYPRE_Real *offd, HYP
 /* par_cheby.c */
 hypre_ParChebyData * hypre_ParChebyCreate( void );
 HYPRE_Int hypre_ParChebyDestroy( hypre_ParChebyData *cheby_data );
-HYPRE_Int hypre_ParChebySetMaxIterations( hypre_ParChebyData *cheby_data, HYPRE_Int max_iterations );
-HYPRE_Int hypre_ParChebyGetMaxIterations( hypre_ParChebyData *cheby_data, HYPRE_Int *max_iterations );
+HYPRE_Int hypre_ParChebySetMaxIterations( hypre_ParChebyData *cheby_data,
+                                          HYPRE_Int max_iterations );
+HYPRE_Int hypre_ParChebyGetMaxIterations( hypre_ParChebyData *cheby_data,
+                                          HYPRE_Int *max_iterations );
 HYPRE_Int hypre_ParChebySetZeroGuess( hypre_ParChebyData *cheby_data, HYPRE_Int zero_guess );
 HYPRE_Int hypre_ParChebyGetZeroGuess( hypre_ParChebyData *cheby_data, HYPRE_Int *zero_guess );
 HYPRE_Int hypre_ParChebySetTolerance( hypre_ParChebyData *cheby_data, HYPRE_Real tol );

--- a/src/seq_mv/_hypre_seq_mv.h
+++ b/src/seq_mv/_hypre_seq_mv.h
@@ -64,7 +64,7 @@ typedef struct
    HYPRE_Int             num_nonzeros;
    hypre_int            *i_short;
    hypre_int            *j_short;
-   HYPRE_Int             owns_data;       /* Does the CSRMatrix create/destroy `j`, `big_j`, and `data'? */
+   HYPRE_Int             owns_data;       /* Matrix creates/destroys `j`, `big_j`, and `data' */
    HYPRE_Int             pattern_only;    /* 1: data array is ignored, and assumed to be all 1's */
    HYPRE_Complex        *data;
    HYPRE_Int            *rownnz;          /* for compressing rows in matrix multiplication  */

--- a/src/seq_mv/csr_matop_device.c
+++ b/src/seq_mv/csr_matop_device.c
@@ -349,7 +349,7 @@ hypre_CSRMatrixDeleteZerosDevice( hypre_CSRMatrix *A,
                                         thrust::make_zip_iterator(thrust::make_tuple(A_data + num_nonzeros, A_j + num_nonzeros)),
                                         A_data,
                                         thrust::make_zip_iterator(thrust::make_tuple(B_data, B_j)),
-					hypreFunctor_NonzeroAboveTol(tol));
+                                        hypreFunctor_NonzeroAboveTol(tol));
       hypre_assert(thrust::get<0>(new_end.get_iterator_tuple()) - B_data == num_nonzeros_B);
 #elif defined(HYPRE_USING_SYCL)
       auto new_end = HYPRE_ONEDPL_CALL( copy_if,
@@ -394,7 +394,7 @@ hypre_CSRMatrixDeleteZerosDevice( hypre_CSRMatrix *A,
                          row_indices + num_nonzeros,
                          A_data,
                          B_row_indices,
-			 hypreFunctor_NonzeroAboveTol(tol));
+                         hypreFunctor_NonzeroAboveTol(tol));
 #elif defined(HYPRE_USING_SYCL)
       hypreSycl_copy_if( row_indices,
                          row_indices + num_nonzeros,

--- a/src/seq_mv/csr_matrix.h
+++ b/src/seq_mv/csr_matrix.h
@@ -40,7 +40,7 @@ typedef struct
    HYPRE_Int             num_nonzeros;
    hypre_int            *i_short;
    hypre_int            *j_short;
-   HYPRE_Int             owns_data;       /* Does the CSRMatrix create/destroy `j`, `big_j`, and `data'? */
+   HYPRE_Int             owns_data;       /* Matrix creates/destroys `j`, `big_j`, and `data' */
    HYPRE_Int             pattern_only;    /* 1: data array is ignored, and assumed to be all 1's */
    HYPRE_Complex        *data;
    HYPRE_Int            *rownnz;          /* for compressing rows in matrix multiplication  */

--- a/src/seq_mv/seq_mv.h
+++ b/src/seq_mv/seq_mv.h
@@ -64,7 +64,8 @@ typedef struct
    HYPRE_Int             num_nonzeros;
    hypre_int            *i_short;
    hypre_int            *j_short;
-   HYPRE_Int             owns_data;       /* Does the CSRMatrix create/destroy `j`, `big_j`, and `data'? */
+   HYPRE_Int
+   owns_data;       /* Does the CSRMatrix create/destroy `j`, `big_j`, and `data'? */
    HYPRE_Int             pattern_only;    /* 1: data array is ignored, and assumed to be all 1's */
    HYPRE_Complex        *data;
    HYPRE_Int            *rownnz;          /* for compressing rows in matrix multiplication  */

--- a/src/seq_mv/seq_mv_mp.c
+++ b/src/seq_mv/seq_mv_mp.c
@@ -57,7 +57,7 @@ hypre_SeqVectorCopy_mp( hypre_Vector *x,
    /* Implicit conversion to generic data type (void pointer) */
    xp = hypre_VectorData(x);
    yp = hypre_VectorData(y);
-   
+
    switch (hypre_VectorPrecision (x))
    {
       case HYPRE_REAL_SINGLE:
@@ -65,7 +65,7 @@ hypre_SeqVectorCopy_mp( hypre_Vector *x,
          {
             case HYPRE_REAL_DOUBLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {
@@ -74,7 +74,7 @@ hypre_SeqVectorCopy_mp( hypre_Vector *x,
                break;
             case HYPRE_REAL_LONGDOUBLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {
@@ -90,7 +90,7 @@ hypre_SeqVectorCopy_mp( hypre_Vector *x,
          {
             case HYPRE_REAL_SINGLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {
@@ -99,7 +99,7 @@ hypre_SeqVectorCopy_mp( hypre_Vector *x,
                break;
             case HYPRE_REAL_LONGDOUBLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {
@@ -115,16 +115,16 @@ hypre_SeqVectorCopy_mp( hypre_Vector *x,
          {
             case HYPRE_REAL_SINGLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {
                   ((hypre_float *)yp)[i] = (hypre_float)((hypre_long_double *)xp)[i];
                }
-               break;            
+               break;
             case HYPRE_REAL_DOUBLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {
@@ -166,7 +166,7 @@ hypre_SeqVectorAxpy_mp( hypre_double alpha,
    HYPRE_Precision precision = hypre_VectorPrecision (y);
 
    void               *xp, *yp;
-   
+
    HYPRE_Int      size   = hypre_VectorSize(x);
    HYPRE_Int      i;
 
@@ -174,7 +174,7 @@ hypre_SeqVectorAxpy_mp( hypre_double alpha,
 
    /* Implicit conversion to generic data type (void pointer) */
    xp = hypre_VectorData(x);
-   yp = hypre_VectorData(y);   
+   yp = hypre_VectorData(y);
 
    switch (precision)
    {
@@ -183,7 +183,7 @@ hypre_SeqVectorAxpy_mp( hypre_double alpha,
          #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
          for (i = 0; i < size; i++)
-         { 
+         {
             ((hypre_float *)yp)[i] += (hypre_float)(alpha * ((hypre_double *)xp)[i]);
          }
          break;
@@ -232,7 +232,9 @@ hypre_SeqVectorConvert_mp (hypre_Vector *v,
    HYPRE_Int i;
 
    if (new_precision == precision)
+   {
       return hypre_error_flag;
+   }
    else
    {
       switch (precision)
@@ -243,22 +245,28 @@ hypre_SeqVectorConvert_mp (hypre_Vector *v,
             {
                case HYPRE_REAL_DOUBLE:
                {
-                  data_mp = (hypre_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_double), memory_location);
+                  data_mp = (hypre_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_double),
+                                                           memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_double *)data_mp)[i] = (hypre_double) ((hypre_float *) data)[i];
+                  }
                }
                break;
                case HYPRE_REAL_LONGDOUBLE:
                {
-                  data_mp = (hypre_long_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_long_double), memory_location);
+                  data_mp = (hypre_long_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_long_double),
+                                                                memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_long_double *)data_mp)[i] = (hypre_long_double) ((hypre_float *) data)[i];
+                  }
                }
                break;
                default:
@@ -274,20 +282,25 @@ hypre_SeqVectorConvert_mp (hypre_Vector *v,
                {
                   data_mp = (hypre_float *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_float), memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_float *)data_mp)[i] = (hypre_float) ((hypre_double *) data)[i];
+                  }
                }
                break;
                case HYPRE_REAL_LONGDOUBLE:
                {
-                  data_mp = (hypre_long_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_long_double), memory_location);
+                  data_mp = (hypre_long_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_long_double),
+                                                                memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_long_double *)data_mp)[i] = (hypre_long_double) ((hypre_double *) data)[i];
+                  }
                }
                break;
                default:
@@ -303,20 +316,25 @@ hypre_SeqVectorConvert_mp (hypre_Vector *v,
                {
                   data_mp = (hypre_float *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_float), memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_float *)data_mp)[i] = (hypre_float) ((hypre_long_double *) data)[i];
+                  }
                }
                break;
                case HYPRE_REAL_DOUBLE:
                {
-                  data_mp = (hypre_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_double), memory_location);
+                  data_mp = (hypre_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_double),
+                                                           memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_double *)data_mp)[i] = (hypre_double) ((hypre_long_double *) data)[i];
+                  }
                }
                break;
                default:
@@ -350,7 +368,9 @@ hypre_CSRMatrixConvert_mp (hypre_CSRMatrix *A,
    HYPRE_Int i;
 
    if (new_precision == precision)
+   {
       return hypre_error_flag;
+   }
    else
    {
       switch (precision)
@@ -361,22 +381,28 @@ hypre_CSRMatrixConvert_mp (hypre_CSRMatrix *A,
             {
                case HYPRE_REAL_DOUBLE:
                {
-                  data_mp = (hypre_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_double), memory_location);
+                  data_mp = (hypre_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_double),
+                                                           memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_double *)data_mp)[i] = (hypre_double) ((hypre_float *) data)[i];
+                  }
                }
                break;
                case HYPRE_REAL_LONGDOUBLE:
                {
-                  data_mp = (hypre_long_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_long_double), memory_location);
+                  data_mp = (hypre_long_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_long_double),
+                                                                memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_long_double *)data_mp)[i] = (hypre_long_double) ((hypre_float *) data)[i];
+                  }
                }
                break;
                default:
@@ -392,20 +418,25 @@ hypre_CSRMatrixConvert_mp (hypre_CSRMatrix *A,
                {
                   data_mp = (hypre_float *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_float), memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_float *)data_mp)[i] = (hypre_float) ((hypre_double *) data)[i];
+                  }
                }
                break;
                case HYPRE_REAL_LONGDOUBLE:
                {
-                  data_mp = (hypre_long_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_long_double), memory_location);
+                  data_mp = (hypre_long_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_long_double),
+                                                                memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_long_double *)data_mp)[i] = (hypre_long_double) ((hypre_double *) data)[i];
+                  }
                }
                break;
                default:
@@ -421,20 +452,25 @@ hypre_CSRMatrixConvert_mp (hypre_CSRMatrix *A,
                {
                   data_mp = (hypre_float *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_float), memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_float *)data_mp)[i] = (hypre_float) ((hypre_long_double *) data)[i];
+                  }
                }
                break;
                case HYPRE_REAL_DOUBLE:
                {
-                  data_mp = (hypre_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_double), memory_location);
+                  data_mp = (hypre_double *) hypre_CAlloc ((size_t)size, (size_t)sizeof(hypre_double),
+                                                           memory_location);
 #ifdef HYPRE_USING_OPENMP
-#pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+                  #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                   for (i = 0; i < size; i++)
+                  {
                      ((hypre_double *)data_mp)[i] = (hypre_double) ((hypre_long_double *) data)[i];
+                  }
                }
                break;
                default:

--- a/src/sstruct_mv/_hypre_sstruct_mv.h
+++ b/src/sstruct_mv/_hypre_sstruct_mv.h
@@ -905,7 +905,8 @@ HYPRE_Int hypre_SStructCopy ( hypre_SStructVector *x, hypre_SStructVector *y );
 HYPRE_Int hypre_SStructGraphRef ( hypre_SStructGraph *graph, hypre_SStructGraph **graph_ref );
 HYPRE_Int hypre_SStructGraphGetUVEntryRank( hypre_SStructGraph *graph, HYPRE_Int part,
                                             HYPRE_Int var, hypre_Index index, HYPRE_BigInt *rank );
-HYPRE_BigInt hypre_SStructGraphFindBoxEndpt ( hypre_SStructGraph *graph, HYPRE_Int part, HYPRE_Int var,
+HYPRE_BigInt hypre_SStructGraphFindBoxEndpt ( hypre_SStructGraph *graph, HYPRE_Int part,
+                                              HYPRE_Int var,
                                               HYPRE_Int proc, HYPRE_Int endpt, HYPRE_Int boxi );
 HYPRE_Int hypre_SStructGraphFindSGridEndpts ( hypre_SStructGraph *graph, HYPRE_Int part,
                                               HYPRE_Int var, HYPRE_Int proc, HYPRE_Int endpt, HYPRE_BigInt *endpts );

--- a/src/sstruct_mv/protos.h
+++ b/src/sstruct_mv/protos.h
@@ -26,7 +26,8 @@ HYPRE_Int hypre_SStructCopy ( hypre_SStructVector *x, hypre_SStructVector *y );
 HYPRE_Int hypre_SStructGraphRef ( hypre_SStructGraph *graph, hypre_SStructGraph **graph_ref );
 HYPRE_Int hypre_SStructGraphGetUVEntryRank( hypre_SStructGraph *graph, HYPRE_Int part,
                                             HYPRE_Int var, hypre_Index index, HYPRE_BigInt *rank );
-HYPRE_BigInt hypre_SStructGraphFindBoxEndpt ( hypre_SStructGraph *graph, HYPRE_Int part, HYPRE_Int var,
+HYPRE_BigInt hypre_SStructGraphFindBoxEndpt ( hypre_SStructGraph *graph, HYPRE_Int part,
+                                              HYPRE_Int var,
                                               HYPRE_Int proc, HYPRE_Int endpt, HYPRE_Int boxi );
 HYPRE_Int hypre_SStructGraphFindSGridEndpts ( hypre_SStructGraph *graph, HYPRE_Int part,
                                               HYPRE_Int var, HYPRE_Int proc, HYPRE_Int endpt, HYPRE_BigInt *endpts );

--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -2422,11 +2422,11 @@ hypre_SStructMatrixCompressUToS( HYPRE_SStructMatrix A,
                if (exec == HYPRE_EXEC_DEVICE)
                {
                   if (ndim > 0) hypre_TMemcpy(indices[0], indices_0, HYPRE_Int, num_indices,
-                                              HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+                                                 HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
                   if (ndim > 1) hypre_TMemcpy(indices[1], indices_1, HYPRE_Int, num_indices,
-                                              HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+                                                 HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
                   if (ndim > 2) hypre_TMemcpy(indices[2], indices_2, HYPRE_Int, num_indices,
-                                              HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
+                                                 HYPRE_MEMORY_HOST, HYPRE_MEMORY_DEVICE);
                }
                else
 #endif

--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -2339,18 +2339,9 @@ hypre_SStructMatrixCompressUToS( HYPRE_SStructMatrix A,
                {
                   hypre_Index index;
                   hypre_BoxLoopGetIndex(index);
-                  if (ndim > 0)
-                  {
-                     all_indices_0[ii] = index[0] + start[0];
-                  }
-                  if (ndim > 1)
-                  {
-                     all_indices_1[ii] = index[1] + start[1];
-                  }
-                  if (ndim > 2)
-                  {
-                     all_indices_2[ii] = index[2] + start[2];
-                  }
+                  if (ndim > 0) { all_indices_0[ii] = index[0] + start[0]; }
+                  if (ndim > 1) { all_indices_1[ii] = index[1] + start[1]; }
+                  if (ndim > 2) { all_indices_2[ii] = index[2] + start[2]; }
                }
                hypre_BoxLoop1End(ii);
 
@@ -2400,6 +2391,7 @@ hypre_SStructMatrixCompressUToS( HYPRE_SStructMatrix A,
                       hypre_CSRMatrixI(A_uo)[offset + ii] > 0)
                   {
                      hypre_Index index;
+                     hypre_SetIndex(index, 0);
                      hypre_BoxLoopGetIndexHost(index);
                      if (ndim > 0) { indices_0[num_indices] = index[0] + start[0]; }
                      if (ndim > 1) { indices_1[num_indices] = index[1] + start[1]; }

--- a/src/struct_ls/HYPRE_struct_ls_mp.c
+++ b/src/struct_ls/HYPRE_struct_ls_mp.c
@@ -11,7 +11,7 @@
  *
  *****************************************************************************/
 
- #include "_hypre_struct_ls.h"
+#include "_hypre_struct_ls.h"
 
 #ifdef HYPRE_MIXED_PRECISION
 
@@ -31,17 +31,17 @@ HYPRE_StructSMGSetup_mp( HYPRE_StructSolver solver,
    HYPRE_Precision precision = hypre_StructMatrixPrecision (A);
 
    /* call standard setup if precisions match */
-   if(precision == hypre_StructVectorPrecision (b))
+   if (precision == hypre_StructVectorPrecision (b))
    {
       return HYPRE_StructSMGSetup( solver, A, b, x );
    }
 
-   HYPRE_StructVectorCreate_pre(precision, 
+   HYPRE_StructVectorCreate_pre(precision,
                                 hypre_StructMatrixComm(A),
                                 hypre_StructMatrixGrid(A),
                                 &btemp);
    HYPRE_StructVectorInitialize_pre( precision, btemp );
-   HYPRE_StructVectorCreate_pre(precision, 
+   HYPRE_StructVectorCreate_pre(precision,
                                 hypre_StructMatrixComm(A),
                                 hypre_StructMatrixGrid(A),
                                 &xtemp);

--- a/src/struct_ls/_hypre_struct_ls.h
+++ b/src/struct_ls/_hypre_struct_ls.h
@@ -74,7 +74,8 @@ HYPRE_Int hypre_HybridSolve ( void *hybrid_vdata, hypre_StructMatrix *A, hypre_S
                               hypre_StructVector *x );
 
 /* diagscale.c */
-HYPRE_Int hypre_StructDiagScale( hypre_StructMatrix *A, hypre_StructVector *y, hypre_StructVector *x );
+HYPRE_Int hypre_StructDiagScale( hypre_StructMatrix *A, hypre_StructVector *y,
+                                 hypre_StructVector *x );
 
 /* jacobi.c */
 void *hypre_StructJacobiCreate ( MPI_Comm comm );

--- a/src/struct_ls/pfmg_coarsen.c
+++ b/src/struct_ls/pfmg_coarsen.c
@@ -407,20 +407,20 @@ hypre_PFMGComputeCxyz_core_VC(hypre_StructMatrix *A,
    switch (ndim)
    {
       case 3:
-        w_data_2 = w_data[2];
-        HYPRE_FALLTHROUGH;
+         w_data_2 = w_data[2];
+         HYPRE_FALLTHROUGH;
 
       case 2:
-        w_data_1 = w_data[1];
-        HYPRE_FALLTHROUGH;
+         w_data_1 = w_data[1];
+         HYPRE_FALLTHROUGH;
 
       case 1:
-        w_data_0 = w_data[0];
-        break;
+         w_data_0 = w_data[0];
+         break;
 
       default:
-        hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Not implemented!");
-        return hypre_error_flag;
+         hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Not implemented!");
+         return hypre_error_flag;
    }
 
 #ifdef HYPRE_CORE_CASE
@@ -494,24 +494,24 @@ hypre_PFMGComputeCxyz_core_VC(hypre_StructMatrix *A,
 
             switch (depth)
             {
-               HYPRE_CORE_CASE(18);
-               HYPRE_CORE_CASE(17);
-               HYPRE_CORE_CASE(16);
-               HYPRE_CORE_CASE(15);
-               HYPRE_CORE_CASE(14);
-               HYPRE_CORE_CASE(13);
-               HYPRE_CORE_CASE(12);
-               HYPRE_CORE_CASE(11);
-               HYPRE_CORE_CASE(10);
-               HYPRE_CORE_CASE(9);
-               HYPRE_CORE_CASE(8);
-               HYPRE_CORE_CASE(7);
-               HYPRE_CORE_CASE(6);
-               HYPRE_CORE_CASE(5);
-               HYPRE_CORE_CASE(4);
-               HYPRE_CORE_CASE(3);
-               HYPRE_CORE_CASE(2);
-               HYPRE_CORE_CASE(1);
+                  HYPRE_CORE_CASE(18);
+                  HYPRE_CORE_CASE(17);
+                  HYPRE_CORE_CASE(16);
+                  HYPRE_CORE_CASE(15);
+                  HYPRE_CORE_CASE(14);
+                  HYPRE_CORE_CASE(13);
+                  HYPRE_CORE_CASE(12);
+                  HYPRE_CORE_CASE(11);
+                  HYPRE_CORE_CASE(10);
+                  HYPRE_CORE_CASE(9);
+                  HYPRE_CORE_CASE(8);
+                  HYPRE_CORE_CASE(7);
+                  HYPRE_CORE_CASE(6);
+                  HYPRE_CORE_CASE(5);
+                  HYPRE_CORE_CASE(4);
+                  HYPRE_CORE_CASE(3);
+                  HYPRE_CORE_CASE(2);
+                  HYPRE_CORE_CASE(1);
 
                default:
                   break;
@@ -588,20 +588,20 @@ hypre_PFMGComputeCxyz_core_CC(hypre_StructMatrix *A,
    switch (ndim)
    {
       case 3:
-        w_data_2 = w_data[2];
-        HYPRE_FALLTHROUGH;
+         w_data_2 = w_data[2];
+         HYPRE_FALLTHROUGH;
 
       case 2:
-        w_data_1 = w_data[1];
-        HYPRE_FALLTHROUGH;
+         w_data_1 = w_data[1];
+         HYPRE_FALLTHROUGH;
 
       case 1:
-        w_data_0 = w_data[0];
-        break;
+         w_data_0 = w_data[0];
+         break;
 
       default:
-        hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Not implemented!");
-        return hypre_error_flag;
+         hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Not implemented!");
+         return hypre_error_flag;
    }
 
 #ifdef HYPRE_CORE_CASE
@@ -669,15 +669,15 @@ hypre_PFMGComputeCxyz_core_CC(hypre_StructMatrix *A,
 
             switch (depth)
             {
-               HYPRE_CORE_CASE(9);
-               HYPRE_CORE_CASE(8);
-               HYPRE_CORE_CASE(7);
-               HYPRE_CORE_CASE(6);
-               HYPRE_CORE_CASE(5);
-               HYPRE_CORE_CASE(4);
-               HYPRE_CORE_CASE(3);
-               HYPRE_CORE_CASE(2);
-               HYPRE_CORE_CASE(1);
+                  HYPRE_CORE_CASE(9);
+                  HYPRE_CORE_CASE(8);
+                  HYPRE_CORE_CASE(7);
+                  HYPRE_CORE_CASE(6);
+                  HYPRE_CORE_CASE(5);
+                  HYPRE_CORE_CASE(4);
+                  HYPRE_CORE_CASE(3);
+                  HYPRE_CORE_CASE(2);
+                  HYPRE_CORE_CASE(1);
 
                default:
                   break;

--- a/src/struct_ls/pfmg_setup_interp.c
+++ b/src/struct_ls/pfmg_setup_interp.c
@@ -276,7 +276,8 @@ hypre_PFMGSetupInterpOp_core_VC( hypre_StructMatrix *P,
 
 #if defined(DEBUG_PFMG)
    hypre_ParPrintf(hypre_MPI_COMM_WORLD, "=== PFMG Interp Stencil ===\n");
-   hypre_ParPrintf(hypre_MPI_COMM_WORLD, "Number of (left, right, middle) stencil. entries: (%d, %d, %d)\n", l ,r, m);
+   hypre_ParPrintf(hypre_MPI_COMM_WORLD,
+                   "Number of (left, right, middle) stencil. entries: (%d, %d, %d)\n", l, r, m);
    hypre_ParPrintf(hypre_MPI_COMM_WORLD, "=== PFMG Interp Stencil ===\n");
 #endif
 

--- a/src/struct_ls/protos.h
+++ b/src/struct_ls/protos.h
@@ -52,7 +52,8 @@ HYPRE_Int hypre_HybridSolve ( void *hybrid_vdata, hypre_StructMatrix *A, hypre_S
                               hypre_StructVector *x );
 
 /* diagscale.c */
-HYPRE_Int hypre_StructDiagScale( hypre_StructMatrix *A, hypre_StructVector *y, hypre_StructVector *x );
+HYPRE_Int hypre_StructDiagScale( hypre_StructMatrix *A, hypre_StructVector *y,
+                                 hypre_StructVector *x );
 
 /* jacobi.c */
 void *hypre_StructJacobiCreate ( MPI_Comm comm );

--- a/src/struct_mv/HYPRE_struct_mv.h
+++ b/src/struct_mv/HYPRE_struct_mv.h
@@ -713,7 +713,7 @@ HYPRE_StructVectorClone(HYPRE_StructVector x,
  * Copy vector x into y (\f$y \leftarrow x\f$).
  **/
 HYPRE_Int
-HYPRE_StructVectorCopy(HYPRE_StructVector x, 
+HYPRE_StructVectorCopy(HYPRE_StructVector x,
                        HYPRE_StructVector y);
 
 /**

--- a/src/struct_mv/_hypre_struct_mv.h
+++ b/src/struct_mv/_hypre_struct_mv.h
@@ -2493,7 +2493,8 @@ HYPRE_Int hypre_StructMatrixResize ( hypre_StructMatrix *matrix, hypre_BoxArray 
 HYPRE_Int hypre_StructMatrixRestore ( hypre_StructMatrix *matrix );
 HYPRE_Int hypre_StructMatrixForget ( hypre_StructMatrix *matrix );
 HYPRE_Int hypre_StructMatrixInitializeShell ( hypre_StructMatrix *matrix );
-HYPRE_Int hypre_StructMatrixInitializeData ( hypre_StructMatrix *matrix, HYPRE_Int zero_init, HYPRE_Complex *data );
+HYPRE_Int hypre_StructMatrixInitializeData ( hypre_StructMatrix *matrix, HYPRE_Int zero_init,
+                                             HYPRE_Complex *data );
 HYPRE_Int hypre_StructMatrixInitialize ( hypre_StructMatrix *matrix );
 HYPRE_Int hypre_StructMatrixSetValues ( hypre_StructMatrix *matrix, hypre_Index grid_index,
                                         HYPRE_Int num_stencil_indices, HYPRE_Int *stencil_indices, HYPRE_Complex *values, HYPRE_Int action,

--- a/src/struct_mv/protos.h
+++ b/src/struct_mv/protos.h
@@ -645,7 +645,8 @@ HYPRE_Int hypre_StructMatrixResize ( hypre_StructMatrix *matrix, hypre_BoxArray 
 HYPRE_Int hypre_StructMatrixRestore ( hypre_StructMatrix *matrix );
 HYPRE_Int hypre_StructMatrixForget ( hypre_StructMatrix *matrix );
 HYPRE_Int hypre_StructMatrixInitializeShell ( hypre_StructMatrix *matrix );
-HYPRE_Int hypre_StructMatrixInitializeData ( hypre_StructMatrix *matrix, HYPRE_Int zero_init, HYPRE_Complex *data );
+HYPRE_Int hypre_StructMatrixInitializeData ( hypre_StructMatrix *matrix, HYPRE_Int zero_init,
+                                             HYPRE_Complex *data );
 HYPRE_Int hypre_StructMatrixInitialize ( hypre_StructMatrix *matrix );
 HYPRE_Int hypre_StructMatrixSetValues ( hypre_StructMatrix *matrix, hypre_Index grid_index,
                                         HYPRE_Int num_stencil_indices, HYPRE_Int *stencil_indices, HYPRE_Complex *values, HYPRE_Int action,

--- a/src/struct_mv/struct_matvec_core.c
+++ b/src/struct_mv/struct_matvec_core.c
@@ -637,60 +637,6 @@ hypre_StructMatvecCompute_core_CC( HYPRE_Complex       alpha,
    depth = hypre_min(HYPRE_UNROLL_MAXDEPTH, nentries);
    switch (depth)
    {
-      HYPRE_CORE_CASE(27);
-      HYPRE_CORE_CASE(26);
-      HYPRE_CORE_CASE(25);
-      HYPRE_CORE_CASE(24);
-      HYPRE_CORE_CASE(23);
-      HYPRE_CORE_CASE(22);
-      HYPRE_CORE_CASE(21);
-      HYPRE_CORE_CASE(20);
-      HYPRE_CORE_CASE(19);
-      HYPRE_CORE_CASE(18);
-      HYPRE_CORE_CASE(17);
-      HYPRE_CORE_CASE(16);
-      HYPRE_CORE_CASE(15);
-      HYPRE_CORE_CASE(14);
-      HYPRE_CORE_CASE(13);
-      HYPRE_CORE_CASE(12);
-      HYPRE_CORE_CASE(11);
-      HYPRE_CORE_CASE(10);
-      HYPRE_CORE_CASE(9);
-      HYPRE_CORE_CASE(8);
-      HYPRE_CORE_CASE(7);
-      HYPRE_CORE_CASE(6);
-      HYPRE_CORE_CASE(5);
-      HYPRE_CORE_CASE(4);
-      HYPRE_CORE_CASE(3);
-      HYPRE_CORE_CASE(2);
-      HYPRE_CORE_CASE(1);
-
-      case 0:
-         break;
-   }
-
-   /* Update output vector with remaining A*x components if any */
-#ifdef HYPRE_CORE_CASE
-#undef HYPRE_CORE_CASE
-#endif
-#define HYPRE_CORE_CASE(n)                                                     \
-   case n:                                                                     \
-      HYPRE_LOAD_CAX_UP_TO_##n(transpose);                                     \
-      hypre_BoxLoop2Begin(ndim, loop_size,                                     \
-                          x_data_box, xdstart, xdstride, xi,                   \
-                          z_data_box, zdstart, zdstride, zi);                  \
-      {                                                                        \
-         zp[zi] += alpha * (HYPRE_CALC_CAX_ADD_UP_TO_##n);                     \
-      }                                                                        \
-      hypre_BoxLoop2End(xi, zi);                                               \
-      break;
-
-   for (si = depth; si < nentries; si += HYPRE_UNROLL_MAXDEPTH)
-   {
-      depth = hypre_min(HYPRE_UNROLL_MAXDEPTH, (nentries - si));
-
-      switch (depth)
-      {
          HYPRE_CORE_CASE(27);
          HYPRE_CORE_CASE(26);
          HYPRE_CORE_CASE(25);
@@ -718,6 +664,60 @@ hypre_StructMatvecCompute_core_CC( HYPRE_Complex       alpha,
          HYPRE_CORE_CASE(3);
          HYPRE_CORE_CASE(2);
          HYPRE_CORE_CASE(1);
+
+      case 0:
+         break;
+   }
+
+   /* Update output vector with remaining A*x components if any */
+#ifdef HYPRE_CORE_CASE
+#undef HYPRE_CORE_CASE
+#endif
+#define HYPRE_CORE_CASE(n)                                                     \
+   case n:                                                                     \
+      HYPRE_LOAD_CAX_UP_TO_##n(transpose);                                     \
+      hypre_BoxLoop2Begin(ndim, loop_size,                                     \
+                          x_data_box, xdstart, xdstride, xi,                   \
+                          z_data_box, zdstart, zdstride, zi);                  \
+      {                                                                        \
+         zp[zi] += alpha * (HYPRE_CALC_CAX_ADD_UP_TO_##n);                     \
+      }                                                                        \
+      hypre_BoxLoop2End(xi, zi);                                               \
+      break;
+
+   for (si = depth; si < nentries; si += HYPRE_UNROLL_MAXDEPTH)
+   {
+      depth = hypre_min(HYPRE_UNROLL_MAXDEPTH, (nentries - si));
+
+      switch (depth)
+      {
+            HYPRE_CORE_CASE(27);
+            HYPRE_CORE_CASE(26);
+            HYPRE_CORE_CASE(25);
+            HYPRE_CORE_CASE(24);
+            HYPRE_CORE_CASE(23);
+            HYPRE_CORE_CASE(22);
+            HYPRE_CORE_CASE(21);
+            HYPRE_CORE_CASE(20);
+            HYPRE_CORE_CASE(19);
+            HYPRE_CORE_CASE(18);
+            HYPRE_CORE_CASE(17);
+            HYPRE_CORE_CASE(16);
+            HYPRE_CORE_CASE(15);
+            HYPRE_CORE_CASE(14);
+            HYPRE_CORE_CASE(13);
+            HYPRE_CORE_CASE(12);
+            HYPRE_CORE_CASE(11);
+            HYPRE_CORE_CASE(10);
+            HYPRE_CORE_CASE(9);
+            HYPRE_CORE_CASE(8);
+            HYPRE_CORE_CASE(7);
+            HYPRE_CORE_CASE(6);
+            HYPRE_CORE_CASE(5);
+            HYPRE_CORE_CASE(4);
+            HYPRE_CORE_CASE(3);
+            HYPRE_CORE_CASE(2);
+            HYPRE_CORE_CASE(1);
 
          case 0:
             break;
@@ -827,33 +827,33 @@ hypre_StructMatvecCompute_core_VC( HYPRE_Complex       alpha,
    depth = only_Ax ? 0 : hypre_min(HYPRE_UNROLL_MAXDEPTH, nentries);
    switch (depth)
    {
-      HYPRE_CORE_CASE(27);
-      HYPRE_CORE_CASE(26);
-      HYPRE_CORE_CASE(25);
-      HYPRE_CORE_CASE(24);
-      HYPRE_CORE_CASE(23);
-      HYPRE_CORE_CASE(22);
-      HYPRE_CORE_CASE(21);
-      HYPRE_CORE_CASE(20);
-      HYPRE_CORE_CASE(19);
-      HYPRE_CORE_CASE(18);
-      HYPRE_CORE_CASE(17);
-      HYPRE_CORE_CASE(16);
-      HYPRE_CORE_CASE(15);
-      HYPRE_CORE_CASE(14);
-      HYPRE_CORE_CASE(13);
-      HYPRE_CORE_CASE(12);
-      HYPRE_CORE_CASE(11);
-      HYPRE_CORE_CASE(10);
-      HYPRE_CORE_CASE(9);
-      HYPRE_CORE_CASE(8);
-      HYPRE_CORE_CASE(7);
-      HYPRE_CORE_CASE(6);
-      HYPRE_CORE_CASE(5);
-      HYPRE_CORE_CASE(4);
-      HYPRE_CORE_CASE(3);
-      HYPRE_CORE_CASE(2);
-      HYPRE_CORE_CASE(1);
+         HYPRE_CORE_CASE(27);
+         HYPRE_CORE_CASE(26);
+         HYPRE_CORE_CASE(25);
+         HYPRE_CORE_CASE(24);
+         HYPRE_CORE_CASE(23);
+         HYPRE_CORE_CASE(22);
+         HYPRE_CORE_CASE(21);
+         HYPRE_CORE_CASE(20);
+         HYPRE_CORE_CASE(19);
+         HYPRE_CORE_CASE(18);
+         HYPRE_CORE_CASE(17);
+         HYPRE_CORE_CASE(16);
+         HYPRE_CORE_CASE(15);
+         HYPRE_CORE_CASE(14);
+         HYPRE_CORE_CASE(13);
+         HYPRE_CORE_CASE(12);
+         HYPRE_CORE_CASE(11);
+         HYPRE_CORE_CASE(10);
+         HYPRE_CORE_CASE(9);
+         HYPRE_CORE_CASE(8);
+         HYPRE_CORE_CASE(7);
+         HYPRE_CORE_CASE(6);
+         HYPRE_CORE_CASE(5);
+         HYPRE_CORE_CASE(4);
+         HYPRE_CORE_CASE(3);
+         HYPRE_CORE_CASE(2);
+         HYPRE_CORE_CASE(1);
 
       case 0:
          break;
@@ -882,33 +882,33 @@ hypre_StructMatvecCompute_core_VC( HYPRE_Complex       alpha,
 
       switch (depth)
       {
-         HYPRE_CORE_CASE(27);
-         HYPRE_CORE_CASE(26);
-         HYPRE_CORE_CASE(25);
-         HYPRE_CORE_CASE(24);
-         HYPRE_CORE_CASE(23);
-         HYPRE_CORE_CASE(22);
-         HYPRE_CORE_CASE(21);
-         HYPRE_CORE_CASE(20);
-         HYPRE_CORE_CASE(19);
-         HYPRE_CORE_CASE(18);
-         HYPRE_CORE_CASE(17);
-         HYPRE_CORE_CASE(16);
-         HYPRE_CORE_CASE(15);
-         HYPRE_CORE_CASE(14);
-         HYPRE_CORE_CASE(13);
-         HYPRE_CORE_CASE(12);
-         HYPRE_CORE_CASE(11);
-         HYPRE_CORE_CASE(10);
-         HYPRE_CORE_CASE(9);
-         HYPRE_CORE_CASE(8);
-         HYPRE_CORE_CASE(7);
-         HYPRE_CORE_CASE(6);
-         HYPRE_CORE_CASE(5);
-         HYPRE_CORE_CASE(4);
-         HYPRE_CORE_CASE(3);
-         HYPRE_CORE_CASE(2);
-         HYPRE_CORE_CASE(1);
+            HYPRE_CORE_CASE(27);
+            HYPRE_CORE_CASE(26);
+            HYPRE_CORE_CASE(25);
+            HYPRE_CORE_CASE(24);
+            HYPRE_CORE_CASE(23);
+            HYPRE_CORE_CASE(22);
+            HYPRE_CORE_CASE(21);
+            HYPRE_CORE_CASE(20);
+            HYPRE_CORE_CASE(19);
+            HYPRE_CORE_CASE(18);
+            HYPRE_CORE_CASE(17);
+            HYPRE_CORE_CASE(16);
+            HYPRE_CORE_CASE(15);
+            HYPRE_CORE_CASE(14);
+            HYPRE_CORE_CASE(13);
+            HYPRE_CORE_CASE(12);
+            HYPRE_CORE_CASE(11);
+            HYPRE_CORE_CASE(10);
+            HYPRE_CORE_CASE(9);
+            HYPRE_CORE_CASE(8);
+            HYPRE_CORE_CASE(7);
+            HYPRE_CORE_CASE(6);
+            HYPRE_CORE_CASE(5);
+            HYPRE_CORE_CASE(4);
+            HYPRE_CORE_CASE(3);
+            HYPRE_CORE_CASE(2);
+            HYPRE_CORE_CASE(1);
 
          case 0:
             break;
@@ -1026,32 +1026,32 @@ hypre_StructMatvecCompute_core_VCC( HYPRE_Complex       alpha,
    depth = hypre_min(HYPRE_UNROLL_MAXDEPTH - 1, nentries);
    switch (depth)
    {
-      HYPRE_CORE_CASE(26);
-      HYPRE_CORE_CASE(25);
-      HYPRE_CORE_CASE(24);
-      HYPRE_CORE_CASE(23);
-      HYPRE_CORE_CASE(22);
-      HYPRE_CORE_CASE(21);
-      HYPRE_CORE_CASE(20);
-      HYPRE_CORE_CASE(19);
-      HYPRE_CORE_CASE(18);
-      HYPRE_CORE_CASE(17);
-      HYPRE_CORE_CASE(16);
-      HYPRE_CORE_CASE(15);
-      HYPRE_CORE_CASE(14);
-      HYPRE_CORE_CASE(13);
-      HYPRE_CORE_CASE(12);
-      HYPRE_CORE_CASE(11);
-      HYPRE_CORE_CASE(10);
-      HYPRE_CORE_CASE(9);
-      HYPRE_CORE_CASE(8);
-      HYPRE_CORE_CASE(7);
-      HYPRE_CORE_CASE(6);
-      HYPRE_CORE_CASE(5);
-      HYPRE_CORE_CASE(4);
-      HYPRE_CORE_CASE(3);
-      HYPRE_CORE_CASE(2);
-      HYPRE_CORE_CASE(1);
+         HYPRE_CORE_CASE(26);
+         HYPRE_CORE_CASE(25);
+         HYPRE_CORE_CASE(24);
+         HYPRE_CORE_CASE(23);
+         HYPRE_CORE_CASE(22);
+         HYPRE_CORE_CASE(21);
+         HYPRE_CORE_CASE(20);
+         HYPRE_CORE_CASE(19);
+         HYPRE_CORE_CASE(18);
+         HYPRE_CORE_CASE(17);
+         HYPRE_CORE_CASE(16);
+         HYPRE_CORE_CASE(15);
+         HYPRE_CORE_CASE(14);
+         HYPRE_CORE_CASE(13);
+         HYPRE_CORE_CASE(12);
+         HYPRE_CORE_CASE(11);
+         HYPRE_CORE_CASE(10);
+         HYPRE_CORE_CASE(9);
+         HYPRE_CORE_CASE(8);
+         HYPRE_CORE_CASE(7);
+         HYPRE_CORE_CASE(6);
+         HYPRE_CORE_CASE(5);
+         HYPRE_CORE_CASE(4);
+         HYPRE_CORE_CASE(3);
+         HYPRE_CORE_CASE(2);
+         HYPRE_CORE_CASE(1);
 
       case 0:
          break;
@@ -1080,32 +1080,32 @@ hypre_StructMatvecCompute_core_VCC( HYPRE_Complex       alpha,
 
       switch (depth)
       {
-         HYPRE_CORE_CASE(26);
-         HYPRE_CORE_CASE(25);
-         HYPRE_CORE_CASE(24);
-         HYPRE_CORE_CASE(23);
-         HYPRE_CORE_CASE(22);
-         HYPRE_CORE_CASE(21);
-         HYPRE_CORE_CASE(20);
-         HYPRE_CORE_CASE(19);
-         HYPRE_CORE_CASE(18);
-         HYPRE_CORE_CASE(17);
-         HYPRE_CORE_CASE(16);
-         HYPRE_CORE_CASE(15);
-         HYPRE_CORE_CASE(14);
-         HYPRE_CORE_CASE(13);
-         HYPRE_CORE_CASE(12);
-         HYPRE_CORE_CASE(11);
-         HYPRE_CORE_CASE(10);
-         HYPRE_CORE_CASE(9);
-         HYPRE_CORE_CASE(8);
-         HYPRE_CORE_CASE(7);
-         HYPRE_CORE_CASE(6);
-         HYPRE_CORE_CASE(5);
-         HYPRE_CORE_CASE(4);
-         HYPRE_CORE_CASE(3);
-         HYPRE_CORE_CASE(2);
-         HYPRE_CORE_CASE(1);
+            HYPRE_CORE_CASE(26);
+            HYPRE_CORE_CASE(25);
+            HYPRE_CORE_CASE(24);
+            HYPRE_CORE_CASE(23);
+            HYPRE_CORE_CASE(22);
+            HYPRE_CORE_CASE(21);
+            HYPRE_CORE_CASE(20);
+            HYPRE_CORE_CASE(19);
+            HYPRE_CORE_CASE(18);
+            HYPRE_CORE_CASE(17);
+            HYPRE_CORE_CASE(16);
+            HYPRE_CORE_CASE(15);
+            HYPRE_CORE_CASE(14);
+            HYPRE_CORE_CASE(13);
+            HYPRE_CORE_CASE(12);
+            HYPRE_CORE_CASE(11);
+            HYPRE_CORE_CASE(10);
+            HYPRE_CORE_CASE(9);
+            HYPRE_CORE_CASE(8);
+            HYPRE_CORE_CASE(7);
+            HYPRE_CORE_CASE(6);
+            HYPRE_CORE_CASE(5);
+            HYPRE_CORE_CASE(4);
+            HYPRE_CORE_CASE(3);
+            HYPRE_CORE_CASE(2);
+            HYPRE_CORE_CASE(1);
 
          case 0:
             break;

--- a/src/struct_mv/struct_mv_mp.c
+++ b/src/struct_mv/struct_mv_mp.c
@@ -62,7 +62,7 @@ hypre_StructVectorCopy_mp( hypre_StructVector *x,
          {
             case HYPRE_REAL_DOUBLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {
@@ -71,7 +71,7 @@ hypre_StructVectorCopy_mp( hypre_StructVector *x,
                break;
             case HYPRE_REAL_LONGDOUBLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {
@@ -87,7 +87,7 @@ hypre_StructVectorCopy_mp( hypre_StructVector *x,
          {
             case HYPRE_REAL_SINGLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {
@@ -96,7 +96,7 @@ hypre_StructVectorCopy_mp( hypre_StructVector *x,
                break;
             case HYPRE_REAL_LONGDOUBLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {
@@ -112,16 +112,16 @@ hypre_StructVectorCopy_mp( hypre_StructVector *x,
          {
             case HYPRE_REAL_SINGLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {
                   ((hypre_float *)yp)[i] = (hypre_float)((hypre_long_double *)xp)[i];
                }
-               break;            
+               break;
             case HYPRE_REAL_DOUBLE:
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+               #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
                for (i = 0; i < size; i++)
                {

--- a/src/test/sstruct.c
+++ b/src/test/sstruct.c
@@ -2432,7 +2432,7 @@ hypre_MuPDataAlloc(HYPRE_Int count, HYPRE_MemoryLocation location)
 
 void
 hypre_MuPDataMemcpy(void *dst, void *src, HYPRE_Int count,
-                   HYPRE_MemoryLocation loc_dst, HYPRE_MemoryLocation loc_src)
+                    HYPRE_MemoryLocation loc_dst, HYPRE_MemoryLocation loc_src)
 {
    HYPRE_Precision precision;
    HYPRE_GetGlobalPrecision(&precision);
@@ -2831,7 +2831,7 @@ main( hypre_int argc,
    vis = 0;
    seed = 1;
    old_default = 0;
-   
+
    /* runtime precision */
    precision_id = -1;
 
@@ -3846,7 +3846,7 @@ main( hypre_int argc,
 
                      hypre_MuPDataCopyToMP(h_values, values, values_size);
                      hypre_MuPDataMemcpy(d_values, h_values, values_size,
-                                        memory_location, HYPRE_MEMORY_HOST);
+                                         memory_location, HYPRE_MEMORY_HOST);
 
                      for (box = 0; box < pdata.nboxes; box++)
                      {
@@ -3866,7 +3866,7 @@ main( hypre_int argc,
 #if 0    // Use AddFEMValues
             hypre_MuPDataCopyToMP(h_values, data.fem_values, data.fem_nsparse);
             hypre_MuPDataMemcpy(d_values, h_values, data.fem_nsparse,
-                               memory_location, HYPRE_MEMORY_HOST);
+                                memory_location, HYPRE_MEMORY_HOST);
 
             for (part = 0; part < data.nparts; part++)
             {
@@ -3898,7 +3898,7 @@ main( hypre_int argc,
             }
             hypre_MuPDataCopyToMP(h_values, values, data.fem_nsparse * data.max_boxsize);
             hypre_MuPDataMemcpy(d_values, h_values, data.fem_nsparse * data.max_boxsize,
-                               memory_location, HYPRE_MEMORY_HOST);
+                                memory_location, HYPRE_MEMORY_HOST);
             for (part = 0; part < data.nparts; part++)
             {
                pdata = data.pdata[part];
@@ -3980,7 +3980,7 @@ main( hypre_int argc,
 
                hypre_MuPDataCopyToMP(h_values, values, values_size);
                hypre_MuPDataMemcpy(d_values, h_values, values_size,
-                                  memory_location, HYPRE_MEMORY_HOST);
+                                   memory_location, HYPRE_MEMORY_HOST);
 
                HYPRE_SStructMatrixSetBoxValues(A, part,
                                                pdata.matset_ilowers[box], pdata.matset_iuppers[box],
@@ -4006,7 +4006,7 @@ main( hypre_int argc,
 
                   hypre_MuPDataCopyToMP(h_values, values, values_size);
                   hypre_MuPDataMemcpy(d_values, h_values, values_size,
-                                     memory_location, HYPRE_MEMORY_HOST);
+                                      memory_location, HYPRE_MEMORY_HOST);
 
                   HYPRE_SStructMatrixAddToBoxValues(A, part,
                                                     pdata.matadd_ilowers[box],
@@ -4043,7 +4043,7 @@ main( hypre_int argc,
 
                hypre_MuPDataCopyToMP(h_values, values, values_size);
                hypre_MuPDataMemcpy(d_values, h_values, values_size,
-                                  memory_location, HYPRE_MEMORY_HOST);
+                                   memory_location, HYPRE_MEMORY_HOST);
 
                for (index[2] = pdata.fem_matadd_ilowers[box][2];
                     index[2] <= pdata.fem_matadd_iuppers[box][2]; index[2]++)
@@ -4135,7 +4135,7 @@ main( hypre_int argc,
 
          hypre_MuPDataCopyToMP(h_values, values, values_size);
          hypre_MuPDataMemcpy(d_values, h_values, values_size,
-                            memory_location, HYPRE_MEMORY_HOST);
+                             memory_location, HYPRE_MEMORY_HOST);
 
          for (part = 0; part < data.nparts; part++)
          {
@@ -4157,7 +4157,7 @@ main( hypre_int argc,
 #if 0    // Use AddFEMValues
             hypre_MuPDataCopyToMP(h_values, data.fem_rhs_values, data.fem_nvars);
             hypre_MuPDataMemcpy(d_values, h_values, data.fem_nvars,
-                               memory_location, HYPRE_MEMORY_HOST);
+                                memory_location, HYPRE_MEMORY_HOST);
 
             for (part = 0; part < data.nparts; part++)
             {
@@ -4189,7 +4189,7 @@ main( hypre_int argc,
             }
             hypre_MuPDataCopyToMP(h_values, values, data.fem_nvars * data.max_boxsize);
             hypre_MuPDataMemcpy(d_values, h_values, data.fem_nvars * data.max_boxsize,
-                               memory_location, HYPRE_MEMORY_HOST);
+                                memory_location, HYPRE_MEMORY_HOST);
             for (part = 0; part < data.nparts; part++)
             {
                pdata = data.pdata[part];
@@ -4217,7 +4217,7 @@ main( hypre_int argc,
 
                hypre_MuPDataCopyToMP(h_values, values, values_size);
                hypre_MuPDataMemcpy(d_values, h_values, values_size,
-                                  memory_location, HYPRE_MEMORY_HOST);
+                                   memory_location, HYPRE_MEMORY_HOST);
 
                HYPRE_SStructVectorAddToBoxValues(b, part,
                                                  pdata.rhsadd_ilowers[box],
@@ -4234,7 +4234,7 @@ main( hypre_int argc,
             {
                hypre_MuPDataCopyToMP(h_values, pdata.fem_rhsadd_values[box], data.fem_nvars);
                hypre_MuPDataMemcpy(d_values, h_values, data.fem_nvars,
-                                  memory_location, HYPRE_MEMORY_HOST);
+                                   memory_location, HYPRE_MEMORY_HOST);
                for (index[2] = pdata.fem_rhsadd_ilowers[box][2];
                     index[2] <= pdata.fem_rhsadd_iuppers[box][2]; index[2]++)
                {
@@ -4288,7 +4288,7 @@ main( hypre_int argc,
 
                            hypre_MuPDataCopyToMP(h_values, values, size);
                            hypre_MuPDataMemcpy(d_values, h_values, size,
-                                              memory_location, HYPRE_MEMORY_HOST);
+                                               memory_location, HYPRE_MEMORY_HOST);
 
                            HYPRE_SStructVectorSetBoxValues(x, part, ilower, iupper, var, d_values);
                         }
@@ -4519,7 +4519,7 @@ main( hypre_int argc,
 
                   hypre_MuPDataCopyToMP(h_values, values, values_size);
                   hypre_MuPDataMemcpy(d_values, h_values, values_size,
-                                     memory_location, HYPRE_MEMORY_HOST);
+                                      memory_location, HYPRE_MEMORY_HOST);
 
                   for (box = 0; box < pdata.nboxes; box++)
                   {

--- a/src/test/struct.c
+++ b/src/test/struct.c
@@ -4287,24 +4287,32 @@ SetStencilBndry( HYPRE_StructMatrix  A,
    HYPRE_Int             stencil_indices[1] = {0};
    HYPRE_Int             stencil_sizes_27pt_neg[3] = {9, 9, 9};
    HYPRE_Int             stencil_indices_27pt_neg[3][9] =
-     {{1, 3, 6, 10, 12, 15, 19, 21, 24},
+   {
+      {1, 3, 6, 10, 12, 15, 19, 21, 24},
       {3, 4, 5, 12, 13, 14, 21, 22, 23},
-      {0, 1, 2, 3, 4, 5, 6, 7, 8}};
+      {0, 1, 2, 3, 4, 5, 6, 7, 8}
+   };
    HYPRE_Int             stencil_sizes_27pt_pos[3] = {9, 9, 9};
    HYPRE_Int             stencil_indices_27pt_pos[3][9] =
-     {{2, 5, 8, 11, 14, 17, 20, 23, 26},
+   {
+      {2, 5, 8, 11, 14, 17, 20, 23, 26},
       {6, 7, 8, 15, 16, 17, 24, 25, 26},
-      {18, 19, 20, 21, 22, 23, 24, 25, 26}};
+      {18, 19, 20, 21, 22, 23, 24, 25, 26}
+   };
    HYPRE_Int             stencil_sizes_27pt_sym_neg[3] = {5, 6, 9};
    HYPRE_Int             stencil_indices_27pt_sym_neg[3][9] =
-     {{1, 2, 6, 8, 11, -1, -1, -1, -1},
+   {
+      {1, 2, 6, 8, 11, -1, -1, -1, -1},
       {2, 3, 4, 8, 9, 10, -1, -1, -1},
-      {5, 6, 7, 8, 9, 10, 11, 12, 13}};
+      {5, 6, 7, 8, 9, 10, 11, 12, 13}
+   };
    HYPRE_Int             stencil_sizes_27pt_sym_pos[3] = {4, 3, 0};
    HYPRE_Int             stencil_indices_27pt_sym_pos[3][4] =
-     {{4, 7, 10, 13},
+   {
+      {4, 7, 10, 13},
       {11, 12, 13, -1},
-      {-1, -1, -1, -1}};
+      {-1, -1, -1, -1}
+   };
 
    boxes  = hypre_StructGridBoxes(grid);
    bbox   = hypre_StructGridBoundingBox(grid);

--- a/src/test/struct_mp.c
+++ b/src/test/struct_mp.c
@@ -30,20 +30,20 @@
 HYPRE_Int  SetStencilBndry_mp(HYPRE_StructMatrix A, HYPRE_StructGrid gridmatrix, HYPRE_Int* period);
 
 HYPRE_Int AddValuesVector_mp(hypre_StructGrid  *gridvector,
-                               hypre_StructVector *zvector,
-                               HYPRE_Int          *period,
-                               void               *value,
-                               size_t             size)  ;
+                             hypre_StructVector *zvector,
+                             HYPRE_Int          *period,
+                             void               *value,
+                             size_t             size)  ;
 
 HYPRE_Int AddValuesMatrix_mp(HYPRE_StructMatrix A,
-                    HYPRE_StructGrid   gridmatrix,
-                    void              *cx,
-                    void              *cy,
-                    void              *cz,
-                    void              *conx,
-                    void              *cony,
-                    void              *conz,
-                    size_t            size);
+                             HYPRE_StructGrid   gridmatrix,
+                             void              *cx,
+                             void              *cy,
+                             void              *cz,
+                             void              *conx,
+                             void              *cony,
+                             void              *conz,
+                             size_t            size);
 
 /*--------------------------------------------------------------------------
  * Test driver for structured matrix interface (structured storage)
@@ -157,10 +157,10 @@ main( hypre_int argc,
    HYPRE_Precision precond_precision = HYPRE_REAL_SINGLE;
    hypre_long_double one_ldbl = 1.0;
    hypre_double      one_dbl = 1.0;
-   hypre_float       one_flt = 1.0f;            
+   hypre_float       one_flt = 1.0f;
    hypre_long_double zero_ldbl = 0.0;
    hypre_double      zero_dbl = 0.0;
-   hypre_float       zero_flt = 0.0f; 
+   hypre_float       zero_flt = 0.0f;
    void        *one_slvr = &one_dbl;
    void        *one_pc = &one_flt;
    void        *zero_slvr = &zero_dbl;
@@ -169,9 +169,9 @@ main( hypre_int argc,
    hypre_long_double   params_ldbl[6]; /*cx, cy, cz, conx, cony, conz*/
    hypre_double        params_dbl[6];
    hypre_float         params_flt[6];
-   
+
    void        *conx_slvr, *cony_slvr, *conz_slvr;
-   void        *cx_slvr, *cy_slvr, *cz_slvr;   
+   void        *cx_slvr, *cy_slvr, *cz_slvr;
    void        *conx_pc, *cony_pc, *conz_pc;
    void        *cx_pc, *cy_pc, *cz_pc;
    /* Size of solver and preconditioner data types */
@@ -217,7 +217,7 @@ main( hypre_int argc,
    conx = 0.0;
    cony = 0.0;
    conz = 0.0;
-   
+
    params_ldbl[0] = (long double)cx;
    params_ldbl[1] = (long double)cy;
    params_ldbl[2] = (long double)cz;
@@ -226,7 +226,7 @@ main( hypre_int argc,
    params_dbl[2] = (double)cz;
    params_flt[0] = (float)cx;
    params_flt[1] = (float)cy;
-   params_flt[2] = (float)cz; 
+   params_flt[2] = (float)cz;
 
    params_ldbl[3] = (long double)conx;
    params_ldbl[4] = (long double)cony;
@@ -236,7 +236,7 @@ main( hypre_int argc,
    params_dbl[5] = (double)conz;
    params_flt[3] = (float)conx;
    params_flt[4] = (float)cony;
-   params_flt[5] = (float)conz;  
+   params_flt[5] = (float)conz;
 
    n_pre  = 1;
    n_post = 1;
@@ -331,7 +331,7 @@ main( hypre_int argc,
          params_dbl[2] = (double)cz;
          params_flt[0] = (float)cx;
          params_flt[1] = (float)cy;
-         params_flt[2] = (float)cz;         
+         params_flt[2] = (float)cz;
       }
       else if ( strcmp(argv[arg_index], "-convect") == 0 )
       {
@@ -474,7 +474,7 @@ main( hypre_int argc,
       {
          arg_index++;
          precision_id = atoi(argv[arg_index++]);
-         
+
          switch (precision_id)
          {
             case 0:
@@ -501,7 +501,7 @@ main( hypre_int argc,
       {
          arg_index++;
          precision_id = atoi(argv[arg_index++]);
-         
+
          switch (precision_id)
          {
             case 0:
@@ -522,7 +522,7 @@ main( hypre_int argc,
                zero_pc = &zero_ldbl;
                pc_size_t = sizeof(hypre_long_double);
                break;
-         }      
+         }
       }
       else
       {
@@ -663,21 +663,21 @@ main( hypre_int argc,
    {
 #if defined(HYPRE_DEVELOP_STRING) && defined(HYPRE_DEVELOP_BRANCH)
       hypre_printf("\nUsing HYPRE_DEVELOP_STRING: %s (branch %s; the develop branch)\n\n",
-                       HYPRE_DEVELOP_STRING, HYPRE_DEVELOP_BRANCH);
+                   HYPRE_DEVELOP_STRING, HYPRE_DEVELOP_BRANCH);
 
 #elif defined(HYPRE_DEVELOP_STRING) && !defined(HYPRE_DEVELOP_BRANCH)
       hypre_printf("\nUsing HYPRE_DEVELOP_STRING: %s (branch %s; not the develop branch)\n\n",
-                       HYPRE_DEVELOP_STRING, HYPRE_BRANCH_NAME);
+                   HYPRE_DEVELOP_STRING, HYPRE_BRANCH_NAME);
 
 #elif defined(HYPRE_RELEASE_VERSION)
       hypre_printf("\nUsing HYPRE_RELEASE_VERSION: %s\n\n",
-                       HYPRE_RELEASE_VERSION);
+                   HYPRE_RELEASE_VERSION);
 #endif
 
       hypre_printf("Running with these driver parameters:\n");
       hypre_printf("  (nx, ny, nz)    = (%d, %d, %d)\n", nx, ny, nz);
       hypre_printf("  (istart[0],istart[1],istart[2]) = (%d, %d, %d)\n", \
-                       istart[0], istart[1], istart[2]);
+                   istart[0], istart[1], istart[2]);
       hypre_printf("  (Px, Py, Pz)    = (%d, %d, %d)\n", P,  Q,  R);
       hypre_printf("  (bx, by, bz)    = (%d, %d, %d)\n", bx, by, bz);
       hypre_printf("  (px, py, pz)    = (%d, %d, %d)\n", px, py, pz);
@@ -860,15 +860,15 @@ main( hypre_int argc,
       /*-----------------------------------------------------------
        * Set up the stencil structure needed for matrix creation
        * which is always the case for read_fromfile_param == 0
-       * 
-       * The following struct stencil functions are integer operations and 
+       *
+       * The following struct stencil functions are integer operations and
        * can be called in any precision. We default to the solver precision here.
        *-----------------------------------------------------------*/
 
-      HYPRE_StructStencilCreate_pre( solver_precision,dim, (2 - sym)*dim + 1, &stencil);
+      HYPRE_StructStencilCreate_pre( solver_precision, dim, (2 - sym)*dim + 1, &stencil);
       for (s = 0; s < (2 - sym)*dim + 1; s++)
       {
-         HYPRE_StructStencilSetElement_pre( solver_precision,stencil, s, offsets[s]);
+         HYPRE_StructStencilSetElement_pre( solver_precision, stencil, s, offsets[s]);
       }
 
       /*-----------------------------------------------------------
@@ -909,15 +909,15 @@ main( hypre_int argc,
           *-----------------------------------------------------------*/
 
          ilower = (HYPRE_Int **) hypre_CAlloc((size_t)(nblocks), (size_t)sizeof(HYPRE_Int*),
-                                                  HYPRE_MEMORY_HOST);
+                                              HYPRE_MEMORY_HOST);
          iupper = (HYPRE_Int **) hypre_CAlloc((size_t)(nblocks), (size_t)sizeof(HYPRE_Int*),
-                                                  HYPRE_MEMORY_HOST);
+                                              HYPRE_MEMORY_HOST);
          for (i = 0; i < nblocks; i++)
          {
             ilower[i] = (HYPRE_Int *) hypre_CAlloc((size_t)(dim), (size_t)sizeof(HYPRE_Int),
-                                                       HYPRE_MEMORY_HOST);
+                                                   HYPRE_MEMORY_HOST);
             iupper[i] = (HYPRE_Int *) hypre_CAlloc((size_t)(dim), (size_t)sizeof(HYPRE_Int),
-                                                       HYPRE_MEMORY_HOST);
+                                                   HYPRE_MEMORY_HOST);
          }
 
          /* compute ilower and iupper from (p,q,r), (bx,by,bz), and (nx,ny,nz) */
@@ -958,19 +958,19 @@ main( hypre_int argc,
                      }
                break;
          }
-         
-         /* The following struct grid functions are integer operations and 
+
+         /* The following struct grid functions are integer operations and
           * can be called in any precision. We default to the solver precision here.
          */
-         HYPRE_StructGridCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, dim, &grid);
+         HYPRE_StructGridCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, dim, &grid);
          for (ib = 0; ib < nblocks; ib++)
          {
             /* Add to the grid a new box defined by ilower[ib], iupper[ib]...*/
-            HYPRE_StructGridSetExtents_pre( solver_precision,grid, ilower[ib], iupper[ib]);
+            HYPRE_StructGridSetExtents_pre( solver_precision, grid, ilower[ib], iupper[ib]);
          }
-         HYPRE_StructGridSetPeriodic_pre( solver_precision,grid, periodic);
-         HYPRE_StructGridSetNumGhost_pre( solver_precision,grid, num_ghost);
-         HYPRE_StructGridAssemble_pre( solver_precision,grid);
+         HYPRE_StructGridSetPeriodic_pre( solver_precision, grid, periodic);
+         HYPRE_StructGridSetNumGhost_pre( solver_precision, grid, num_ghost);
+         HYPRE_StructGridAssemble_pre( solver_precision, grid);
 
          /*-----------------------------------------------------------
           * Set up the matrix structure
@@ -985,7 +985,7 @@ main( hypre_int argc,
             stencil_size  = hypre_StructStencilSize(stencil);
             /* integer array allocation */
             stencil_entries = (HYPRE_Int *) hypre_CAlloc ((size_t)(stencil_size), (size_t)sizeof(HYPRE_Int),
-                                                              HYPRE_MEMORY_HOST);
+                                                          HYPRE_MEMORY_HOST);
             if ( solver_id == 3 || solver_id == 13)
             {
                for ( i = 0; i < stencil_size; ++i )
@@ -1027,10 +1027,10 @@ main( hypre_int argc,
             }
          }
 
-         HYPRE_StructMatrixSetSymmetric_pre( solver_precision,A_dbl, sym);
-         HYPRE_StructMatrixInitialize_pre( solver_precision,A_dbl);
-         HYPRE_StructMatrixSetSymmetric_pre( precond_precision,A_flt, sym);
-         HYPRE_StructMatrixInitialize_pre( precond_precision,A_flt);
+         HYPRE_StructMatrixSetSymmetric_pre( solver_precision, A_dbl, sym);
+         HYPRE_StructMatrixInitialize_pre( solver_precision, A_dbl);
+         HYPRE_StructMatrixSetSymmetric_pre( precond_precision, A_flt, sym);
+         HYPRE_StructMatrixInitialize_pre( precond_precision, A_flt);
 
          /*-----------------------------------------------------------
           * Fill in the matrix elements
@@ -1052,7 +1052,7 @@ main( hypre_int argc,
                conx_slvr = &params_dbl[3];
                cony_slvr = &params_dbl[4];
                conz_slvr = &params_dbl[5];
-               break;               
+               break;
             case HYPRE_REAL_LONGDOUBLE:
                cx_slvr = &params_ldbl[0];
                cy_slvr = &params_ldbl[1];
@@ -1080,7 +1080,7 @@ main( hypre_int argc,
                conx_pc = &params_dbl[3];
                cony_pc = &params_dbl[4];
                conz_pc = &params_dbl[5];
-               break;               
+               break;
             case HYPRE_REAL_LONGDOUBLE:
                cx_pc = &params_ldbl[0];
                cy_pc = &params_ldbl[1];
@@ -1089,8 +1089,9 @@ main( hypre_int argc,
                cony_pc = &params_ldbl[4];
                conz_pc = &params_ldbl[5];
                break;
-         }         
-         AddValuesMatrix_mp(A_dbl, grid, cx_slvr, cy_slvr, cz_slvr, conx_slvr, cony_slvr, conz_slvr, slvr_size_t);
+         }
+         AddValuesMatrix_mp(A_dbl, grid, cx_slvr, cy_slvr, cz_slvr, conx_slvr, cony_slvr, conz_slvr,
+                            slvr_size_t);
          AddValuesMatrix_mp(A_flt, grid, cx_pc, cy_pc, cz_pc, conx_pc, cony_pc, conz_pc, pc_size_t);
 
          /* Zero out stencils reaching to real boundary */
@@ -1101,16 +1102,16 @@ main( hypre_int argc,
             SetStencilBndry_mp(A_dbl, grid, periodic);
             SetStencilBndry_mp(A_flt, grid, periodic);
          }
-         HYPRE_StructMatrixAssemble_pre( solver_precision,A_dbl);
-         HYPRE_StructMatrixAssemble_pre( precond_precision,A_flt);
+         HYPRE_StructMatrixAssemble_pre( solver_precision, A_dbl);
+         HYPRE_StructMatrixAssemble_pre( precond_precision, A_flt);
          /*-----------------------------------------------------------
           * Set up the linear system
           *-----------------------------------------------------------*/
 
-         HYPRE_StructVectorCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, grid, &b_dbl);
-         HYPRE_StructVectorInitialize_pre( solver_precision,b_dbl);
-         HYPRE_StructVectorCreate_pre( precond_precision,hypre_MPI_COMM_WORLD, grid, &b_flt);
-         HYPRE_StructVectorInitialize_pre( precond_precision,b_flt);
+         HYPRE_StructVectorCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, grid, &b_dbl);
+         HYPRE_StructVectorInitialize_pre( solver_precision, b_dbl);
+         HYPRE_StructVectorCreate_pre( precond_precision, hypre_MPI_COMM_WORLD, grid, &b_flt);
+         HYPRE_StructVectorInitialize_pre( precond_precision, b_flt);
 
          /*-----------------------------------------------------------
           * For periodic b.c. in all directions, need rhs to satisfy
@@ -1120,20 +1121,20 @@ main( hypre_int argc,
 
          AddValuesVector_mp(grid, b_dbl, periodic, one_slvr, slvr_size_t);
          AddValuesVector_mp(grid, b_flt, periodic, one_pc, pc_size_t);
-         HYPRE_StructVectorAssemble_pre( solver_precision,b_dbl);
-         HYPRE_StructVectorAssemble_pre( precond_precision,b_flt);
+         HYPRE_StructVectorAssemble_pre( solver_precision, b_dbl);
+         HYPRE_StructVectorAssemble_pre( precond_precision, b_flt);
 
-         HYPRE_StructVectorCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, grid, &x_dbl);
-         HYPRE_StructVectorCreate_pre( precond_precision,hypre_MPI_COMM_WORLD, grid, &x_flt);
-         HYPRE_StructVectorInitialize_pre( solver_precision,x_dbl);
-         HYPRE_StructVectorInitialize_pre( precond_precision,x_flt);
-       
+         HYPRE_StructVectorCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, grid, &x_dbl);
+         HYPRE_StructVectorCreate_pre( precond_precision, hypre_MPI_COMM_WORLD, grid, &x_flt);
+         HYPRE_StructVectorInitialize_pre( solver_precision, x_dbl);
+         HYPRE_StructVectorInitialize_pre( precond_precision, x_flt);
+
          AddValuesVector_mp(grid, x_dbl, periodx0, zero_slvr, slvr_size_t);
          AddValuesVector_mp(grid, x_flt, periodx0, zero_pc, pc_size_t);
-         HYPRE_StructVectorAssemble_pre(solver_precision,x_dbl);
-         HYPRE_StructVectorAssemble_pre(precond_precision,x_flt);
+         HYPRE_StructVectorAssemble_pre(solver_precision, x_dbl);
+         HYPRE_StructVectorAssemble_pre(precond_precision, x_flt);
 
-         HYPRE_StructGridDestroy_pre( solver_precision,grid);
+         HYPRE_StructGridDestroy_pre( solver_precision, grid);
 
          for (i = 0; i < nblocks; i++)
          {
@@ -1180,14 +1181,14 @@ main( hypre_int argc,
          time_index = hypre_InitializeTiming("SMG Setup");
          hypre_BeginTiming(time_index);
 
-         HYPRE_StructSMGCreate_pre( solver_precision,MPI_COMM_WORLD, &solver);
-         HYPRE_StructSMGSetMaxIter_pre( solver_precision,solver, 50);
-         HYPRE_StructSMGSetTol_pre( solver_precision,solver, tol);
-         HYPRE_StructSMGSetRelChange_pre( solver_precision,solver, 0);
-         HYPRE_StructSMGSetNumPreRelax_pre( solver_precision,solver, n_pre);
-         HYPRE_StructSMGSetNumPostRelax_pre( solver_precision,solver, n_post);
-         HYPRE_StructSMGSetPrintLevel_pre( solver_precision,solver, 1);
-         HYPRE_StructSMGSetLogging_pre( solver_precision,solver, 1);
+         HYPRE_StructSMGCreate_pre( solver_precision, MPI_COMM_WORLD, &solver);
+         HYPRE_StructSMGSetMaxIter_pre( solver_precision, solver, 50);
+         HYPRE_StructSMGSetTol_pre( solver_precision, solver, tol);
+         HYPRE_StructSMGSetRelChange_pre( solver_precision, solver, 0);
+         HYPRE_StructSMGSetNumPreRelax_pre( solver_precision, solver, n_pre);
+         HYPRE_StructSMGSetNumPostRelax_pre( solver_precision, solver, n_post);
+         HYPRE_StructSMGSetPrintLevel_pre( solver_precision, solver, 1);
+         HYPRE_StructSMGSetLogging_pre( solver_precision, solver, 1);
 #if 0//defined(HYPRE_USING_CUDA)
          HYPRE_StructSMGSetDeviceLevel(solver, device_level);
 #endif
@@ -1195,7 +1196,7 @@ main( hypre_int argc,
 #if 0//defined(HYPRE_USING_CUDA)
          hypre_box_print = 0;
 #endif
-         HYPRE_StructSMGSetup_pre( solver_precision,solver, A_dbl, b_dbl, x_dbl);
+         HYPRE_StructSMGSetup_pre( solver_precision, solver, A_dbl, b_dbl, x_dbl);
 
 #if 0//defined(HYPRE_USING_CUDA)
          hypre_box_print = 0;
@@ -1216,7 +1217,7 @@ main( hypre_int argc,
          time_index = hypre_InitializeTiming("SMG Solve");
          hypre_BeginTiming(time_index);
 
-         HYPRE_StructSMGSolve_pre( solver_precision,solver, A_dbl, b_dbl, x_dbl);
+         HYPRE_StructSMGSolve_pre( solver_precision, solver, A_dbl, b_dbl, x_dbl);
 
          hypre_EndTiming(time_index);
          if ( reps == 1 )
@@ -1228,14 +1229,14 @@ main( hypre_int argc,
          else if ( rep == reps - 1 )
          {
             hypre_PrintTiming("Interface, Setup, and Solve times:",
-                                  hypre_MPI_COMM_WORLD );
+                              hypre_MPI_COMM_WORLD );
             hypre_FinalizeTiming(time_index);
             hypre_ClearTiming();
          }
 
-         HYPRE_StructSMGGetNumIterations_pre( solver_precision,solver, &num_iterations);
-         HYPRE_StructSMGGetFinalRelativeResidualNorm_pre( solver_precision,solver, &final_res_norm);
-         HYPRE_StructSMGDestroy_pre( solver_precision,solver);
+         HYPRE_StructSMGGetNumIterations_pre( solver_precision, solver, &num_iterations);
+         HYPRE_StructSMGGetFinalRelativeResidualNorm_pre( solver_precision, solver, &final_res_norm);
+         HYPRE_StructSMGDestroy_pre( solver_precision, solver);
       }
 
       /*-----------------------------------------------------------
@@ -1247,27 +1248,27 @@ main( hypre_int argc,
          time_index = hypre_InitializeTiming("PFMG Setup");
          hypre_BeginTiming(time_index);
 
-         HYPRE_StructPFMGCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, &solver);
-         HYPRE_StructPFMGSetMaxIter_pre( solver_precision,solver, 200);
-         HYPRE_StructPFMGSetTol_pre( solver_precision,solver, tol);
-         HYPRE_StructPFMGSetRelChange_pre( solver_precision,solver, 0);
-         HYPRE_StructPFMGSetRAPType_pre( solver_precision,solver, rap);
-         HYPRE_StructPFMGSetRelaxType_pre( solver_precision,solver, relax);
+         HYPRE_StructPFMGCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, &solver);
+         HYPRE_StructPFMGSetMaxIter_pre( solver_precision, solver, 200);
+         HYPRE_StructPFMGSetTol_pre( solver_precision, solver, tol);
+         HYPRE_StructPFMGSetRelChange_pre( solver_precision, solver, 0);
+         HYPRE_StructPFMGSetRAPType_pre( solver_precision, solver, rap);
+         HYPRE_StructPFMGSetRelaxType_pre( solver_precision, solver, relax);
          if (usr_jacobi_weight)
          {
-            HYPRE_StructPFMGSetJacobiWeight_pre( solver_precision,solver, jacobi_weight);
+            HYPRE_StructPFMGSetJacobiWeight_pre( solver_precision, solver, jacobi_weight);
          }
-         HYPRE_StructPFMGSetNumPreRelax_pre( solver_precision,solver, n_pre);
-         HYPRE_StructPFMGSetNumPostRelax_pre( solver_precision,solver, n_post);
-         HYPRE_StructPFMGSetSkipRelax_pre( solver_precision,solver, skip);
-         HYPRE_StructPFMGSetPrintLevel_pre( solver_precision,solver, 1);
-         HYPRE_StructPFMGSetLogging_pre( solver_precision,solver, 1);
+         HYPRE_StructPFMGSetNumPreRelax_pre( solver_precision, solver, n_pre);
+         HYPRE_StructPFMGSetNumPostRelax_pre( solver_precision, solver, n_post);
+         HYPRE_StructPFMGSetSkipRelax_pre( solver_precision, solver, skip);
+         HYPRE_StructPFMGSetPrintLevel_pre( solver_precision, solver, 1);
+         HYPRE_StructPFMGSetLogging_pre( solver_precision, solver, 1);
 
 #if 0//defined(HYPRE_USING_CUDA)
          HYPRE_StructPFMGSetDeviceLevel(solver, device_level);
 #endif
 
-         HYPRE_StructPFMGSetup_pre( solver_precision,solver, A_dbl, b_dbl, x_dbl);
+         HYPRE_StructPFMGSetup_pre( solver_precision, solver, A_dbl, b_dbl, x_dbl);
 
          hypre_EndTiming(time_index);
          if ( reps == 1 )
@@ -1285,7 +1286,7 @@ main( hypre_int argc,
          hypre_BeginTiming(time_index);
 
 
-         HYPRE_StructPFMGSolve_pre( solver_precision,solver, A_dbl, b_dbl, x_dbl);
+         HYPRE_StructPFMGSolve_pre( solver_precision, solver, A_dbl, b_dbl, x_dbl);
 
          hypre_EndTiming(time_index);
          if ( reps == 1 )
@@ -1297,14 +1298,14 @@ main( hypre_int argc,
          else if ( rep == reps - 1 )
          {
             hypre_PrintTiming("Interface, Setup, and Solve times",
-                                  hypre_MPI_COMM_WORLD);
+                              hypre_MPI_COMM_WORLD);
             hypre_FinalizeTiming(time_index);
             hypre_ClearTiming();
          }
 
-         HYPRE_StructPFMGGetNumIterations_pre( solver_precision,solver, &num_iterations);
-         HYPRE_StructPFMGGetFinalRelativeResidualNorm_pre( solver_precision,solver, &final_res_norm);
-         HYPRE_StructPFMGDestroy_pre( solver_precision,solver);
+         HYPRE_StructPFMGGetNumIterations_pre( solver_precision, solver, &num_iterations);
+         HYPRE_StructPFMGGetFinalRelativeResidualNorm_pre( solver_precision, solver, &final_res_norm);
+         HYPRE_StructPFMGDestroy_pre( solver_precision, solver);
       }
 
       /*-----------------------------------------------------------
@@ -1316,7 +1317,7 @@ main( hypre_int argc,
          time_index = hypre_InitializeTiming("PCG Setup");
          hypre_BeginTiming(time_index);
 
-         HYPRE_StructPCGCreate_pre( solver_precision,MPI_COMM_WORLD, &solver);
+         HYPRE_StructPCGCreate_pre( solver_precision, MPI_COMM_WORLD, &solver);
          HYPRE_PCGSetMaxIter_pre( solver_precision, (HYPRE_Solver)solver, 100 );
          HYPRE_PCGSetTol_pre( solver_precision, (HYPRE_Solver)solver, tol );
          HYPRE_PCGSetTwoNorm_pre( solver_precision, (HYPRE_Solver)solver, 1 );
@@ -1328,15 +1329,15 @@ main( hypre_int argc,
          if (solver_id == 10)
          {
             /* use symmetric SMG as preconditioner */
-            HYPRE_StructSMGCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructSMGCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, &precond);
             //HYPRE_StructSMGSetMemoryUse_pre( solver_precision,precond, 0);
-            HYPRE_StructSMGSetMaxIter_pre( solver_precision,precond, 1);
-            HYPRE_StructSMGSetTol_pre( solver_precision,precond, 0.0);
-            HYPRE_StructSMGSetZeroGuess_pre( solver_precision,precond);
-            HYPRE_StructSMGSetNumPreRelax_pre( solver_precision,precond, n_pre);
-            HYPRE_StructSMGSetNumPostRelax_pre( solver_precision,precond, n_post);
-            HYPRE_StructSMGSetPrintLevel_pre( solver_precision,precond, 0);
-            HYPRE_StructSMGSetLogging_pre( solver_precision,precond, 0);
+            HYPRE_StructSMGSetMaxIter_pre( solver_precision, precond, 1);
+            HYPRE_StructSMGSetTol_pre( solver_precision, precond, 0.0);
+            HYPRE_StructSMGSetZeroGuess_pre( solver_precision, precond);
+            HYPRE_StructSMGSetNumPreRelax_pre( solver_precision, precond, n_pre);
+            HYPRE_StructSMGSetNumPostRelax_pre( solver_precision, precond, n_post);
+            HYPRE_StructSMGSetPrintLevel_pre( solver_precision, precond, 0);
+            HYPRE_StructSMGSetLogging_pre( solver_precision, precond, 0);
 
             HYPRE_PCGSetPrecond_pre( solver_precision, (HYPRE_Solver) solver,
                                      (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSolve_dbl,
@@ -1345,15 +1346,15 @@ main( hypre_int argc,
          }
          else if (solver_id == 15)
          {
-            HYPRE_StructSMGCreate_pre( precond_precision,hypre_MPI_COMM_WORLD, &precond);
-            HYPRE_StructSMGSetMaxIter_pre( precond_precision,precond, 1);
-            HYPRE_StructSMGSetTol_pre( precond_precision,precond, 0.0);
-            HYPRE_StructSMGSetZeroGuess_pre( precond_precision,precond);
-            HYPRE_StructSMGSetNumPreRelax_pre( precond_precision,precond, n_pre);
-            HYPRE_StructSMGSetNumPostRelax_pre( precond_precision,precond, n_post);
-            HYPRE_StructSMGSetPrintLevel_pre( precond_precision,precond, 0);
-            HYPRE_StructSMGSetLogging_pre( precond_precision,precond, 0);
-            HYPRE_PCGSetPrecondMatrix_pre( solver_precision,(HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
+            HYPRE_StructSMGCreate_pre( precond_precision, hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructSMGSetMaxIter_pre( precond_precision, precond, 1);
+            HYPRE_StructSMGSetTol_pre( precond_precision, precond, 0.0);
+            HYPRE_StructSMGSetZeroGuess_pre( precond_precision, precond);
+            HYPRE_StructSMGSetNumPreRelax_pre( precond_precision, precond, n_pre);
+            HYPRE_StructSMGSetNumPostRelax_pre( precond_precision, precond, n_post);
+            HYPRE_StructSMGSetPrintLevel_pre( precond_precision, precond, 0);
+            HYPRE_StructSMGSetLogging_pre( precond_precision, precond, 0);
+            HYPRE_PCGSetPrecondMatrix_pre( solver_precision, (HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
             HYPRE_PCGSetPrecond_pre( solver_precision, (HYPRE_Solver) solver,
                                      (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSolve_mp,
                                      (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSetup_mp,
@@ -1363,62 +1364,62 @@ main( hypre_int argc,
          else if (solver_id == 11 || solver_id == 13 || solver_id == 14)
          {
             /* use symmetric PFMG as preconditioner */
-            HYPRE_StructPFMGCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, &precond);
-            HYPRE_StructPFMGSetMaxIter_pre( solver_precision,precond, 1);
-            HYPRE_StructPFMGSetTol_pre( solver_precision,precond, 0.0);
-            HYPRE_StructPFMGSetZeroGuess_pre( solver_precision,precond);
-            HYPRE_StructPFMGSetRAPType_pre( solver_precision,precond, rap);
-            HYPRE_StructPFMGSetRelaxType_pre( solver_precision,precond, relax);
+            HYPRE_StructPFMGCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructPFMGSetMaxIter_pre( solver_precision, precond, 1);
+            HYPRE_StructPFMGSetTol_pre( solver_precision, precond, 0.0);
+            HYPRE_StructPFMGSetZeroGuess_pre( solver_precision, precond);
+            HYPRE_StructPFMGSetRAPType_pre( solver_precision, precond, rap);
+            HYPRE_StructPFMGSetRelaxType_pre( solver_precision, precond, relax);
             if (usr_jacobi_weight)
             {
-               HYPRE_StructPFMGSetJacobiWeight_pre( solver_precision,precond, jacobi_weight);
+               HYPRE_StructPFMGSetJacobiWeight_pre( solver_precision, precond, jacobi_weight);
             }
-            HYPRE_StructPFMGSetNumPreRelax_pre( solver_precision,precond, n_pre);
-            HYPRE_StructPFMGSetNumPostRelax_pre( solver_precision,precond, n_post);
-            HYPRE_StructPFMGSetSkipRelax_pre( solver_precision,precond, skip);
+            HYPRE_StructPFMGSetNumPreRelax_pre( solver_precision, precond, n_pre);
+            HYPRE_StructPFMGSetNumPostRelax_pre( solver_precision, precond, n_post);
+            HYPRE_StructPFMGSetSkipRelax_pre( solver_precision, precond, skip);
             /*HYPRE_StructPFMGSetDxyz_pre( solver_precision,precond, dxyz);*/
-            HYPRE_StructPFMGSetPrintLevel_pre( solver_precision,precond, 0);
-            HYPRE_StructPFMGSetLogging_pre( solver_precision,precond, 0);
+            HYPRE_StructPFMGSetPrintLevel_pre( solver_precision, precond, 0);
+            HYPRE_StructPFMGSetLogging_pre( solver_precision, precond, 0);
 #if 0//defined(HYPRE_USING_CUDA)
             HYPRE_StructPFMGSetDeviceLevel(precond, device_level);
 #endif
-            HYPRE_PCGSetPrecond_pre( solver_precision,(HYPRE_Solver) solver,
-                                    (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_dbl,
-                                    (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_dbl,
-                                    (HYPRE_Solver) precond);
+            HYPRE_PCGSetPrecond_pre( solver_precision, (HYPRE_Solver) solver,
+                                     (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_dbl,
+                                     (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_dbl,
+                                     (HYPRE_Solver) precond);
          }
          else if (solver_id == 16)
          {
-            HYPRE_StructPFMGCreate_pre( precond_precision,hypre_MPI_COMM_WORLD, &precond);
-            HYPRE_StructPFMGSetMaxIter_pre( precond_precision,precond, 1);
-            HYPRE_StructPFMGSetTol_pre( precond_precision,precond, 0.0);
-            HYPRE_StructPFMGSetZeroGuess_pre( precond_precision,precond);
-            HYPRE_StructPFMGSetRAPType_pre( precond_precision,precond, rap);
-            HYPRE_StructPFMGSetRelaxType_pre( precond_precision,precond, relax);
+            HYPRE_StructPFMGCreate_pre( precond_precision, hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructPFMGSetMaxIter_pre( precond_precision, precond, 1);
+            HYPRE_StructPFMGSetTol_pre( precond_precision, precond, 0.0);
+            HYPRE_StructPFMGSetZeroGuess_pre( precond_precision, precond);
+            HYPRE_StructPFMGSetRAPType_pre( precond_precision, precond, rap);
+            HYPRE_StructPFMGSetRelaxType_pre( precond_precision, precond, relax);
             if (usr_jacobi_weight)
             {
-               HYPRE_StructPFMGSetJacobiWeight_pre( precond_precision,precond, jacobi_weight);
+               HYPRE_StructPFMGSetJacobiWeight_pre( precond_precision, precond, jacobi_weight);
             }
-            HYPRE_StructPFMGSetNumPreRelax_pre( precond_precision,precond, n_pre);
-            HYPRE_StructPFMGSetNumPostRelax_pre( precond_precision,precond, n_post);
-            HYPRE_StructPFMGSetSkipRelax_pre( precond_precision,precond, skip);
-            HYPRE_StructPFMGSetPrintLevel_pre( precond_precision,precond, 0);
-            HYPRE_StructPFMGSetLogging_pre( precond_precision,precond, 0);
-            HYPRE_PCGSetPrecondMatrix_pre( solver_precision,(HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
-            HYPRE_PCGSetPrecond_pre( solver_precision,(HYPRE_Solver) solver,
-                                    (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_mp,
-                                    (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_mp,
-                                    (HYPRE_Solver) precond);
+            HYPRE_StructPFMGSetNumPreRelax_pre( precond_precision, precond, n_pre);
+            HYPRE_StructPFMGSetNumPostRelax_pre( precond_precision, precond, n_post);
+            HYPRE_StructPFMGSetSkipRelax_pre( precond_precision, precond, skip);
+            HYPRE_StructPFMGSetPrintLevel_pre( precond_precision, precond, 0);
+            HYPRE_StructPFMGSetLogging_pre( precond_precision, precond, 0);
+            HYPRE_PCGSetPrecondMatrix_pre( solver_precision, (HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
+            HYPRE_PCGSetPrecond_pre( solver_precision, (HYPRE_Solver) solver,
+                                     (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_mp,
+                                     (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_mp,
+                                     (HYPRE_Solver) precond);
          }
 
          else if (solver_id == 18)
          {
             /* use diagonal scaling as preconditioner */
             precond = NULL;
-            HYPRE_PCGSetPrecond_pre( solver_precision,(HYPRE_Solver) solver,
-                                    (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScale_dbl,
-                                    (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScaleSetup_dbl,
-                                    (HYPRE_Solver) precond);
+            HYPRE_PCGSetPrecond_pre( solver_precision, (HYPRE_Solver) solver,
+                                     (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScale_dbl,
+                                     (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScaleSetup_dbl,
+                                     (HYPRE_Solver) precond);
          }
 
          HYPRE_PCGSetup_pre( solver_precision, (HYPRE_Solver)solver,
@@ -1443,23 +1444,23 @@ main( hypre_int argc,
          HYPRE_PCGGetNumIterations_pre( solver_precision, (HYPRE_Solver)solver, &num_iterations );
          HYPRE_PCGGetFinalRelativeResidualNorm_pre( solver_precision, (HYPRE_Solver)solver,
                                                     &final_res_norm );
-         HYPRE_StructPCGDestroy_pre( solver_precision,solver);
+         HYPRE_StructPCGDestroy_pre( solver_precision, solver);
 
          if (solver_id == 10)
          {
-            HYPRE_StructSMGDestroy_pre( solver_precision,precond);
+            HYPRE_StructSMGDestroy_pre( solver_precision, precond);
          }
          else if (solver_id == 15)
          {
-            HYPRE_StructSMGDestroy_pre( precond_precision,precond);
+            HYPRE_StructSMGDestroy_pre( precond_precision, precond);
          }
          else if (solver_id == 11 || solver_id == 13 || solver_id == 14)
          {
-            HYPRE_StructPFMGDestroy_pre( solver_precision,precond);
+            HYPRE_StructPFMGDestroy_pre( solver_precision, precond);
          }
          else if (solver_id == 16)
          {
-            HYPRE_StructPFMGDestroy_pre( precond_precision,precond);
+            HYPRE_StructPFMGDestroy_pre( precond_precision, precond);
          }
       }
 
@@ -1472,7 +1473,7 @@ main( hypre_int argc,
          time_index = hypre_InitializeTiming("GMRES Setup");
          hypre_BeginTiming(time_index);
 
-         HYPRE_StructGMRESCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, &solver);
+         HYPRE_StructGMRESCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, &solver);
          HYPRE_GMRESSetKDim_pre( solver_precision, (HYPRE_Solver) solver, 5 );
          HYPRE_GMRESSetMaxIter_pre( solver_precision, (HYPRE_Solver)solver, 100 );
          HYPRE_GMRESSetTol_pre( solver_precision, (HYPRE_Solver)solver, tol );
@@ -1483,93 +1484,93 @@ main( hypre_int argc,
          if (solver_id == 30)
          {
             /* use symmetric SMG as preconditioner */
-            HYPRE_StructSMGCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructSMGCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, &precond);
             //HYPRE_StructSMGSetMemoryUse_pre( solver_precision,precond, 0);
-            HYPRE_StructSMGSetMaxIter_pre( solver_precision,precond, 1);
-            HYPRE_StructSMGSetTol_pre( solver_precision,precond, 0.0);
-            HYPRE_StructSMGSetZeroGuess_pre( solver_precision,precond);
-            HYPRE_StructSMGSetNumPreRelax_pre( solver_precision,precond, n_pre);
-            HYPRE_StructSMGSetNumPostRelax_pre( solver_precision,precond, n_post);
-            HYPRE_StructSMGSetPrintLevel_pre( solver_precision,precond, 0);
-            HYPRE_StructSMGSetLogging_pre( solver_precision,precond, 0);
-            HYPRE_GMRESSetPrecond_pre( solver_precision,(HYPRE_Solver)solver,
-                                      (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSolve_dbl,
-                                      (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSetup_dbl,
-                                      (HYPRE_Solver)precond);
+            HYPRE_StructSMGSetMaxIter_pre( solver_precision, precond, 1);
+            HYPRE_StructSMGSetTol_pre( solver_precision, precond, 0.0);
+            HYPRE_StructSMGSetZeroGuess_pre( solver_precision, precond);
+            HYPRE_StructSMGSetNumPreRelax_pre( solver_precision, precond, n_pre);
+            HYPRE_StructSMGSetNumPostRelax_pre( solver_precision, precond, n_post);
+            HYPRE_StructSMGSetPrintLevel_pre( solver_precision, precond, 0);
+            HYPRE_StructSMGSetLogging_pre( solver_precision, precond, 0);
+            HYPRE_GMRESSetPrecond_pre( solver_precision, (HYPRE_Solver)solver,
+                                       (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSolve_dbl,
+                                       (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSetup_dbl,
+                                       (HYPRE_Solver)precond);
          }
          else if (solver_id == 35)
          {
-            HYPRE_StructSMGCreate_pre( precond_precision,hypre_MPI_COMM_WORLD, &precond);
-            HYPRE_StructSMGSetMaxIter_pre( precond_precision,precond, 1);
-            HYPRE_StructSMGSetTol_pre( precond_precision,precond, 0.0);
-            HYPRE_StructSMGSetZeroGuess_pre( precond_precision,precond);
-            HYPRE_StructSMGSetNumPreRelax_pre( precond_precision,precond, n_pre);
-            HYPRE_StructSMGSetNumPostRelax_pre( precond_precision,precond, n_post);
-            HYPRE_StructSMGSetPrintLevel_pre( precond_precision,precond, 0);
-            HYPRE_StructSMGSetLogging_pre( precond_precision,precond, 0);
-            HYPRE_GMRESSetPrecondMatrix_pre( solver_precision,(HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
-            HYPRE_GMRESSetPrecond_pre( solver_precision,(HYPRE_Solver)solver,
-                                      (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSolve_mp,
-                                      (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSetup_mp,
-                                      (HYPRE_Solver)precond);
+            HYPRE_StructSMGCreate_pre( precond_precision, hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructSMGSetMaxIter_pre( precond_precision, precond, 1);
+            HYPRE_StructSMGSetTol_pre( precond_precision, precond, 0.0);
+            HYPRE_StructSMGSetZeroGuess_pre( precond_precision, precond);
+            HYPRE_StructSMGSetNumPreRelax_pre( precond_precision, precond, n_pre);
+            HYPRE_StructSMGSetNumPostRelax_pre( precond_precision, precond, n_post);
+            HYPRE_StructSMGSetPrintLevel_pre( precond_precision, precond, 0);
+            HYPRE_StructSMGSetLogging_pre( precond_precision, precond, 0);
+            HYPRE_GMRESSetPrecondMatrix_pre( solver_precision, (HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
+            HYPRE_GMRESSetPrecond_pre( solver_precision, (HYPRE_Solver)solver,
+                                       (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSolve_mp,
+                                       (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSetup_mp,
+                                       (HYPRE_Solver)precond);
          }
 
          else if (solver_id == 31)
          {
             /* use symmetric PFMG as preconditioner */
-            HYPRE_StructPFMGCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, &precond);
-            HYPRE_StructPFMGSetMaxIter_pre( solver_precision,precond, 1);
-            HYPRE_StructPFMGSetTol_pre( solver_precision,precond, 0.0);
-            HYPRE_StructPFMGSetZeroGuess_pre( solver_precision,precond);
-            HYPRE_StructPFMGSetRAPType_pre( solver_precision,precond, rap);
-            HYPRE_StructPFMGSetRelaxType_pre( solver_precision,precond, relax);
+            HYPRE_StructPFMGCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructPFMGSetMaxIter_pre( solver_precision, precond, 1);
+            HYPRE_StructPFMGSetTol_pre( solver_precision, precond, 0.0);
+            HYPRE_StructPFMGSetZeroGuess_pre( solver_precision, precond);
+            HYPRE_StructPFMGSetRAPType_pre( solver_precision, precond, rap);
+            HYPRE_StructPFMGSetRelaxType_pre( solver_precision, precond, relax);
             if (usr_jacobi_weight)
             {
-               HYPRE_StructPFMGSetJacobiWeight_pre( solver_precision,precond, jacobi_weight);
+               HYPRE_StructPFMGSetJacobiWeight_pre( solver_precision, precond, jacobi_weight);
             }
-            HYPRE_StructPFMGSetNumPreRelax_pre( solver_precision,precond, n_pre);
-            HYPRE_StructPFMGSetNumPostRelax_pre( solver_precision,precond, n_post);
-            HYPRE_StructPFMGSetSkipRelax_pre( solver_precision,precond, skip);
+            HYPRE_StructPFMGSetNumPreRelax_pre( solver_precision, precond, n_pre);
+            HYPRE_StructPFMGSetNumPostRelax_pre( solver_precision, precond, n_post);
+            HYPRE_StructPFMGSetSkipRelax_pre( solver_precision, precond, skip);
             /*HYPRE_StructPFMGSetDxyz_pre( solver_precision,precond, dxyz);*/
-            HYPRE_StructPFMGSetPrintLevel_pre( solver_precision,precond, 0);
-            HYPRE_StructPFMGSetLogging_pre( solver_precision,precond, 0);
-            HYPRE_GMRESSetPrecond_pre( solver_precision,(HYPRE_Solver)solver,
-                                      (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_dbl,
-                                      (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_dbl,
-                                      (HYPRE_Solver)precond);
+            HYPRE_StructPFMGSetPrintLevel_pre( solver_precision, precond, 0);
+            HYPRE_StructPFMGSetLogging_pre( solver_precision, precond, 0);
+            HYPRE_GMRESSetPrecond_pre( solver_precision, (HYPRE_Solver)solver,
+                                       (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_dbl,
+                                       (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_dbl,
+                                       (HYPRE_Solver)precond);
          }
          else if (solver_id == 36)
          {
-            HYPRE_StructPFMGCreate_pre( precond_precision,hypre_MPI_COMM_WORLD, &precond);
-            HYPRE_StructPFMGSetMaxIter_pre( precond_precision,precond, 1);
-            HYPRE_StructPFMGSetTol_pre( precond_precision,precond, 0.0);
-            HYPRE_StructPFMGSetZeroGuess_pre( precond_precision,precond);
-            HYPRE_StructPFMGSetRAPType_pre( precond_precision,precond, rap);
-            HYPRE_StructPFMGSetRelaxType_pre( precond_precision,precond, relax);
+            HYPRE_StructPFMGCreate_pre( precond_precision, hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructPFMGSetMaxIter_pre( precond_precision, precond, 1);
+            HYPRE_StructPFMGSetTol_pre( precond_precision, precond, 0.0);
+            HYPRE_StructPFMGSetZeroGuess_pre( precond_precision, precond);
+            HYPRE_StructPFMGSetRAPType_pre( precond_precision, precond, rap);
+            HYPRE_StructPFMGSetRelaxType_pre( precond_precision, precond, relax);
             if (usr_jacobi_weight)
             {
-               HYPRE_StructPFMGSetJacobiWeight_pre( precond_precision,precond, jacobi_weight);
+               HYPRE_StructPFMGSetJacobiWeight_pre( precond_precision, precond, jacobi_weight);
             }
-            HYPRE_StructPFMGSetNumPreRelax_pre( precond_precision,precond, n_pre);
-            HYPRE_StructPFMGSetNumPostRelax_pre( precond_precision,precond, n_post);
-            HYPRE_StructPFMGSetSkipRelax_pre( precond_precision,precond, skip);
-            HYPRE_StructPFMGSetPrintLevel_pre( precond_precision,precond, 0);
-            HYPRE_StructPFMGSetLogging_pre( precond_precision,precond, 0);
-            HYPRE_GMRESSetPrecondMatrix_pre( solver_precision,(HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
-            HYPRE_GMRESSetPrecond_pre( solver_precision,(HYPRE_Solver)solver,
-                                      (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_mp,
-                                      (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_mp,
-                                      (HYPRE_Solver)precond);
+            HYPRE_StructPFMGSetNumPreRelax_pre( precond_precision, precond, n_pre);
+            HYPRE_StructPFMGSetNumPostRelax_pre( precond_precision, precond, n_post);
+            HYPRE_StructPFMGSetSkipRelax_pre( precond_precision, precond, skip);
+            HYPRE_StructPFMGSetPrintLevel_pre( precond_precision, precond, 0);
+            HYPRE_StructPFMGSetLogging_pre( precond_precision, precond, 0);
+            HYPRE_GMRESSetPrecondMatrix_pre( solver_precision, (HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
+            HYPRE_GMRESSetPrecond_pre( solver_precision, (HYPRE_Solver)solver,
+                                       (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_mp,
+                                       (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_mp,
+                                       (HYPRE_Solver)precond);
          }
 
          else if (solver_id == 38)
          {
             /* use diagonal scaling as preconditioner */
             precond = NULL;
-            HYPRE_GMRESSetPrecond_pre( solver_precision,(HYPRE_Solver)solver,
-                                      (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScale_dbl,
-                                      (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScaleSetup_dbl,
-                                      (HYPRE_Solver)precond);
+            HYPRE_GMRESSetPrecond_pre( solver_precision, (HYPRE_Solver)solver,
+                                       (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScale_dbl,
+                                       (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScaleSetup_dbl,
+                                       (HYPRE_Solver)precond);
          }
 
          HYPRE_GMRESSetup_dbl ( (HYPRE_Solver)solver, (HYPRE_Matrix)A_dbl, (HYPRE_Vector)b_dbl,
@@ -1592,24 +1593,25 @@ main( hypre_int argc,
          hypre_ClearTiming();
 
          HYPRE_GMRESGetNumIterations_pre( solver_precision, (HYPRE_Solver)solver, &num_iterations);
-         HYPRE_GMRESGetFinalRelativeResidualNorm_pre( solver_precision, (HYPRE_Solver)solver, &final_res_norm);
-         HYPRE_StructGMRESDestroy_pre( solver_precision,solver);
+         HYPRE_GMRESGetFinalRelativeResidualNorm_pre( solver_precision, (HYPRE_Solver)solver,
+                                                      &final_res_norm);
+         HYPRE_StructGMRESDestroy_pre( solver_precision, solver);
 
          if (solver_id == 30)
          {
-            HYPRE_StructSMGDestroy_pre( solver_precision,precond);
+            HYPRE_StructSMGDestroy_pre( solver_precision, precond);
          }
          else if (solver_id == 35)
          {
-            HYPRE_StructSMGDestroy_pre( precond_precision,precond);
+            HYPRE_StructSMGDestroy_pre( precond_precision, precond);
          }
          else if (solver_id == 31)
          {
-            HYPRE_StructPFMGDestroy_pre( solver_precision,precond);
+            HYPRE_StructPFMGDestroy_pre( solver_precision, precond);
          }
          else if (solver_id == 36)
          {
-            HYPRE_StructPFMGDestroy_pre( precond_precision,precond);
+            HYPRE_StructPFMGDestroy_pre( precond_precision, precond);
          }
       }
 
@@ -1622,7 +1624,7 @@ main( hypre_int argc,
          time_index = hypre_InitializeTiming("BiCGSTAB Setup");
          hypre_BeginTiming(time_index);
 
-         HYPRE_StructBiCGSTABCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, &solver);
+         HYPRE_StructBiCGSTABCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, &solver);
          HYPRE_BiCGSTABSetMaxIter_pre( solver_precision, (HYPRE_Solver)solver, 100 );
          HYPRE_BiCGSTABSetTol_pre( solver_precision, (HYPRE_Solver)solver, tol );
          HYPRE_BiCGSTABSetPrintLevel_pre( solver_precision, (HYPRE_Solver)solver, print_level );
@@ -1631,93 +1633,93 @@ main( hypre_int argc,
          if (solver_id == 40)
          {
             /* use symmetric SMG as preconditioner */
-            HYPRE_StructSMGCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructSMGCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, &precond);
             //HYPRE_StructSMGSetMemoryUse_pre( solver_precision,precond, 0);
-            HYPRE_StructSMGSetMaxIter_pre( solver_precision,precond, 1);
-            HYPRE_StructSMGSetTol_pre( solver_precision,precond, 0.0);
-            HYPRE_StructSMGSetZeroGuess_pre( solver_precision,precond);
-            HYPRE_StructSMGSetNumPreRelax_pre( solver_precision,precond, n_pre);
-            HYPRE_StructSMGSetNumPostRelax_pre( solver_precision,precond, n_post);
-            HYPRE_StructSMGSetPrintLevel_pre( solver_precision,precond, 0);
-            HYPRE_StructSMGSetLogging_pre( solver_precision,precond, 0);
-            HYPRE_BiCGSTABSetPrecond_pre( solver_precision,(HYPRE_Solver)solver,
-                                         (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSolve_dbl,
-                                         (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSetup_dbl,
-                                         (HYPRE_Solver)precond);
+            HYPRE_StructSMGSetMaxIter_pre( solver_precision, precond, 1);
+            HYPRE_StructSMGSetTol_pre( solver_precision, precond, 0.0);
+            HYPRE_StructSMGSetZeroGuess_pre( solver_precision, precond);
+            HYPRE_StructSMGSetNumPreRelax_pre( solver_precision, precond, n_pre);
+            HYPRE_StructSMGSetNumPostRelax_pre( solver_precision, precond, n_post);
+            HYPRE_StructSMGSetPrintLevel_pre( solver_precision, precond, 0);
+            HYPRE_StructSMGSetLogging_pre( solver_precision, precond, 0);
+            HYPRE_BiCGSTABSetPrecond_pre( solver_precision, (HYPRE_Solver)solver,
+                                          (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSolve_dbl,
+                                          (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSetup_dbl,
+                                          (HYPRE_Solver)precond);
          }
          else if (solver_id == 45)
          {
-            HYPRE_StructSMGCreate_pre( precond_precision,hypre_MPI_COMM_WORLD, &precond);
-            HYPRE_StructSMGSetMaxIter_pre( precond_precision,precond, 1);
-            HYPRE_StructSMGSetTol_pre( precond_precision,precond, 0.0);
-            HYPRE_StructSMGSetZeroGuess_pre( precond_precision,precond);
-            HYPRE_StructSMGSetNumPreRelax_pre( precond_precision,precond, n_pre);
-            HYPRE_StructSMGSetNumPostRelax_pre( precond_precision,precond, n_post);
-            HYPRE_StructSMGSetPrintLevel_pre( precond_precision,precond, 0);
-            HYPRE_StructSMGSetLogging_pre( precond_precision,precond, 0);
-            HYPRE_BiCGSTABSetPrecondMatrix_pre( solver_precision,(HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
-            HYPRE_BiCGSTABSetPrecond_pre( solver_precision,(HYPRE_Solver)solver,
-                                         (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSolve_mp,
-                                         (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSetup_mp,
-                                         (HYPRE_Solver)precond);
+            HYPRE_StructSMGCreate_pre( precond_precision, hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructSMGSetMaxIter_pre( precond_precision, precond, 1);
+            HYPRE_StructSMGSetTol_pre( precond_precision, precond, 0.0);
+            HYPRE_StructSMGSetZeroGuess_pre( precond_precision, precond);
+            HYPRE_StructSMGSetNumPreRelax_pre( precond_precision, precond, n_pre);
+            HYPRE_StructSMGSetNumPostRelax_pre( precond_precision, precond, n_post);
+            HYPRE_StructSMGSetPrintLevel_pre( precond_precision, precond, 0);
+            HYPRE_StructSMGSetLogging_pre( precond_precision, precond, 0);
+            HYPRE_BiCGSTABSetPrecondMatrix_pre( solver_precision, (HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
+            HYPRE_BiCGSTABSetPrecond_pre( solver_precision, (HYPRE_Solver)solver,
+                                          (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSolve_mp,
+                                          (HYPRE_PtrToSolverFcn) HYPRE_StructSMGSetup_mp,
+                                          (HYPRE_Solver)precond);
          }
 
          else if (solver_id == 41)
          {
             /* use symmetric PFMG as preconditioner */
-            HYPRE_StructPFMGCreate_pre( solver_precision,hypre_MPI_COMM_WORLD, &precond);
-            HYPRE_StructPFMGSetMaxIter_pre( solver_precision,precond, 1);
-            HYPRE_StructPFMGSetTol_pre( solver_precision,precond, 0.0);
-            HYPRE_StructPFMGSetZeroGuess_pre( solver_precision,precond);
-            HYPRE_StructPFMGSetRAPType_pre( solver_precision,precond, rap);
-            HYPRE_StructPFMGSetRelaxType_pre( solver_precision,precond, relax);
+            HYPRE_StructPFMGCreate_pre( solver_precision, hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructPFMGSetMaxIter_pre( solver_precision, precond, 1);
+            HYPRE_StructPFMGSetTol_pre( solver_precision, precond, 0.0);
+            HYPRE_StructPFMGSetZeroGuess_pre( solver_precision, precond);
+            HYPRE_StructPFMGSetRAPType_pre( solver_precision, precond, rap);
+            HYPRE_StructPFMGSetRelaxType_pre( solver_precision, precond, relax);
             if (usr_jacobi_weight)
             {
-               HYPRE_StructPFMGSetJacobiWeight_pre( solver_precision,precond, jacobi_weight);
+               HYPRE_StructPFMGSetJacobiWeight_pre( solver_precision, precond, jacobi_weight);
             }
-            HYPRE_StructPFMGSetNumPreRelax_pre( solver_precision,precond, n_pre);
-            HYPRE_StructPFMGSetNumPostRelax_pre( solver_precision,precond, n_post);
-            HYPRE_StructPFMGSetSkipRelax_pre( solver_precision,precond, skip);
+            HYPRE_StructPFMGSetNumPreRelax_pre( solver_precision, precond, n_pre);
+            HYPRE_StructPFMGSetNumPostRelax_pre( solver_precision, precond, n_post);
+            HYPRE_StructPFMGSetSkipRelax_pre( solver_precision, precond, skip);
             /*HYPRE_StructPFMGSetDxyz_pre( solver_precision,precond, dxyz);*/
-            HYPRE_StructPFMGSetPrintLevel_pre( solver_precision,precond, 0);
-            HYPRE_StructPFMGSetLogging_pre( solver_precision,precond, 0);
-            HYPRE_BiCGSTABSetPrecond_pre( solver_precision,(HYPRE_Solver)solver,
-                                         (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_dbl,
-                                         (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_dbl,
-                                         (HYPRE_Solver)precond);
+            HYPRE_StructPFMGSetPrintLevel_pre( solver_precision, precond, 0);
+            HYPRE_StructPFMGSetLogging_pre( solver_precision, precond, 0);
+            HYPRE_BiCGSTABSetPrecond_pre( solver_precision, (HYPRE_Solver)solver,
+                                          (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_dbl,
+                                          (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_dbl,
+                                          (HYPRE_Solver)precond);
          }
          else if (solver_id == 46)
          {
-            HYPRE_StructPFMGCreate_pre( precond_precision,hypre_MPI_COMM_WORLD, &precond);
-            HYPRE_StructPFMGSetMaxIter_pre( precond_precision,precond, 1);
-            HYPRE_StructPFMGSetTol_pre( precond_precision,precond, 0.0);
-            HYPRE_StructPFMGSetZeroGuess_pre( solver_precision,precond);
-            HYPRE_StructPFMGSetRAPType_pre( precond_precision,precond, rap);
-            HYPRE_StructPFMGSetRelaxType_pre( precond_precision,precond, relax);
+            HYPRE_StructPFMGCreate_pre( precond_precision, hypre_MPI_COMM_WORLD, &precond);
+            HYPRE_StructPFMGSetMaxIter_pre( precond_precision, precond, 1);
+            HYPRE_StructPFMGSetTol_pre( precond_precision, precond, 0.0);
+            HYPRE_StructPFMGSetZeroGuess_pre( solver_precision, precond);
+            HYPRE_StructPFMGSetRAPType_pre( precond_precision, precond, rap);
+            HYPRE_StructPFMGSetRelaxType_pre( precond_precision, precond, relax);
             if (usr_jacobi_weight)
             {
-               HYPRE_StructPFMGSetJacobiWeight_pre( precond_precision,precond, jacobi_weight);
+               HYPRE_StructPFMGSetJacobiWeight_pre( precond_precision, precond, jacobi_weight);
             }
-            HYPRE_StructPFMGSetNumPreRelax_pre( precond_precision,precond, n_pre);
-            HYPRE_StructPFMGSetNumPostRelax_pre( precond_precision,precond, n_post);
-            HYPRE_StructPFMGSetSkipRelax_pre( precond_precision,precond, skip);
-            HYPRE_StructPFMGSetPrintLevel_pre( precond_precision,precond, 0);
-            HYPRE_StructPFMGSetLogging_pre( precond_precision,precond, 0);
-            HYPRE_BiCGSTABSetPrecondMatrix_pre( solver_precision,(HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
-            HYPRE_BiCGSTABSetPrecond_pre( solver_precision,(HYPRE_Solver)solver,
-                                         (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_mp,
-                                         (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_mp,
-                                         (HYPRE_Solver)precond);
+            HYPRE_StructPFMGSetNumPreRelax_pre( precond_precision, precond, n_pre);
+            HYPRE_StructPFMGSetNumPostRelax_pre( precond_precision, precond, n_post);
+            HYPRE_StructPFMGSetSkipRelax_pre( precond_precision, precond, skip);
+            HYPRE_StructPFMGSetPrintLevel_pre( precond_precision, precond, 0);
+            HYPRE_StructPFMGSetLogging_pre( precond_precision, precond, 0);
+            HYPRE_BiCGSTABSetPrecondMatrix_pre( solver_precision, (HYPRE_Solver)solver, (HYPRE_Matrix)A_flt);
+            HYPRE_BiCGSTABSetPrecond_pre( solver_precision, (HYPRE_Solver)solver,
+                                          (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSolve_mp,
+                                          (HYPRE_PtrToSolverFcn) HYPRE_StructPFMGSetup_mp,
+                                          (HYPRE_Solver)precond);
          }
 
          else if (solver_id == 48)
          {
             /* use diagonal scaling as preconditioner */
             precond = NULL;
-            HYPRE_BiCGSTABSetPrecond_pre( solver_precision,(HYPRE_Solver)solver,
-                                         (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScale_dbl,
-                                         (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScaleSetup_dbl,
-                                         (HYPRE_Solver)precond);
+            HYPRE_BiCGSTABSetPrecond_pre( solver_precision, (HYPRE_Solver)solver,
+                                          (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScale_dbl,
+                                          (HYPRE_PtrToSolverFcn) HYPRE_StructDiagScaleSetup_dbl,
+                                          (HYPRE_Solver)precond);
          }
 
          HYPRE_BiCGSTABSetup_dbl
@@ -1740,24 +1742,25 @@ main( hypre_int argc,
          hypre_ClearTiming();
 
          HYPRE_BiCGSTABGetNumIterations_pre( solver_precision, (HYPRE_Solver)solver, &num_iterations);
-         HYPRE_BiCGSTABGetFinalRelativeResidualNorm_pre( solver_precision, (HYPRE_Solver)solver, &final_res_norm);
-         HYPRE_StructBiCGSTABDestroy_pre( solver_precision,solver);
+         HYPRE_BiCGSTABGetFinalRelativeResidualNorm_pre( solver_precision, (HYPRE_Solver)solver,
+                                                         &final_res_norm);
+         HYPRE_StructBiCGSTABDestroy_pre( solver_precision, solver);
 
          if (solver_id == 40)
          {
-            HYPRE_StructSMGDestroy_pre( solver_precision,precond);
+            HYPRE_StructSMGDestroy_pre( solver_precision, precond);
          }
          else if (solver_id == 45)
          {
-            HYPRE_StructSMGDestroy_pre( precond_precision,precond);
+            HYPRE_StructSMGDestroy_pre( precond_precision, precond);
          }
          else if (solver_id == 41)
          {
-            HYPRE_StructPFMGDestroy_pre( solver_precision,precond);
+            HYPRE_StructPFMGDestroy_pre( solver_precision, precond);
          }
          else if (solver_id == 46)
          {
-            HYPRE_StructPFMGDestroy_pre( precond_precision,precond);
+            HYPRE_StructPFMGDestroy_pre( precond_precision, precond);
          }
       }
 
@@ -1767,7 +1770,7 @@ main( hypre_int argc,
 
       if (print_system)
       {
-         HYPRE_StructVectorPrint_pre( solver_precision,"struct.out.x", x_dbl, 0);
+         HYPRE_StructVectorPrint_pre( solver_precision, "struct.out.x", x_dbl, 0);
       }
 
       if (myid == 0 && rep == reps - 1 )
@@ -1794,24 +1797,24 @@ main( hypre_int argc,
          imax = (5 * 1000000) / N;
 
          matvec_data = hypre_StructMatvecCreate_pre( solver_precision,);
-         hypre_StructMatvecSetup_pre( solver_precision,matvec_data, A, x);
+         hypre_StructMatvecSetup_pre( solver_precision, matvec_data, A, x);
 
          time_index = hypre_InitializeTiming("Matvec");
          hypre_BeginTiming(time_index);
 
          for (i = 0; i < imax; i++)
          {
-            hypre_StructMatvecCompute_pre( solver_precision,matvec_data, 1.0, A, x, 1.0, b);
+            hypre_StructMatvecCompute_pre( solver_precision, matvec_data, 1.0, A, x, 1.0, b);
          }
          /* this counts mult-adds */
-         hypre_IncFLOPCount_pre( solver_precision,7 * N * imax);
+         hypre_IncFLOPCount_pre( solver_precision, 7 * N * imax);
 
          hypre_EndTiming(time_index);
          hypre_PrintTiming("Matvec time", hypre_MPI_COMM_WORLD);
          hypre_FinalizeTiming(time_index);
          hypre_ClearTiming();
 
-         hypre_StructMatvecDestroy_pre( solver_precision,matvec_data);
+         hypre_StructMatvecDestroy_pre( solver_precision, matvec_data);
       }
 #endif
 
@@ -1819,10 +1822,10 @@ main( hypre_int argc,
        * Finalize things
        *-----------------------------------------------------------*/
 
-      HYPRE_StructStencilDestroy_pre( solver_precision,stencil);
-      HYPRE_StructMatrixDestroy_pre( solver_precision,A_dbl);
-      HYPRE_StructVectorDestroy_pre( solver_precision,b_dbl);
-      HYPRE_StructVectorDestroy_pre( solver_precision,x_dbl);
+      HYPRE_StructStencilDestroy_pre( solver_precision, stencil);
+      HYPRE_StructMatrixDestroy_pre( solver_precision, A_dbl);
+      HYPRE_StructVectorDestroy_pre( solver_precision, b_dbl);
+      HYPRE_StructVectorDestroy_pre( solver_precision, x_dbl);
 
       for ( i = 0; i < (dim + 1); i++)
       {
@@ -1863,10 +1866,10 @@ main( hypre_int argc,
 
 HYPRE_Int
 AddValuesVector_mp(hypre_StructGrid   *gridvector,
-                     hypre_StructVector *zvector,
-                     HYPRE_Int          *period,
-                     void               *value,
-                     size_t             size  )
+                   hypre_StructVector *zvector,
+                   HYPRE_Int          *period,
+                   void               *value,
+                   size_t             size  )
 {
    /* #include  "_hypre_struct_mv.h" */
    HYPRE_Int            i, ierr = 0;
@@ -1880,7 +1883,7 @@ AddValuesVector_mp(hypre_StructGrid   *gridvector,
 
    gridboxes =  hypre_StructGridBoxes(gridvector);
    dim       =  hypre_StructGridNDim(gridvector);
-   
+
    ib = 0;
    hypre_ForBoxI(ib, gridboxes)
    {
@@ -1897,8 +1900,9 @@ AddValuesVector_mp(hypre_StructGrid   *gridvector,
       if ((dim == 2 && period[0] != 0 && period[1] != 0) ||
           (dim == 3 && period[0] != 0 && period[1] != 0 && period[2] != 0))
       {
-         memcpy(&values[0],&value,size);
-         switch (hypre_StructVectorPrecision(zvector)){
+         memcpy(&values[0], &value, size);
+         switch (hypre_StructVectorPrecision(zvector))
+         {
             case HYPRE_REAL_SINGLE:
                ((hypre_float*)values)[volume - 1] = -(*(hypre_float *)value);
                break;
@@ -1914,14 +1918,15 @@ AddValuesVector_mp(hypre_StructGrid   *gridvector,
       {
          for (i = 0; i < volume; i++)
          {
-            memcpy((values + i*size),value,size);
+            memcpy((values + i * size), value, size);
          }
       }
 
       ilower = hypre_BoxIMin(box);
       iupper = hypre_BoxIMax(box);
 
-      HYPRE_StructVectorSetBoxValues_pre(hypre_StructVectorPrecision(zvector), zvector, ilower, iupper, values);
+      HYPRE_StructVectorSetBoxValues_pre(hypre_StructVectorPrecision(zvector), zvector, ilower, iupper,
+                                         values);
 
       hypre_Free(values, HYPRE_MEMORY_HOST);
    }
@@ -1938,14 +1943,14 @@ AddValuesVector_mp(hypre_StructGrid   *gridvector,
 
 HYPRE_Int
 AddValuesMatrix_mp(HYPRE_StructMatrix A,
-                    HYPRE_StructGrid   gridmatrix,
-                    void              *cx,
-                    void              *cy,
-                    void              *cz,
-                    void              *conx,
-                    void              *cony,
-                    void              *conz,
-                    size_t            size)
+                   HYPRE_StructGrid   gridmatrix,
+                   void              *cx,
+                   void              *cy,
+                   void              *cz,
+                   void              *conx,
+                   void              *cony,
+                   void              *conz,
+                   size_t            size)
 {
 
    HYPRE_Int            d, ierr = 0;
@@ -1974,18 +1979,19 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
    constant_coefficient = hypre_StructMatrixConstantCoefficient(A);
 
    bi = 0;
-   
+
    /* Alocate and set pointers to stencil coeffs */
    stcoeffs = hypre_CAlloc((size_t) 7, size, HYPRE_MEMORY_HOST);
    center = stcoeffs;
    east   = stcoeffs + size;
-   west   = stcoeffs + 2*size;
-   north  = stcoeffs + 3*size;
-   south  = stcoeffs + 4*size;
-   top    = stcoeffs + 5*size;
-   bottom = stcoeffs + 6*size;
+   west   = stcoeffs + 2 * size;
+   north  = stcoeffs + 3 * size;
+   south  = stcoeffs + 4 * size;
+   top    = stcoeffs + 5 * size;
+   bottom = stcoeffs + 6 * size;
    /* set stencil values */
-   switch (precision_A) {
+   switch (precision_A)
+   {
       case HYPRE_REAL_SINGLE:
          *(hypre_float*)east = -(*(hypre_float *)cx);
          *(hypre_float*)west = -(*(hypre_float *)cx);
@@ -2007,7 +2013,7 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
          *(hypre_double*)center = 2 * (*(hypre_double *)cx);
          if (dim > 1) { *(hypre_double*)center += 2.0 * (*(hypre_double *)cy); }
          if (dim > 2) { *(hypre_double*)center += 2.0 * (*(hypre_double *)cz); }
-         break;      
+         break;
       case HYPRE_REAL_LONGDOUBLE:
          *(hypre_long_double*)east = -(*(hypre_long_double *)cx);
          *(hypre_long_double*)west = -(*(hypre_long_double *)cx);
@@ -2022,7 +2028,7 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
    }
    stencil_size = 1 + (2 - sym) * dim;
    stencil_indices = hypre_CAlloc((size_t) stencil_size, (size_t)sizeof(HYPRE_Int),
-                                      HYPRE_MEMORY_HOST);
+                                  HYPRE_MEMORY_HOST);
    for (s = 0; s < stencil_size; s++)
    {
       stencil_indices[s] = s;
@@ -2043,8 +2049,8 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
                for (d = 0; d < volume; d++)
                {
                   HYPRE_Int i = stencil_size * d;
-                  memcpy((values + i*size),west,size);
-                  memcpy((values + (i+1)*size),center,size);
+                  memcpy((values + i * size), west, size);
+                  memcpy((values + (i + 1)*size), center, size);
                }
             }
             else if (dim == 2)
@@ -2052,9 +2058,9 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
                for (d = 0; d < volume; d++)
                {
                   HYPRE_Int i = stencil_size * d;
-                  memcpy((values + i*size),west,size);
-                  memcpy((values + (i+1)*size),south,size);                  
-                  memcpy((values + (i+2)*size),center,size);    
+                  memcpy((values + i * size), west, size);
+                  memcpy((values + (i + 1)*size), south, size);
+                  memcpy((values + (i + 2)*size), center, size);
                }
             }
             else if (dim == 3)
@@ -2062,10 +2068,10 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
                for (d = 0; d < volume; d++)
                {
                   HYPRE_Int i = stencil_size * d;
-                  memcpy((values + i*size),west,size);
-                  memcpy((values + (i+1)*size),south,size);                  
-                  memcpy((values + (i+2)*size),bottom,size);   
-                  memcpy((values + (i+3)*size),center,size);
+                  memcpy((values + i * size), west, size);
+                  memcpy((values + (i + 1)*size), south, size);
+                  memcpy((values + (i + 2)*size), bottom, size);
+                  memcpy((values + (i + 3)*size), center, size);
                }
             }
 
@@ -2082,19 +2088,19 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
          switch (dim)
          {
             case 1:
-               memcpy((values),west,size);
-               memcpy((values + size),center,size);
+               memcpy((values), west, size);
+               memcpy((values + size), center, size);
                break;
             case 2:
-               memcpy((values),west,size);
-               memcpy((values + size),south,size);
-               memcpy((values + 2*size),center,size);
+               memcpy((values), west, size);
+               memcpy((values + size), south, size);
+               memcpy((values + 2 * size), center, size);
                break;
             case 3:
-               memcpy((values),west,size);
-               memcpy((values + size),south,size);
-               memcpy((values + 2*size),bottom,size);
-               memcpy((values + 3*size),center,size);
+               memcpy((values), west, size);
+               memcpy((values + size), south, size);
+               memcpy((values + 2 * size), bottom, size);
+               memcpy((values + 3 * size), center, size);
                break;
          }
          if (hypre_BoxArraySize(gridboxes) > 0)
@@ -2111,16 +2117,16 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
          switch (dim)
          {
             case 1:
-               memcpy((values),west,size);
+               memcpy((values), west, size);
                break;
             case 2:
-               memcpy((values),west,size);
-               memcpy((values + size),south,size);
+               memcpy((values), west, size);
+               memcpy((values + size), south, size);
                break;
             case 3:
-               memcpy((values),west,size);
-               memcpy((values + size),south,size);
-               memcpy((values + 2*size),bottom,size);
+               memcpy((values), west, size);
+               memcpy((values + size), south, size);
+               memcpy((values + 2 * size), bottom, size);
                break;
          }
          if (hypre_BoxArraySize(gridboxes) > 0)
@@ -2140,7 +2146,7 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
 
             for (i = 0; i < volume; i++)
             {
-               memcpy((values +i*size), center, size);
+               memcpy((values + i * size), center, size);
             }
 
             ilower = hypre_BoxIMin(box);
@@ -2153,7 +2159,8 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
    }
    else
    {
-      switch (precision_A){
+      switch (precision_A)
+      {
          case HYPRE_REAL_SINGLE:
             if (*(hypre_float *)conx > 0.0f)
             {
@@ -2266,25 +2273,25 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
                switch (dim)
                {
                   case 1:
-                     memcpy(values + i*size, west, size);
-                     memcpy(values + (i+1)*size, center, size);
-                     memcpy(values + (i+2)*size, east, size);
+                     memcpy(values + i * size, west, size);
+                     memcpy(values + (i + 1)*size, center, size);
+                     memcpy(values + (i + 2)*size, east, size);
                      break;
                   case 2:
-                     memcpy(values + i*size, west, size);
-                     memcpy(values + (i+1)*size, south, size);
-                     memcpy(values + (i+2)*size, center, size);
-                     memcpy(values + (i+3)*size, east, size);
-                     memcpy(values + (i+4)*size, north, size);
+                     memcpy(values + i * size, west, size);
+                     memcpy(values + (i + 1)*size, south, size);
+                     memcpy(values + (i + 2)*size, center, size);
+                     memcpy(values + (i + 3)*size, east, size);
+                     memcpy(values + (i + 4)*size, north, size);
                      break;
                   case 3:
-                     memcpy(values + i*size, west, size);
-                     memcpy(values + (i+1)*size, south, size);
-                     memcpy(values + (i+2)*size, bottom, size);
-                     memcpy(values + (i+3)*size, center, size);
-                     memcpy(values + (i+4)*size, east, size);
-                     memcpy(values + (i+5)*size, north, size);
-                     memcpy(values + (i+6)*size, top, size);
+                     memcpy(values + i * size, west, size);
+                     memcpy(values + (i + 1)*size, south, size);
+                     memcpy(values + (i + 2)*size, bottom, size);
+                     memcpy(values + (i + 3)*size, center, size);
+                     memcpy(values + (i + 4)*size, east, size);
+                     memcpy(values + (i + 5)*size, north, size);
+                     memcpy(values + (i + 6)*size, top, size);
                      break;
                }
             }
@@ -2304,25 +2311,25 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
          switch (dim)
          {
             case 1:
-               memcpy((values),west,size);
-               memcpy((values + size),center,size);
-               memcpy((values + 2*size),east,size);
+               memcpy((values), west, size);
+               memcpy((values + size), center, size);
+               memcpy((values + 2 * size), east, size);
                break;
             case 2:
-               memcpy((values),west,size);
-               memcpy((values + size),south,size);
-               memcpy((values + 2*size),center,size);            
-               memcpy((values + 3*size),east,size);     
-               memcpy((values + 4*size),north,size);   
+               memcpy((values), west, size);
+               memcpy((values + size), south, size);
+               memcpy((values + 2 * size), center, size);
+               memcpy((values + 3 * size), east, size);
+               memcpy((values + 4 * size), north, size);
                break;
             case 3:
-               memcpy((values),west,size);
-               memcpy((values + size),south,size);
-               memcpy((values + 2*size),bottom,size);            
-               memcpy((values + 3*size),center,size);     
-               memcpy((values + 4*size),east,size);             
-               memcpy((values + 5*size),north,size);             
-               memcpy((values + 6*size),top,size);
+               memcpy((values), west, size);
+               memcpy((values + size), south, size);
+               memcpy((values + 2 * size), bottom, size);
+               memcpy((values + 3 * size), center, size);
+               memcpy((values + 4 * size), east, size);
+               memcpy((values + 5 * size), north, size);
+               memcpy((values + 6 * size), top, size);
                break;
          }
 
@@ -2352,8 +2359,8 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
                stencil_indices[3] = 4;
                memcpy((values), west, size);
                memcpy((values + size), south, size);
-               memcpy((values + 2*size), east, size);
-               memcpy((values + 3*size), north, size);
+               memcpy((values + 2 * size), east, size);
+               memcpy((values + 3 * size), north, size);
                break;
             case 3:
                stencil_indices[0] = 0;
@@ -2364,10 +2371,10 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
                stencil_indices[5] = 6;
                memcpy((values), west, size);
                memcpy((values + size), south, size);
-               memcpy((values + 2*size), bottom, size);
-               memcpy((values + 3*size), east, size);
-               memcpy((values + 4*size), north, size);
-               memcpy((values + 5*size), top, size);
+               memcpy((values + 2 * size), bottom, size);
+               memcpy((values + 3 * size), east, size);
+               memcpy((values + 4 * size), north, size);
+               memcpy((values + 5 * size), top, size);
                break;
          }
          if (hypre_BoxArraySize(gridboxes) > 0)
@@ -2388,7 +2395,7 @@ AddValuesMatrix_mp(HYPRE_StructMatrix A,
 
             for (i = 0; i < volume; i++)
             {
-               memcpy(values + i*size, &center, size);
+               memcpy(values + i * size, &center, size);
             }
 
             ilower = hypre_BoxIMin(box);
@@ -2442,7 +2449,7 @@ SetStencilBndry_mp(HYPRE_StructMatrix A,
 
    /* Declare values as a (void *) to allow for generic data types */
    void              *values;
-   
+
    stencil_indices = (HYPRE_Int *)hypre_CAlloc(1, (size_t)sizeof(HYPRE_Int), HYPRE_MEMORY_HOST);
 
    constant_coefficient = hypre_StructMatrixConstantCoefficient(A);
@@ -2484,7 +2491,7 @@ SetStencilBndry_mp(HYPRE_StructMatrix A,
       {
          for (ib = 0; ib < size; ib++)
          {
-            /* Allocate memory for values data. 
+            /* Allocate memory for values data.
              * Use long_double size to ensure enough memory is allocated for all supported types
              */
             values = hypre_CAlloc((size_t)(vol[ib]), (size_t)sizeof(hypre_long_double), HYPRE_MEMORY_HOST);
@@ -2494,24 +2501,24 @@ SetStencilBndry_mp(HYPRE_StructMatrix A,
                j = iupper[ib][d];
                iupper[ib][d] = istart[d];
                stencil_indices[0] = d;
-               
+
                /* Precision should match values datatype */
                switch (precision_A)
                {
                   case HYPRE_REAL_SINGLE:
                      HYPRE_StructMatrixSetBoxValues_pre( HYPRE_REAL_SINGLE, A, ilower[ib], iupper[ib],
-                                                  1, stencil_indices, (hypre_float *)values);
+                                                         1, stencil_indices, (hypre_float *)values);
                      break;
                   case HYPRE_REAL_DOUBLE:
                      HYPRE_StructMatrixSetBoxValues_pre( HYPRE_REAL_DOUBLE, A, ilower[ib], iupper[ib],
-                                                  1, stencil_indices, (hypre_double *)values);                  
+                                                         1, stencil_indices, (hypre_double *)values);
                      break;
                   case HYPRE_REAL_LONGDOUBLE:
                      HYPRE_StructMatrixSetBoxValues_pre( HYPRE_REAL_LONGDOUBLE, A, ilower[ib], iupper[ib],
-                                                  1, stencil_indices, (hypre_long_double *)values);                  
+                                                         1, stencil_indices, (hypre_long_double *)values);
                      break;
                }
-                                                
+
                iupper[ib][d] = j;
             }
 
@@ -2520,21 +2527,21 @@ SetStencilBndry_mp(HYPRE_StructMatrix A,
                j = ilower[ib][d];
                ilower[ib][d] = iend[d];
                stencil_indices[0] = dim + 1 + d;
-               
+
                /* Precision should match values datatype */
                switch (precision_A)
                {
                   case HYPRE_REAL_SINGLE:
                      HYPRE_StructMatrixSetBoxValues_pre( HYPRE_REAL_SINGLE, A, ilower[ib], iupper[ib],
-                                                  1, stencil_indices, (hypre_float *)values);
+                                                         1, stencil_indices, (hypre_float *)values);
                      break;
                   case HYPRE_REAL_DOUBLE:
                      HYPRE_StructMatrixSetBoxValues_pre( HYPRE_REAL_DOUBLE, A, ilower[ib], iupper[ib],
-                                                  1, stencil_indices, (hypre_double *)values);                  
+                                                         1, stencil_indices, (hypre_double *)values);
                      break;
                   case HYPRE_REAL_LONGDOUBLE:
                      HYPRE_StructMatrixSetBoxValues_pre( HYPRE_REAL_LONGDOUBLE, A, ilower[ib], iupper[ib],
-                                                  1, stencil_indices, (hypre_long_double *)values);                  
+                                                         1, stencil_indices, (hypre_long_double *)values);
                      break;
                }
                ilower[ib][d] = j;

--- a/src/test/test_mp.c
+++ b/src/test/test_mp.c
@@ -330,13 +330,13 @@ int main (int argc, char *argv[])
 
       /* step 2: compute residual */
       /* This copy routine will copy from single precision, par_x, to double precision, par_xb */
-         float rprod0=0.;
-         HYPRE_ParVectorInnerProd_flt(par_x, par_x, &rprod0);
-         printf("rprod0 = %f\n",rprod0);
+      float rprod0 = 0.;
+      HYPRE_ParVectorInnerProd_flt(par_x, par_x, &rprod0);
+      printf("rprod0 = %f\n", rprod0);
       HYPRE_ParVectorCopy_mp(par_x, par_xb);
-         double rprod1=0.;
-         HYPRE_ParVectorInnerProd_dbl(par_xb, par_xb, &rprod1);
-         printf("rprod1 = %f\n",rprod1);
+      double rprod1 = 0.;
+      HYPRE_ParVectorInnerProd_dbl(par_xb, par_xb, &rprod1);
+      printf("rprod1 = %f\n", rprod1);
       //HYPRE_ParVectorPrint_flt( par_x, "par_x.flt");
       //HYPRE_ParVectorPrint_dbl( par_xb, "par_x.dbl");
       //exit(0);
@@ -362,7 +362,7 @@ int main (int argc, char *argv[])
          rprod = 0.;
          HYPRE_ParVectorInnerProd_dbl(hres, hres, &rprod);
          rnrm[i] = rprod;
-         printf("rprod = %f\n",rprod);
+         printf("rprod = %f\n", rprod);
          /*=====================*/
 
          /* step 4: solver for error in single precision */

--- a/src/utilities/ap.c
+++ b/src/utilities/ap.c
@@ -15,7 +15,8 @@
 /* returns 1 if the assumed partition is in use */
 HYPRE_Int HYPRE_AssumedPartitionCheck(void)
 {
-   hypre_error_w_msg(HYPRE_ERROR_GENERIC, "HYPRE_AssumedPartitionCheck is obsolete and will eventually be removed.");
+   hypre_error_w_msg(HYPRE_ERROR_GENERIC,
+                     "HYPRE_AssumedPartitionCheck is obsolete and will eventually be removed.");
    return 1;
 }
 


### PR DESCRIPTION
Remaining fixes for today's regressions

- Fix local vector resize in AMG (needed by Chebyshev relaxation)
- Run astyle

@ulrikeyang most of the changes in this PR are related to code style. Apparently, we forgot to run it during the hypre-3 release.

Regression tests:
- [x] tux
- [x] tioga