### PR TITLE
Fix option tables in SSAMG docs

### DIFF
--- a/src/sstruct_ls/HYPRE_sstruct_ls.h
+++ b/src/sstruct_ls/HYPRE_sstruct_ls.h
@@ -316,10 +316,8 @@ HYPRE_SStructSSAMGSetRelChange(HYPRE_SStructSolver solver,
  *
  * Current operators set by {\tt rap\_type} are:
  *
- * \begin{tabular}{l@{ -- }l}
- * 0 & Galerkin (default) \\
- * 1 & non-Galerkin 5-pt or 7-pt stencils \\
- * \end{tabular}
+ *    - 0 : Galerkin (default)
+ *    - 1 : non-Galerkin 5-pt or 7-pt stencils
  *
  * Both operators are constructed algebraically. The non-Galerkin option
  * maintains a 5-pt stencil in 2D and a 7-pt stencil in 3D on all grid levels.
@@ -349,10 +347,8 @@ HYPRE_SStructSSAMGSetNonZeroGuess(HYPRE_SStructSolver solver);
  *
  * Current interpolation methods set by {\tt interp\_type} are:
  *
- * \begin{tabular}{l@{ -- }l}
- * -1  & Structured interpolation only (default) \\
- *  0  & Structured and classical modified unstructured interpolation \\
- * \end{tabular}
+ *    - -1 : Structured interpolation only (default)
+ *    -  0 : Structured and classical modified unstructured interpolation
  **/
 HYPRE_Int
 HYPRE_SStructSSAMGSetInterpType(HYPRE_SStructSolver solver,
@@ -363,12 +359,10 @@ HYPRE_SStructSSAMGSetInterpType(HYPRE_SStructSolver solver,
  *
  * Current relaxation methods set by {\tt relax\_type} are:
  *
- * \begin{tabular}{l@{ -- }l}
- * 0  & Jacobi \\
- * 1  & Weighted Jacobi (default) \\
- * 2  & L1-Jacobi \\
- * 10 & Red/Black Gauss-Seidel (symmetric: RB pre-relaxation, BR post-relaxation) \\
- * \end{tabular}
+ *    - 0  : Jacobi
+ *    - 1  : Weighted Jacobi (default)
+ *    - 2  : L1-Jacobi
+ *    - 10 : Red/Black Gauss-Seidel (symmetric: RB pre-relaxation, BR post-relaxation)
  **/
 HYPRE_Int
 HYPRE_SStructSSAMGSetRelaxType(HYPRE_SStructSolver solver,
@@ -421,10 +415,8 @@ HYPRE_SStructSSAMGSetMaxCoarseSize(HYPRE_SStructSolver solver,
 
 /**
  * (Optional) Set coarse solver type for SSAMG. Current options are
- * \begin{tabular}{l@{ -- }l}
- * 0 & Weighted Jacobi (default) \\
- * 1 & BoomerAMG \\
- * \end{tabular}
+ *    - 0 : Weighted Jacobi (default)
+ *    - 1 : BoomerAMG
  **/
 HYPRE_Int
 HYPRE_SStructSSAMGSetCoarseSolverType(HYPRE_SStructSolver solver,

--- a/src/sstruct_ls/ssamg.c
+++ b/src/sstruct_ls/ssamg.c
@@ -29,7 +29,7 @@ hypre_SSAMGCreate( hypre_MPI_Comm comm )
    (ssamg_data -> non_galerkin)     = 0;
    (ssamg_data -> zero_guess)       = 0;
    (ssamg_data -> max_levels)       = 0;
-   (ssamg_data -> relax_type)       = 0;
+   (ssamg_data -> relax_type)       = 1;
    (ssamg_data -> interp_type)      = 0;
    (ssamg_data -> skip_relax)       = 0;
    (ssamg_data -> usr_relax_weight) = 1.0;

--- a/src/test/sstruct.c
+++ b/src/test/sstruct.c
@@ -2312,13 +2312,19 @@ PrintUsage( char *progname,
       hypre_printf("  -interp <r>        : SSAMG unstructured interpolation type\n");
       hypre_printf("                       -1 - No unstructured interpolation\n");
       hypre_printf("                        0 - Classical modified interpolation\n");
-      hypre_printf("  -relax <r>         : (S)Struct - relaxation type\n");
+      hypre_printf("  -relax <r>         : (Sys)PFMG - relaxation type\n");
       hypre_printf("                        0 - Jacobi\n");
       hypre_printf("                        1 - Weighted Jacobi (default)\n");
       hypre_printf("                        2 - R/B Gauss-Seidel\n");
       hypre_printf("                        3 - R/B Gauss-Seidel (nonsymmetric)\n");
       hypre_printf("\n");
-      hypre_printf("                       ParCSR - relaxation type\n");
+      hypre_printf("                       SSAMG - relaxation type\n");
+      hypre_printf("                        0 - Jacobi\n");
+      hypre_printf("                        1 - Weighted Jacobi (default)\n");
+      hypre_printf("                        2 - L1 Jacobi\n");
+      hypre_printf("                       10 - symmetric R/B Gauss-Seidel\n");
+      hypre_printf("\n");
+      hypre_printf("                       BoomerAMG - relaxation type\n");
       hypre_printf("                        0 - Weighted Jacobi\n");
       hypre_printf("                        1 - Gauss-Seidel (very slow!)\n");
       hypre_printf("                        3 - Hybrid Gauss-Seidel\n");
@@ -4776,7 +4782,6 @@ main( hypre_int argc,
          HYPRE_SStructSSAMGSetRelChange(solver, rel_change);
          HYPRE_SStructSSAMGSetSkipRelax(solver, skip);
          HYPRE_SStructSSAMGSetInterpType(solver, interp_type);
-         /* weighted Jacobi = 1; red-black GS = 2 */
          HYPRE_SStructSSAMGSetRelaxType(solver, relax[0]);
          if (usr_jacobi_weight)
          {


### PR DESCRIPTION
Latex syntax in tables was not being parsed correctly by the hypre docs scripts. This PR updates the table to a simpler format 