### PR TITLE
Fix for host execution with device build

### DIFF
--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -441,7 +441,12 @@ hypre_SStructPMatrixSetBoxValues( hypre_SStructPMatrix *pmatrix,
 
    /* TODO: Why need DeviceSync? */
 #if defined(HYPRE_USING_GPU)
-   hypre_SyncDevice();
+   HYPRE_MemoryLocation loc;
+   HYPRE_GetMemoryLocation(&loc);
+   if (loc == HYPRE_EXEC_DEVICE)
+   {
+      hypre_SyncDevice();
+   }
 #endif
 
    /* set (AddTo/Get) or clear (Set) values outside the grid in ghost zones */

--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -441,9 +441,7 @@ hypre_SStructPMatrixSetBoxValues( hypre_SStructPMatrix *pmatrix,
 
    /* TODO: Why need DeviceSync? */
 #if defined(HYPRE_USING_GPU)
-   HYPRE_MemoryLocation loc;
-   HYPRE_GetMemoryLocation(&loc);
-   if (loc == HYPRE_EXEC_DEVICE)
+   if (hypre_GetExecPolicy1(hypre_StructMatrixMemoryLocation(smatrix)) == HYPRE_EXEC_DEVICE)
    {
       hypre_SyncDevice();
    }

--- a/src/sstruct_mv/sstruct_vector.c
+++ b/src/sstruct_mv/sstruct_vector.c
@@ -247,9 +247,7 @@ hypre_SStructPVectorSetBoxValues( hypre_SStructPVector *pvector,
 
    /* TODO: Why need DeviceSync? */
 #if defined(HYPRE_USING_GPU)
-   HYPRE_MemoryLocation loc;
-   HYPRE_GetMemoryLocation(&loc);
-   if (loc == HYPRE_EXEC_DEVICE)
+   if (hypre_GetExecPolicy1(hypre_StructVectorMemoryLocation(svector)) == HYPRE_EXEC_DEVICE)
    {
       hypre_SyncDevice();
    }

--- a/src/sstruct_mv/sstruct_vector.c
+++ b/src/sstruct_mv/sstruct_vector.c
@@ -247,7 +247,12 @@ hypre_SStructPVectorSetBoxValues( hypre_SStructPVector *pvector,
 
    /* TODO: Why need DeviceSync? */
 #if defined(HYPRE_USING_GPU)
-   hypre_SyncDevice();
+   HYPRE_MemoryLocation loc;
+   HYPRE_GetMemoryLocation(&loc);
+   if (loc == HYPRE_EXEC_DEVICE)
+   {
+      hypre_SyncDevice();
+   }
 #endif
 
    /* set (AddTo/Get) or clear (Set) values outside the grid in ghost zones */


### PR DESCRIPTION
Extends #1427 

Main goal is to run device synchronization only when GPUs are used.

cc: @tomstitt 

Question to @liruipeng: I see we have a `TODO` comment questioning whether the sync call is needed, do you any thoughts?