### PR TITLE
Casts to avoid overflow of 32-bit integers before casting to uint64

### DIFF
--- a/src/multivector/seq_multivector.c
+++ b/src/multivector/seq_multivector.c
@@ -53,8 +53,9 @@ hypre_SeqMultivectorInitialize( hypre_Multivector *mvector )
    num_vectors = hypre_MultivectorNumVectors(mvector);
 
    if (NULL == hypre_MultivectorData(mvector))
+      /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
       hypre_MultivectorData(mvector) =
-         hypre_TAlloc(HYPRE_Complex, size * num_vectors, HYPRE_MEMORY_HOST);
+         hypre_TAlloc(HYPRE_Complex, (size_t)size * (size_t)num_vectors, HYPRE_MEMORY_HOST);
 
    /* now we create a "mask" of "active" vectors; initially all active */
    if (NULL == mvector->active_indices)

--- a/src/parcsr_ls/par_krylov_func.c
+++ b/src/parcsr_ls/par_krylov_func.c
@@ -76,7 +76,8 @@ hypre_ParKrylovCreateVectorArray(HYPRE_Int n, void *vvector )
 
    size = hypre_VectorSize(hypre_ParVectorLocalVector(vector));
    num_vectors = hypre_VectorNumVectors(hypre_ParVectorLocalVector(vector));
-   array_data = hypre_CTAlloc(HYPRE_Complex, (n * size * num_vectors), memory_location);
+   /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
+   array_data = hypre_CTAlloc(HYPRE_Complex, ((size_t)n * (size_t)size * (size_t)num_vectors), memory_location);
    new_vector = hypre_CTAlloc(hypre_ParVector*, n, HYPRE_MEMORY_HOST);
    for (i = 0; i < n; i++)
    {

--- a/src/seq_mv/vector.c
+++ b/src/seq_mv/vector.c
@@ -314,8 +314,8 @@ hypre_SeqVectorInitialize_v2( hypre_Vector         *vector,
     * when being used, and freed */
    if (!hypre_VectorData(vector))
    {
-      hypre_assert((num_vectors * size) >= 0);
-      hypre_VectorData(vector) = hypre_CTAlloc(HYPRE_Complex, num_vectors * size, memory_location);
+      /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
+      hypre_VectorData(vector) = hypre_CTAlloc(HYPRE_Complex, (size_t)num_vectors * (size_t)size, memory_location);
    }
 
    return hypre_error_flag;
@@ -378,8 +378,9 @@ hypre_SeqVectorResize( hypre_Vector *vector,
    HYPRE_Int  method        = hypre_VectorMultiVecStorageMethod(vector);
    HYPRE_Int  size          = hypre_VectorSize(vector);
    HYPRE_Int  num_vectors   = hypre_VectorNumVectors(vector);
-   HYPRE_Int  total_size    = num_vectors * size;
-   HYPRE_Int  total_size_in = num_vectors_in * size_in;
+   /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
+   size_t     total_size    = (size_t)num_vectors * (size_t)size;
+   size_t     total_size_in = (size_t)num_vectors_in * (size_t)size_in;
 
    /* Reallocate data array */
    if (total_size_in > total_size)

--- a/src/seq_mv/vector_device.c
+++ b/src/seq_mv/vector_device.c
@@ -29,7 +29,8 @@ hypre_SeqVectorSetConstantValuesDevice( hypre_Vector *v,
    HYPRE_Complex *vector_data = hypre_VectorData(v);
    HYPRE_Int      num_vectors = hypre_VectorNumVectors(v);
    HYPRE_Int      size        = hypre_VectorSize(v);
-   HYPRE_Int      total_size  = size * num_vectors;
+   /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
+   size_t         total_size  = (size_t)size * (size_t)num_vectors;
 
    //hypre_SeqVectorPrefetch(v, HYPRE_MEMORY_DEVICE);
 
@@ -90,7 +91,8 @@ hypre_SeqVectorScaleDevice( HYPRE_Complex alpha,
    HYPRE_Complex *y_data      = hypre_VectorData(y);
    HYPRE_Int      num_vectors = hypre_VectorNumVectors(y);
    HYPRE_Int      size        = hypre_VectorSize(y);
-   HYPRE_Int      total_size  = size * num_vectors;
+   /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
+   size_t         total_size  = (size_t)size * (size_t)num_vectors;
 
    hypre_GpuProfilingPushRange("SeqVectorScale");
    //hypre_SeqVectorPrefetch(y, HYPRE_MEMORY_DEVICE);
@@ -138,7 +140,8 @@ hypre_SeqVectorAxpyDevice( HYPRE_Complex alpha,
    HYPRE_Complex *y_data      = hypre_VectorData(y);
    HYPRE_Int      num_vectors = hypre_VectorNumVectors(x);
    HYPRE_Int      size        = hypre_VectorSize(x);
-   HYPRE_Int      total_size  = size * num_vectors;
+   /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
+   size_t         total_size  = (size_t)size * (size_t)num_vectors;
 
 #if defined(HYPRE_USING_GPU)
 
@@ -186,7 +189,8 @@ hypre_SeqVectorAxpyzDevice( HYPRE_Complex  alpha,
 
    HYPRE_Int       num_vectors = hypre_VectorNumVectors(x);
    HYPRE_Int       size        = hypre_VectorSize(x);
-   HYPRE_Int       total_size  = size * num_vectors;
+   /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
+   size_t          total_size  = (size_t)size * (size_t)num_vectors;
 
 #if defined(HYPRE_USING_GPU)
    hypreDevice_ComplexAxpyzn(total_size, x_data, y_data, z_data, alpha, beta);
@@ -291,7 +295,8 @@ hypre_SeqVectorInnerProdDevice( hypre_Vector *x,
    HYPRE_Complex *y_data      = hypre_VectorData(y);
    HYPRE_Int      num_vectors = hypre_VectorNumVectors(x);
    HYPRE_Int      size        = hypre_VectorSize(x);
-   HYPRE_Int      total_size  = size * num_vectors;
+   /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
+   size_t         total_size  = (size_t)size * (size_t)num_vectors;
 
    HYPRE_Real     result = 0.0;
 
@@ -346,7 +351,8 @@ hypre_SeqVectorSumEltsDevice( hypre_Vector *vector )
    HYPRE_Complex  *data        = hypre_VectorData(vector);
    HYPRE_Int       num_vectors = hypre_VectorNumVectors(vector);
    HYPRE_Int       size        = hypre_VectorSize(vector);
-   HYPRE_Int       total_size  = size * num_vectors;
+   /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
+   size_t          total_size  = (size_t)size * (size_t)num_vectors;
    HYPRE_Complex   sum = 0.0;
 
 #if defined(HYPRE_USING_GPU)
@@ -415,7 +421,8 @@ hypre_SeqVectorPrefetch( hypre_Vector        *x,
    HYPRE_Complex  *x_data      = hypre_VectorData(x);
    HYPRE_Int       num_vectors = hypre_VectorNumVectors(x);
    HYPRE_Int       size        = hypre_VectorSize(x);
-   HYPRE_Int       total_size  = size * num_vectors;
+   /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
+   size_t          total_size  = (size_t)size * (size_t)num_vectors;
 
    if (total_size == 0)
    {


### PR DESCRIPTION
I came across this issue when running larger solves on GPUs. The error was in `par_krylov_func.c`
```
array_data = hypre_CTAlloc(HYPRE_Complex, (n * size * num_vectors), memory_location);
```
The expression `n * size * num_vectors` overflowed, leading to undefined behavior and crashes. I found a number of other places where this could possibly happen and fixed them as well, but they are less likely because they don't have the extra `n` parameter.