### PR TITLE
Fix correctness bugs across parcsr_ls, sstruct_mv, and krylov (potential bugs found by AI agent team)

### DIFF
--- a/src/krylov/cogmres.c
+++ b/src/krylov/cogmres.c
@@ -397,6 +397,13 @@ hypre_COGMRESSolve(void  *cogmres_vdata,
          hypre_printf("ERROR detected by Hypre ... END\n\n\n");
       }
       hypre_error(HYPRE_ERROR_GENERIC);
+      hypre_TFreeF(c, cogmres_functions);
+      hypre_TFreeF(s, cogmres_functions);
+      hypre_TFreeF(rs, cogmres_functions);
+      hypre_TFreeF(rv, cogmres_functions);
+      if (rel_change) { hypre_TFreeF(rs_2, cogmres_functions); }
+      hypre_TFreeF(hh, cogmres_functions);
+      hypre_TFreeF(uu, cogmres_functions);
       HYPRE_ANNOTATE_FUNC_END;
 
       return hypre_error_flag;
@@ -424,6 +431,13 @@ hypre_COGMRESSolve(void  *cogmres_vdata,
          hypre_printf("ERROR detected by Hypre ... END\n\n\n");
       }
       hypre_error(HYPRE_ERROR_GENERIC);
+      hypre_TFreeF(c, cogmres_functions);
+      hypre_TFreeF(s, cogmres_functions);
+      hypre_TFreeF(rs, cogmres_functions);
+      hypre_TFreeF(rv, cogmres_functions);
+      if (rel_change) { hypre_TFreeF(rs_2, cogmres_functions); }
+      hypre_TFreeF(hh, cogmres_functions);
+      hypre_TFreeF(uu, cogmres_functions);
       HYPRE_ANNOTATE_FUNC_END;
 
       return hypre_error_flag;

--- a/src/krylov/flexgmres.c
+++ b/src/krylov/flexgmres.c
@@ -409,6 +409,17 @@ hypre_FlexGMRESSolve(void  *fgmres_vdata,
          hypre_printf("ERROR detected by Hypre ... END\n\n\n");
       }
       hypre_error(HYPRE_ERROR_GENERIC);
+      hypre_TFree(iprod, HYPRE_MEMORY_HOST);
+      hypre_TFree(biprod, HYPRE_MEMORY_HOST);
+      hypre_TFreeF(rs_3, fgmres_functions);
+      hypre_TFreeF(c, fgmres_functions);
+      hypre_TFreeF(s, fgmres_functions);
+      hypre_TFreeF(rs, fgmres_functions);
+      for (i = 0; i < k_dim + 1; i++)
+      {
+         hypre_TFreeF(hh[i], fgmres_functions);
+      }
+      hypre_TFreeF(hh, fgmres_functions);
       HYPRE_ANNOTATE_FUNC_END;
 
       return hypre_error_flag;
@@ -437,6 +448,17 @@ hypre_FlexGMRESSolve(void  *fgmres_vdata,
          hypre_printf("ERROR detected by Hypre ... END\n\n\n");
       }
       hypre_error(HYPRE_ERROR_GENERIC);
+      hypre_TFree(iprod, HYPRE_MEMORY_HOST);
+      hypre_TFree(biprod, HYPRE_MEMORY_HOST);
+      hypre_TFreeF(rs_3, fgmres_functions);
+      hypre_TFreeF(c, fgmres_functions);
+      hypre_TFreeF(s, fgmres_functions);
+      hypre_TFreeF(rs, fgmres_functions);
+      for (i = 0; i < k_dim + 1; i++)
+      {
+         hypre_TFreeF(hh[i], fgmres_functions);
+      }
+      hypre_TFreeF(hh, fgmres_functions);
       HYPRE_ANNOTATE_FUNC_END;
 
       return hypre_error_flag;

--- a/src/krylov/gmres.c
+++ b/src/krylov/gmres.c
@@ -437,6 +437,16 @@ hypre_GMRESSolve(void  *gmres_vdata,
          hypre_printf("ERROR detected by Hypre ... END\n\n\n");
       }
       hypre_error(HYPRE_ERROR_GENERIC);
+      hypre_TFree(iprod, HYPRE_MEMORY_HOST);
+      hypre_TFree(xiprod, HYPRE_MEMORY_HOST);
+      hypre_TFree(biprod, HYPRE_MEMORY_HOST);
+      hypre_TFreeF(c, gmres_functions);
+      hypre_TFreeF(s, gmres_functions);
+      hypre_TFreeF(rs, gmres_functions);
+      if (rel_change) { hypre_TFreeF(rs_2, gmres_functions); }
+      if (print_level > 2) { hypre_TFreeF(rs_3, gmres_functions); }
+      for (i = 0; i < k_dim + 1; i++) { hypre_TFreeF(hh[i], gmres_functions); }
+      hypre_TFreeF(hh, gmres_functions);
       HYPRE_ANNOTATE_FUNC_END;
 
       return hypre_error_flag;
@@ -468,6 +478,16 @@ hypre_GMRESSolve(void  *gmres_vdata,
          hypre_printf("ERROR detected by Hypre ... END\n\n\n");
       }
       hypre_error(HYPRE_ERROR_GENERIC);
+      hypre_TFree(iprod, HYPRE_MEMORY_HOST);
+      hypre_TFree(xiprod, HYPRE_MEMORY_HOST);
+      hypre_TFree(biprod, HYPRE_MEMORY_HOST);
+      hypre_TFreeF(c, gmres_functions);
+      hypre_TFreeF(s, gmres_functions);
+      hypre_TFreeF(rs, gmres_functions);
+      if (rel_change) { hypre_TFreeF(rs_2, gmres_functions); }
+      if (print_level > 2) { hypre_TFreeF(rs_3, gmres_functions); }
+      for (i = 0; i < k_dim + 1; i++) { hypre_TFreeF(hh[i], gmres_functions); }
+      hypre_TFreeF(hh, gmres_functions);
       HYPRE_ANNOTATE_FUNC_END;
 
       return hypre_error_flag;

--- a/src/krylov/gmres.c
+++ b/src/krylov/gmres.c
@@ -715,7 +715,7 @@ hypre_GMRESSolve(void  *gmres_vdata,
 
                /* Apply preconditioner to get the correction */
                (*(gmres_functions->ClearVector))(w);
-               precond(precond_data, A, w_3, w);
+               precond(precond_data, precond_Mat, w_3, w);
 
                /* Compute current approximate solution x_i = x_0 + correction */
                (*(gmres_functions->CopyVector))(x, w_3);

--- a/src/krylov/lgmres.c
+++ b/src/krylov/lgmres.c
@@ -443,6 +443,14 @@ hypre_LGMRESSolve(void  *lgmres_vdata,
          hypre_printf("ERROR detected by Hypre ... END\n\n\n");
       }
       hypre_error(HYPRE_ERROR_GENERIC);
+      hypre_TFreeF(c, lgmres_functions);
+      hypre_TFreeF(s, lgmres_functions);
+      hypre_TFreeF(rs, lgmres_functions);
+      for (i = 0; i < k_dim + aug_dim + 1; i++)
+      {
+         hypre_TFreeF(hh[i], lgmres_functions);
+      }
+      hypre_TFreeF(hh, lgmres_functions);
       HYPRE_ANNOTATE_FUNC_END;
 
       return hypre_error_flag;
@@ -470,6 +478,14 @@ hypre_LGMRESSolve(void  *lgmres_vdata,
          hypre_printf("ERROR detected by Hypre ... END\n\n\n");
       }
       hypre_error(HYPRE_ERROR_GENERIC);
+      hypre_TFreeF(c, lgmres_functions);
+      hypre_TFreeF(s, lgmres_functions);
+      hypre_TFreeF(rs, lgmres_functions);
+      for (i = 0; i < k_dim + aug_dim + 1; i++)
+      {
+         hypre_TFreeF(hh[i], lgmres_functions);
+      }
+      hypre_TFreeF(hh, lgmres_functions);
       HYPRE_ANNOTATE_FUNC_END;
 
       return hypre_error_flag;

--- a/src/krylov/pcg.c
+++ b/src/krylov/pcg.c
@@ -267,7 +267,7 @@ hypre_PCGSetup( void *pcg_vdata,
 
    if (flex)
    {
-      if ( pcg_data -> v != NULL )
+      if ( pcg_data -> r_old != NULL )
       {
          (*(pcg_functions->DestroyVector))(pcg_data -> r_old);
       }

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -515,7 +515,7 @@ hypre_MGRSetup( void               *mgr_vdata,
    /* Setup for global block smoothers*/
    if (set_c_points_method == 0)
    {
-      if (my_id == num_procs)
+      if (my_id == (num_procs - 1))
       {
          mgr_data -> n_block   = (n - reserved_coarse_size) / block_size;
          mgr_data -> left_size = n - block_size * (mgr_data -> n_block);

--- a/src/parcsr_ls/par_mgr_setup.c
+++ b/src/parcsr_ls/par_mgr_setup.c
@@ -887,7 +887,7 @@ hypre_MGRSetup( void               *mgr_vdata,
       {
          if (aff_solver[j])
          {
-            if ((mgr_data -> Frelax_type)[i] == 29)
+            if ((mgr_data -> Frelax_type)[j] == 29)
             {
                hypre_MGRDirectSolverDestroy(aff_solver[j]);
             }

--- a/src/sstruct_mv/sstruct_matop.c
+++ b/src/sstruct_mv/sstruct_matop.c
@@ -31,7 +31,10 @@ hypre_SStructPMatrixComputeRowSum( hypre_SStructPMatrix  *pA,
       for (vj = 0; vj < nvars; vj++)
       {
          sA = hypre_SStructPMatrixSMatrix(pA, vi, vj);
-         hypre_StructMatrixComputeRowSum(sA, type, sv);
+         if (sA != NULL)
+         {
+            hypre_StructMatrixComputeRowSum(sA, type, sv);
+         }
       }
    }
 

--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -686,9 +686,9 @@ hypre_SStructPMatrixSetSymmetric( hypre_SStructPMatrix *pmatrix,
       tsize  = hypre_SStructPMatrixNVars(pmatrix);
    }
 
-   for (v = vstart; v < vsize; v++)
+   for (v = vstart; v < (vstart + vsize); v++)
    {
-      for (t = tstart; t < tsize; t++)
+      for (t = tstart; t < (tstart + tsize); t++)
       {
          pmsymmetric[v][t] = symmetric;
       }

--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -1128,7 +1128,7 @@ hypre_SStructUMatrixSetValues( hypre_SStructMatrix *matrix,
             hypre_SStructBoxManEntryGetGlobalRank(boxman_entry, to_index,
                                                   &col_coords[ncoeffs], matrix_type);
 
-            coeffs[ncoeffs] = values[i];
+            coeffs[ncoeffs] = h_values[i];
             ncoeffs++;
          }
       }

--- a/src/sstruct_mv/sstruct_vector.c
+++ b/src/sstruct_mv/sstruct_vector.c
@@ -616,7 +616,7 @@ hypre_SStructVectorSetRandomValues( hypre_SStructVector *vector,
    HYPRE_Int             pseed;
    HYPRE_Int             myid;
 
-   myid  = hypre_MPI_Comm_rank(hypre_SStructVectorComm(vector), &myid);
+   hypre_MPI_Comm_rank(hypre_SStructVectorComm(vector), &myid);
    pseed = seed * (myid + 1);
    for (part = 0; part < nparts; part++)
    {


### PR DESCRIPTION
Fix 9 correctness bugs across parcsr_ls, sstruct_mv, and krylov, based on potential bugs found by AI agent team.
Each bug fix is a separate commit for cherry-pickable review.

1. `src/parcsr_ls/par_mgr_setup.c:890` — wrong index `Frelax_type[i]` inside `j` loop (`Frelax_type[j]` expected).
2. `src/parcsr_ls/par_mgr_setup.c:518` — unreachable `my_id == num_procs` condition (`num_procs - 1` expected).
3. `src/sstruct_mv/sstruct_matrix.c:689` — symmetric loop bound should use `vstart + vsize` and `tstart + tsize`.
4. `src/sstruct_mv/sstruct_matrix.c:1131` — stencil host path should read `h_values[i]` instead of `values[i]`.
5. `src/sstruct_mv/sstruct_matop.c:33` — add missing NULL guard before `hypre_StructMatrixComputeRowSum`.
6. `src/sstruct_mv/sstruct_vector.c:619` — do not overwrite `myid` with MPI return code.
7. `src/krylov/{gmres,flexgmres,cogmres,lgmres}.c` — free work arrays on NaN/Inf early-return paths.
8. `src/krylov/pcg.c:270` — guard should check `r_old` before destroying `r_old`.
9. `src/krylov/gmres.c:698` — tagged residual preconditioner path should pass `precond_Mat` instead of `A`.

Tested:
- `cmake -S src -B build-pr2 -DHYPRE_ENABLE_MPI=OFF -DHYPRE_BUILD_TESTS=OFF`
- `cmake --build build-pr2 -j4`
