### PR TITLE
Improve build robustness with external BLAS/LAPACK

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -217,6 +217,7 @@ set_hypre_option(SKIP TPL_LAPACK_LIBRARIES              "Absolute paths to LAPAC
 set_hypre_option(SKIP TPL_FEI_INCLUDE_DIRS              "Absolute paths to FEI include directories [Optional]." "")
 
 # Extra flags
+set_hypre_option(SKIP HYPRE_ALLOW_BIGINT_WITH_LP64_BLAS "Allow potentially unsafe BIGINT with external LP64 BLAS/LAPACK" OFF)
 set(HYPRE_WITH_EXTRA_CFLAGS "" CACHE STRING             "Define extra C compile flags")
 set(HYPRE_WITH_EXTRA_CXXFLAGS "" CACHE STRING           "Define extra CXX compile flags")
 set(HYPRE_SYCL_TARGET "" CACHE STRING                   "Target SYCL architecture, e.g. 'spir64_gen'.")
@@ -479,6 +480,7 @@ setup_tpl(magma)
 setup_tpl(caliper)
 setup_tpl_or_internal(blas)
 setup_tpl_or_internal(lapack)
+check_bigint_external_lapack_abi()
 
 # Some TPLs need C++ to be enabled (GPU already enables C++ by default)
 if(HYPRE_NEEDS_CXX AND NOT HYPRE_USING_GPU)

--- a/src/distributed_ls/ParaSails/ParaSails.c
+++ b/src/distributed_ls/ParaSails/ParaSails.c
@@ -1020,7 +1020,7 @@ static HYPRE_Int ComputeValuesSym(StoredRows *stored_rows, Matrix *mat,
 #ifndef ESSL
     char uplo = 'L';
     HYPRE_Int one = 1;
-    HYPRE_Int info;
+    HYPRE_Int info = 0;
 #endif
 
     /* Allocate and initialize full length marker array */
@@ -1228,7 +1228,7 @@ static HYPRE_Int ComputeValuesNonsym(StoredRows *stored_rows, Matrix *mat,
     HYPRE_Int pattsize = 1000;
     HYPRE_Int *patt = hypre_TAlloc(HYPRE_Int, pattsize, HYPRE_MEMORY_HOST);
 
-    HYPRE_Int info;
+    HYPRE_Int info = 0;
 
     HYPRE_Int error = 0;
 

--- a/src/krylov/lobpcg.c
+++ b/src/krylov/lobpcg.c
@@ -43,7 +43,7 @@ lobpcg_chol( utilities_FortranMatrix* a,
    HYPRE_Int lda, n;
    HYPRE_Real* aval;
    char uplo;
-   HYPRE_Int ierr;
+   HYPRE_Int ierr = 0;
 
    lda  = (HYPRE_Int) utilities_FortranMatrixGlobalHeight( a );
    n    = (HYPRE_Int) utilities_FortranMatrixHeight( a );
@@ -66,7 +66,7 @@ lobpcg_solveGEVP(
 )
 {
 
-   HYPRE_Int n, lda, ldb, itype, lwork, info;
+   HYPRE_Int n, lda, ldb, itype, lwork, info = 0;
    char jobz, uplo;
    HYPRE_Real* work;
    HYPRE_Real* a;
@@ -124,7 +124,7 @@ lobpcg_MultiVectorImplicitQR(
 
    /* B-orthonormalizes x using y = B x */
 
-   HYPRE_Int ierr;
+   HYPRE_Int ierr = 0;
 
    lobpcg_MultiVectorByMultiVector( x, y, r );
 

--- a/src/parcsr_block_mv/csr_block_matrix.c
+++ b/src/parcsr_block_mv/csr_block_matrix.c
@@ -1441,7 +1441,7 @@ hypre_CSRBlockMatrixBlockMultInv(HYPRE_Complex* i1, HYPRE_Complex* i2, HYPRE_Com
    {
       /* same as solving A^T C^T = B^T */
       HYPRE_Complex *m_i1;
-      HYPRE_Int info;
+      HYPRE_Int info = 0;
       HYPRE_Int *piv;
       HYPRE_Int sz, one;
 

--- a/src/parcsr_ls/par_gsmg.c
+++ b/src/parcsr_ls/par_gsmg.c
@@ -660,7 +660,7 @@ hypre_BoomerAMGFitVectors(HYPRE_Int ip, HYPRE_Int n, HYPRE_Int num, const HYPRE_
    HYPRE_Int i, j;
    HYPRE_Real *work;
    HYPRE_Int    work_size;
-   HYPRE_Int    info;
+   HYPRE_Int    info = 0;
    HYPRE_Int  temp;
 
    /*

--- a/src/parcsr_ls/par_sv_interp_lsfit.c
+++ b/src/parcsr_ls/par_sv_interp_lsfit.c
@@ -58,7 +58,7 @@ HYPRE_Int hypre_BoomerAMGFitInterpVectors( hypre_ParCSRMatrix *A,
    HYPRE_Int  i, j, k;
 
    HYPRE_Int  one_i = 1;
-   HYPRE_Int  info;
+   HYPRE_Int  info = 0;
    HYPRE_Int  coarse_index;;
    HYPRE_Int  num_coarse_diag;
    HYPRE_Int  num_coarse_offd;


### PR DESCRIPTION
When users request:

1. An external (32-bit) BLAS/LAPACK distribution in hypre (e.g., spack does it by default)
2. 64-bit integers support via the BigInt build option (`HYPRE_ENABLE_BIGINT`) 

hypre will build successfully, but will lead to runtime errors such as the one reported in https://github.com/hypre-space/hypre/issues/1467#issue-3876485233 

There are a couple of ways of handling this issue:

1. Use `HYPRE_ENABLE_MIXEDINT`, so hypre will pass 32-bit integer pointers to BLAS/LAPACK as we rely on `HYPRE_Int`
2. Link to an external BLAS/LAPACK distribution that is 64-bit enabled
3. Do not rely on external BLAS/LAPACK (instead rely on our internal one, which is usually the case).

Still, the scenario that was originally described (BigInt + external 32-bit BLAS/LAPACK) could be better handled in hypre, which brings to the purpose of this PR: 

- if users request "BigInt + external 32-bit BLAS/LAPACK", this branch will error out during build time giving a nice error msg to users (only via our primary cmake build):
```
CMake Error at config/cmake/HYPRE_CMakeUtilities.cmake:742 (message):
  Incompatible external LAPACK integer ABI for HYPRE_ENABLE_BIGINT=ON.

  The configured external LAPACK appears to use LP64 integers (32-bit), but
  BIGINT requires an ILP64-compatible BLAS/LAPACK integer interface.

  Use one of:

    1) Provide ILP64 BLAS/LAPACK libraries
    2) Set -DHYPRE_ENABLE_MIXEDINT=ON (recommended for external LP64 BLAS/LAPACK)
    3) Use internal BLAS/LAPACK: -DHYPRE_ENABLE_HYPRE_BLAS=ON -DHYPRE_ENABLE_HYPRE_LAPACK=ON

Call Stack (most recent call first):
  CMakeLists.txt:483 (check_bigint_external_lapack_abi)
```

A separate PR (on spack-packages) will add this logic to the spack build as well.

Closes #1467 