### PR TITLE
Fix HYPRE_Int -> HYPRE_BigInt

### DIFF
--- a/src/config/cmake/HYPRE_CMakeUtilities.cmake
+++ b/src/config/cmake/HYPRE_CMakeUtilities.cmake
@@ -778,6 +778,9 @@ function(maybe_build_umpire)
   set(ENABLE_HIP  ${HYPRE_ENABLE_HIP}  CACHE BOOL "Enable HIP in Umpire" FORCE)
   set(ENABLE_SYCL ${HYPRE_ENABLE_SYCL} CACHE BOOL "Enable SYCL in Umpire" FORCE)
 
+  # Rename Umpire's 'check' target to 'umpire_check' to avoid conflicts
+  set(BLT_CODE_CHECK_TARGET_NAME "umpire_check" CACHE STRING "Rename Umpire's check target" FORCE)
+
   # Ensure Umpire installs to the same prefix as hypre
   set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Install prefix" FORCE)
 

--- a/src/parcsr_ls/par_ge_device.c
+++ b/src/parcsr_ls/par_ge_device.c
@@ -32,7 +32,7 @@ hypre_GaussElimSetupDevice(hypre_ParAMGData *amg_data,
    HYPRE_Int           *A_piv           = hypre_ParAMGDataAPiv(amg_data);
    HYPRE_Real          *A_mat           = hypre_ParAMGDataAMat(amg_data);
    HYPRE_Real          *A_work          = hypre_ParAMGDataAWork(amg_data);
-   HYPRE_Int            global_size     = hypre_BigIntSafeMult(global_num_rows, global_num_rows);
+   HYPRE_Int            global_size     = hypre_IntSafeMult(global_num_rows, global_num_rows);
 
    /* Local variables */
    HYPRE_Int            buffer_size     = 0;

--- a/src/parcsr_ls/par_ge_device.c
+++ b/src/parcsr_ls/par_ge_device.c
@@ -32,7 +32,7 @@ hypre_GaussElimSetupDevice(hypre_ParAMGData *amg_data,
    HYPRE_Int           *A_piv           = hypre_ParAMGDataAPiv(amg_data);
    HYPRE_Real          *A_mat           = hypre_ParAMGDataAMat(amg_data);
    HYPRE_Real          *A_work          = hypre_ParAMGDataAWork(amg_data);
-   HYPRE_Int            global_size     = global_num_rows * global_num_rows;
+   HYPRE_Int            global_size     = hypre_BigIntSafeMult(global_num_rows, global_num_rows);
 
    /* Local variables */
    HYPRE_Int            buffer_size     = 0;
@@ -46,7 +46,7 @@ hypre_GaussElimSetupDevice(hypre_ParAMGData *amg_data,
       return hypre_error_flag;
    }
 
-   if (global_size < 0)
+   if (global_size == HYPRE_BIG_INT_MAX)
    {
       hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Detected overflow!");
       return hypre_error_flag;

--- a/src/parcsr_ls/par_ge_device.c
+++ b/src/parcsr_ls/par_ge_device.c
@@ -46,7 +46,7 @@ hypre_GaussElimSetupDevice(hypre_ParAMGData *amg_data,
       return hypre_error_flag;
    }
 
-   if (global_size == HYPRE_BIG_INT_MAX)
+   if (global_size == HYPRE_INT_MAX)
    {
       hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Detected overflow!");
       return hypre_error_flag;

--- a/src/parcsr_ls/par_ge_device.c
+++ b/src/parcsr_ls/par_ge_device.c
@@ -27,12 +27,12 @@ hypre_GaussElimSetupDevice(hypre_ParAMGData *amg_data,
 {
    /* Input data */
    hypre_ParCSRMatrix  *par_A           = hypre_ParAMGDataAArray(amg_data)[level];
-   HYPRE_Int            global_num_rows = (HYPRE_Int) hypre_ParCSRMatrixGlobalNumRows(par_A);
+   HYPRE_BigInt         global_num_rows = hypre_ParCSRMatrixGlobalNumRows(par_A);
    HYPRE_Int            num_rows        = hypre_ParCSRMatrixNumRows(par_A);
    HYPRE_Int           *A_piv           = hypre_ParAMGDataAPiv(amg_data);
    HYPRE_Real          *A_mat           = hypre_ParAMGDataAMat(amg_data);
    HYPRE_Real          *A_work          = hypre_ParAMGDataAWork(amg_data);
-   HYPRE_Int            global_size     = hypre_IntSafeMult(global_num_rows, global_num_rows);
+   HYPRE_BigInt         global_size     = hypre_squared(global_num_rows);
 
    /* Local variables */
    HYPRE_Int            buffer_size     = 0;
@@ -43,12 +43,6 @@ hypre_GaussElimSetupDevice(hypre_ParAMGData *amg_data,
    /* Sanity checks */
    if (!num_rows || !global_size)
    {
-      return hypre_error_flag;
-   }
-
-   if (global_size == HYPRE_INT_MAX)
-   {
-      hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Detected overflow!");
       return hypre_error_flag;
    }
 

--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -94,38 +94,6 @@ typedef int HYPRE_Int;
 #define HYPRE_INT_MIN INT_MIN
 #endif
 
-static inline HYPRE_Int
-hypre_IntSafeMult(HYPRE_Int a, HYPRE_Int b)
-{
-   if (a == 0 || b == 0)
-   {
-      return 0;
-   }
-
-   if (a > HYPRE_INT_MAX / b)
-   {
-      return HYPRE_INT_MAX;
-   }
-
-   return a * b;
-}
-
-static inline HYPRE_BigInt
-hypre_BigIntSafeMult(HYPRE_BigInt a, HYPRE_BigInt b)
-{
-   if (a == 0 || b == 0)
-   {
-      return 0;
-   }
-
-   if (a > HYPRE_BIG_INT_MAX / b)
-   {
-      return HYPRE_BIG_INT_MAX;
-   }
-
-   return a * b;
-}
-
 /*--------------------------------------------------------------------------
  * Real and Complex Types
  *--------------------------------------------------------------------------*/

--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -94,6 +94,22 @@ typedef int HYPRE_Int;
 #define HYPRE_INT_MIN INT_MIN
 #endif
 
+static inline HYPRE_Int
+hypre_IntSafeMult(HYPRE_Int a, HYPRE_Int b)
+{
+   if (a == 0 || b == 0)
+   {
+      return 0;
+   }
+
+   if (a > HYPRE_INT_MAX / b)
+   {
+      return HYPRE_INT_MAX;
+   }
+
+   return a * b;
+}
+
 static inline HYPRE_BigInt
 hypre_BigIntSafeMult(HYPRE_BigInt a, HYPRE_BigInt b)
 {

--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -94,6 +94,22 @@ typedef int HYPRE_Int;
 #define HYPRE_INT_MIN INT_MIN
 #endif
 
+static inline HYPRE_BigInt
+hypre_BigIntSafeMult(HYPRE_BigInt a, HYPRE_BigInt b)
+{
+   if (a == 0 || b == 0)
+   {
+      return 0;
+   }
+
+   if (a > HYPRE_BIG_INT_MAX / b)
+   {
+      return HYPRE_BIG_INT_MAX;
+   }
+
+   return a * b;
+}
+
 /*--------------------------------------------------------------------------
  * Real and Complex Types
  *--------------------------------------------------------------------------*/


### PR DESCRIPTION
~~Adds `hypre_(Big)IntSafeMult` for multiplying two HYPRE_(Big)Ints safely, i.e., guaranteeing that overflow doesn't occur.  If multiplying the operands would lead to overflow, the function returns `HYPRE_(BIG_)INT_MAX` and lets the caller decide how to handle the error~~

Fix variable from HYPRE_Int to HYPRE_BigInt

Closes #1407 