### PR TITLE
Preserve order of linking configuration arguments

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -1596,7 +1596,7 @@ AS_HELP_STRING([--with-umpire-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for UMPIRE. OK to use -L and -l flags in the list]),
 [for umpire_lib in $withval; do
-       HYPRE_UMPIRE_LIB="$umpire_lib $HYPRE_UMPIRE_LIB"
+       HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB $umpire_lib"
  done;
  hypre_user_gave_umpire_lib=yes]
 )
@@ -1607,7 +1607,7 @@ AS_HELP_STRING([--with-umpire-libs=LIBS],
                 needed for UMPIRE (base name only). The options --with-umpire-libs and
                 --with-umpire-dirs must be used together.]),
 [for umpire_lib in $withval; do
-    HYPRE_UMPIRE_LIB="-l$umpire_lib $HYPRE_UMPIRE_LIB"
+    HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB -l$umpire_lib"
  done;
  hypre_user_gave_umpire_libs=yes]
 )

--- a/src/configure
+++ b/src/configure
@@ -5157,7 +5157,7 @@ fi
 if test ${with_umpire_lib+y}
 then :
   withval=$with_umpire_lib; for umpire_lib in $withval; do
-       HYPRE_UMPIRE_LIB="$umpire_lib $HYPRE_UMPIRE_LIB"
+       HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB $umpire_lib"
  done;
  hypre_user_gave_umpire_lib=yes
 
@@ -5169,7 +5169,7 @@ fi
 if test ${with_umpire_libs+y}
 then :
   withval=$with_umpire_libs; for umpire_lib in $withval; do
-    HYPRE_UMPIRE_LIB="-l$umpire_lib $HYPRE_UMPIRE_LIB"
+    HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB -l$umpire_lib"
  done;
  hypre_user_gave_umpire_libs=yes
 


### PR DESCRIPTION
Since link line ordering is critical users (should) think about the order they pass them in to configure, so we should preserve the ordering they give us instead of reversing them. For me, this lead to an undefined reference