### PR TITLE
Update memory location check for ParCSRMatrix

### DIFF
--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -443,18 +443,20 @@ hypre_ParCSRMatrixMemoryLocation(hypre_ParCSRMatrix *matrix)
 
    hypre_CSRMatrix *diag = hypre_ParCSRMatrixDiag(matrix);
    hypre_CSRMatrix *offd = hypre_ParCSRMatrixOffd(matrix);
-   HYPRE_MemoryLocation memory_diag = diag ? hypre_CSRMatrixMemoryLocation(
-                                         diag) : HYPRE_MEMORY_UNDEFINED;
-   HYPRE_MemoryLocation memory_offd = offd ? hypre_CSRMatrixMemoryLocation(
-                                         offd) : HYPRE_MEMORY_UNDEFINED;
+   HYPRE_MemoryLocation memory_diag = diag ?
+     hypre_CSRMatrixMemoryLocation(diag) : HYPRE_MEMORY_UNDEFINED;
+   HYPRE_MemoryLocation memory_offd = offd ?
+     hypre_CSRMatrixMemoryLocation(offd) : HYPRE_MEMORY_UNDEFINED;
 
    if (diag && offd)
    {
-      if (memory_diag != memory_offd)
+      if (hypre_GetActualMemLocation(memory_diag) !=
+          hypre_GetActualMemLocation(memory_offd))
       {
          char err_msg[1024];
-         hypre_sprintf(err_msg, "Error: ParCSRMatrix Memory Location Diag (%d) != Offd (%d)\n", memory_diag,
-                       memory_offd);
+         hypre_sprintf(err_msg,
+                       "Error: ParCSRMatrix Memory Location Diag (%d) != Offd (%d)\n",
+                       memory_diag, memory_offd);
          hypre_error_w_msg(HYPRE_ERROR_MEMORY, err_msg);
          hypre_assert(0);
 

--- a/src/parcsr_mv/_hypre_parcsr_mv.h
+++ b/src/parcsr_mv/_hypre_parcsr_mv.h
@@ -444,9 +444,9 @@ hypre_ParCSRMatrixMemoryLocation(hypre_ParCSRMatrix *matrix)
    hypre_CSRMatrix *diag = hypre_ParCSRMatrixDiag(matrix);
    hypre_CSRMatrix *offd = hypre_ParCSRMatrixOffd(matrix);
    HYPRE_MemoryLocation memory_diag = diag ?
-     hypre_CSRMatrixMemoryLocation(diag) : HYPRE_MEMORY_UNDEFINED;
+                                      hypre_CSRMatrixMemoryLocation(diag) : HYPRE_MEMORY_UNDEFINED;
    HYPRE_MemoryLocation memory_offd = offd ?
-     hypre_CSRMatrixMemoryLocation(offd) : HYPRE_MEMORY_UNDEFINED;
+                                      hypre_CSRMatrixMemoryLocation(offd) : HYPRE_MEMORY_UNDEFINED;
 
    if (diag && offd)
    {

--- a/src/parcsr_mv/par_csr_matrix.h
+++ b/src/parcsr_mv/par_csr_matrix.h
@@ -143,9 +143,9 @@ hypre_ParCSRMatrixMemoryLocation(hypre_ParCSRMatrix *matrix)
    hypre_CSRMatrix *diag = hypre_ParCSRMatrixDiag(matrix);
    hypre_CSRMatrix *offd = hypre_ParCSRMatrixOffd(matrix);
    HYPRE_MemoryLocation memory_diag = diag ?
-     hypre_CSRMatrixMemoryLocation(diag) : HYPRE_MEMORY_UNDEFINED;
+                                      hypre_CSRMatrixMemoryLocation(diag) : HYPRE_MEMORY_UNDEFINED;
    HYPRE_MemoryLocation memory_offd = offd ?
-     hypre_CSRMatrixMemoryLocation(offd) : HYPRE_MEMORY_UNDEFINED;
+                                      hypre_CSRMatrixMemoryLocation(offd) : HYPRE_MEMORY_UNDEFINED;
 
    if (diag && offd)
    {

--- a/src/parcsr_mv/par_csr_matrix.h
+++ b/src/parcsr_mv/par_csr_matrix.h
@@ -142,18 +142,20 @@ hypre_ParCSRMatrixMemoryLocation(hypre_ParCSRMatrix *matrix)
 
    hypre_CSRMatrix *diag = hypre_ParCSRMatrixDiag(matrix);
    hypre_CSRMatrix *offd = hypre_ParCSRMatrixOffd(matrix);
-   HYPRE_MemoryLocation memory_diag = diag ? hypre_CSRMatrixMemoryLocation(
-                                         diag) : HYPRE_MEMORY_UNDEFINED;
-   HYPRE_MemoryLocation memory_offd = offd ? hypre_CSRMatrixMemoryLocation(
-                                         offd) : HYPRE_MEMORY_UNDEFINED;
+   HYPRE_MemoryLocation memory_diag = diag ?
+     hypre_CSRMatrixMemoryLocation(diag) : HYPRE_MEMORY_UNDEFINED;
+   HYPRE_MemoryLocation memory_offd = offd ?
+     hypre_CSRMatrixMemoryLocation(offd) : HYPRE_MEMORY_UNDEFINED;
 
    if (diag && offd)
    {
-      if (memory_diag != memory_offd)
+      if (hypre_GetActualMemLocation(memory_diag) !=
+          hypre_GetActualMemLocation(memory_offd))
       {
          char err_msg[1024];
-         hypre_sprintf(err_msg, "Error: ParCSRMatrix Memory Location Diag (%d) != Offd (%d)\n", memory_diag,
-                       memory_offd);
+         hypre_sprintf(err_msg,
+                       "Error: ParCSRMatrix Memory Location Diag (%d) != Offd (%d)\n",
+                       memory_diag, memory_offd);
          hypre_error_w_msg(HYPRE_ERROR_MEMORY, err_msg);
          hypre_assert(0);
 


### PR DESCRIPTION
Replace check on abstract memory location with the actual memory location

Fixes issues with printing SStructMatrix to file and solving with SSAMG after reading it.