### PR TITLE
Fix Thrust iterator type mismatch in par_ge_device.c

### DIFF
--- a/src/parcsr_ls/par_ge_device.c
+++ b/src/parcsr_ls/par_ge_device.c
@@ -163,7 +163,7 @@ hypre_GaussElimSetupDevice(hypre_ParAMGData *amg_data,
                    (size_t) global_size * sizeof(HYPRE_Real),
                    HYPRE_MEMORY_DEVICE);
       HYPRE_THRUST_CALL(for_each,
-                        thrust::make_counting_iterator(0),
+                        thrust::make_counting_iterator((HYPRE_BigInt)0),
                         thrust::make_counting_iterator(global_num_rows),
                         hypreFunctor_DenseMatrixIdentity(global_num_rows, A_work));
 


### PR DESCRIPTION
Cast literal 0 to `HYPRE_BigInt` in `thrust::make_counting_iterator` call to match the type of `global_num_rows` iterator. This solves the following CUDA compilation error:

```cpp
/data/home/gbozzola/palace/g5/extern/hypre/src/parcsr_ls/par_ge_device.c(165): error: no instance of overloaded function "thrust::for_each" matches the argument list
            argument types are: (thrust::THRUST_200802_SM_860_NS::detail::execute_with_allocator<hypre_device_allocator &, thrust::THRUST_200802_SM_860_NS::cuda_cub::execute_on_stream_base>, thrust::THRUST_200802_SM_860_NS::counting_iterator<int, thrust::THRUST_200802_SM_860_NS::use_default, thrust::THRUST_200802_SM_860_NS::use_default, thrust::THRUST_200802_SM_860_NS::use_default>, thrust::THRUST_200802_SM_860_NS::counting_iterator<HYPRE_BigInt, thrust::THRUST_200802_SM_860_NS::use_default, thrust::THRUST_200802_SM_860_NS::use_default, thrust::THRUST_200802_SM_860_NS::use_default>, hypreFunctor_DenseMatrixIdentity)
        thrust::for_each(thrust::cuda::par(((((hypre_handle()) -> device_data)) -> device_allocator)).on(hypre_DeviceDataComputeStream(((hypre_handle()) -> device_data))), thrust::make_counting_iterator(0), thrust::make_counting_iterator(global_num_rows), hypreFunctor_DenseMatrixIdentity(global_num_rows, A_work));
        ^
/usr/local/cuda/targets/x86_64-linux/include/thrust/detail/for_each.inl(38): note #3327-D: candidate function template "thrust::THRUST_200802_SM_860_NS::for_each(const thrust::THRUST_200802_SM_860_NS::detail::execution_policy_base<DerivedPolicy> &, InputIterator, InputIterator, UnaryFunction)" failed deduction
  __attribute__((host)) __attribute__((device)) InputIterator for_each(
                                                              ^
/usr/local/cuda/targets/x86_64-linux/include/thrust/detail/for_each.inl(50): note #3322-D: number of parameters of function template "thrust::THRUST_200802_SM_860_NS::for_each(InputIterator, InputIterator, UnaryFunction)" does not match the call
  InputIterator for_each(InputIterator first, InputIterator last, UnaryFunction f)
                ^
```