### PR TITLE
Update SuperLU interface + MGR

### DIFF
--- a/AUTOTEST/machine-tux.sh
+++ b/AUTOTEST/machine-tux.sh
@@ -104,7 +104,7 @@ co="--enable-maxdim=4 --enable-debug"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -eo: -maxdim
 ./renametest.sh basic $output_dir/basic--enable-maxdim=4
 
-co="--enable-complex --enable-maxdim=4 --enable-debug"
+co="--enable-complex --enable-maxdim=4 --enable-debug --with-extra-CFLAGS='-Wno-incompatible-pointer-types'"
 ./test.sh basic.sh $src_dir -co: $co -mo: $mo -eo: -complex
 # ignore complex compiler output for now
 rm -fr basic.dir/make.???

--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -2931,10 +2931,12 @@ HYPRE_Int hypre_BoomerAMGBuildRestrNeumannAIRDevice( hypre_ParCSRMatrix *A, HYPR
 HYPRE_Int hypre_BoomerAMGCFMarkerTo1minus1Device( HYPRE_Int *CF_marker, HYPRE_Int size );
 
 #ifdef HYPRE_USING_DSUPERLU
-/* superlu.c */
-HYPRE_Int hypre_SLUDistSetup( HYPRE_Solver *solver, hypre_ParCSRMatrix *A, HYPRE_Int print_level);
-HYPRE_Int hypre_SLUDistSolve( void* solver, hypre_ParVector *b, hypre_ParVector *x);
-HYPRE_Int hypre_SLUDistDestroy( void* solver);
+/* dsuperlu.c */
+void *hypre_SLUDistCreate( void );
+HYPRE_Int hypre_SLUDistSetPrintLevel( void *solver, HYPRE_Int print_level );
+HYPRE_Int hypre_SLUDistSetup( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b, hypre_ParVector *x );
+HYPRE_Int hypre_SLUDistSolve( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b, hypre_ParVector *x );
+HYPRE_Int hypre_SLUDistDestroy( void *solver );
 #endif
 
 /* par_mgr.c */

--- a/src/parcsr_ls/dsuperlu.c
+++ b/src/parcsr_ls/dsuperlu.c
@@ -6,43 +6,79 @@
  ******************************************************************************/
 
 #include "_hypre_parcsr_ls.h"
-#include <math.h>
 
 #ifdef HYPRE_USING_DSUPERLU
 #include "dsuperlu.h"
 
-#include <math.h>
-#include "superlu_ddefs.h"
-/*
-#ifndef hypre_DSLU_DATA_HEADER
-#define hypre_DSLU_DATA_HEADER
+/*--------------------------------------------------------------------------
+ * hypre_SLUDistCreate
+ *--------------------------------------------------------------------------*/
 
-typedef struct
+void *
+hypre_SLUDistCreate(void)
 {
-   HYPRE_BigInt global_num_rows;
-   SuperMatrix A_dslu;
-   HYPRE_Real *berr;
-   dLUstruct_t dslu_data_LU;
-   SuperLUStat_t dslu_data_stat;
-   superlu_dist_options_t dslu_options;
-   gridinfo_t dslu_data_grid;
-   dScalePermstruct_t dslu_ScalePermstruct;
-   dSOLVEstruct_t dslu_solve;
-}
-hypre_DSLUData;
+   hypre_DSLUData *dslu_data;
+   hypre_Solver   *base;
 
-#endif
-*/
+   dslu_data = hypre_CTAlloc(hypre_DSLUData, 1, HYPRE_MEMORY_HOST);
+   base      = (hypre_Solver *) dslu_data;
+
+   /* Initialize base solver function pointers first */
+   hypre_SolverSetup(base)   = NULL;
+   hypre_SolverSolve(base)   = NULL;
+   hypre_SolverDestroy(base) = NULL;
+
+   /* Set base solver function pointers */
+   hypre_SolverSetup(base)   = (HYPRE_PtrToSolverFcn)  hypre_SLUDistSetup;
+   hypre_SolverSolve(base)   = (HYPRE_PtrToSolverFcn)  hypre_SLUDistSolve;
+   hypre_SolverDestroy(base) = (HYPRE_PtrToDestroyFcn) hypre_SLUDistDestroy;
+
+   /* Initialize all fields */
+   hypre_DSLUDataGlobalNumRows(dslu_data) = 0;
+   hypre_DSLUDataA(dslu_data) = NULL;
+   hypre_DSLUDataBerr(dslu_data) = NULL;
+   hypre_DSLUDataLU(dslu_data) = NULL;
+   hypre_DSLUDataStat(dslu_data) = NULL;
+   hypre_DSLUDataOptions(dslu_data) = NULL;
+   hypre_DSLUDataGrid(dslu_data) = NULL;
+   hypre_DSLUDataScalePermstruct(dslu_data) = NULL;
+   hypre_DSLUDataSolve(dslu_data) = NULL;
+   hypre_DSLUDataPrintLevel(dslu_data) = 0;
+
+   return (void*) dslu_data;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_SLUDistSetPrintLevel
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_SLUDistSetPrintLevel(void      *solver,
+                           HYPRE_Int  print_level)
+{
+   hypre_DSLUData *dslu_data = (hypre_DSLUData *) solver;
+
+   if (dslu_data)
+   {
+      hypre_DSLUDataPrintLevel(dslu_data) = print_level;
+   }
+
+   return hypre_error_flag;
+}
 
 /*--------------------------------------------------------------------------
  * hypre_SLUDistSetup
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_SLUDistSetup(HYPRE_Solver       *solver,
+hypre_SLUDistSetup(void               *solver,
                    hypre_ParCSRMatrix *A,
-                   HYPRE_Int           print_level)
+                   hypre_ParVector    *b,
+                   hypre_ParVector    *x)
 {
+   HYPRE_UNUSED_VAR(b);
+   HYPRE_UNUSED_VAR(x);
+
    /* Par Data Structure variables */
    HYPRE_BigInt       global_num_rows = hypre_ParCSRMatrixGlobalNumRows(A);
    MPI_Comm           comm            = hypre_ParCSRMatrixComm(A);
@@ -50,7 +86,7 @@ hypre_SLUDistSetup(HYPRE_Solver       *solver,
 
    HYPRE_Int          pcols = 1;
    HYPRE_Int          prows = 1;
-   hypre_DSLUData    *dslu_data = NULL;
+   hypre_DSLUData    *dslu_data = (hypre_DSLUData *) solver;
    HYPRE_Int          nrhs = 0;
 
    HYPRE_Int          num_rows;
@@ -65,11 +101,6 @@ hypre_SLUDistSetup(HYPRE_Solver       *solver,
 
    hypre_MPI_Comm_size(comm, &num_procs);
    hypre_MPI_Comm_rank(comm, &my_id);
-
-   /* destroy solver if already setup */
-   //   if (solver != NULL) { hypre_SLUDistDestroy(solver); }
-   /* allocate memory for new solver */
-   dslu_data = hypre_CTAlloc(hypre_DSLUData, 1, HYPRE_MEMORY_HOST);
 
    /* Merge diag and offd into one matrix (global ids) */
    A_local = hypre_MergeDiagAndOffd(A);
@@ -126,8 +157,9 @@ hypre_SLUDistSetup(HYPRE_Solver       *solver,
    }
 
    /* Now convert hypre matrix to a SuperMatrix */
+   hypre_DSLUDataA(dslu_data) = hypre_CTAlloc(SuperMatrix, 1, HYPRE_MEMORY_HOST);
    dCreate_CompRowLoc_Matrix_dist(
-      &(dslu_data->A_dslu),
+      hypre_DSLUDataA(dslu_data),
       (int_t) global_num_rows,
       (int_t) global_num_rows,
       (int_t) hypre_CSRMatrixNumNonzeros(A_local),
@@ -154,6 +186,14 @@ hypre_SLUDistSetup(HYPRE_Solver       *solver,
    }
    hypre_CSRMatrixDestroy(A_local);
 
+   /* Allocate SuperLU structures */
+   hypre_DSLUDataGrid(dslu_data) = hypre_CTAlloc(gridinfo_t, 1, HYPRE_MEMORY_HOST);
+   hypre_DSLUDataOptions(dslu_data) = hypre_CTAlloc(superlu_dist_options_t, 1, HYPRE_MEMORY_HOST);
+   hypre_DSLUDataScalePermstruct(dslu_data) = hypre_CTAlloc(dScalePermstruct_t, 1, HYPRE_MEMORY_HOST);
+   hypre_DSLUDataLU(dslu_data) = hypre_CTAlloc(dLUstruct_t, 1, HYPRE_MEMORY_HOST);
+   hypre_DSLUDataStat(dslu_data) = hypre_CTAlloc(SuperLUStat_t, 1, HYPRE_MEMORY_HOST);
+   hypre_DSLUDataSolve(dslu_data) = hypre_CTAlloc(dSOLVEstruct_t, 1, HYPRE_MEMORY_HOST);
+
    /* Create process grid */
    while (prows * pcols <= num_procs) { ++prows; }
    --prows;
@@ -165,35 +205,42 @@ hypre_SLUDistSetup(HYPRE_Solver       *solver,
    }
    //hypre_printf(" prows %d pcols %d\n", prows, pcols);
 
-   superlu_gridinit(comm, prows, pcols, &(dslu_data->dslu_data_grid));
+   superlu_gridinit(comm, prows, pcols, hypre_DSLUDataGrid(dslu_data));
 
-   set_default_options_dist(&(dslu_data->dslu_options));
+   set_default_options_dist(hypre_DSLUDataOptions(dslu_data));
 
-   dslu_data->dslu_options.Fact = DOFACT;
-   if (print_level == 0 || print_level == 2) { dslu_data->dslu_options.PrintStat = NO; }
-   /*dslu_data->dslu_options.IterRefine = SLU_DOUBLE;
-   dslu_data->dslu_options.ColPerm = MMD_AT_PLUS_A;
-   dslu_data->dslu_options.DiagPivotThresh = 1.0;
-   dslu_data->dslu_options.ReplaceTinyPivot = NO; */
+   hypre_DSLUDataOptions(dslu_data)->Fact = DOFACT;
+   if (hypre_DSLUDataPrintLevel(dslu_data) == 0 || hypre_DSLUDataPrintLevel(dslu_data) == 2)
+   {
+      hypre_DSLUDataOptions(dslu_data)->PrintStat = NO;
+   }
+   /*hypre_DSLUDataOptions(dslu_data)->IterRefine = SLU_DOUBLE;
+   hypre_DSLUDataOptions(dslu_data)->ColPerm = MMD_AT_PLUS_A;
+   hypre_DSLUDataOptions(dslu_data)->DiagPivotThresh = 1.0;
+   hypre_DSLUDataOptions(dslu_data)->ReplaceTinyPivot = NO; */
 
-   dScalePermstructInit(global_num_rows, global_num_rows, &(dslu_data->dslu_ScalePermstruct));
+   dScalePermstructInit(global_num_rows, global_num_rows, hypre_DSLUDataScalePermstruct(dslu_data));
 
-   dLUstructInit(global_num_rows, &(dslu_data->dslu_data_LU));
+   dLUstructInit(global_num_rows, hypre_DSLUDataLU(dslu_data));
 
-   PStatInit(&(dslu_data->dslu_data_stat));
+   PStatInit(hypre_DSLUDataStat(dslu_data));
 
-   dslu_data->global_num_rows = global_num_rows;
+   hypre_DSLUDataGlobalNumRows(dslu_data) = global_num_rows;
 
-   dslu_data->berr = hypre_CTAlloc(HYPRE_Real, 1, HYPRE_MEMORY_HOST);
-   dslu_data->berr[0] = 0.0;
+   hypre_DSLUDataBerr(dslu_data) = hypre_CTAlloc(HYPRE_Real, 1, HYPRE_MEMORY_HOST);
 
-   pdgssvx(&(dslu_data->dslu_options), &(dslu_data->A_dslu),
-           &(dslu_data->dslu_ScalePermstruct), NULL, num_rows, nrhs,
-           &(dslu_data->dslu_data_grid), &(dslu_data->dslu_data_LU),
-           &(dslu_data->dslu_solve), dslu_data->berr, &(dslu_data->dslu_data_stat), &slu_info);
+   pdgssvx(hypre_DSLUDataOptions(dslu_data),
+           hypre_DSLUDataA(dslu_data),
+           hypre_DSLUDataScalePermstruct(dslu_data),
+           NULL, num_rows, nrhs,
+           hypre_DSLUDataGrid(dslu_data),
+           hypre_DSLUDataLU(dslu_data),
+           hypre_DSLUDataSolve(dslu_data),
+           hypre_DSLUDataBerr(dslu_data),
+           hypre_DSLUDataStat(dslu_data),
+           &slu_info);
 
-   dslu_data->dslu_options.Fact = FACTORED;
-   *solver = (HYPRE_Solver) dslu_data;
+   hypre_DSLUDataOptions(dslu_data)->Fact = FACTORED;
 
    return hypre_error_flag;
 }
@@ -203,10 +250,13 @@ hypre_SLUDistSetup(HYPRE_Solver       *solver,
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_SLUDistSolve(void            *solver,
-                   hypre_ParVector *b,
-                   hypre_ParVector *x)
+hypre_SLUDistSolve(void               *solver,
+                   hypre_ParCSRMatrix *A,
+                   hypre_ParVector    *b,
+                   hypre_ParVector    *x)
 {
+   HYPRE_UNUSED_VAR(A);
+
    hypre_DSLUData  *dslu_data = (hypre_DSLUData *) solver;
    HYPRE_Real      *x_data;
    HYPRE_Int        size = hypre_VectorSize(hypre_ParVectorLocalVector(x));
@@ -246,17 +296,17 @@ hypre_SLUDistSolve(void            *solver,
       slu_data = (hypre_double*) x_data;
    }
 
-   pdgssvx(&(dslu_data->dslu_options),
-           &(dslu_data->A_dslu),
-           &(dslu_data->dslu_ScalePermstruct),
+   pdgssvx(hypre_DSLUDataOptions(dslu_data),
+           hypre_DSLUDataA(dslu_data),
+           hypre_DSLUDataScalePermstruct(dslu_data),
            slu_data,
            (int_t) size,
            (int_t) nrhs,
-           &(dslu_data->dslu_data_grid),
-           &(dslu_data->dslu_data_LU),
-           &(dslu_data->dslu_solve),
-           dslu_data->berr,
-           &(dslu_data->dslu_data_stat),
+           hypre_DSLUDataGrid(dslu_data),
+           hypre_DSLUDataLU(dslu_data),
+           hypre_DSLUDataSolve(dslu_data),
+           hypre_DSLUDataBerr(dslu_data),
+           hypre_DSLUDataStat(dslu_data),
            &slu_info);
 
    /* Free memory */
@@ -281,25 +331,47 @@ hypre_SLUDistSolve(void            *solver,
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_SLUDistDestroy(void* solver)
+hypre_SLUDistDestroy(void *solver)
 {
    hypre_DSLUData *dslu_data = (hypre_DSLUData *) solver;
 
    if (dslu_data)
    {
-      PStatFree(&(dslu_data->dslu_data_stat));
-      Destroy_CompRowLoc_Matrix_dist(&(dslu_data->A_dslu));
-      dScalePermstructFree(&(dslu_data->dslu_ScalePermstruct));
-      dDestroy_LU(dslu_data->global_num_rows,
-                  &(dslu_data->dslu_data_grid),
-                  &(dslu_data->dslu_data_LU));
-      dLUstructFree(&(dslu_data->dslu_data_LU));
-      if (dslu_data->dslu_options.SolveInitialized)
+      if (hypre_DSLUDataStat(dslu_data))
       {
-         dSolveFinalize(&(dslu_data->dslu_options), &(dslu_data->dslu_solve));
+         PStatFree(hypre_DSLUDataStat(dslu_data));
       }
-      superlu_gridexit(&(dslu_data->dslu_data_grid));
-      hypre_TFree(dslu_data->berr, HYPRE_MEMORY_HOST);
+      if (hypre_DSLUDataA(dslu_data))
+      {
+         Destroy_CompRowLoc_Matrix_dist(hypre_DSLUDataA(dslu_data));
+      }
+      if (hypre_DSLUDataScalePermstruct(dslu_data))
+      {
+         dScalePermstructFree(hypre_DSLUDataScalePermstruct(dslu_data));
+      }
+      if (hypre_DSLUDataLU(dslu_data) && hypre_DSLUDataGrid(dslu_data))
+      {
+         dDestroy_LU(hypre_DSLUDataGlobalNumRows(dslu_data),
+                     hypre_DSLUDataGrid(dslu_data),
+                     hypre_DSLUDataLU(dslu_data));
+         dLUstructFree(hypre_DSLUDataLU(dslu_data));
+      }
+      if (hypre_DSLUDataOptions(dslu_data) && hypre_DSLUDataOptions(dslu_data)->SolveInitialized)
+      {
+         dSolveFinalize(hypre_DSLUDataOptions(dslu_data), hypre_DSLUDataSolve(dslu_data));
+      }
+      if (hypre_DSLUDataGrid(dslu_data))
+      {
+         superlu_gridexit(hypre_DSLUDataGrid(dslu_data));
+      }
+      hypre_TFree(hypre_DSLUDataA(dslu_data), HYPRE_MEMORY_HOST);
+      hypre_TFree(hypre_DSLUDataGrid(dslu_data), HYPRE_MEMORY_HOST);
+      hypre_TFree(hypre_DSLUDataOptions(dslu_data), HYPRE_MEMORY_HOST);
+      hypre_TFree(hypre_DSLUDataScalePermstruct(dslu_data), HYPRE_MEMORY_HOST);
+      hypre_TFree(hypre_DSLUDataLU(dslu_data), HYPRE_MEMORY_HOST);
+      hypre_TFree(hypre_DSLUDataStat(dslu_data), HYPRE_MEMORY_HOST);
+      hypre_TFree(hypre_DSLUDataSolve(dslu_data), HYPRE_MEMORY_HOST);
+      hypre_TFree(hypre_DSLUDataBerr(dslu_data), HYPRE_MEMORY_HOST);
       hypre_TFree(dslu_data, HYPRE_MEMORY_HOST);
    }
 

--- a/src/parcsr_ls/dsuperlu.h
+++ b/src/parcsr_ls/dsuperlu.h
@@ -16,15 +16,33 @@
 
 typedef struct
 {
+   /* Base solver data structure */
+   hypre_Solver            base;
+   HYPRE_Int               print_level;
    HYPRE_BigInt            global_num_rows;
-   SuperMatrix             A_dslu;
+   SuperMatrix            *A_dslu;
    hypre_double           *berr;
-   dLUstruct_t             dslu_data_LU;
-   SuperLUStat_t           dslu_data_stat;
-   superlu_dist_options_t  dslu_options;
-   gridinfo_t              dslu_data_grid;
-   dScalePermstruct_t      dslu_ScalePermstruct;
-   dSOLVEstruct_t          dslu_solve;
+   dLUstruct_t            *dslu_data_LU;
+   SuperLUStat_t          *dslu_data_stat;
+   superlu_dist_options_t *dslu_options;
+   gridinfo_t             *dslu_data_grid;
+   dScalePermstruct_t     *dslu_ScalePermstruct;
+   dSOLVEstruct_t         *dslu_solve;
 } hypre_DSLUData;
+
+/*--------------------------------------------------------------------------
+ * Accessor macros
+ *--------------------------------------------------------------------------*/
+
+#define hypre_DSLUDataPrintLevel(data)           ((data) -> print_level)
+#define hypre_DSLUDataGlobalNumRows(data)        ((data) -> global_num_rows)
+#define hypre_DSLUDataA(data)                    ((data) -> A_dslu)
+#define hypre_DSLUDataBerr(data)                 ((data) -> berr)
+#define hypre_DSLUDataLU(data)                   ((data) -> dslu_data_LU)
+#define hypre_DSLUDataStat(data)                 ((data) -> dslu_data_stat)
+#define hypre_DSLUDataOptions(data)              ((data) -> dslu_options)
+#define hypre_DSLUDataGrid(data)                 ((data) -> dslu_data_grid)
+#define hypre_DSLUDataScalePermstruct(data)      ((data) -> dslu_ScalePermstruct)
+#define hypre_DSLUDataSolve(data)                ((data) -> dslu_solve)
 
 #endif

--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -3152,8 +3152,9 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
             (coarse_size > (HYPRE_BigInt)coarse_threshold) &&
             (level != max_levels - 1))
    {
-      HYPRE_Solver dslu_solver;
-      hypre_SLUDistSetup(&dslu_solver, A_array[level], amg_print_level);
+      HYPRE_Solver dslu_solver = hypre_SLUDistCreate();
+      hypre_SLUDistSetPrintLevel(dslu_solver, amg_print_level);
+      hypre_SLUDistSetup(dslu_solver, A_array[level], NULL, NULL);
       hypre_ParAMGDataDSLUSolver(amg_data) = dslu_solver;
    }
 #endif

--- a/src/parcsr_ls/par_cycle.c
+++ b/src/parcsr_ls/par_cycle.c
@@ -367,11 +367,11 @@ hypre_BoomerAMGCycle( void              *amg_vdata,
          hypre_GpuProfilingPopRange();
       }
 #ifdef HYPRE_USING_DSUPERLU
-      else if (cycle_param == 3 && hypre_ParAMGDataDSLUSolver(amg_data) != NULL)
+      else if (cycle_param == 3 && hypre_ParAMGDataCoarseSolver(amg_data) != NULL)
       {
          HYPRE_ANNOTATE_REGION_BEGIN("%s", "Coarse solve");
          hypre_GpuProfilingPushRange("Coarse solve");
-         hypre_SLUDistSolve(hypre_ParAMGDataDSLUSolver(amg_data), Aux_F, Aux_U);
+         hypre_SLUDistSolve(hypre_ParAMGDataDSLUSolver(amg_data), NULL, Aux_F, Aux_U);
          HYPRE_ANNOTATE_REGION_END("%s", "Coarse solve");
          hypre_GpuProfilingPopRange();
       }

--- a/src/parcsr_ls/par_mgr.h
+++ b/src/parcsr_ls/par_mgr.h
@@ -47,7 +47,7 @@ typedef struct
 
    hypre_ParVector     **F_fine_array;
    hypre_ParVector     **U_fine_array;
-   HYPRE_Solver        **aff_solver;
+   HYPRE_Solver         *aff_solver;
    HYPRE_Int           (*fine_grid_solver_setup)(void*, void*, void*, void*);
    HYPRE_Int           (*fine_grid_solver_solve)(void*, void*, void*, void*);
 

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -1326,15 +1326,9 @@ hypre_MGRSetup( void               *mgr_vdata,
             aff_solver[lev] = (HYPRE_Solver) hypre_BoomerAMGCreate();
             hypre_BoomerAMGSetMaxIter(aff_solver[lev], (mgr_data -> num_relax_sweeps)[lev]);
             hypre_BoomerAMGSetTol(aff_solver[lev], 0.0);
-            //hypre_BoomerAMGSetStrongThreshold(aff_solver[lev], 0.6);
-#if defined(HYPRE_USING_GPU)
-            hypre_BoomerAMGSetRelaxType(aff_solver[lev], 18);
-            hypre_BoomerAMGSetCoarsenType(aff_solver[lev], 8);
-            hypre_BoomerAMGSetNumSweeps(aff_solver[lev], 3);
-#else
+#if !defined(HYPRE_USING_GPU)
             hypre_BoomerAMGSetRelaxOrder(aff_solver[lev], 1);
 #endif
-            hypre_BoomerAMGSetPrintLevel(aff_solver[lev], mgr_data -> frelax_print_level);
 
             /* Call setup function */
             aff_base = (hypre_Solver*) aff_solver[lev];
@@ -1351,11 +1345,11 @@ hypre_MGRSetup( void               *mgr_vdata,
             A_ff_array[lev] = A_FF;
 
             /* Create direct solver */
-            aff_solver[lev] = hypre_MGRDirectSolverCreate();
+            aff_solver[lev] = (HYPRE_Solver) hypre_MGRDirectSolverCreate();
 
             /* Call setup function through base solver interface */
             aff_base = (hypre_Solver*) aff_solver[lev];
-            hypre_SolverSetup(aff_base)(aff_solver[lev],
+            hypre_SolverSetup(aff_base)((HYPRE_Solver) aff_solver[lev],
                                         (HYPRE_Matrix) A_ff_array[lev],
                                         (HYPRE_Vector) F_fine_array[lev + 1],
                                         (HYPRE_Vector) U_fine_array[lev + 1]);

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -85,7 +85,7 @@ hypre_MGRSetup( void               *mgr_vdata,
    hypre_ParCSRMatrix  *A_CC = NULL;
 
    hypre_Solver         *aff_base;
-   HYPRE_Solver        **aff_solver = (mgr_data -> aff_solver);
+   HYPRE_Solver         *aff_solver = (mgr_data -> aff_solver);
    hypre_ParCSRMatrix  **A_ff_array = (mgr_data -> A_ff_array);
    hypre_ParVector     **F_fine_array = (mgr_data -> F_fine_array);
    hypre_ParVector     **U_fine_array = (mgr_data -> U_fine_array);
@@ -885,21 +885,24 @@ hypre_MGRSetup( void               *mgr_vdata,
    {
       for (j = 1; j < (old_num_coarse_levels); j++)
       {
-         if ((mgr_data -> Frelax_type)[i] == 29)
+         if (aff_solver[j])
          {
-            hypre_MGRDirectSolverDestroy(aff_solver[j]);
-            aff_solver[j] = NULL;
-         }
-         else if (aff_solver[j])
-         {
-            aff_base = (hypre_Solver*) aff_solver[j];
-            hypre_SolverDestroy(aff_base)((HYPRE_Solver) (aff_base));
+            if ((mgr_data -> Frelax_type)[i] == 29)
+            {
+               hypre_MGRDirectSolverDestroy(aff_solver[j]);
+            }
+            else
+            {
+               aff_base = (hypre_Solver*) aff_solver[j];
+               hypre_SolverDestroy(aff_base)((HYPRE_Solver) (aff_base));
+            }
             aff_solver[j] = NULL;
          }
       }
-      if (mgr_data -> fsolver_mode == 2)
+      if (mgr_data -> fsolver_mode == 2 && aff_solver[0])
       {
          hypre_BoomerAMGDestroy(aff_solver[0]);
+         aff_solver[0] = NULL;
       }
    }
 
@@ -952,7 +955,7 @@ hypre_MGRSetup( void               *mgr_vdata,
    }
    if (aff_solver == NULL)
    {
-      aff_solver = hypre_CTAlloc(HYPRE_Solver*, max_num_coarse_levels, HYPRE_MEMORY_HOST);
+      aff_solver = hypre_CTAlloc(HYPRE_Solver, max_num_coarse_levels, HYPRE_MEMORY_HOST);
    }
    if (A_ff_array == NULL)
    {
@@ -1261,7 +1264,7 @@ hypre_MGRSetup( void               *mgr_vdata,
          {
             if (Frelax_type[lev] == 2 || Frelax_type[lev] == 32)
             {
-               if (Frelax_type[lev] == 2 && ((hypre_ParAMGData*)aff_solver[lev])->A_array != NULL)
+               if (Frelax_type[lev] == 2 && aff_solver[lev] && ((hypre_ParAMGData*)aff_solver[lev])->A_array != NULL)
                {
                   if (((hypre_ParAMGData*)aff_solver[lev])->A_array[0] != NULL)
                   {
@@ -1320,7 +1323,7 @@ hypre_MGRSetup( void               *mgr_vdata,
             A_ff_array[lev] = A_FF;
 
             /* Create BoomerAMG solver for A_FF */
-            aff_solver[lev] = (HYPRE_Solver*) hypre_BoomerAMGCreate();
+            aff_solver[lev] = (HYPRE_Solver) hypre_BoomerAMGCreate();
             hypre_BoomerAMGSetMaxIter(aff_solver[lev], (mgr_data -> num_relax_sweeps)[lev]);
             hypre_BoomerAMGSetTol(aff_solver[lev], 0.0);
             //hypre_BoomerAMGSetStrongThreshold(aff_solver[lev], 0.6);
@@ -1347,11 +1350,15 @@ hypre_MGRSetup( void               *mgr_vdata,
             /* Save A_FF splitting */
             A_ff_array[lev] = A_FF;
 
-            /* Call setup function */
-            hypre_MGRDirectSolverSetup(&aff_solver[lev],
-                                       A_ff_array[lev],
-                                       F_fine_array[lev + 1],
-                                       U_fine_array[lev + 1]);
+            /* Create direct solver */
+            aff_solver[lev] = hypre_MGRDirectSolverCreate();
+
+            /* Call setup function through base solver interface */
+            aff_base = (hypre_Solver*) aff_solver[lev];
+            hypre_SolverSetup(aff_base)(aff_solver[lev],
+                                        (HYPRE_Matrix) A_ff_array[lev],
+                                        (HYPRE_Vector) F_fine_array[lev + 1],
+                                        (HYPRE_Vector) U_fine_array[lev + 1]);
          }
          else if (Frelax_type[lev] == 32) /* Construct default ILU solver */
          {
@@ -1359,8 +1366,8 @@ hypre_MGRSetup( void               *mgr_vdata,
             A_ff_array[lev] = A_FF;
 
             /* Create ILU solver for A_FF */
-            aff_solver[lev] = (HYPRE_Solver*) hypre_ILUCreate();
-            HYPRE_ILUSetLocalReordering(*aff_solver[lev], 0);
+            aff_solver[lev] = (HYPRE_Solver) hypre_ILUCreate();
+            HYPRE_ILUSetLocalReordering(aff_solver[lev], 0);
 
             /* Call setup function */
             aff_base = (hypre_Solver*) aff_solver[lev];

--- a/src/parcsr_ls/par_mgr_solve.c
+++ b/src/parcsr_ls/par_mgr_solve.c
@@ -1027,10 +1027,11 @@ hypre_MGRCycle( void              *mgr_vdata,
             }
             else if (Frelax_type[level] == 29)
             {
-               hypre_MGRDirectSolverSolve((mgr_data -> aff_solver)[level],
-                                          A_ff_array[level],
-                                          F_fine_array[coarse_grid],
-                                          U_fine_array[coarse_grid]);
+               aff_base = (hypre_Solver*) (mgr_data -> aff_solver)[level];
+               hypre_SolverSolve(aff_base)((mgr_data -> aff_solver)[level],
+                                           (HYPRE_Matrix) A_ff_array[level],
+                                           (HYPRE_Vector) F_fine_array[coarse_grid],
+                                           (HYPRE_Vector) U_fine_array[coarse_grid]);
             }
             else
             {

--- a/src/parcsr_ls/par_mgr_stats.c
+++ b/src/parcsr_ls/par_mgr_stats.c
@@ -270,7 +270,7 @@ hypre_MGRSetupStats(void *mgr_vdata)
    hypre_ParCSRMatrix        *A_coarsest      = hypre_ParMGRDataRAP(mgr_data);
    HYPRE_Int                  num_levels_mgr  = hypre_ParMGRDataNumCoarseLevels(mgr_data);
    HYPRE_Solver               coarse_solver   = hypre_ParMGRDataCoarseGridSolver(mgr_data);
-   HYPRE_Solver             **A_FF_solver     = hypre_ParMGRDataAFFsolver(mgr_data);
+   HYPRE_Solver              *A_FF_solver     = hypre_ParMGRDataAFFsolver(mgr_data);
    HYPRE_Int                 *Frelax_type     = hypre_ParMGRDataFRelaxType(mgr_data);
    HYPRE_Int                  block_size      = hypre_ParMGRDataBlockSize(mgr_data);
    HYPRE_Int                 *block_num_Cpts  = hypre_ParMGRDataBlockNumCoarseIndexes(mgr_data);

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -1389,10 +1389,12 @@ HYPRE_Int hypre_BoomerAMGBuildRestrNeumannAIRDevice( hypre_ParCSRMatrix *A, HYPR
 HYPRE_Int hypre_BoomerAMGCFMarkerTo1minus1Device( HYPRE_Int *CF_marker, HYPRE_Int size );
 
 #ifdef HYPRE_USING_DSUPERLU
-/* superlu.c */
-HYPRE_Int hypre_SLUDistSetup( HYPRE_Solver *solver, hypre_ParCSRMatrix *A, HYPRE_Int print_level);
-HYPRE_Int hypre_SLUDistSolve( void* solver, hypre_ParVector *b, hypre_ParVector *x);
-HYPRE_Int hypre_SLUDistDestroy( void* solver);
+/* dsuperlu.c */
+void *hypre_SLUDistCreate( void );
+HYPRE_Int hypre_SLUDistSetPrintLevel( void *solver, HYPRE_Int print_level );
+HYPRE_Int hypre_SLUDistSetup( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b, hypre_ParVector *x );
+HYPRE_Int hypre_SLUDistSolve( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b, hypre_ParVector *x );
+HYPRE_Int hypre_SLUDistDestroy( void *solver );
 #endif
 
 /* par_mgr.c */


### PR DESCRIPTION
The main goal of this PR is to conform the interface to SuperLU_Dist with the general solver structure in hypre. Particularly:

- Add `hypre_SLUDistCreate` for creating the solver object
- Change the `hypre_DSLUData` struct members to pointers
- Remove `print_level` from `hypre_SLUDistSetup` and create a dedicate `hypre_SLUDistSetPrintLevel`
- Update the setup/solve `hypre_SLUDist` function signatures to take A, b, and x
- Update SuperLU_Dist and `aff_solver` usage in MGR to reflect the above changes