### PR TITLE
MinGW-w64: fix undefined ffs() in src/utilities/_hypre_utilities.h

### DIFF
--- a/src/utilities/_hypre_utilities.h
+++ b/src/utilities/_hypre_utilities.h
@@ -2678,6 +2678,8 @@ first_lsb_bit_indx( hypre_uint x )
          x >>= 1;
       }
    }
+#elif defined(__MINGW32__)
+   pos = __builtin_ffs((hypre_int) x);
 #else
    pos = ffs((hypre_int) x);
 #endif


### PR DESCRIPTION
Fix undefined ffs() in src/utilities/_hypre_utilities.h when building with MinGW-w64.