### PR TITLE
Link order used in `configure`

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -768,7 +768,7 @@ AS_HELP_STRING([--with-MPI-libs=LIBS],
                 --with-MPI-include --with-MPI-libs and --with-MPI-lib-dirs
                 must be used together.]),
 [for mpi_lib in $withval; do
-    MPILIBS="$MPILIBS -l$mpi_lib"
+    MPILIBS+=" -l$mpi_lib"
  done;
  hypre_user_chose_mpi=yes]
 )
@@ -781,7 +781,7 @@ AS_HELP_STRING([--with-MPI-lib-dirs=DIRS],
                 The options --with-MPI-include --with-MPI-libs and
                 --with-MPI-lib-dirs must be used together.]),
 [for mpi_lib_dir in $withval; do
-    MPILIBDIRS="-L$mpi_lib_dir $MPILIBDIRS"
+    MPILIBDIRS+=" -L$mpi_lib_dir"
  done;
  hypre_user_chose_mpi=yes]
 )
@@ -859,7 +859,7 @@ dnl    if test $libprefix = "-L"
 dnl    then
 dnl       BLASLIBDIRS="$blas_lib $BLASLIBDIRS"
 dnl    else
-       BLASLIBS="$BLASLIBS $blas_lib"
+       BLASLIBS+=" $blas_lib"
 dnl    fi
  done;
  hypre_user_chose_blas=yes]
@@ -871,7 +871,7 @@ AS_HELP_STRING([--with-blas-libs=LIBS],
                 needed for BLAS (base name only). The options --with-blas-libs and
                 --with-blas-lib-dirs must be used together.]),
 [for blas_lib in $withval; do
-    BLASLIBS="$BLASLIBS -l$blas_lib"
+    BLASLIBS+=" -l$blas_lib"
  done;
  hypre_user_chose_blas=yes
  hypre_blas_lib_old_style=yes]
@@ -885,7 +885,7 @@ AS_HELP_STRING([--with-blas-lib-dirs=DIRS],
                 The  options --with-blas-libs and --with-blas-lib-dirs
                 must be used together.]),
 [for blas_lib_dir in $withval; do
-    BLASLIBDIRS="-L$blas_lib_dir $BLASLIBDIRS"
+    BLASLIBDIRS+=" -L$blas_lib_dir"
  done;
  hypre_user_chose_blas=yes
  hypre_blas_lib_dir_old_style=yes]
@@ -903,7 +903,7 @@ dnl    if test $libprefix = "-L"
 dnl    then
 dnl       LAPACKLIBDIRS="$lapack_lib $LAPACKLIBDIRS"
 dnl    else
-       LAPACKLIBS="$LAPACKLIBS $lapack_lib"
+       LAPACKLIBS+=" $lapack_lib"
 dnl    fi
  done;
  hypre_user_chose_lapack=yes]
@@ -915,7 +915,7 @@ AS_HELP_STRING([--with-lapack-libs=LIBS],
                 needed for LAPACK (base name only). The options --with-lapack-libs and
                 --with-lapack-lib-dirs must be used together.]),
 [for lapack_lib in $withval; do
-    LAPACKLIBS="$LAPACKLIBS -l$lapack_lib"
+    LAPACKLIBS+=" -l$lapack_lib"
  done;
  hypre_user_chose_lapack=yes
  hypre_lapack_lib_old_style=yes]
@@ -929,7 +929,7 @@ AS_HELP_STRING([--with-lapack-lib-dirs=DIRS],
                 The options --with-lapack-libs and --with-lapack-lib-dirs
                 must be used together.]),
 [for lapack_lib_dir in $withval; do
-    LAPACKLIBDIRS="-L$lapack_lib_dir $LAPACKLIBDIRS"
+    LAPACKLIBDIRS+=" -L$lapack_lib_dir"
  done;
  hypre_user_chose_lapack=yes
  hypre_lapack_lib_dir_old_style=yes]
@@ -1077,7 +1077,7 @@ AS_HELP_STRING([--with-superlu-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for SuperLU. OK to use -L and -l flags in the list]),
 [for superlu_lib in $withval; do
-    SUPERLU_LIBS="$SUPERLU_LIBS $superlu_lib"
+    SUPERLU_LIBS+=" $superlu_lib"
  done]
 )
 
@@ -1109,7 +1109,7 @@ AS_HELP_STRING([--with-dsuperlu-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for DSuperLU. OK to use -L and -l flags in the list]),
 [for dsuperlu_lib in $withval; do
-    DSUPERLU_LIBS="$DSUPERLU_LIBS $dsuperlu_lib"
+    DSUPERLU_LIBS+=" $dsuperlu_lib"
  done]
 )
 
@@ -1433,7 +1433,7 @@ AS_HELP_STRING([--with-raja-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for RAJA. OK to use -L and -l flags in the list]),
 [for raja_lib in $withval; do
-       HYPRE_RAJA_LIB="$raja_lib $HYPRE_RAJA_LIB"
+       HYPRE_RAJA_LIB+=" $raja_lib"
  done;
 hypre_user_chose_raja=yes]
 )
@@ -1444,7 +1444,7 @@ AS_HELP_STRING([--with-raja-libs=LIBS],
                 needed for RAJA (base name only). The options --with-raja-libs and
                 --with-raja-lib-dirs must be used together.]),
 [for raja_lib in $withval; do
-    HYPRE_RAJA_LIB="-l$raja_lib $HYPRE_RAJA_LIB"
+    HYPRE_RAJA_LIB+=" -l$raja_lib"
  done;
 hypre_user_chose_raja=yes]
 )
@@ -1457,7 +1457,7 @@ AS_HELP_STRING([--with-raja-lib-dirs=DIRS],
                 The  options --with-raja-libs and --raja-blas-lib-dirs
                 must be used together.]),
 [for raja_lib_dir in $withval; do
-    HYPRE_RAJA_LIB_DIR="-L$raja_lib_dir $HYPRE_RAJA_LIB_DIR"
+    HYPRE_RAJA_LIB_DIR+=" -L$raja_lib_dir"
  done;
  hypre_user_chose_raja=yes]
 )
@@ -1491,7 +1491,7 @@ AS_HELP_STRING([--with-kokkos-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for KOKKOS. OK to use -L and -l flags in the list]),
 [for kokkos_lib in $withval; do
-       HYPRE_KOKKOS_LIB="$kokkos_lib $HYPRE_KOKKOS_LIB"
+       HYPRE_KOKKOS_LIB+=" $kokkos_lib"
  done;
 hypre_user_chose_kokkos=yes]
 )
@@ -1502,7 +1502,7 @@ AS_HELP_STRING([--with-kokkos-libs=LIBS],
                 needed for KOKKOS (base name only). The options --with-kokkos-libs and
                 --with-kokkos-dirs must be used together.]),
 [for kokkos_lib in $withval; do
-    HYPRE_KOKKOS_LIB="-l$kokkos_lib $HYPRE_KOKKOS_LIB"
+    HYPRE_KOKKOS_LIB+=" -l$kokkos_lib"
  done;
 hypre_user_chose_kokkos=yes]
 )
@@ -1515,7 +1515,7 @@ AS_HELP_STRING([--with-kokkos-lib-dirs=DIRS],
                 The  options --with-kokkos-libs and --with-kokkos-dirs
                 must be used together.]),
 [for kokkos_lib_dir in $withval; do
-    HYPRE_KOKKOS_LIB_DIR="-L$kokkos_lib_dir $HYPRE_KOKKOS_LIB_DIR"
+    HYPRE_KOKKOS_LIB_DIR+=" -L$kokkos_lib_dir"
  done;
 hypre_user_chose_kokkos=yes]
 )
@@ -1596,7 +1596,7 @@ AS_HELP_STRING([--with-umpire-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for UMPIRE. OK to use -L and -l flags in the list]),
 [for umpire_lib in $withval; do
-       HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB $umpire_lib"
+       HYPRE_UMPIRE_LIB+=" $umpire_lib"
  done;
  hypre_user_gave_umpire_lib=yes]
 )
@@ -1607,7 +1607,7 @@ AS_HELP_STRING([--with-umpire-libs=LIBS],
                 needed for UMPIRE (base name only). The options --with-umpire-libs and
                 --with-umpire-dirs must be used together.]),
 [for umpire_lib in $withval; do
-    HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB -l$umpire_lib"
+    HYPRE_UMPIRE_LIB+=" -l$umpire_lib"
  done;
  hypre_user_gave_umpire_libs=yes]
 )
@@ -1620,8 +1620,8 @@ AS_HELP_STRING([--with-umpire-lib-dirs=DIRS],
                 The  options --with-umpire-libs and --with-umpire-dirs
                 must be used together.]),
 [for umpire_lib_dir in $withval; do
-    HYPRE_UMPIRE_LIB_DIR="-L$umpire_lib_dir $HYPRE_UMPIRE_LIB_DIR"
-    HYPRE_UMPIRE_RPATH="${HYPRE_UMPIRE_RPATH} -Wl,-rpath,${umpire_lib_dir}"
+    HYPRE_UMPIRE_LIB_DIR+=" -L$umpire_lib_dir"
+    HYPRE_UMPIRE_RPATH+=" -Wl,-rpath,${umpire_lib_dir}"
  done;
  hypre_user_gave_umpire_lib_dirs=yes]
 )
@@ -1659,7 +1659,7 @@ AS_HELP_STRING([--with-magma-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for MAGMA. OK to use -L and -l flags in the list]),
 [for magma_lib in $withval; do
-    HYPRE_MAGMA_LIB="$magma_lib $HYPRE_MAGMA_LIB"
+    HYPRE_MAGMA_LIB+=" $magma_lib"
  done;
 hypre_user_gave_magma_lib=yes]
 )
@@ -1670,7 +1670,7 @@ AS_HELP_STRING([--with-magma-libs=LIBS],
                 needed for MAGMA (base name only). The options --with-magma-libs and
                 --with-magma-lib-dirs must be used together.]),
 [for magma_lib in $withval; do
-    HYPRE_MAGMA_LIB="-l$magma_lib $HYPRE_MAGMA_LIB"
+    HYPRE_MAGMA_LIB+=" -l$magma_lib"
  done;
 hypre_user_gave_magma_libs=yes]
 )
@@ -1683,7 +1683,7 @@ AS_HELP_STRING([--with-magma-lib-dirs=DIRS],
                 The  options --with-magma-libs and --with-magma-lib-dirs
                 must be used together.]),
 [for magma_lib_dir in $withval; do
-    HYPRE_MAGMA_LIB_DIR="-L$magma_lib_dir $HYPRE_MAGMA_LIB_DIR"
+    HYPRE_MAGMA_LIB_DIR+=" -L$magma_lib_dir"
  done;
 hypre_user_gave_magma_lib_dirs=yes]
 )
@@ -1717,7 +1717,7 @@ AS_HELP_STRING([--with-caliper-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for Caliper. OK to use -L and -l flags in the list]),
 [for caliper_lib in $withval; do
-    CALIPER_LIBS="$CALIPER_LIBS $caliper_lib"
+    CALIPER_LIBS+=" $caliper_lib"
  done;
  hypre_user_gave_caliper_lib=yes]
 )
@@ -1906,7 +1906,7 @@ if test "$hypre_using_mpi" = "no"
 then
    AC_DEFINE(HYPRE_SEQUENTIAL, 1, [Disable MPI, enable serial codes.])
 else
-   AC_HYPRE_CHECK_MPI([LIBS="$LIBS $MPILIBS"])
+   AC_HYPRE_CHECK_MPI([LIBS+=" $MPILIBS"])
    AC_CHECK_FUNCS([MPI_Comm_f2c])
    AC_CACHE_CHECK([whether MPI_Comm_f2c is a macro],
      hypre_cv_func_MPI_Comm_f2c_macro,
@@ -2048,7 +2048,7 @@ then
          AC_DEFINE(HAVE_MLI, 1, [Define to 1 if using MLI])
       fi
    fi
-   AC_CHECK_LIB(stdc++, __gxx_personality_v0, LIBS="$LIBS -lstdc++")
+   AC_CHECK_LIB(stdc++, __gxx_personality_v0, LIBS+=" -lstdc++")
 else
    HYPRE_FEI_SRC_DIR=
    HYPRE_FEI_BASE_DIR=
@@ -2124,7 +2124,7 @@ fi
 dnl *********************************************************************
 dnl * FIND libraries needed to link with hypre
 dnl *********************************************************************
-AC_CHECK_LIB(m, cabs, LIBS="$LIBS -lm")
+AC_CHECK_LIB(m, cabs, LIBS+=" -lm")
 dnl * Commenting this out because it doesn't really behave correctly.
 dnl * This should probably be deleted altogether at some point. (RDF)
 dnl AC_HYPRE_FIND_G2C
@@ -2538,6 +2538,8 @@ then
     if test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_hip" = "xyes"
     then
       hypre_using_umpire=yes
+      hypre_using_umpire_device=yes
+      hypre_using_umpire_um=yes
       AC_MSG_NOTICE([Enabling Umpire automatically for GPU build (CUDA/HIP) for performance and allocator features. Use --without-umpire to opt out.])
     fi
   fi
@@ -2603,7 +2605,7 @@ However, Umpire include and/or library paths were not provided.
 Provide the following flags as appropriate:
   --with-umpire-include="/path-to-umpire-install/include"
   --with-umpire-lib-dirs="/path-to-umpire-install/lib"
-  --with-umpire-libs="umpire"  or  --with-umpire-lib="-lumpire"
+  --with-umpire-libs="umpire camp"
 
 To opt out (not recommended), configure with --without-umpire.
 ===============================================================])
@@ -2875,8 +2877,8 @@ AS_IF([test x"$hypre_using_sycl" == x"yes"],
               [AC_CHECK_HEADER(["${MKLROOT}/include/mkl.h"],
                                [hypre_found_mkl=yes],
                                AC_MSG_ERROR([unable to find oneMKL ... Ensure that MKLROOT is set]))
-               HYPRE_SYCL_LIBS="${HYPRE_SYCL_LIBS} -qmkl -Wl,-export-dynamic -Wl,--start-group -Wl,--end-group -lsycl -lOpenCL -lpthread -lm -ldl"
-               HYPRE_SYCL_INCL="${HYPRE_SYCL_INCL} -qmkl -I${DPLROOT}/include -DMKL_ILP64 -I${MKLROOT}/include"
+               HYPRE_SYCL_LIBS+=" -qmkl -Wl,-export-dynamic -Wl,--start-group -Wl,--end-group -lsycl -lOpenCL -lpthread -lm -ldl"
+               HYPRE_SYCL_INCL+=" -qmkl -I${DPLROOT}/include -DMKL_ILP64 -I${MKLROOT}/include"
                ])
 
         AS_IF([test x"$hypre_using_onemklsparse" == x"yes"], [AC_DEFINE(HYPRE_USING_ONEMKLSPARSE, 1, [onemkl::SPARSE being used])])

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -768,7 +768,7 @@ AS_HELP_STRING([--with-MPI-libs=LIBS],
                 --with-MPI-include --with-MPI-libs and --with-MPI-lib-dirs
                 must be used together.]),
 [for mpi_lib in $withval; do
-    MPILIBS="$MPILIBS -l$mpi_lib"
+    MPILIBS+=" -l$mpi_lib"
  done;
  hypre_user_chose_mpi=yes]
 )
@@ -781,7 +781,7 @@ AS_HELP_STRING([--with-MPI-lib-dirs=DIRS],
                 The options --with-MPI-include --with-MPI-libs and
                 --with-MPI-lib-dirs must be used together.]),
 [for mpi_lib_dir in $withval; do
-    MPILIBDIRS="-L$mpi_lib_dir $MPILIBDIRS"
+    MPILIBDIRS+=" -L$mpi_lib_dir"
  done;
  hypre_user_chose_mpi=yes]
 )
@@ -859,7 +859,7 @@ dnl    if test $libprefix = "-L"
 dnl    then
 dnl       BLASLIBDIRS="$blas_lib $BLASLIBDIRS"
 dnl    else
-       BLASLIBS="$BLASLIBS $blas_lib"
+       BLASLIBS+=" $blas_lib"
 dnl    fi
  done;
  hypre_user_chose_blas=yes]
@@ -871,7 +871,7 @@ AS_HELP_STRING([--with-blas-libs=LIBS],
                 needed for BLAS (base name only). The options --with-blas-libs and
                 --with-blas-lib-dirs must be used together.]),
 [for blas_lib in $withval; do
-    BLASLIBS="$BLASLIBS -l$blas_lib"
+    BLASLIBS+=" -l$blas_lib"
  done;
  hypre_user_chose_blas=yes
  hypre_blas_lib_old_style=yes]
@@ -885,7 +885,7 @@ AS_HELP_STRING([--with-blas-lib-dirs=DIRS],
                 The  options --with-blas-libs and --with-blas-lib-dirs
                 must be used together.]),
 [for blas_lib_dir in $withval; do
-    BLASLIBDIRS="-L$blas_lib_dir $BLASLIBDIRS"
+    BLASLIBDIRS+=" -L$blas_lib_dir"
  done;
  hypre_user_chose_blas=yes
  hypre_blas_lib_dir_old_style=yes]
@@ -903,7 +903,7 @@ dnl    if test $libprefix = "-L"
 dnl    then
 dnl       LAPACKLIBDIRS="$lapack_lib $LAPACKLIBDIRS"
 dnl    else
-       LAPACKLIBS="$LAPACKLIBS $lapack_lib"
+       LAPACKLIBS+=" $lapack_lib"
 dnl    fi
  done;
  hypre_user_chose_lapack=yes]
@@ -915,7 +915,7 @@ AS_HELP_STRING([--with-lapack-libs=LIBS],
                 needed for LAPACK (base name only). The options --with-lapack-libs and
                 --with-lapack-lib-dirs must be used together.]),
 [for lapack_lib in $withval; do
-    LAPACKLIBS="$LAPACKLIBS -l$lapack_lib"
+    LAPACKLIBS+=" -l$lapack_lib"
  done;
  hypre_user_chose_lapack=yes
  hypre_lapack_lib_old_style=yes]
@@ -929,7 +929,7 @@ AS_HELP_STRING([--with-lapack-lib-dirs=DIRS],
                 The options --with-lapack-libs and --with-lapack-lib-dirs
                 must be used together.]),
 [for lapack_lib_dir in $withval; do
-    LAPACKLIBDIRS="-L$lapack_lib_dir $LAPACKLIBDIRS"
+    LAPACKLIBDIRS+=" -L$lapack_lib_dir"
  done;
  hypre_user_chose_lapack=yes
  hypre_lapack_lib_dir_old_style=yes]
@@ -1077,7 +1077,7 @@ AS_HELP_STRING([--with-superlu-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for SuperLU. OK to use -L and -l flags in the list]),
 [for superlu_lib in $withval; do
-    SUPERLU_LIBS="$SUPERLU_LIBS $superlu_lib"
+    SUPERLU_LIBS+=" $superlu_lib"
  done]
 )
 
@@ -1109,7 +1109,7 @@ AS_HELP_STRING([--with-dsuperlu-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for DSuperLU. OK to use -L and -l flags in the list]),
 [for dsuperlu_lib in $withval; do
-    DSUPERLU_LIBS="$DSUPERLU_LIBS $dsuperlu_lib"
+    DSUPERLU_LIBS+=" $dsuperlu_lib"
  done]
 )
 
@@ -1433,7 +1433,7 @@ AS_HELP_STRING([--with-raja-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for RAJA. OK to use -L and -l flags in the list]),
 [for raja_lib in $withval; do
-       HYPRE_RAJA_LIB="$raja_lib $HYPRE_RAJA_LIB"
+       HYPRE_RAJA_LIB+=" $raja_lib"
  done;
 hypre_user_chose_raja=yes]
 )
@@ -1444,7 +1444,7 @@ AS_HELP_STRING([--with-raja-libs=LIBS],
                 needed for RAJA (base name only). The options --with-raja-libs and
                 --with-raja-lib-dirs must be used together.]),
 [for raja_lib in $withval; do
-    HYPRE_RAJA_LIB="-l$raja_lib $HYPRE_RAJA_LIB"
+    HYPRE_RAJA_LIB+=" -l$raja_lib"
  done;
 hypre_user_chose_raja=yes]
 )
@@ -1457,7 +1457,7 @@ AS_HELP_STRING([--with-raja-lib-dirs=DIRS],
                 The  options --with-raja-libs and --raja-blas-lib-dirs
                 must be used together.]),
 [for raja_lib_dir in $withval; do
-    HYPRE_RAJA_LIB_DIR="-L$raja_lib_dir $HYPRE_RAJA_LIB_DIR"
+    HYPRE_RAJA_LIB_DIR+=" -L$raja_lib_dir"
  done;
  hypre_user_chose_raja=yes]
 )
@@ -1491,7 +1491,7 @@ AS_HELP_STRING([--with-kokkos-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for KOKKOS. OK to use -L and -l flags in the list]),
 [for kokkos_lib in $withval; do
-       HYPRE_KOKKOS_LIB="$kokkos_lib $HYPRE_KOKKOS_LIB"
+       HYPRE_KOKKOS_LIB+=" $kokkos_lib"
  done;
 hypre_user_chose_kokkos=yes]
 )
@@ -1502,7 +1502,7 @@ AS_HELP_STRING([--with-kokkos-libs=LIBS],
                 needed for KOKKOS (base name only). The options --with-kokkos-libs and
                 --with-kokkos-dirs must be used together.]),
 [for kokkos_lib in $withval; do
-    HYPRE_KOKKOS_LIB="-l$kokkos_lib $HYPRE_KOKKOS_LIB"
+    HYPRE_KOKKOS_LIB+=" -l$kokkos_lib"
  done;
 hypre_user_chose_kokkos=yes]
 )
@@ -1515,7 +1515,7 @@ AS_HELP_STRING([--with-kokkos-lib-dirs=DIRS],
                 The  options --with-kokkos-libs and --with-kokkos-dirs
                 must be used together.]),
 [for kokkos_lib_dir in $withval; do
-    HYPRE_KOKKOS_LIB_DIR="-L$kokkos_lib_dir $HYPRE_KOKKOS_LIB_DIR"
+    HYPRE_KOKKOS_LIB_DIR+=" -L$kokkos_lib_dir"
  done;
 hypre_user_chose_kokkos=yes]
 )
@@ -1596,7 +1596,7 @@ AS_HELP_STRING([--with-umpire-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for UMPIRE. OK to use -L and -l flags in the list]),
 [for umpire_lib in $withval; do
-       HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB $umpire_lib"
+       HYPRE_UMPIRE_LIB+=" $umpire_lib"
  done;
  hypre_user_gave_umpire_lib=yes]
 )
@@ -1607,7 +1607,7 @@ AS_HELP_STRING([--with-umpire-libs=LIBS],
                 needed for UMPIRE (base name only). The options --with-umpire-libs and
                 --with-umpire-dirs must be used together.]),
 [for umpire_lib in $withval; do
-    HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB -l$umpire_lib"
+    HYPRE_UMPIRE_LIB+=" -l$umpire_lib"
  done;
  hypre_user_gave_umpire_libs=yes]
 )
@@ -1620,8 +1620,8 @@ AS_HELP_STRING([--with-umpire-lib-dirs=DIRS],
                 The  options --with-umpire-libs and --with-umpire-dirs
                 must be used together.]),
 [for umpire_lib_dir in $withval; do
-    HYPRE_UMPIRE_LIB_DIR="-L$umpire_lib_dir $HYPRE_UMPIRE_LIB_DIR"
-    HYPRE_UMPIRE_RPATH="${HYPRE_UMPIRE_RPATH} -Wl,-rpath,${umpire_lib_dir}"
+    HYPRE_UMPIRE_LIB_DIR+=" -L$umpire_lib_dir"
+    HYPRE_UMPIRE_RPATH+=" -Wl,-rpath,${umpire_lib_dir}"
  done;
  hypre_user_gave_umpire_lib_dirs=yes]
 )
@@ -1659,7 +1659,7 @@ AS_HELP_STRING([--with-magma-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for MAGMA. OK to use -L and -l flags in the list]),
 [for magma_lib in $withval; do
-    HYPRE_MAGMA_LIB="$magma_lib $HYPRE_MAGMA_LIB"
+    HYPRE_MAGMA_LIB+=" $magma_lib"
  done;
 hypre_user_gave_magma_lib=yes]
 )
@@ -1670,7 +1670,7 @@ AS_HELP_STRING([--with-magma-libs=LIBS],
                 needed for MAGMA (base name only). The options --with-magma-libs and
                 --with-magma-lib-dirs must be used together.]),
 [for magma_lib in $withval; do
-    HYPRE_MAGMA_LIB="-l$magma_lib $HYPRE_MAGMA_LIB"
+    HYPRE_MAGMA_LIB+=" -l$magma_lib"
  done;
 hypre_user_gave_magma_libs=yes]
 )
@@ -1683,7 +1683,7 @@ AS_HELP_STRING([--with-magma-lib-dirs=DIRS],
                 The  options --with-magma-libs and --with-magma-lib-dirs
                 must be used together.]),
 [for magma_lib_dir in $withval; do
-    HYPRE_MAGMA_LIB_DIR="-L$magma_lib_dir $HYPRE_MAGMA_LIB_DIR"
+    HYPRE_MAGMA_LIB_DIR+=" -L$magma_lib_dir"
  done;
 hypre_user_gave_magma_lib_dirs=yes]
 )
@@ -1717,7 +1717,7 @@ AS_HELP_STRING([--with-caliper-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for Caliper. OK to use -L and -l flags in the list]),
 [for caliper_lib in $withval; do
-    CALIPER_LIBS="$CALIPER_LIBS $caliper_lib"
+    CALIPER_LIBS+=" $caliper_lib"
  done;
  hypre_user_gave_caliper_lib=yes]
 )
@@ -1906,7 +1906,7 @@ if test "$hypre_using_mpi" = "no"
 then
    AC_DEFINE(HYPRE_SEQUENTIAL, 1, [Disable MPI, enable serial codes.])
 else
-   AC_HYPRE_CHECK_MPI([LIBS="$LIBS $MPILIBS"])
+   AC_HYPRE_CHECK_MPI([LIBS+=" $MPILIBS"])
    AC_CHECK_FUNCS([MPI_Comm_f2c])
    AC_CACHE_CHECK([whether MPI_Comm_f2c is a macro],
      hypre_cv_func_MPI_Comm_f2c_macro,
@@ -2048,7 +2048,7 @@ then
          AC_DEFINE(HAVE_MLI, 1, [Define to 1 if using MLI])
       fi
    fi
-   AC_CHECK_LIB(stdc++, __gxx_personality_v0, LIBS="$LIBS -lstdc++")
+   AC_CHECK_LIB(stdc++, __gxx_personality_v0, LIBS+=" -lstdc++")
 else
    HYPRE_FEI_SRC_DIR=
    HYPRE_FEI_BASE_DIR=
@@ -2124,7 +2124,7 @@ fi
 dnl *********************************************************************
 dnl * FIND libraries needed to link with hypre
 dnl *********************************************************************
-AC_CHECK_LIB(m, cabs, LIBS="$LIBS -lm")
+AC_CHECK_LIB(m, cabs, LIBS+=" -lm")
 dnl * Commenting this out because it doesn't really behave correctly.
 dnl * This should probably be deleted altogether at some point. (RDF)
 dnl AC_HYPRE_FIND_G2C
@@ -2875,8 +2875,8 @@ AS_IF([test x"$hypre_using_sycl" == x"yes"],
               [AC_CHECK_HEADER(["${MKLROOT}/include/mkl.h"],
                                [hypre_found_mkl=yes],
                                AC_MSG_ERROR([unable to find oneMKL ... Ensure that MKLROOT is set]))
-               HYPRE_SYCL_LIBS="${HYPRE_SYCL_LIBS} -qmkl -Wl,-export-dynamic -Wl,--start-group -Wl,--end-group -lsycl -lOpenCL -lpthread -lm -ldl"
-               HYPRE_SYCL_INCL="${HYPRE_SYCL_INCL} -qmkl -I${DPLROOT}/include -DMKL_ILP64 -I${MKLROOT}/include"
+               HYPRE_SYCL_LIBS+=" -qmkl -Wl,-export-dynamic -Wl,--start-group -Wl,--end-group -lsycl -lOpenCL -lpthread -lm -ldl"
+               HYPRE_SYCL_INCL+=" -qmkl -I${DPLROOT}/include -DMKL_ILP64 -I${MKLROOT}/include"
                ])
 
         AS_IF([test x"$hypre_using_onemklsparse" == x"yes"], [AC_DEFINE(HYPRE_USING_ONEMKLSPARSE, 1, [onemkl::SPARSE being used])])

--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -1596,7 +1596,7 @@ AS_HELP_STRING([--with-umpire-lib=LIBS],
                [LIBS is space-separated linkable list (enclosed in quotes) of libraries
                 needed for UMPIRE. OK to use -L and -l flags in the list]),
 [for umpire_lib in $withval; do
-       HYPRE_UMPIRE_LIB="$umpire_lib $HYPRE_UMPIRE_LIB"
+       HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB $umpire_lib"
  done;
  hypre_user_gave_umpire_lib=yes]
 )
@@ -1607,7 +1607,7 @@ AS_HELP_STRING([--with-umpire-libs=LIBS],
                 needed for UMPIRE (base name only). The options --with-umpire-libs and
                 --with-umpire-dirs must be used together.]),
 [for umpire_lib in $withval; do
-    HYPRE_UMPIRE_LIB="-l$umpire_lib $HYPRE_UMPIRE_LIB"
+    HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB -l$umpire_lib"
  done;
  hypre_user_gave_umpire_libs=yes]
 )

--- a/src/configure
+++ b/src/configure
@@ -4207,7 +4207,7 @@ fi
 if test ${with_MPI_libs+y}
 then :
   withval=$with_MPI_libs; for mpi_lib in $withval; do
-    MPILIBS="$MPILIBS -l$mpi_lib"
+    MPILIBS+=" -l$mpi_lib"
  done;
  hypre_user_chose_mpi=yes
 
@@ -4219,7 +4219,7 @@ fi
 if test ${with_MPI_lib_dirs+y}
 then :
   withval=$with_MPI_lib_dirs; for mpi_lib_dir in $withval; do
-    MPILIBDIRS="-L$mpi_lib_dir $MPILIBDIRS"
+    MPILIBDIRS+=" -L$mpi_lib_dir"
  done;
  hypre_user_chose_mpi=yes
 
@@ -4304,7 +4304,7 @@ fi
 if test ${with_blas_lib+y}
 then :
   withval=$with_blas_lib; for blas_lib in $withval; do
-       BLASLIBS="$BLASLIBS $blas_lib"
+       BLASLIBS+=" $blas_lib"
  done;
  hypre_user_chose_blas=yes
 
@@ -4316,7 +4316,7 @@ fi
 if test ${with_blas_libs+y}
 then :
   withval=$with_blas_libs; for blas_lib in $withval; do
-    BLASLIBS="$BLASLIBS -l$blas_lib"
+    BLASLIBS+=" -l$blas_lib"
  done;
  hypre_user_chose_blas=yes
  hypre_blas_lib_old_style=yes
@@ -4329,7 +4329,7 @@ fi
 if test ${with_blas_lib_dirs+y}
 then :
   withval=$with_blas_lib_dirs; for blas_lib_dir in $withval; do
-    BLASLIBDIRS="-L$blas_lib_dir $BLASLIBDIRS"
+    BLASLIBDIRS+=" -L$blas_lib_dir"
  done;
  hypre_user_chose_blas=yes
  hypre_blas_lib_dir_old_style=yes
@@ -4343,7 +4343,7 @@ fi
 if test ${with_lapack_lib+y}
 then :
   withval=$with_lapack_lib; for lapack_lib in $withval; do
-       LAPACKLIBS="$LAPACKLIBS $lapack_lib"
+       LAPACKLIBS+=" $lapack_lib"
  done;
  hypre_user_chose_lapack=yes
 
@@ -4355,7 +4355,7 @@ fi
 if test ${with_lapack_libs+y}
 then :
   withval=$with_lapack_libs; for lapack_lib in $withval; do
-    LAPACKLIBS="$LAPACKLIBS -l$lapack_lib"
+    LAPACKLIBS+=" -l$lapack_lib"
  done;
  hypre_user_chose_lapack=yes
  hypre_lapack_lib_old_style=yes
@@ -4368,7 +4368,7 @@ fi
 if test ${with_lapack_lib_dirs+y}
 then :
   withval=$with_lapack_lib_dirs; for lapack_lib_dir in $withval; do
-    LAPACKLIBDIRS="-L$lapack_lib_dir $LAPACKLIBDIRS"
+    LAPACKLIBDIRS+=" -L$lapack_lib_dir"
  done;
  hypre_user_chose_lapack=yes
  hypre_lapack_lib_dir_old_style=yes
@@ -4540,7 +4540,7 @@ fi
 if test ${with_superlu_lib+y}
 then :
   withval=$with_superlu_lib; for superlu_lib in $withval; do
-    SUPERLU_LIBS="$SUPERLU_LIBS $superlu_lib"
+    SUPERLU_LIBS+=" $superlu_lib"
  done
 
 fi
@@ -4582,7 +4582,7 @@ fi
 if test ${with_dsuperlu_lib+y}
 then :
   withval=$with_dsuperlu_lib; for dsuperlu_lib in $withval; do
-    DSUPERLU_LIBS="$DSUPERLU_LIBS $dsuperlu_lib"
+    DSUPERLU_LIBS+=" $dsuperlu_lib"
  done
 
 fi
@@ -4970,7 +4970,7 @@ fi
 if test ${with_raja_lib+y}
 then :
   withval=$with_raja_lib; for raja_lib in $withval; do
-       HYPRE_RAJA_LIB="$raja_lib $HYPRE_RAJA_LIB"
+       HYPRE_RAJA_LIB+=" $raja_lib"
  done;
 hypre_user_chose_raja=yes
 
@@ -4982,7 +4982,7 @@ fi
 if test ${with_raja_libs+y}
 then :
   withval=$with_raja_libs; for raja_lib in $withval; do
-    HYPRE_RAJA_LIB="-l$raja_lib $HYPRE_RAJA_LIB"
+    HYPRE_RAJA_LIB+=" -l$raja_lib"
  done;
 hypre_user_chose_raja=yes
 
@@ -4994,7 +4994,7 @@ fi
 if test ${with_raja_lib_dirs+y}
 then :
   withval=$with_raja_lib_dirs; for raja_lib_dir in $withval; do
-    HYPRE_RAJA_LIB_DIR="-L$raja_lib_dir $HYPRE_RAJA_LIB_DIR"
+    HYPRE_RAJA_LIB_DIR+=" -L$raja_lib_dir"
  done;
  hypre_user_chose_raja=yes
 
@@ -5034,7 +5034,7 @@ fi
 if test ${with_kokkos_lib+y}
 then :
   withval=$with_kokkos_lib; for kokkos_lib in $withval; do
-       HYPRE_KOKKOS_LIB="$kokkos_lib $HYPRE_KOKKOS_LIB"
+       HYPRE_KOKKOS_LIB+=" $kokkos_lib"
  done;
 hypre_user_chose_kokkos=yes
 
@@ -5046,7 +5046,7 @@ fi
 if test ${with_kokkos_libs+y}
 then :
   withval=$with_kokkos_libs; for kokkos_lib in $withval; do
-    HYPRE_KOKKOS_LIB="-l$kokkos_lib $HYPRE_KOKKOS_LIB"
+    HYPRE_KOKKOS_LIB+=" -l$kokkos_lib"
  done;
 hypre_user_chose_kokkos=yes
 
@@ -5058,7 +5058,7 @@ fi
 if test ${with_kokkos_lib_dirs+y}
 then :
   withval=$with_kokkos_lib_dirs; for kokkos_lib_dir in $withval; do
-    HYPRE_KOKKOS_LIB_DIR="-L$kokkos_lib_dir $HYPRE_KOKKOS_LIB_DIR"
+    HYPRE_KOKKOS_LIB_DIR+=" -L$kokkos_lib_dir"
  done;
 hypre_user_chose_kokkos=yes
 
@@ -5157,7 +5157,7 @@ fi
 if test ${with_umpire_lib+y}
 then :
   withval=$with_umpire_lib; for umpire_lib in $withval; do
-       HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB $umpire_lib"
+       HYPRE_UMPIRE_LIB+=" $umpire_lib"
  done;
  hypre_user_gave_umpire_lib=yes
 
@@ -5169,7 +5169,7 @@ fi
 if test ${with_umpire_libs+y}
 then :
   withval=$with_umpire_libs; for umpire_lib in $withval; do
-    HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB -l$umpire_lib"
+    HYPRE_UMPIRE_LIB+=" -l$umpire_lib"
  done;
  hypre_user_gave_umpire_libs=yes
 
@@ -5181,8 +5181,8 @@ fi
 if test ${with_umpire_lib_dirs+y}
 then :
   withval=$with_umpire_lib_dirs; for umpire_lib_dir in $withval; do
-    HYPRE_UMPIRE_LIB_DIR="-L$umpire_lib_dir $HYPRE_UMPIRE_LIB_DIR"
-    HYPRE_UMPIRE_RPATH="${HYPRE_UMPIRE_RPATH} -Wl,-rpath,${umpire_lib_dir}"
+    HYPRE_UMPIRE_LIB_DIR+=" -L$umpire_lib_dir"
+    HYPRE_UMPIRE_RPATH+=" -Wl,-rpath,${umpire_lib_dir}"
  done;
  hypre_user_gave_umpire_lib_dirs=yes
 
@@ -5229,7 +5229,7 @@ fi
 if test ${with_magma_lib+y}
 then :
   withval=$with_magma_lib; for magma_lib in $withval; do
-    HYPRE_MAGMA_LIB="$magma_lib $HYPRE_MAGMA_LIB"
+    HYPRE_MAGMA_LIB+=" $magma_lib"
  done;
 hypre_user_gave_magma_lib=yes
 
@@ -5241,7 +5241,7 @@ fi
 if test ${with_magma_libs+y}
 then :
   withval=$with_magma_libs; for magma_lib in $withval; do
-    HYPRE_MAGMA_LIB="-l$magma_lib $HYPRE_MAGMA_LIB"
+    HYPRE_MAGMA_LIB+=" -l$magma_lib"
  done;
 hypre_user_gave_magma_libs=yes
 
@@ -5253,7 +5253,7 @@ fi
 if test ${with_magma_lib_dirs+y}
 then :
   withval=$with_magma_lib_dirs; for magma_lib_dir in $withval; do
-    HYPRE_MAGMA_LIB_DIR="-L$magma_lib_dir $HYPRE_MAGMA_LIB_DIR"
+    HYPRE_MAGMA_LIB_DIR+=" -L$magma_lib_dir"
  done;
 hypre_user_gave_magma_lib_dirs=yes
 
@@ -5298,7 +5298,7 @@ fi
 if test ${with_caliper_lib+y}
 then :
   withval=$with_caliper_lib; for caliper_lib in $withval; do
-    CALIPER_LIBS="$CALIPER_LIBS $caliper_lib"
+    CALIPER_LIBS+=" $caliper_lib"
  done;
  hypre_user_gave_caliper_lib=yes
 
@@ -8940,7 +8940,7 @@ else
 
 printf "%s\n" "#define HYPRE_HAVE_MPI 1" >>confdefs.h
 
-  LIBS="$LIBS $MPILIBS"
+  LIBS+=" $MPILIBS"
   :
 fi
 
@@ -9753,7 +9753,7 @@ fi
 printf "%s\n" "$ac_cv_lib_stdcpp___gxx_personality_v0" >&6; }
 if test "x$ac_cv_lib_stdcpp___gxx_personality_v0" = xyes
 then :
-  LIBS="$LIBS -lstdc++"
+  LIBS+=" -lstdc++"
 fi
 
 else
@@ -10084,7 +10084,7 @@ fi
 printf "%s\n" "$ac_cv_lib_m_cabs" >&6; }
 if test "x$ac_cv_lib_m_cabs" = xyes
 then :
-  LIBS="$LIBS -lm"
+  LIBS+=" -lm"
 fi
 
 
@@ -11121,8 +11121,8 @@ else $as_nop
   as_fn_error $? "unable to find oneMKL ... Ensure that MKLROOT is set" "$LINENO" 5
 fi
 
-               HYPRE_SYCL_LIBS="${HYPRE_SYCL_LIBS} -qmkl -Wl,-export-dynamic -Wl,--start-group -Wl,--end-group -lsycl -lOpenCL -lpthread -lm -ldl"
-               HYPRE_SYCL_INCL="${HYPRE_SYCL_INCL} -qmkl -I${DPLROOT}/include -DMKL_ILP64 -I${MKLROOT}/include"
+               HYPRE_SYCL_LIBS+=" -qmkl -Wl,-export-dynamic -Wl,--start-group -Wl,--end-group -lsycl -lOpenCL -lpthread -lm -ldl"
+               HYPRE_SYCL_INCL+=" -qmkl -I${DPLROOT}/include -DMKL_ILP64 -I${MKLROOT}/include"
 
 fi
 

--- a/src/configure
+++ b/src/configure
@@ -4207,7 +4207,7 @@ fi
 if test ${with_MPI_libs+y}
 then :
   withval=$with_MPI_libs; for mpi_lib in $withval; do
-    MPILIBS="$MPILIBS -l$mpi_lib"
+    MPILIBS+=" -l$mpi_lib"
  done;
  hypre_user_chose_mpi=yes
 
@@ -4219,7 +4219,7 @@ fi
 if test ${with_MPI_lib_dirs+y}
 then :
   withval=$with_MPI_lib_dirs; for mpi_lib_dir in $withval; do
-    MPILIBDIRS="-L$mpi_lib_dir $MPILIBDIRS"
+    MPILIBDIRS+=" -L$mpi_lib_dir"
  done;
  hypre_user_chose_mpi=yes
 
@@ -4304,7 +4304,7 @@ fi
 if test ${with_blas_lib+y}
 then :
   withval=$with_blas_lib; for blas_lib in $withval; do
-       BLASLIBS="$BLASLIBS $blas_lib"
+       BLASLIBS+=" $blas_lib"
  done;
  hypre_user_chose_blas=yes
 
@@ -4316,7 +4316,7 @@ fi
 if test ${with_blas_libs+y}
 then :
   withval=$with_blas_libs; for blas_lib in $withval; do
-    BLASLIBS="$BLASLIBS -l$blas_lib"
+    BLASLIBS+=" -l$blas_lib"
  done;
  hypre_user_chose_blas=yes
  hypre_blas_lib_old_style=yes
@@ -4329,7 +4329,7 @@ fi
 if test ${with_blas_lib_dirs+y}
 then :
   withval=$with_blas_lib_dirs; for blas_lib_dir in $withval; do
-    BLASLIBDIRS="-L$blas_lib_dir $BLASLIBDIRS"
+    BLASLIBDIRS+=" -L$blas_lib_dir"
  done;
  hypre_user_chose_blas=yes
  hypre_blas_lib_dir_old_style=yes
@@ -4343,7 +4343,7 @@ fi
 if test ${with_lapack_lib+y}
 then :
   withval=$with_lapack_lib; for lapack_lib in $withval; do
-       LAPACKLIBS="$LAPACKLIBS $lapack_lib"
+       LAPACKLIBS+=" $lapack_lib"
  done;
  hypre_user_chose_lapack=yes
 
@@ -4355,7 +4355,7 @@ fi
 if test ${with_lapack_libs+y}
 then :
   withval=$with_lapack_libs; for lapack_lib in $withval; do
-    LAPACKLIBS="$LAPACKLIBS -l$lapack_lib"
+    LAPACKLIBS+=" -l$lapack_lib"
  done;
  hypre_user_chose_lapack=yes
  hypre_lapack_lib_old_style=yes
@@ -4368,7 +4368,7 @@ fi
 if test ${with_lapack_lib_dirs+y}
 then :
   withval=$with_lapack_lib_dirs; for lapack_lib_dir in $withval; do
-    LAPACKLIBDIRS="-L$lapack_lib_dir $LAPACKLIBDIRS"
+    LAPACKLIBDIRS+=" -L$lapack_lib_dir"
  done;
  hypre_user_chose_lapack=yes
  hypre_lapack_lib_dir_old_style=yes
@@ -4540,7 +4540,7 @@ fi
 if test ${with_superlu_lib+y}
 then :
   withval=$with_superlu_lib; for superlu_lib in $withval; do
-    SUPERLU_LIBS="$SUPERLU_LIBS $superlu_lib"
+    SUPERLU_LIBS+=" $superlu_lib"
  done
 
 fi
@@ -4582,7 +4582,7 @@ fi
 if test ${with_dsuperlu_lib+y}
 then :
   withval=$with_dsuperlu_lib; for dsuperlu_lib in $withval; do
-    DSUPERLU_LIBS="$DSUPERLU_LIBS $dsuperlu_lib"
+    DSUPERLU_LIBS+=" $dsuperlu_lib"
  done
 
 fi
@@ -4970,7 +4970,7 @@ fi
 if test ${with_raja_lib+y}
 then :
   withval=$with_raja_lib; for raja_lib in $withval; do
-       HYPRE_RAJA_LIB="$raja_lib $HYPRE_RAJA_LIB"
+       HYPRE_RAJA_LIB+=" $raja_lib"
  done;
 hypre_user_chose_raja=yes
 
@@ -4982,7 +4982,7 @@ fi
 if test ${with_raja_libs+y}
 then :
   withval=$with_raja_libs; for raja_lib in $withval; do
-    HYPRE_RAJA_LIB="-l$raja_lib $HYPRE_RAJA_LIB"
+    HYPRE_RAJA_LIB+=" -l$raja_lib"
  done;
 hypre_user_chose_raja=yes
 
@@ -4994,7 +4994,7 @@ fi
 if test ${with_raja_lib_dirs+y}
 then :
   withval=$with_raja_lib_dirs; for raja_lib_dir in $withval; do
-    HYPRE_RAJA_LIB_DIR="-L$raja_lib_dir $HYPRE_RAJA_LIB_DIR"
+    HYPRE_RAJA_LIB_DIR+=" -L$raja_lib_dir"
  done;
  hypre_user_chose_raja=yes
 
@@ -5034,7 +5034,7 @@ fi
 if test ${with_kokkos_lib+y}
 then :
   withval=$with_kokkos_lib; for kokkos_lib in $withval; do
-       HYPRE_KOKKOS_LIB="$kokkos_lib $HYPRE_KOKKOS_LIB"
+       HYPRE_KOKKOS_LIB+=" $kokkos_lib"
  done;
 hypre_user_chose_kokkos=yes
 
@@ -5046,7 +5046,7 @@ fi
 if test ${with_kokkos_libs+y}
 then :
   withval=$with_kokkos_libs; for kokkos_lib in $withval; do
-    HYPRE_KOKKOS_LIB="-l$kokkos_lib $HYPRE_KOKKOS_LIB"
+    HYPRE_KOKKOS_LIB+=" -l$kokkos_lib"
  done;
 hypre_user_chose_kokkos=yes
 
@@ -5058,7 +5058,7 @@ fi
 if test ${with_kokkos_lib_dirs+y}
 then :
   withval=$with_kokkos_lib_dirs; for kokkos_lib_dir in $withval; do
-    HYPRE_KOKKOS_LIB_DIR="-L$kokkos_lib_dir $HYPRE_KOKKOS_LIB_DIR"
+    HYPRE_KOKKOS_LIB_DIR+=" -L$kokkos_lib_dir"
  done;
 hypre_user_chose_kokkos=yes
 
@@ -5157,7 +5157,7 @@ fi
 if test ${with_umpire_lib+y}
 then :
   withval=$with_umpire_lib; for umpire_lib in $withval; do
-       HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB $umpire_lib"
+       HYPRE_UMPIRE_LIB+=" $umpire_lib"
  done;
  hypre_user_gave_umpire_lib=yes
 
@@ -5169,7 +5169,7 @@ fi
 if test ${with_umpire_libs+y}
 then :
   withval=$with_umpire_libs; for umpire_lib in $withval; do
-    HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB -l$umpire_lib"
+    HYPRE_UMPIRE_LIB+=" -l$umpire_lib"
  done;
  hypre_user_gave_umpire_libs=yes
 
@@ -5181,8 +5181,8 @@ fi
 if test ${with_umpire_lib_dirs+y}
 then :
   withval=$with_umpire_lib_dirs; for umpire_lib_dir in $withval; do
-    HYPRE_UMPIRE_LIB_DIR="-L$umpire_lib_dir $HYPRE_UMPIRE_LIB_DIR"
-    HYPRE_UMPIRE_RPATH="${HYPRE_UMPIRE_RPATH} -Wl,-rpath,${umpire_lib_dir}"
+    HYPRE_UMPIRE_LIB_DIR+=" -L$umpire_lib_dir"
+    HYPRE_UMPIRE_RPATH+=" -Wl,-rpath,${umpire_lib_dir}"
  done;
  hypre_user_gave_umpire_lib_dirs=yes
 
@@ -5229,7 +5229,7 @@ fi
 if test ${with_magma_lib+y}
 then :
   withval=$with_magma_lib; for magma_lib in $withval; do
-    HYPRE_MAGMA_LIB="$magma_lib $HYPRE_MAGMA_LIB"
+    HYPRE_MAGMA_LIB+=" $magma_lib"
  done;
 hypre_user_gave_magma_lib=yes
 
@@ -5241,7 +5241,7 @@ fi
 if test ${with_magma_libs+y}
 then :
   withval=$with_magma_libs; for magma_lib in $withval; do
-    HYPRE_MAGMA_LIB="-l$magma_lib $HYPRE_MAGMA_LIB"
+    HYPRE_MAGMA_LIB+=" -l$magma_lib"
  done;
 hypre_user_gave_magma_libs=yes
 
@@ -5253,7 +5253,7 @@ fi
 if test ${with_magma_lib_dirs+y}
 then :
   withval=$with_magma_lib_dirs; for magma_lib_dir in $withval; do
-    HYPRE_MAGMA_LIB_DIR="-L$magma_lib_dir $HYPRE_MAGMA_LIB_DIR"
+    HYPRE_MAGMA_LIB_DIR+=" -L$magma_lib_dir"
  done;
 hypre_user_gave_magma_lib_dirs=yes
 
@@ -5298,7 +5298,7 @@ fi
 if test ${with_caliper_lib+y}
 then :
   withval=$with_caliper_lib; for caliper_lib in $withval; do
-    CALIPER_LIBS="$CALIPER_LIBS $caliper_lib"
+    CALIPER_LIBS+=" $caliper_lib"
  done;
  hypre_user_gave_caliper_lib=yes
 
@@ -8940,7 +8940,7 @@ else
 
 printf "%s\n" "#define HYPRE_HAVE_MPI 1" >>confdefs.h
 
-  LIBS="$LIBS $MPILIBS"
+  LIBS+=" $MPILIBS"
   :
 fi
 
@@ -9753,7 +9753,7 @@ fi
 printf "%s\n" "$ac_cv_lib_stdcpp___gxx_personality_v0" >&6; }
 if test "x$ac_cv_lib_stdcpp___gxx_personality_v0" = xyes
 then :
-  LIBS="$LIBS -lstdc++"
+  LIBS+=" -lstdc++"
 fi
 
 else
@@ -10084,7 +10084,7 @@ fi
 printf "%s\n" "$ac_cv_lib_m_cabs" >&6; }
 if test "x$ac_cv_lib_m_cabs" = xyes
 then :
-  LIBS="$LIBS -lm"
+  LIBS+=" -lm"
 fi
 
 
@@ -10759,6 +10759,8 @@ then
     if test "x$hypre_using_cuda" = "xyes" || test "x$hypre_using_hip" = "xyes"
     then
       hypre_using_umpire=yes
+      hypre_using_umpire_device=yes
+      hypre_using_umpire_um=yes
       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Enabling Umpire automatically for GPU build (CUDA/HIP) for performance and allocator features. Use --without-umpire to opt out." >&5
 printf "%s\n" "$as_me: Enabling Umpire automatically for GPU build (CUDA/HIP) for performance and allocator features. Use --without-umpire to opt out." >&6;}
     fi
@@ -10837,7 +10839,7 @@ However, Umpire include and/or library paths were not provided.
 Provide the following flags as appropriate:
   --with-umpire-include=\"/path-to-umpire-install/include\"
   --with-umpire-lib-dirs=\"/path-to-umpire-install/lib\"
-  --with-umpire-libs=\"umpire\"  or  --with-umpire-lib=\"-lumpire\"
+  --with-umpire-libs=\"umpire camp\"
 
 To opt out (not recommended), configure with --without-umpire.
 ===============================================================" "$LINENO" 5
@@ -11121,8 +11123,8 @@ else $as_nop
   as_fn_error $? "unable to find oneMKL ... Ensure that MKLROOT is set" "$LINENO" 5
 fi
 
-               HYPRE_SYCL_LIBS="${HYPRE_SYCL_LIBS} -qmkl -Wl,-export-dynamic -Wl,--start-group -Wl,--end-group -lsycl -lOpenCL -lpthread -lm -ldl"
-               HYPRE_SYCL_INCL="${HYPRE_SYCL_INCL} -qmkl -I${DPLROOT}/include -DMKL_ILP64 -I${MKLROOT}/include"
+               HYPRE_SYCL_LIBS+=" -qmkl -Wl,-export-dynamic -Wl,--start-group -Wl,--end-group -lsycl -lOpenCL -lpthread -lm -ldl"
+               HYPRE_SYCL_INCL+=" -qmkl -I${DPLROOT}/include -DMKL_ILP64 -I${MKLROOT}/include"
 
 fi
 

--- a/src/configure
+++ b/src/configure
@@ -5157,7 +5157,7 @@ fi
 if test ${with_umpire_lib+y}
 then :
   withval=$with_umpire_lib; for umpire_lib in $withval; do
-       HYPRE_UMPIRE_LIB="$umpire_lib $HYPRE_UMPIRE_LIB"
+       HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB $umpire_lib"
  done;
  hypre_user_gave_umpire_lib=yes
 
@@ -5169,7 +5169,7 @@ fi
 if test ${with_umpire_libs+y}
 then :
   withval=$with_umpire_libs; for umpire_lib in $withval; do
-    HYPRE_UMPIRE_LIB="-l$umpire_lib $HYPRE_UMPIRE_LIB"
+    HYPRE_UMPIRE_LIB="$HYPRE_UMPIRE_LIB -l$umpire_lib"
  done;
  hypre_user_gave_umpire_libs=yes
 

--- a/src/docs/usr-manual/ch-misc.rst
+++ b/src/docs/usr-manual/ch-misc.rst
@@ -499,10 +499,9 @@ follow these steps:
 
 .. code-block:: bash
 
-   git clone https://github.com/LLNL/Umpire.git
-   cd Umpire
-   git submodule update --init
+   git clone --recursive https://github.com/LLNL/Umpire.git
 
+   cd Umpire
    cmake -S . -B build \
      -DUMPIRE_ENABLE_C=ON \
      -DUMPIRE_ENABLE_TOOLS=OFF \
@@ -530,7 +529,7 @@ or provide it to hypre at configure time. For example:
 
    ./configure --with-umpire-include=/path-to-umpire-install/include \
                --with-umpire-lib-dirs=/path-to-umpire-install/lib \
-               --with-umpire-libs="camp umpire" \
+               --with-umpire-libs="umpire camp" \
 
 or with CMake:
 


### PR DESCRIPTION
Extends #1399 by @lindsayad 

- Preserve the order of library paths/files passed as input to configure
- Minor adjustments to the documentation