### PR TITLE
Fix POSIX compliance in configure (potential bugs found by AI agent team)

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -2233,7 +2233,7 @@ dnl   BUILD_F77_SHARED="${F77} ${SHARED_BUILD_FLAG}"
       BUILD_CC_SHARED="\${CC} ${SHARED_BUILD_FLAG}"
    fi
    BUILD_CXX_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
-   if test "$hypre_using_cuda" == "yes" || test "$hypre_using_hip" == "yes" || test "$hypre_using_kokkos" == "yes"
+   if test "$hypre_using_cuda" = "yes" || test "$hypre_using_hip" = "yes" || test "$hypre_using_kokkos" = "yes"
    then
       dnl BUILD_CC_SHARED="\${CUCC} ${SHARED_BUILD_FLAG}"
       BUILD_CC_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
@@ -2421,7 +2421,7 @@ dnl then we default to `/opt/rocm`.
 dnl
 dnl TODO: Add an ARG_WITH for rocm so the user can control the ROCm path
 dnl       through the configure line
-AS_IF([ test x"$hypre_using_hip" == x"yes" ],
+AS_IF([ test x"$hypre_using_hip" = x"yes" ],
       [ AS_IF([ test -n "$ROCM_PATH"],
               [ HYPRE_ROCM_PREFIX=$ROCM_PATH ],
               [ HYPRE_ROCM_PREFIX=/opt/rocm ])
@@ -2673,39 +2673,39 @@ then
    HYPRE_CUDA_INCLUDE='-I${HYPRE_CUDA_PATH}/include'
    HYPRE_CUDA_LIBS='-L${HYPRE_CUDA_PATH}/lib64 -lcudart'
 
-   AS_IF([test x"$hypre_using_cusparse" == x"yes" || test x"$hypre_using_cublas" == x"yes" || test x"$hypre_using_cusolver" == x"yes"],
+   AS_IF([test x"$hypre_using_cusparse" = x"yes" || test x"$hypre_using_cublas" = x"yes" || test x"$hypre_using_cusolver" = x"yes"],
          [AS_IF([test "x$HYPRE_CUDA_PATH" != "x$HYPRE_VENDOR_MATH_PATH"],
-          [HYPRE_CUDA_INCLUDE+=" -I${HYPRE_VENDOR_MATH_PATH}/include"
-           HYPRE_CUDA_LIBS+=" -L${HYPRE_VENDOR_MATH_PATH}/lib64"])])
+          [HYPRE_CUDA_INCLUDE="$HYPRE_CUDA_INCLUDE -I${HYPRE_VENDOR_MATH_PATH}/include"
+           HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -L${HYPRE_VENDOR_MATH_PATH}/lib64"])])
 
    if test "$hypre_using_gpu_profiling" = "yes"
    then
       AC_DEFINE(HYPRE_USING_NVTX, 1, [Define to 1 if using NVIDIA Tools Extension (NVTX)])
-      HYPRE_CUDA_LIBS+=" -lnvToolsExt"
+      HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -lnvToolsExt"
    fi
 
    if test "$hypre_using_cusparse" = "yes"
    then
       AC_DEFINE(HYPRE_USING_CUSPARSE, 1, [Define to 1 if using cuSPARSE])
-      HYPRE_CUDA_LIBS+=" -lcusparse"
+      HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -lcusparse"
    fi
 
    if test "$hypre_using_cublas" = "yes"
    then
       AC_DEFINE(HYPRE_USING_CUBLAS, 1, [Define to 1 if using cuBLAS])
-      HYPRE_CUDA_LIBS+=" -lcublas"
+      HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -lcublas"
    fi
 
    if test "$hypre_using_curand" = "yes"
    then
       AC_DEFINE(HYPRE_USING_CURAND, 1, [Define to 1 if using cuRAND])
-      HYPRE_CUDA_LIBS+=" -lcurand"
+      HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -lcurand"
    fi
 
    if test "$hypre_using_cusolver" = "yes"
    then
       AC_DEFINE(HYPRE_USING_CUSOLVER, 1, [Define to 1 if using cuSOLVER])
-      HYPRE_CUDA_LIBS+=" -lcusolver"
+      HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -lcusolver"
    fi
 
    if test "$hypre_using_device_malloc_async" = "yes"
@@ -2727,7 +2727,7 @@ fi
 dnl *********************************************************************
 dnl * Set HIP options
 dnl *********************************************************************
-AS_IF([test x"$hypre_using_hip" == x"yes"],
+AS_IF([test x"$hypre_using_hip" = x"yes"],
       [
         AC_DEFINE(HYPRE_USING_GPU, 1, [Define to 1 if executing on GPU device])
         AC_DEFINE(HYPRE_USING_HIP, 1, [HIP being used])
@@ -2765,7 +2765,7 @@ AS_IF([test x"$hypre_using_hip" == x"yes"],
         dnl If not in debug mode, at least -O2, but the user can override with
         dnl with HIPCXXFLAGS on the configure line. If in debug mode, -O0 -Wall
         dnl plus flags for debugging symbols
-        AS_IF([test x"$hypre_using_debug" == x"yes"],
+        AS_IF([test x"$hypre_using_debug" = x"yes"],
               [HIPCXXFLAGS="-O1 -Wall -g -ggdb ${HIPCXXFLAGS}"],
               [HIPCXXFLAGS="-O2 ${HIPCXXFLAGS}"],)
 
@@ -2794,46 +2794,46 @@ AS_IF([test x"$hypre_using_hip" == x"yes"],
         HYPRE_HIP_LIBS="-L${HYPRE_ROCM_PREFIX}/lib -lamdhip64"
 
         dnl rocSPARSE, for things like dcsrmv on AMD GPUs
-        AS_IF([test x"$hypre_using_rocsparse" == x"yes"],
+        AS_IF([test x"$hypre_using_rocsparse" = x"yes"],
               [AC_DEFINE(HYPRE_USING_ROCSPARSE, 1, [rocSPARSE being used])
-               HYPRE_HIP_LIBS+=" -lrocsparse"
+               HYPRE_HIP_LIBS="$HYPRE_HIP_LIBS -lrocsparse"
                ])
 
         dnl rocBLAS: basic linear algebra operations on AMD GPUs
-        AS_IF([test x"$hypre_using_rocblas" == x"yes"],
+        AS_IF([test x"$hypre_using_rocblas" = x"yes"],
               [AC_DEFINE(HYPRE_USING_ROCBLAS, 1, [rocBLAS being used])
-               HYPRE_HIP_LIBS+=" -lrocblas"
+               HYPRE_HIP_LIBS="$HYPRE_HIP_LIBS -lrocblas"
               ])
 
         dnl rocSOLVER: dense linear solvers on AMD GPUs (requires rocBLAS)
-        AS_IF([test x"$hypre_using_rocsolver" == x"yes"],
+        AS_IF([test x"$hypre_using_rocsolver" = x"yes"],
               [AC_DEFINE(HYPRE_USING_ROCSOLVER, 1, [rocSOLVER being used])
-               HYPRE_HIP_LIBS+=" -lrocsolver"
+               HYPRE_HIP_LIBS="$HYPRE_HIP_LIBS -lrocsolver"
                ])
 
         dnl rocRAND: random number generation on AMD GPUs
-        AS_IF([test x"$hypre_using_rocrand" == x"yes"],
+        AS_IF([test x"$hypre_using_rocrand" = x"yes"],
               [AC_DEFINE(HYPRE_USING_ROCRAND, 1, [rocRAND being used])
-               HYPRE_HIP_LIBS+=" -lrocrand"
+               HYPRE_HIP_LIBS="$HYPRE_HIP_LIBS -lrocrand"
                ])
 
         dnl rocTX tracing API
-        AS_IF([test x"$hypre_using_gpu_profiling" == x"yes"],
+        AS_IF([test x"$hypre_using_gpu_profiling" = x"yes"],
               [AC_DEFINE(HYPRE_USING_ROCTX, 1, [Define to 1 if using AMD rocTX profiling])
-               HYPRE_HIP_LIBS+=" -lroctx64"
+               HYPRE_HIP_LIBS="$HYPRE_HIP_LIBS -lroctx64"
                ])
 
-        AS_IF([test x"$hypre_using_cuda_streams" == x"yes"],
+        AS_IF([test x"$hypre_using_cuda_streams" = x"yes"],
               [AC_DEFINE(HYPRE_USING_CUDA_STREAMS, 1, [Define to 1 if using streams])
                ])
 
-      ]) dnl AS_IF([test x"$hypre_using_hip" == x"yes"]
+      ]) dnl AS_IF([test x"$hypre_using_hip" = x"yes"]
 
 
 dnl *********************************************************************
 dnl * Set SYCL options
 dnl *********************************************************************
-AS_IF([test x"$hypre_using_sycl" == x"yes"],
+AS_IF([test x"$hypre_using_sycl" = x"yes"],
       [
         AC_DEFINE(HYPRE_USING_GPU,  1, [Define to 1 if executing on GPU device])
         AC_DEFINE(HYPRE_USING_SYCL, 1, [SYCL being used])
@@ -2851,16 +2851,16 @@ AS_IF([test x"$hypre_using_sycl" == x"yes"],
            SYCLFLAGS="-O3 ${SYCLFLAGS}"
         fi
 
-        LDFLAGS+=" -fsycl -fsycl-device-code-split=per_kernel -Wl,--no-relax"
+        LDFLAGS="$LDFLAGS -fsycl -fsycl-device-code-split=per_kernel -Wl,--no-relax"
 
         dnl AOT compilation for specific devices
         if test "x${HYPRE_SYCL_TARGET}" != "x"
         then
-           LDFLAGS+=" -fsycl-targets=${HYPRE_SYCL_TARGET}"
+           LDFLAGS="$LDFLAGS -fsycl-targets=${HYPRE_SYCL_TARGET}"
         fi
         if test "x${HYPRE_SYCL_TARGET_BACKEND}" != "x"
         then
-           LDFLAGS+=" -Xsycl-target-backend ${HYPRE_SYCL_TARGET_BACKEND}"
+           LDFLAGS="$LDFLAGS -Xsycl-target-backend ${HYPRE_SYCL_TARGET_BACKEND}"
         fi
 
         dnl Shared build needs the sycl compiler
@@ -2876,7 +2876,7 @@ AS_IF([test x"$hypre_using_sycl" == x"yes"],
            CUFLAGS="${SYCLFLAGS}"
         fi
 
-        AS_IF([test x"$hypre_using_onemklsparse" == x"yes" || test x"$hypre_using_onemklblas" == x"yes" || test x"$hypre_using_onemklrand" == x"yes"],
+        AS_IF([test x"$hypre_using_onemklsparse" = x"yes" || test x"$hypre_using_onemklblas" = x"yes" || test x"$hypre_using_onemklrand" = x"yes"],
               [AC_CHECK_HEADER(["${MKLROOT}/include/mkl.h"],
                                [hypre_found_mkl=yes],
                                AC_MSG_ERROR([unable to find oneMKL ... Ensure that MKLROOT is set]))
@@ -2884,16 +2884,16 @@ AS_IF([test x"$hypre_using_sycl" == x"yes"],
                HYPRE_SYCL_INCL="${HYPRE_SYCL_INCL} -qmkl -I${DPLROOT}/include -DMKL_ILP64 -I${MKLROOT}/include"
                ])
 
-        AS_IF([test x"$hypre_using_onemklsparse" == x"yes"], [AC_DEFINE(HYPRE_USING_ONEMKLSPARSE, 1, [onemkl::SPARSE being used])])
+        AS_IF([test x"$hypre_using_onemklsparse" = x"yes"], [AC_DEFINE(HYPRE_USING_ONEMKLSPARSE, 1, [onemkl::SPARSE being used])])
 
-        AS_IF([test x"$hypre_using_onemklblas" == x"yes"], [AC_DEFINE(HYPRE_USING_ONEMKLBLAS, 1, [onemkl::BLAS being used])])
+        AS_IF([test x"$hypre_using_onemklblas" = x"yes"], [AC_DEFINE(HYPRE_USING_ONEMKLBLAS, 1, [onemkl::BLAS being used])])
 
-        AS_IF([test x"$hypre_using_onemklrand" == x"yes"], [AC_DEFINE(HYPRE_USING_ONEMKLRAND, 1, [onemkl::rng being used])])
+        AS_IF([test x"$hypre_using_onemklrand" = x"yes"], [AC_DEFINE(HYPRE_USING_ONEMKLRAND, 1, [onemkl::rng being used])])
 
         dnl SYCL should always use streams
         AC_DEFINE(HYPRE_USING_CUDA_STREAMS, 1, [Define to 1 if using streams])
 
-      ]) dnl AS_IF([test x"$hypre_using_sycl" == x"yes"]
+      ]) dnl AS_IF([test x"$hypre_using_sycl" = x"yes"]
 
 
 dnl *********************************************************************
@@ -2965,7 +2965,7 @@ then
       dnl fi
       if [test "$CUCC" = "icx" || test "$CUCC" = "icpx" || test "$CUCC" = "mpiicx" || test "$CUCC" = "mpiicpx"]
       then
-         CUFLAGS+="-qopenmp -fopenmp-targets=spir64"
+         CUFLAGS="$CUFLAGS -qopenmp -fopenmp-targets=spir64"
       fi
    fi
 
@@ -2973,7 +2973,7 @@ then
    then
       if [test "$CUCC" = "icx" || test "$CUCC" = "icpx" || test "$CUCC" = "mpiicx" || test "$CUCC" = "mpiicpx"]
       then
-         LDFLAGS+="-qopenmp -fopenmp-targets=spir64"
+         LDFLAGS="$LDFLAGS -qopenmp -fopenmp-targets=spir64"
       fi
    fi
 

--- a/src/config/hypre_macros_misc.m4
+++ b/src/config/hypre_macros_misc.m4
@@ -102,29 +102,29 @@ then
       gcc|mpigcc|mpicc)
         CFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -fopenmp"
-          LDFLAGS+=" -fopenmp"
+          CFLAGS="$CFLAGS -fopenmp"
+          LDFLAGS="$LDFLAGS -fopenmp"
         fi
         ;;
       icc|mpiicc|icx|mpiicx)
         CFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -qopenmp"
-          LDFLAGS+=" -qopenmp"
+          CFLAGS="$CFLAGS -qopenmp"
+          LDFLAGS="$LDFLAGS -qopenmp"
         fi
         ;;
       pgcc|mpipgcc|mpipgicc)
         CFLAGS="-fast"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -mp"
-          LDFLAGS+=" -mp"
+          CFLAGS="$CFLAGS -mp"
+          LDFLAGS="$LDFLAGS -mp"
         fi
         ;;
       cc|xlc|xlc_r|mpxlc|mpixlc|mpixlc_r|mpixlc-gpu|mpcc)
         CFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -qsmp=omp"
-          LDFLAGS+=" -qsmp=omp"
+          CFLAGS="$CFLAGS -qsmp=omp"
+          LDFLAGS="$LDFLAGS -qsmp=omp"
         fi
         ;;
       KCC|mpiKCC)
@@ -142,25 +142,25 @@ then
       g++|gCC|mpig++|mpicxx|mpic++|mpiCC)
         CXXFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -fopenmp"
+          CXXFLAGS="$CXXFLAGS -fopenmp"
         fi
         ;;
       icpc|icc|mpiicpc|mpiicc|icpx|mpiicpx)
         CXXFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -qopenmp"
+          CXXFLAGS="$CXXFLAGS -qopenmp"
         fi
         ;;
       pgCC|mpipgCC|pgc++|mpipgic++)
         CXXFLAGS="-fast"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -mp"
+          CXXFLAGS="$CXXFLAGS -mp"
         fi
         ;;
       CC|cxx|xlC|xlC_r|mpxlC|mpixlC|mpixlC-gpu|mpixlcxx|mpixlcxx_r|mpCC)
         CXXFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -qsmp=omp"
+          CXXFLAGS="$CXXFLAGS -qsmp=omp"
         fi
         ;;
       KCC|mpiKCC)
@@ -178,25 +178,25 @@ then
       g77|gfortran|mpigfortran|mpif77)
         FFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          FFLAGS+=" -fopenmp"
+          FFLAGS="$FFLAGS -fopenmp"
         fi
         ;;
       ifort|mpiifort)
         FFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          FFLAGS+=" -qopenmp"
+          FFLAGS="$FFLAGS -qopenmp"
         fi
         ;;
       pgf77|mpipgf77|pgfortran|mpipgifort)
         FFLAGS="-fast"
         if test "$hypre_using_openmp" = "yes" ; then
-          FFLAGS+=" -mp"
+          FFLAGS="$FFLAGS -mp"
         fi
         ;;
       f77|f90|xlf|xlf_r|mpxlf|mpixlf77|mpixlf77_r)
         FFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          FFLAGS+=" -qsmp=omp"
+          FFLAGS="$FFLAGS -qsmp=omp"
         fi
         ;;
       kf77|mpikf77)
@@ -222,29 +222,29 @@ then
       gcc|mpigcc|mpicc)
         CFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -fopenmp"
-          LDFLAGS+=" -fopenmp"
+          CFLAGS="$CFLAGS -fopenmp"
+          LDFLAGS="$LDFLAGS -fopenmp"
         fi
         ;;
       icc|mpiicc|icx|mpiicx)
         CFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -qopenmp"
-          LDFLAGS+=" -qopenmp"
+          CFLAGS="$CFLAGS -qopenmp"
+          LDFLAGS="$LDFLAGS -qopenmp"
         fi
         ;;
       pgcc|mpipgcc|mpipgicc)
         CFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -mp"
-          LDFLAGS+=" -mp"
+          CFLAGS="$CFLAGS -mp"
+          LDFLAGS="$LDFLAGS -mp"
         fi
         ;;
       cc|xlc|mpxlc|mpixlc|mpcc)
         CFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -qsmp=omp"
-          LDFLAGS+=" -qsmp=omp"
+          CFLAGS="$CFLAGS -qsmp=omp"
+          LDFLAGS="$LDFLAGS -qsmp=omp"
         fi
         ;;
       KCC|mpiKCC)
@@ -262,25 +262,25 @@ then
       g++|gCC|mpig++|mpicxx|mpic++|mpiCC)
         CXXFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -fopenmp"
+          CXXFLAGS="$CXXFLAGS -fopenmp"
         fi
         ;;
       icpc|icc|mpiicpc|mpiicc|icpx|mpiicpx)
         CXXFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -qopenmp"
+          CXXFLAGS="$CXXFLAGS -qopenmp"
         fi
         ;;
       pgCC|mpipgCC|pgc++|mpipgic++)
         CXXFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -mp"
+          CXXFLAGS="$CXXFLAGS -mp"
         fi
         ;;
       CC|cxx|xlC|mpxlC|mpixlcxx|mpCC)
         CXXFLAGS="-O0 -g"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -qsmp=omp"
+          CXXFLAGS="$CXXFLAGS -qsmp=omp"
         fi
         ;;
       KCC|mpiKCC)

--- a/src/configure
+++ b/src/configure
@@ -9795,29 +9795,29 @@ then
       gcc|mpigcc|mpicc)
         CFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -fopenmp"
-          LDFLAGS+=" -fopenmp"
+          CFLAGS="$CFLAGS -fopenmp"
+          LDFLAGS="$LDFLAGS -fopenmp"
         fi
         ;;
       icc|mpiicc|icx|mpiicx)
         CFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -qopenmp"
-          LDFLAGS+=" -qopenmp"
+          CFLAGS="$CFLAGS -qopenmp"
+          LDFLAGS="$LDFLAGS -qopenmp"
         fi
         ;;
       pgcc|mpipgcc|mpipgicc)
         CFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -mp"
-          LDFLAGS+=" -mp"
+          CFLAGS="$CFLAGS -mp"
+          LDFLAGS="$LDFLAGS -mp"
         fi
         ;;
       cc|xlc|mpxlc|mpixlc|mpcc)
         CFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -qsmp=omp"
-          LDFLAGS+=" -qsmp=omp"
+          CFLAGS="$CFLAGS -qsmp=omp"
+          LDFLAGS="$LDFLAGS -qsmp=omp"
         fi
         ;;
       KCC|mpiKCC)
@@ -9835,25 +9835,25 @@ then
       g++|gCC|mpig++|mpicxx|mpic++|mpiCC)
         CXXFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -fopenmp"
+          CXXFLAGS="$CXXFLAGS -fopenmp"
         fi
         ;;
       icpc|icc|mpiicpc|mpiicc|icpx|mpiicpx)
         CXXFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -qopenmp"
+          CXXFLAGS="$CXXFLAGS -qopenmp"
         fi
         ;;
       pgCC|mpipgCC|pgc++|mpipgic++)
         CXXFLAGS="-O0 -g -Wall"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -mp"
+          CXXFLAGS="$CXXFLAGS -mp"
         fi
         ;;
       CC|cxx|xlC|mpxlC|mpixlcxx|mpCC)
         CXXFLAGS="-O0 -g"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -qsmp=omp"
+          CXXFLAGS="$CXXFLAGS -qsmp=omp"
         fi
         ;;
       KCC|mpiKCC)
@@ -9911,29 +9911,29 @@ then
       gcc|mpigcc|mpicc)
         CFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -fopenmp"
-          LDFLAGS+=" -fopenmp"
+          CFLAGS="$CFLAGS -fopenmp"
+          LDFLAGS="$LDFLAGS -fopenmp"
         fi
         ;;
       icc|mpiicc|icx|mpiicx)
         CFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -qopenmp"
-          LDFLAGS+=" -qopenmp"
+          CFLAGS="$CFLAGS -qopenmp"
+          LDFLAGS="$LDFLAGS -qopenmp"
         fi
         ;;
       pgcc|mpipgcc|mpipgicc)
         CFLAGS="-fast"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -mp"
-          LDFLAGS+=" -mp"
+          CFLAGS="$CFLAGS -mp"
+          LDFLAGS="$LDFLAGS -mp"
         fi
         ;;
       cc|xlc|xlc_r|mpxlc|mpixlc|mpixlc_r|mpixlc-gpu|mpcc)
         CFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CFLAGS+=" -qsmp=omp"
-          LDFLAGS+=" -qsmp=omp"
+          CFLAGS="$CFLAGS -qsmp=omp"
+          LDFLAGS="$LDFLAGS -qsmp=omp"
         fi
         ;;
       KCC|mpiKCC)
@@ -9951,25 +9951,25 @@ then
       g++|gCC|mpig++|mpicxx|mpic++|mpiCC)
         CXXFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -fopenmp"
+          CXXFLAGS="$CXXFLAGS -fopenmp"
         fi
         ;;
       icpc|icc|mpiicpc|mpiicc|icpx|mpiicpx)
         CXXFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -qopenmp"
+          CXXFLAGS="$CXXFLAGS -qopenmp"
         fi
         ;;
       pgCC|mpipgCC|pgc++|mpipgic++)
         CXXFLAGS="-fast"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -mp"
+          CXXFLAGS="$CXXFLAGS -mp"
         fi
         ;;
       CC|cxx|xlC|xlC_r|mpxlC|mpixlC|mpixlC-gpu|mpixlcxx|mpixlcxx_r|mpCC)
         CXXFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          CXXFLAGS+=" -qsmp=omp"
+          CXXFLAGS="$CXXFLAGS -qsmp=omp"
         fi
         ;;
       KCC|mpiKCC)
@@ -9987,25 +9987,25 @@ then
       g77|gfortran|mpigfortran|mpif77)
         FFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          FFLAGS+=" -fopenmp"
+          FFLAGS="$FFLAGS -fopenmp"
         fi
         ;;
       ifort|mpiifort)
         FFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          FFLAGS+=" -qopenmp"
+          FFLAGS="$FFLAGS -qopenmp"
         fi
         ;;
       pgf77|mpipgf77|pgfortran|mpipgifort)
         FFLAGS="-fast"
         if test "$hypre_using_openmp" = "yes" ; then
-          FFLAGS+=" -mp"
+          FFLAGS="$FFLAGS -mp"
         fi
         ;;
       f77|f90|xlf|xlf_r|mpxlf|mpixlf77|mpixlf77_r)
         FFLAGS="-O2"
         if test "$hypre_using_openmp" = "yes" ; then
-          FFLAGS+=" -qsmp=omp"
+          FFLAGS="$FFLAGS -qsmp=omp"
         fi
         ;;
       kf77|mpikf77)
@@ -10176,7 +10176,7 @@ then
       BUILD_CC_SHARED="\${CC} ${SHARED_BUILD_FLAG}"
    fi
    BUILD_CXX_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
-   if test "$hypre_using_cuda" == "yes" || test "$hypre_using_hip" == "yes" || test "$hypre_using_kokkos" == "yes"
+   if test "$hypre_using_cuda" = "yes" || test "$hypre_using_hip" = "yes" || test "$hypre_using_kokkos" = "yes"
    then
             BUILD_CC_SHARED="\${CXX} ${SHARED_BUILD_FLAG}"
    fi
@@ -10639,7 +10639,7 @@ fi
 fi
 
 
-if  test x"$hypre_using_hip" == x"yes"
+if  test x"$hypre_using_hip" = x"yes"
 then :
    if  test -n "$ROCM_PATH"
 then :
@@ -10897,12 +10897,12 @@ printf "%s\n" "#define HYPRE_USING_CUDA 1" >>confdefs.h
          HYPRE_CUDA_INCLUDE='-I${HYPRE_CUDA_PATH}/include'
    HYPRE_CUDA_LIBS='-L${HYPRE_CUDA_PATH}/lib64 -lcudart'
 
-   if test x"$hypre_using_cusparse" == x"yes" || test x"$hypre_using_cublas" == x"yes" || test x"$hypre_using_cusolver" == x"yes"
+   if test x"$hypre_using_cusparse" = x"yes" || test x"$hypre_using_cublas" = x"yes" || test x"$hypre_using_cusolver" = x"yes"
 then :
   if test "x$HYPRE_CUDA_PATH" != "x$HYPRE_VENDOR_MATH_PATH"
 then :
-  HYPRE_CUDA_INCLUDE+=" -I${HYPRE_VENDOR_MATH_PATH}/include"
-           HYPRE_CUDA_LIBS+=" -L${HYPRE_VENDOR_MATH_PATH}/lib64"
+  HYPRE_CUDA_INCLUDE="$HYPRE_CUDA_INCLUDE -I${HYPRE_VENDOR_MATH_PATH}/include"
+           HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -L${HYPRE_VENDOR_MATH_PATH}/lib64"
 fi
 fi
 
@@ -10911,7 +10911,7 @@ fi
 
 printf "%s\n" "#define HYPRE_USING_NVTX 1" >>confdefs.h
 
-      HYPRE_CUDA_LIBS+=" -lnvToolsExt"
+      HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -lnvToolsExt"
    fi
 
    if test "$hypre_using_cusparse" = "yes"
@@ -10919,7 +10919,7 @@ printf "%s\n" "#define HYPRE_USING_NVTX 1" >>confdefs.h
 
 printf "%s\n" "#define HYPRE_USING_CUSPARSE 1" >>confdefs.h
 
-      HYPRE_CUDA_LIBS+=" -lcusparse"
+      HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -lcusparse"
    fi
 
    if test "$hypre_using_cublas" = "yes"
@@ -10927,7 +10927,7 @@ printf "%s\n" "#define HYPRE_USING_CUSPARSE 1" >>confdefs.h
 
 printf "%s\n" "#define HYPRE_USING_CUBLAS 1" >>confdefs.h
 
-      HYPRE_CUDA_LIBS+=" -lcublas"
+      HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -lcublas"
    fi
 
    if test "$hypre_using_curand" = "yes"
@@ -10935,7 +10935,7 @@ printf "%s\n" "#define HYPRE_USING_CUBLAS 1" >>confdefs.h
 
 printf "%s\n" "#define HYPRE_USING_CURAND 1" >>confdefs.h
 
-      HYPRE_CUDA_LIBS+=" -lcurand"
+      HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -lcurand"
    fi
 
    if test "$hypre_using_cusolver" = "yes"
@@ -10943,7 +10943,7 @@ printf "%s\n" "#define HYPRE_USING_CURAND 1" >>confdefs.h
 
 printf "%s\n" "#define HYPRE_USING_CUSOLVER 1" >>confdefs.h
 
-      HYPRE_CUDA_LIBS+=" -lcusolver"
+      HYPRE_CUDA_LIBS="$HYPRE_CUDA_LIBS -lcusolver"
    fi
 
    if test "$hypre_using_device_malloc_async" = "yes"
@@ -10968,7 +10968,7 @@ printf "%s\n" "#define HYPRE_USING_CUDA_STREAMS 1" >>confdefs.h
    fi
 fi
 
-if test x"$hypre_using_hip" == x"yes"
+if test x"$hypre_using_hip" = x"yes"
 then :
 
 
@@ -10993,7 +10993,7 @@ printf "%s\n" "#define HYPRE_USING_HIP 1" >>confdefs.h
 
                                         HIPCXXFLAGS="-x hip -fPIE -std=c++${hypre_cxxstd} ${HIPCXXFLAGS}"
 
-                                if test x"$hypre_using_debug" == x"yes"
+                                if test x"$hypre_using_debug" = x"yes"
 then :
   HIPCXXFLAGS="-O1 -Wall -g -ggdb ${HIPCXXFLAGS}"
 elif HIPCXXFLAGS="-O2 ${HIPCXXFLAGS}"
@@ -11016,52 +11016,52 @@ fi
 
                 HYPRE_HIP_LIBS="-L${HYPRE_ROCM_PREFIX}/lib -lamdhip64"
 
-                if test x"$hypre_using_rocsparse" == x"yes"
+                if test x"$hypre_using_rocsparse" = x"yes"
 then :
 
 printf "%s\n" "#define HYPRE_USING_ROCSPARSE 1" >>confdefs.h
 
-               HYPRE_HIP_LIBS+=" -lrocsparse"
+               HYPRE_HIP_LIBS="$HYPRE_HIP_LIBS -lrocsparse"
 
 fi
 
-                if test x"$hypre_using_rocblas" == x"yes"
+                if test x"$hypre_using_rocblas" = x"yes"
 then :
 
 printf "%s\n" "#define HYPRE_USING_ROCBLAS 1" >>confdefs.h
 
-               HYPRE_HIP_LIBS+=" -lrocblas"
+               HYPRE_HIP_LIBS="$HYPRE_HIP_LIBS -lrocblas"
 
 fi
 
-                if test x"$hypre_using_rocsolver" == x"yes"
+                if test x"$hypre_using_rocsolver" = x"yes"
 then :
 
 printf "%s\n" "#define HYPRE_USING_ROCSOLVER 1" >>confdefs.h
 
-               HYPRE_HIP_LIBS+=" -lrocsolver"
+               HYPRE_HIP_LIBS="$HYPRE_HIP_LIBS -lrocsolver"
 
 fi
 
-                if test x"$hypre_using_rocrand" == x"yes"
+                if test x"$hypre_using_rocrand" = x"yes"
 then :
 
 printf "%s\n" "#define HYPRE_USING_ROCRAND 1" >>confdefs.h
 
-               HYPRE_HIP_LIBS+=" -lrocrand"
+               HYPRE_HIP_LIBS="$HYPRE_HIP_LIBS -lrocrand"
 
 fi
 
-                if test x"$hypre_using_gpu_profiling" == x"yes"
+                if test x"$hypre_using_gpu_profiling" = x"yes"
 then :
 
 printf "%s\n" "#define HYPRE_USING_ROCTX 1" >>confdefs.h
 
-               HYPRE_HIP_LIBS+=" -lroctx64"
+               HYPRE_HIP_LIBS="$HYPRE_HIP_LIBS -lroctx64"
 
 fi
 
-        if test x"$hypre_using_cuda_streams" == x"yes"
+        if test x"$hypre_using_cuda_streams" = x"yes"
 then :
 
 printf "%s\n" "#define HYPRE_USING_CUDA_STREAMS 1" >>confdefs.h
@@ -11072,7 +11072,7 @@ fi
 
 fi
 
-if test x"$hypre_using_sycl" == x"yes"
+if test x"$hypre_using_sycl" = x"yes"
 then :
 
 
@@ -11093,15 +11093,15 @@ printf "%s\n" "#define HYPRE_USING_SYCL 1" >>confdefs.h
            SYCLFLAGS="-O3 ${SYCLFLAGS}"
         fi
 
-        LDFLAGS+=" -fsycl -fsycl-device-code-split=per_kernel -Wl,--no-relax"
+        LDFLAGS="$LDFLAGS -fsycl -fsycl-device-code-split=per_kernel -Wl,--no-relax"
 
                 if test "x${HYPRE_SYCL_TARGET}" != "x"
         then
-           LDFLAGS+=" -fsycl-targets=${HYPRE_SYCL_TARGET}"
+           LDFLAGS="$LDFLAGS -fsycl-targets=${HYPRE_SYCL_TARGET}"
         fi
         if test "x${HYPRE_SYCL_TARGET_BACKEND}" != "x"
         then
-           LDFLAGS+=" -Xsycl-target-backend ${HYPRE_SYCL_TARGET_BACKEND}"
+           LDFLAGS="$LDFLAGS -Xsycl-target-backend ${HYPRE_SYCL_TARGET_BACKEND}"
         fi
 
                 if test "$hypre_using_shared" = "yes"
@@ -11115,7 +11115,7 @@ printf "%s\n" "#define HYPRE_USING_SYCL 1" >>confdefs.h
            CUFLAGS="${SYCLFLAGS}"
         fi
 
-        if test x"$hypre_using_onemklsparse" == x"yes" || test x"$hypre_using_onemklblas" == x"yes" || test x"$hypre_using_onemklrand" == x"yes"
+        if test x"$hypre_using_onemklsparse" = x"yes" || test x"$hypre_using_onemklblas" = x"yes" || test x"$hypre_using_onemklrand" = x"yes"
 then :
   as_ac_Header=`printf "%s\n" "ac_cv_header_"${MKLROOT}/include/mkl.h"" | $as_tr_sh`
 ac_fn_c_check_header_compile "$LINENO" ""${MKLROOT}/include/mkl.h"" "$as_ac_Header" "$ac_includes_default"
@@ -11131,21 +11131,21 @@ fi
 
 fi
 
-        if test x"$hypre_using_onemklsparse" == x"yes"
+        if test x"$hypre_using_onemklsparse" = x"yes"
 then :
 
 printf "%s\n" "#define HYPRE_USING_ONEMKLSPARSE 1" >>confdefs.h
 
 fi
 
-        if test x"$hypre_using_onemklblas" == x"yes"
+        if test x"$hypre_using_onemklblas" = x"yes"
 then :
 
 printf "%s\n" "#define HYPRE_USING_ONEMKLBLAS 1" >>confdefs.h
 
 fi
 
-        if test x"$hypre_using_onemklrand" == x"yes"
+        if test x"$hypre_using_onemklrand" = x"yes"
 then :
 
 printf "%s\n" "#define HYPRE_USING_ONEMKLRAND 1" >>confdefs.h
@@ -11240,7 +11240,7 @@ printf "%s\n" "#define HYPRE_DEVICE_OPENMP_ALLOC 1" >>confdefs.h
          #CUFLAGS+=" -fopenmp-nonaliased-maps"
             if test "$CUCC" = "icx" || test "$CUCC" = "icpx" || test "$CUCC" = "mpiicx" || test "$CUCC" = "mpiicpx"
       then
-         CUFLAGS+="-qopenmp -fopenmp-targets=spir64"
+         CUFLAGS="$CUFLAGS -qopenmp -fopenmp-targets=spir64"
       fi
    fi
 
@@ -11248,7 +11248,7 @@ printf "%s\n" "#define HYPRE_DEVICE_OPENMP_ALLOC 1" >>confdefs.h
    then
       if test "$CUCC" = "icx" || test "$CUCC" = "icpx" || test "$CUCC" = "mpiicx" || test "$CUCC" = "mpiicpx"
       then
-         LDFLAGS+="-qopenmp -fopenmp-targets=spir64"
+         LDFLAGS="$LDFLAGS -qopenmp -fopenmp-targets=spir64"
       fi
    fi
 
@@ -12790,4 +12790,3 @@ fi
 mv HYPRE_config.h HYPRE_config.h.tmp
 sed 's/FC_FUNC/HYPRE_FC_FUNC/g' < HYPRE_config.h.tmp > HYPRE_config.h
 rm -f HYPRE_config.h.tmp
-


### PR DESCRIPTION
Fix non-POSIX shell constructs in the configure flow, based on potential bugs found by AI agent team.

1. Replace shell `test ... == ...` with `test ... = ...`.
2. Replace shell `VAR+=...` appends with POSIX-safe `VAR="$VAR ..."` where applicable.
3. Regenerate and update `src/configure` consistently with source templates.

Tested:
- `dash -n src/configure`
- `dash src/configure --help`
- `cmake -S src -B build-pr1 -DHYPRE_ENABLE_MPI=OFF -DHYPRE_BUILD_TESTS=OFF`
- `cmake --build build-pr1 -j4`
