### PR TITLE
Fix incorrect handling of rows in `hypre_ParCSRMatrixGenerateFFFC`

### DIFF
--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -2934,8 +2934,10 @@ HYPRE_Int hypre_BoomerAMGCFMarkerTo1minus1Device( HYPRE_Int *CF_marker, HYPRE_In
 /* dsuperlu.c */
 void *hypre_SLUDistCreate( void );
 HYPRE_Int hypre_SLUDistSetPrintLevel( void *solver, HYPRE_Int print_level );
-HYPRE_Int hypre_SLUDistSetup( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b, hypre_ParVector *x );
-HYPRE_Int hypre_SLUDistSolve( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b, hypre_ParVector *x );
+HYPRE_Int hypre_SLUDistSetup( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b,
+                              hypre_ParVector *x );
+HYPRE_Int hypre_SLUDistSolve( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b,
+                              hypre_ParVector *x );
 HYPRE_Int hypre_SLUDistDestroy( void *solver );
 #endif
 

--- a/src/parcsr_ls/par_cycle.c
+++ b/src/parcsr_ls/par_cycle.c
@@ -367,7 +367,7 @@ hypre_BoomerAMGCycle( void              *amg_vdata,
          hypre_GpuProfilingPopRange();
       }
 #ifdef HYPRE_USING_DSUPERLU
-      else if (cycle_param == 3 && hypre_ParAMGDataCoarseSolver(amg_data) != NULL)
+      else if (cycle_param == 3 && hypre_ParAMGDataDSLUSolver(amg_data) != NULL)
       {
          HYPRE_ANNOTATE_REGION_BEGIN("%s", "Coarse solve");
          hypre_GpuProfilingPushRange("Coarse solve");

--- a/src/parcsr_ls/par_krylov_func.c
+++ b/src/parcsr_ls/par_krylov_func.c
@@ -77,7 +77,8 @@ hypre_ParKrylovCreateVectorArray(HYPRE_Int n, void *vvector )
    size = hypre_VectorSize(hypre_ParVectorLocalVector(vector));
    num_vectors = hypre_VectorNumVectors(hypre_ParVectorLocalVector(vector));
    /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
-   array_data = hypre_CTAlloc(HYPRE_Complex, ((size_t)n * (size_t)size * (size_t)num_vectors), memory_location);
+   array_data = hypre_CTAlloc(HYPRE_Complex, ((size_t)n * (size_t)size * (size_t)num_vectors),
+                              memory_location);
    new_vector = hypre_CTAlloc(hypre_ParVector*, n, HYPRE_MEMORY_HOST);
    for (i = 0; i < n; i++)
    {

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -1264,7 +1264,8 @@ hypre_MGRSetup( void               *mgr_vdata,
          {
             if (Frelax_type[lev] == 2 || Frelax_type[lev] == 32)
             {
-               if (Frelax_type[lev] == 2 && aff_solver[lev] && ((hypre_ParAMGData*)aff_solver[lev])->A_array != NULL)
+               if (Frelax_type[lev] == 2 && aff_solver[lev] &&
+                   ((hypre_ParAMGData*)aff_solver[lev])->A_array != NULL)
                {
                   if (((hypre_ParAMGData*)aff_solver[lev])->A_array[0] != NULL)
                   {

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -1392,8 +1392,10 @@ HYPRE_Int hypre_BoomerAMGCFMarkerTo1minus1Device( HYPRE_Int *CF_marker, HYPRE_In
 /* dsuperlu.c */
 void *hypre_SLUDistCreate( void );
 HYPRE_Int hypre_SLUDistSetPrintLevel( void *solver, HYPRE_Int print_level );
-HYPRE_Int hypre_SLUDistSetup( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b, hypre_ParVector *x );
-HYPRE_Int hypre_SLUDistSolve( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b, hypre_ParVector *x );
+HYPRE_Int hypre_SLUDistSetup( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b,
+                              hypre_ParVector *x );
+HYPRE_Int hypre_SLUDistSolve( void *solver, hypre_ParCSRMatrix *A, hypre_ParVector *b,
+                              hypre_ParVector *x );
 HYPRE_Int hypre_SLUDistDestroy( void *solver );
 #endif
 

--- a/src/parcsr_mv/gen_fffc.c
+++ b/src/parcsr_mv/gen_fffc.c
@@ -299,7 +299,11 @@ hypre_ParCSRMatrixGenerateFFFCHost( hypre_ParCSRMatrix  *A,
          if (CF_marker[i] < 0)
          {
             row++;
-            d_count_FF++; /* account for diagonal element */
+            /* account for diagonal element if it exists */
+            if (A_diag_i[i] < A_diag_i[i + 1] && A_diag_j[A_diag_i[i]] == i)
+            {
+               d_count_FF++;
+            }
             for (j = S_diag_i[i] + skip_diag; j < S_diag_i[i + 1]; j++)
             {
                jj = S_diag_j[j];
@@ -381,9 +385,13 @@ hypre_ParCSRMatrixGenerateFFFCHost( hypre_ParCSRMatrix  *A,
          {
             HYPRE_Int jS, jA;
             row++;
+            /* copy diagonal element if it exists */
             jA = A_diag_i[i];
-            A_FF_diag_j[d_count_FF] = fine_to_fine[A_diag_j[jA]];
-            A_FF_diag_data[d_count_FF++] = A_diag_data[jA++];
+            if (jA < A_diag_i[i + 1] && A_diag_j[jA] == i)
+            {
+               A_FF_diag_j[d_count_FF] = fine_to_fine[A_diag_j[jA]];
+               A_FF_diag_data[d_count_FF++] = A_diag_data[jA];
+            }
             for (j = S_diag_i[i] + skip_diag; j < S_diag_i[i + 1]; j++)
             {
                jA = A_diag_i[i] + 1;

--- a/src/seq_mv/vector.c
+++ b/src/seq_mv/vector.c
@@ -315,7 +315,8 @@ hypre_SeqVectorInitialize_v2( hypre_Vector         *vector,
    if (!hypre_VectorData(vector))
    {
       /* Cast to size_t before multiplication to avoid integer overflow when HYPRE_Int is 32-bit */
-      hypre_VectorData(vector) = hypre_CTAlloc(HYPRE_Complex, (size_t)num_vectors * (size_t)size, memory_location);
+      hypre_VectorData(vector) = hypre_CTAlloc(HYPRE_Complex, (size_t)num_vectors * (size_t)size,
+                                               memory_location);
    }
 
    return hypre_error_flag;

--- a/src/utilities/general.c
+++ b/src/utilities/general.c
@@ -375,7 +375,7 @@ HYPRE_DeviceInitialize(void)
       {
          hypre_HandleDeviceUVM(handle) = 1;
       }
-  }
+   }
 
 #endif
 


### PR DESCRIPTION
Fixes a bug in `hypre_ParCSRMatrixGenerateFFFCHost` where the code assumed that when `S == A`, the diagonal is always the first entry in each row. For rows without a diagonal, this skipped the first off-diagonal entry, causing missing entries in `A_CF` and `A_FC`.