### PR TITLE
Fix for host exec with device build

### DIFF
--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -441,7 +441,12 @@ hypre_SStructPMatrixSetBoxValues( hypre_SStructPMatrix *pmatrix,
 
    /* TODO: Why need DeviceSync? */
 #if defined(HYPRE_USING_GPU)
-   hypre_SyncDevice();
+   HYPRE_MemoryLocation loc;
+   HYPRE_GetMemoryLocation(&loc);
+   if (loc == HYPRE_EXEC_DEVICE)
+   {
+      hypre_SyncDevice();
+   }
 #endif
 
    /* set (AddTo/Get) or clear (Set) values outside the grid in ghost zones */

--- a/src/sstruct_mv/sstruct_vector.c
+++ b/src/sstruct_mv/sstruct_vector.c
@@ -247,7 +247,12 @@ hypre_SStructPVectorSetBoxValues( hypre_SStructPVector *pvector,
 
    /* TODO: Why need DeviceSync? */
 #if defined(HYPRE_USING_GPU)
-   hypre_SyncDevice();
+   HYPRE_MemoryLocation loc;
+   HYPRE_GetMemoryLocation(&loc);
+   if (loc == HYPRE_EXEC_DEVICE)
+   {
+      hypre_SyncDevice();
+   }
 #endif
 
    /* set (AddTo/Get) or clear (Set) values outside the grid in ghost zones */


### PR DESCRIPTION
Only `hypre_SyncDevice` if the exec policy is device, otherwise we initialize the device context for a host-only run