### PR TITLE
Fix documentation on HYPRE_ENABLE_BLAS/LAPACK

### DIFF
--- a/src/docs/usr-manual/ch-misc.rst
+++ b/src/docs/usr-manual/ch-misc.rst
@@ -294,15 +294,17 @@ For GPU-specific options, see the :ref:`gpu_build` section below.
      - ``--with-fmangle-lapack``
      - ``-DHYPRE_ENABLE_FMANGLE_LAPACK=0``
    * - | External BLAS
-       | (default is off)
+       | (if not provided, the internal BLAS is used)
      - | ``--with-blas-lib=<lib>``
        | ``--with-blas-lib-dirs=<path>``
-     - ``-DHYPRE_ENABLE_HYPRE_BLAS=OFF``
+     - | Disable internal BLAS with
+       | ``-DHYPRE_ENABLE_HYPRE_BLAS=OFF``
    * - | External LAPACK
-       | (default is off)
+       | (if not provided, the internal LAPACK is used)
      - | ``--with-lapack-lib=<lib>``
        | ``--with-lapack-lib-dirs=<path>``
-     - ``-DHYPRE_ENABLE_HYPRE_LAPACK=OFF``
+     - | Disable internal LAPACK with
+       | ``-DHYPRE_ENABLE_HYPRE_LAPACK=OFF``
    * - | SuperLU_DIST Support
        | (default is off)
      - ``--with-dsuperlu``


### PR DESCRIPTION
I think the Spack package was incorrectly setting the lapack flags. This took a while to understand because the documentation was using double negatives. I tried making it more explicit.

https://github.com/spack/spack-packages/pull/3966