### PR TITLE
Fix mixed precision build in shared mode

### DIFF
--- a/AUTOTEST/machine-tux.sh
+++ b/AUTOTEST/machine-tux.sh
@@ -142,6 +142,10 @@ co="--enable-debug --enable-mixed-precision"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $ro
 ./renametest.sh basic $output_dir/basic--mixed-precision
 
+co="--enable-debug --enable-mixed-precision --enable-shared"
+./test.sh basic.sh $src_dir -co: $co -mo: $mo
+./renametest.sh basic $output_dir/basic--mixed-precision-shared
+
 co="--enable-mixedint --enable-debug"
 RO="-ams -ij-mixed -sstruct-mixed -struct -lobpcg-mixed"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -ro: $RO
@@ -188,6 +192,10 @@ co="-DHYPRE_BIGINT=ON"
 co="-DCMAKE_BUILD_TYPE=Debug -DHYPRE_ENABLE_MIXED_PRECISION=ON"
 ./test.sh cmake.sh $root_dir -co: $co -mo: $mo
 ./renametest.sh cmake $output_dir/cmake-mixed-precision
+
+co="-DCMAKE_BUILD_TYPE=Debug -DHYPRE_ENABLE_MIXED_PRECISION=ON -DBUILD_SHARED_LIBS=ON"
+./test.sh cmake.sh $root_dir -co: $co -mo: $mo
+./renametest.sh cmake $output_dir/cmake-mixed-precision-shared
 
 # cmake build doesn't currently support maxdim
 # cmake build doesn't currently support complex

--- a/src/config/cmake/HYPRE_CMakeUtilities.cmake
+++ b/src/config/cmake/HYPRE_CMakeUtilities.cmake
@@ -1228,6 +1228,13 @@ macro(setup_mixed_precision_compilation module_name)
       ${CMAKE_SOURCE_DIR}/matrix_matrix
       ${CMAKE_SOURCE_DIR}/multivector
     )
+    # Set position independent code for shared library builds
+    # Object libraries need explicit -fPIC when used in shared libraries
+    if(BUILD_SHARED_LIBS)
+      set_target_properties(${module_name}_${precision} PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+      )
+    endif()
     # Link to MPI if it's enabled
     if(HYPRE_ENABLE_MPI)
       target_link_libraries(${module_name}_${precision} PRIVATE MPI::MPI_C)

--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -1729,11 +1729,7 @@ typedef struct
 
 } hypre_TimingType;
 
-#ifdef HYPRE_TIMING_GLOBALS
-hypre_TimingType *hypre_global_timing = NULL;
-#else
 extern hypre_TimingType *hypre_global_timing;
-#endif
 
 /*-------------------------------------------------------
  * Accessor functions

--- a/src/utilities/timing.c
+++ b/src/utilities/timing.c
@@ -12,9 +12,14 @@
  *****************************************************************************/
 
 #define HYPRE_TIMING
-#define HYPRE_TIMING_GLOBALS
 #include "_hypre_utilities.h"
 #include "timing.h"
+
+/* Global variable for timing */
+/* guard definition of global variables to avoid linker errors for multiprecision build */
+#if defined (hypre_DEFINE_GLOBAL)
+hypre_TimingType *hypre_global_timing = NULL;
+#endif
 
 /*-------------------------------------------------------
  * Timing macros

--- a/src/utilities/timing.h
+++ b/src/utilities/timing.h
@@ -88,11 +88,7 @@ typedef struct
 
 } hypre_TimingType;
 
-#ifdef HYPRE_TIMING_GLOBALS
-hypre_TimingType *hypre_global_timing = NULL;
-#else
 extern hypre_TimingType *hypre_global_timing;
-#endif
 
 /*-------------------------------------------------------
  * Accessor functions


### PR DESCRIPTION
Fix build issues (both on CMake and autotools builds)

See PETSc issue: https://gitlab.com/petsc/petsc/-/issues/1828

cc: @balay 

```
[100%] Linking C shared library lib/libHYPRE.so
/usr/bin/ld: utilities/CMakeFiles/utilities_dbl.dir/timing.c.o:(.bss+0x0): multiple definition of `hypre_global_timing'; utilities/CMakeFiles/utilities_flt.dir/timing.c.o:(.bss+0x0): first defined here
/usr/bin/ld: utilities/CMakeFiles/utilities_ldbl.dir/timing.c.o:(.bss+0x0): multiple definition of `hypre_global_timing'; utilities/CMakeFiles/utilities_flt.dir/timing.c.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/HYPRE.dir/build.make:5141: lib/libHYPRE.so.3.0.0] Error 1
make[1]: *** [CMakeFiles/Makefile2:599: CMakeFiles/HYPRE.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

```
[100%] Linking C shared library lib/libHYPRE.so
/usr/bin/ld: utilities/CMakeFiles/utilities_ldbl.dir/state.c.o: warning: relocation against `hypre__global_state' in read-only section `.text'
/usr/bin/ld: struct_mv/CMakeFiles/struct_mv_flt.dir/box_ds.c.o: relocation R_X86_64_PC32 against symbol `hypre__global_error' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/HYPRE.dir/build.make:5141: lib/libHYPRE.so.3.0.0] Error 1
make[1]: *** [CMakeFiles/Makefile2:599: CMakeFiles/HYPRE.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```