### PR TITLE
Add level set partitioning

### DIFF
--- a/src/parcsr_ls/par_ilu.c
+++ b/src/parcsr_ls/par_ilu.c
@@ -295,6 +295,7 @@ hypre_ILUGetName(void *ilu_vdata)
       case 40: return (ilu_fill == 0) ? "ddPQ-GMRES-ILU0"  : "ddPQ-GMRES-ILUK";
       case 41: return "ddPQ-GMRES-ILUT";
       case 50: return "RAP-modILU0";
+      case 60: return "BJ-LS_ILU0";
       default: return "Unknown";
    }
 }

--- a/src/parcsr_ls/par_ilu_setup_device.c
+++ b/src/parcsr_ls/par_ilu_setup_device.c
@@ -94,6 +94,12 @@ hypre_ILUSetupDevice(hypre_ParILUData       *ilu_data,
    HYPRE_Real              *parD                = NULL;
    HYPRE_Int               *uend                = NULL;
 
+   /* level-set datastructures */
+   HYPRE_Int              *low_set_offsets      = NULL;
+   HYPRE_Int              *low_level_sets       = NULL;
+   HYPRE_Int              *upp_set_offsets      = NULL;
+   HYPRE_Int              *upp_level_sets       = NULL;
+
    /* Local variables */
    HYPRE_BigInt            *send_buf            = NULL;
    hypre_ParCSRCommPkg     *comm_pkg;
@@ -121,6 +127,43 @@ hypre_ILUSetupDevice(hypre_ParILUData       *ilu_data,
       return hypre_error_flag;
    }
 #endif
+
+   /* TODO: move level set computation to something like `hypre_CSRMatrixComputeLevelSet` in `seq_mv` */
+   if (ilu_type == 60)
+   {
+      /* We need to create a partitioning of the rows in level sets based on matrix structure
+         Not assuming symmetric structure we partition once for lower and one for upper solves */
+
+      hypre_CSRMatrix *A_diag_d = hypre_ParCSRMatrixDiag(A);
+      /* Will the copy call only copying the structure avoid the allocation for the data or just the transfer of the data? */
+      hypre_CSRMatrix *A_diag_h = hypre_CSRMatrixClone_v2(A_diag_d, /*only copy structure*/ 0,
+                                                          HYPRE_MEMORY_HOST);
+
+      HYPRE_Int *h_low_set_offsets = NULL;
+      HYPRE_Int *h_low_level_sets = NULL;
+      HYPRE_Int *h_upp_set_offsets = NULL;
+      HYPRE_Int *h_upp_level_sets = NULL;
+
+      hypre_CSRMatrixComputeLevelSetsHost(A_diag_h, h_low_set_offsets, h_low_level_sets,
+                                          h_upp_set_offsets, h_upp_level_sets);
+
+      /* Allocate device memory and copy level set data */
+      HYPRE_Int num_rows = hypre_CSRMatrixNumRows(A_diag_h);
+      low_level_sets = hypre_TAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_DEVICE);
+      upp_level_sets = hypre_TAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_DEVICE);
+
+      hypre_TMemcpy(low_level_sets, h_low_level_sets, HYPRE_Int, num_rows,
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+      hypre_TMemcpy(upp_level_sets, h_upp_level_sets, HYPRE_Int, num_rows,
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+
+      hypre_TFree(h_low_set_offsets, HYPRE_MEMORY_HOST);
+      hypre_TFree(h_low_level_sets, HYPRE_MEMORY_HOST);
+      hypre_TFree(h_upp_set_offsets, HYPRE_MEMORY_HOST);
+      hypre_TFree(h_upp_level_sets, HYPRE_MEMORY_HOST);
+
+      hypre_CSRMatrixDestroy(A_diag_h);
+   }
 
    /* Build the inverse permutation arrays */
    if (perm_data && qperm_data)

--- a/src/parcsr_ls/par_ilu_solve.c
+++ b/src/parcsr_ls/par_ilu_solve.c
@@ -245,7 +245,7 @@ hypre_ILUSolve( void               *ilu_vdata,
       /* Do one solve on LU*e = r */
       switch (ilu_type)
       {
-      case 0: case 1: default:
+      case 0: case 1: case 60: default:
             /* TODO (VPM): Encapsulate host and device functions into a single one */
 #if defined(HYPRE_USING_GPU)
             if (exec == HYPRE_EXEC_DEVICE)

--- a/src/seq_mv/_hypre_seq_mv.h
+++ b/src/seq_mv/_hypre_seq_mv.h
@@ -354,6 +354,12 @@ HYPRE_Int hypre_CSRMatrixSetConstantValues( hypre_CSRMatrix *A, HYPRE_Complex va
 HYPRE_Int hypre_CSRMatrixDiagScale( hypre_CSRMatrix *A, hypre_Vector *ld, hypre_Vector *rd);
 HYPRE_Int hypre_CSRMatrixTaggedFnorm( hypre_CSRMatrix *A, HYPRE_Int num_tags, HYPRE_Int *tags,
                                       HYPRE_Real **tnorms_ptr );
+HYPRE_Int
+hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
+                                    HYPRE_Int       *low_set_offsets,
+                                    HYPRE_Int       *low_level_sets,
+                                    HYPRE_Int       *upp_set_offsets,
+                                    HYPRE_Int       *upp_level_sets);
 
 /* csr_matop_device.c */
 hypre_CSRMatrix *hypre_CSRMatrixAddDevice ( HYPRE_Complex alpha, hypre_CSRMatrix *A,

--- a/src/seq_mv/_hypre_seq_mv_mup.h
+++ b/src/seq_mv/_hypre_seq_mv_mup.h
@@ -98,6 +98,13 @@ HYPRE_Int
 hypre_CSRMatrixComputeColSum_long_dbl( hypre_CSRMatrix *A, hypre_long_double *col_sum, HYPRE_Int type, hypre_long_double scal );
 
 HYPRE_Int
+hypre_CSRMatrixComputeLevelSetsHost_flt( hypre_CSRMatrix *A, HYPRE_Int *low_set_offsets, HYPRE_Int *low_level_sets, HYPRE_Int *upp_set_offsets, HYPRE_Int *upp_level_sets );
+HYPRE_Int
+hypre_CSRMatrixComputeLevelSetsHost_dbl( hypre_CSRMatrix *A, HYPRE_Int *low_set_offsets, HYPRE_Int *low_level_sets, HYPRE_Int *upp_set_offsets, HYPRE_Int *upp_level_sets );
+HYPRE_Int
+hypre_CSRMatrixComputeLevelSetsHost_long_dbl( hypre_CSRMatrix *A, HYPRE_Int *low_set_offsets, HYPRE_Int *low_level_sets, HYPRE_Int *upp_set_offsets, HYPRE_Int *upp_level_sets );
+
+HYPRE_Int
 hypre_CSRMatrixComputeRowSum_flt( hypre_CSRMatrix *A, HYPRE_Int *CF_i, HYPRE_Int *CF_j, hypre_float *row_sum, HYPRE_Int type, hypre_float scal, const char *set_or_add );
 HYPRE_Int
 hypre_CSRMatrixComputeRowSum_dbl( hypre_CSRMatrix *A, HYPRE_Int *CF_i, HYPRE_Int *CF_j, hypre_double *row_sum, HYPRE_Int type, hypre_double scal, const char *set_or_add );

--- a/src/seq_mv/_hypre_seq_mv_mup_def.h
+++ b/src/seq_mv/_hypre_seq_mv_mup_def.h
@@ -58,6 +58,7 @@
 #define hypre_CSRMatrixClone_v2 HYPRE_FIXEDPRECISION_FUNC ( hypre_CSRMatrixClone_v2 )
 #define hypre_CSRMatrixComputeColSum HYPRE_FIXEDPRECISION_FUNC ( hypre_CSRMatrixComputeColSum )
 #define hypre_CSRMatrixComputeColSumHost HYPRE_FIXEDPRECISION_FUNC ( hypre_CSRMatrixComputeColSumHost )
+#define hypre_CSRMatrixComputeLevelSetsHost HYPRE_FIXEDPRECISION_FUNC ( hypre_CSRMatrixComputeLevelSetsHost )
 #define hypre_CSRMatrixComputeRowSum HYPRE_FIXEDPRECISION_FUNC ( hypre_CSRMatrixComputeRowSum )
 #define hypre_CSRMatrixComputeRowSumHost HYPRE_FIXEDPRECISION_FUNC ( hypre_CSRMatrixComputeRowSumHost )
 #define hypre_CSRMatrixCopy HYPRE_FIXEDPRECISION_FUNC ( hypre_CSRMatrixCopy )

--- a/src/seq_mv/_hypre_seq_mv_mup_undef.h
+++ b/src/seq_mv/_hypre_seq_mv_mup_undef.h
@@ -55,6 +55,7 @@
 #undef hypre_CSRMatrixClone_v2
 #undef hypre_CSRMatrixComputeColSum
 #undef hypre_CSRMatrixComputeColSumHost
+#undef hypre_CSRMatrixComputeLevelSetsHost
 #undef hypre_CSRMatrixComputeRowSum
 #undef hypre_CSRMatrixComputeRowSumHost
 #undef hypre_CSRMatrixCopy

--- a/src/seq_mv/csr_matop.c
+++ b/src/seq_mv/csr_matop.c
@@ -2492,3 +2492,177 @@ hypre_CSRMatrixTaggedFnorm(hypre_CSRMatrix  *A,
 
    return hypre_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ * hypre_CSRMatrixComputeLevelSetsHost
+ * *A is a assumed to be a CSR matrix on the host with the diagonal entries as the first in their row
+ * XXX_set_offsets are the offsets where the level sets start in the XXX_level_sets buffers
+ * low/upp refer to the level sets induced by partitioning for a lower or upper triangular solve
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
+                                    HYPRE_Int       *low_set_offsets,
+                                    HYPRE_Int       *low_level_sets,
+                                    HYPRE_Int       *upp_set_offsets,
+                                    HYPRE_Int       *upp_level_sets)
+{
+   /* Traverse matrix structure to verify index operations */
+   HYPRE_Int num_rows = hypre_CSRMatrixNumRows(A);
+   HYPRE_Int *A_i = hypre_CSRMatrixI(A);
+   HYPRE_Int *A_j = hypre_CSRMatrixJ(A);
+
+   /* Compute level sets for the lower triangular part of the matrix */
+   /* Each row starts in level set 0, then is assigned to max(level[dep]) + 1 */
+   HYPRE_Int *row_level_low = hypre_CTAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_HOST);
+
+   HYPRE_Int num_levels_low = 1;
+   /* Compute row_level_low which maps every row to a level-set */
+   for (HYPRE_Int row_idx = 0; row_idx < num_rows; row_idx++)
+   {
+      for (HYPRE_Int j = A_i[row_idx]; j < A_i[row_idx + 1]; j++)
+      {
+         HYPRE_Int col_idx = A_j[j];
+         /* For now we only handle the lower triangular solve dependencies */
+         if (col_idx < row_idx)
+         {
+            if (row_level_low[col_idx] + 1 > row_level_low[row_idx])
+            {
+               row_level_low[row_idx] = row_level_low[col_idx] + 1;
+
+               /* Keep track of the amount of level sets */
+               if (row_level_low[row_idx] + 1 > num_levels_low)
+               {
+                  num_levels_low = row_level_low[row_idx] + 1;
+               }
+            }
+         }
+      }
+   }
+
+   /* TODO: if this function ends up being slow then consider loop fusions on lower/upper and more buffer reuse */
+
+   /* Count the number of rows in each level set */
+   HYPRE_Int *low_set_sizes = hypre_CTAlloc(HYPRE_Int, num_levels_low, HYPRE_MEMORY_HOST);
+   for (HYPRE_Int row_idx = 0; row_idx < num_rows; row_idx++)
+   {
+      low_set_sizes[row_level_low[row_idx]]++;
+   }
+
+   /* Compute offsets for each level set, this is just a prefix sum of level set sizes*/
+   low_set_offsets = hypre_CTAlloc(HYPRE_Int, num_levels_low + 1, HYPRE_MEMORY_HOST);
+   for (HYPRE_Int i = 0; i < num_levels_low; i++)
+   {
+      low_set_offsets[i + 1] = low_set_offsets[i] + low_set_sizes[i];
+   }
+
+   /* Fill in the row indices grouped by level set */
+   HYPRE_Int *lower_level_set = hypre_CTAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_HOST);
+
+   /* Fill level sets in correct places by starting at offsets and incrementing from there*/
+   HYPRE_Int *fill_pos_low = hypre_CTAlloc(HYPRE_Int, num_levels_low, HYPRE_MEMORY_HOST);
+
+   for (HYPRE_Int i = 0; i < num_levels_low; i++)
+   {
+      fill_pos_low[i] = low_set_offsets[i];
+   }
+   for (HYPRE_Int i = 0; i < num_rows; i++)
+   {
+      HYPRE_Int lvl = row_level_low[i];
+      lower_level_set[fill_pos_low[lvl]++] = i;
+   }
+
+   /* Compute level sets for the upper triangular part of the matrix */
+   /* Traverse rows in reverse: each row depends on rows with higher index */
+   HYPRE_Int *row_level_upp = hypre_CTAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_HOST);
+
+   HYPRE_Int num_levels_upp = 1;
+   for (HYPRE_Int row_idx = num_rows - 1; row_idx >= 0; row_idx--)
+   {
+      for (HYPRE_Int j = A_i[row_idx]; j < A_i[row_idx + 1]; j++)
+      {
+         HYPRE_Int col_idx = A_j[j];
+         /* Handle upper triangular solve dependencies */
+         if (col_idx > row_idx)
+         {
+            if (row_level_upp[col_idx] + 1 > row_level_upp[row_idx])
+            {
+               row_level_upp[row_idx] = row_level_upp[col_idx] + 1;
+
+               /* Keep track of the amount of level sets */
+               if (row_level_upp[row_idx] + 1 > num_levels_upp)
+               {
+                  num_levels_upp = row_level_upp[row_idx] + 1;
+               }
+            }
+         }
+      }
+   }
+
+   /* Count the number of rows in each upper level set */
+   HYPRE_Int *upp_set_sizes = hypre_CTAlloc(HYPRE_Int, num_levels_upp, HYPRE_MEMORY_HOST);
+   for (HYPRE_Int row_idx = 0; row_idx < num_rows; row_idx++)
+   {
+      upp_set_sizes[row_level_upp[row_idx]]++;
+   }
+
+   /* Compute offsets for each upper level set */
+   upp_set_offsets = hypre_CTAlloc(HYPRE_Int, num_levels_upp + 1, HYPRE_MEMORY_HOST);
+   for (HYPRE_Int i = 0; i < num_levels_upp; i++)
+   {
+      upp_set_offsets[i + 1] = upp_set_offsets[i] + upp_set_sizes[i];
+   }
+
+   /* Fill in the row indices grouped by upper level set */
+   HYPRE_Int *upper_level_set = hypre_CTAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_HOST);
+
+   HYPRE_Int *fill_pos_upp = hypre_CTAlloc(HYPRE_Int, num_levels_upp, HYPRE_MEMORY_HOST);
+   for (HYPRE_Int i = 0; i < num_levels_upp; i++)
+   {
+      fill_pos_upp[i] = upp_set_offsets[i];
+   }
+   for (HYPRE_Int i = 0; i < num_rows; i++)
+   {
+      HYPRE_Int lvl = row_level_upp[i];
+      upper_level_set[fill_pos_upp[lvl]++] = i;
+   }
+
+   /* Temporary to validate reasonable results. */
+#ifdef DEBUG_LVLSET
+   FILE *fp = fopen("level_sets.txt", "w");
+   if (fp)
+   {
+      fprintf(fp, "Number of lower levels: %d\n", num_levels_low);
+      for (HYPRE_Int i = 0; i < num_levels_low; i++)
+      {
+         fprintf(fp, "Lower level %d (size %d): ", i, low_set_sizes[i]);
+         for (HYPRE_Int j = low_set_offsets[i]; j < low_set_offsets[i + 1]; j++)
+         {
+            fprintf(fp, "%d ", lower_level_set[j]);
+         }
+         fprintf(fp, "\n");
+      }
+      fprintf(fp, "Number of upper levels: %d\n", num_levels_upp);
+      for (HYPRE_Int i = 0; i < num_levels_upp; i++)
+      {
+         fprintf(fp, "Upper level %d (size %d): ", i, upp_set_sizes[i]);
+         for (HYPRE_Int j = upp_set_offsets[i]; j < upp_set_offsets[i + 1]; j++)
+         {
+            fprintf(fp, "%d ", upper_level_set[j]);
+         }
+         fprintf(fp, "\n");
+      }
+      fclose(fp);
+   }
+#endif
+
+   /* Clean up */
+   hypre_TFree(fill_pos_low, HYPRE_MEMORY_HOST);
+   hypre_TFree(fill_pos_upp, HYPRE_MEMORY_HOST);
+   hypre_TFree(row_level_low, HYPRE_MEMORY_HOST);
+   hypre_TFree(row_level_upp, HYPRE_MEMORY_HOST);
+   hypre_TFree(low_set_sizes, HYPRE_MEMORY_HOST);
+   hypre_TFree(upp_set_sizes, HYPRE_MEMORY_HOST);
+
+   return hypre_error_flag;
+}

--- a/src/seq_mv/mup.fixed
+++ b/src/seq_mv/mup.fixed
@@ -10,6 +10,7 @@ hypre_CSRMatrixClone
 hypre_CSRMatrixClone_v2
 hypre_CSRMatrixComputeColSum
 hypre_CSRMatrixComputeColSumHost
+hypre_CSRMatrixComputeLevelSetsHost
 hypre_CSRMatrixComputeRowSum
 hypre_CSRMatrixComputeRowSumHost
 hypre_CSRMatrixCopy

--- a/src/seq_mv/mup_fixed.c
+++ b/src/seq_mv/mup_fixed.c
@@ -105,6 +105,14 @@ hypre_CSRMatrixComputeColSum( hypre_CSRMatrix *A, HYPRE_Complex *col_sum, HYPRE_
 /*--------------------------------------------------------------------------*/
 
 HYPRE_Int
+hypre_CSRMatrixComputeLevelSetsHost( hypre_CSRMatrix *A, HYPRE_Int *low_set_offsets, HYPRE_Int *low_level_sets, HYPRE_Int *upp_set_offsets, HYPRE_Int *upp_level_sets )
+{
+   return HYPRE_CURRENTPRECISION_FUNC(hypre_CSRMatrixComputeLevelSetsHost)( A, low_set_offsets, low_level_sets, upp_set_offsets, upp_level_sets );
+}
+
+/*--------------------------------------------------------------------------*/
+
+HYPRE_Int
 hypre_CSRMatrixComputeRowSum( hypre_CSRMatrix *A, HYPRE_Int *CF_i, HYPRE_Int *CF_j, HYPRE_Complex *row_sum, HYPRE_Int type, HYPRE_Complex scal, const char *set_or_add )
 {
    return HYPRE_CURRENTPRECISION_FUNC(hypre_CSRMatrixComputeRowSum)( A, CF_i, CF_j, row_sum, type, scal, set_or_add );

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -52,6 +52,12 @@ HYPRE_Int hypre_CSRMatrixSetConstantValues( hypre_CSRMatrix *A, HYPRE_Complex va
 HYPRE_Int hypre_CSRMatrixDiagScale( hypre_CSRMatrix *A, hypre_Vector *ld, hypre_Vector *rd);
 HYPRE_Int hypre_CSRMatrixTaggedFnorm( hypre_CSRMatrix *A, HYPRE_Int num_tags, HYPRE_Int *tags,
                                       HYPRE_Real **tnorms_ptr );
+HYPRE_Int
+hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
+                                    HYPRE_Int       *low_set_offsets,
+                                    HYPRE_Int       *low_level_sets,
+                                    HYPRE_Int       *upp_set_offsets,
+                                    HYPRE_Int       *upp_level_sets);
 
 /* csr_matop_device.c */
 hypre_CSRMatrix *hypre_CSRMatrixAddDevice ( HYPRE_Complex alpha, hypre_CSRMatrix *A,

--- a/src/test/TEST_ij/ilu.jobs
+++ b/src/test/TEST_ij/ilu.jobs
@@ -47,3 +47,7 @@ mpirun -np 2  ./ij -solver 82 -ilu_type 50 -ilu_lfil 0 > ilu.out.323
 ## ILU smoother for AMG
 mpirun -np 2  ./ij -solver 0 -smtype 5  -smlv 1 -ilu_type 30 > ilu.out.324
 mpirun -np 2  ./ij -solver 0 -smtype 15 -smlv 1 -ilu_type 30 > ilu.out.325
+
+## TODO: organize
+# new ILU test (GPU)
+mpirun -np 1  ./ij -solver 80 -ilu_type 60 -ilu_lfil 0 -exec_device -memory_device > ilu.out.326

--- a/src/test/TEST_ij/ilu.saved
+++ b/src/test/TEST_ij/ilu.saved
@@ -102,3 +102,6 @@ Final Relative Residual Norm = 8.380440e-09
 BoomerAMG Iterations = 7
 Final Relative Residual Norm = 7.074639e-09
 
+# Output file: solvers.out.326
+hypre_ILU Iterations = 85
+Final Relative Residual Norm = 9.266244e-09

--- a/src/test/TEST_ij/ilu.sh
+++ b/src/test/TEST_ij/ilu.sh
@@ -35,6 +35,7 @@ FILES="\
  ${TNAME}.out.323\
  ${TNAME}.out.324\
  ${TNAME}.out.325\
+ ${TNAME}.out.326\
 "
 
 for i in $FILES

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -2723,6 +2723,8 @@ main( hypre_int argc,
          hypre_printf("  -ilu_type   40                   : ddPQ + GMRES with ILU(k) variants \n");
          hypre_printf("  -ilu_type   41                   : ddPQ + GMRES with ILUT \n");
          hypre_printf("  -ilu_type   50                   : GMRES with ILU(0): RAP variant with MILU(0)  \n");
+         hypre_printf("  -ilu_type   60                   : ILU0 with level-sets \n"); // TODO: add more variants or add new options
+         hypre_printf("  -ilu_type   70                   : DILU with level-sets \n"); // TODO: add more variants or add new options
          hypre_printf("  -ilu_lfil   <val>                : set level of fill (k) for ILU(k) = val\n");
          hypre_printf("  -ilu_droptol   <val>             : set drop tolerance threshold for ILUT = val \n");
          hypre_printf("  -ilu_max_row_nnz   <val>         : set max. num of nonzeros to keep per row = val \n");


### PR DESCRIPTION
This partitioning is preparatory work for adding level-set based ILU preconditioners on GPU (https://github.com/hypre-space/hypre/issues/1470)

For now registers a new ILU0 preconditioner and createes a another ilu test that calls it that expects same results as original ilu0.

TODOs:
- [x] Move partitioning to a more appropriate location (where?)
- [x] Add upper coloring as  well if matrix is non-symmetric in sparsity structure (we can't assume this symmetry, right?)
- [ ] Replace printing with a test case that validates coloring on some simple matrices (not sure where/how do this)
- [ ] Ensure that host-device transfers are minimal

Questions:
- Should any logic be done with the ilu_type, registering a new preconditioner be done now when strictly speaking we only need to add the partitioning routines and validate them?
- Where do I add custom tests where I can create a simple matrix and validate that the partitioning works as intended?
- If we register the preconditioner in this PR, what to name the ILU without causing confusion?
