### PR TITLE
Fix MGR bugs

### DIFF
--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -310,7 +310,6 @@ hypre_MGRSetup( void               *mgr_vdata,
             if (isCpoint)
             {
                level_coarse_indexes[i][final_coarse_size++] = row;
-               //printf("%d\n",row);
             }
          }
       }
@@ -539,7 +538,7 @@ hypre_MGRSetup( void               *mgr_vdata,
       {
          if ((mgr_data -> l1_norms)[j])
          {
-            hypre_SeqVectorDestroy((mgr_data -> l1_norms)[i]);
+            hypre_SeqVectorDestroy((mgr_data -> l1_norms)[j]);
             (mgr_data -> l1_norms)[j] = NULL;
          }
       }


### PR DESCRIPTION
Fix a couple of issues in MGR

- Incorrect index used for accessing `l1_norms` array
- Divide-by-zero happening in operator complexity calculation