### PR TITLE
Update RAJA/Kokkos support

### DIFF
--- a/src/config/configure.in
+++ b/src/config/configure.in
@@ -1413,10 +1413,11 @@ AS_HELP_STRING([--enable-onemklrand],
 )
 
 dnl ***** RAJA
+dnl * Legacy developer-only option: keep support wired up, but omit it from
+dnl * configure --help since RAJA is no longer being actively developed here.
 
 AC_ARG_WITH(raja,
-AS_HELP_STRING([--with-raja],
-               [Use RAJA. Require RAJA package to be compiled properly (default is NO).]),
+[],
 [case "$withval" in
     yes) hypre_using_raja=yes;;
     no)  hypre_using_raja=no ;;
@@ -1426,10 +1427,7 @@ AS_HELP_STRING([--with-raja],
 )
 
 AC_ARG_WITH(raja-include,
-AS_HELP_STRING([--with-raja-include=DIR],
-               [User specifies that RAJA/*.h is in DIR.  The options
-                --with-raja-include --with-raja-libs and
-                --with-raja-lib-dirs must be used together.]),
+[],
 [for raja_dir in $withval; do
     HYPRE_RAJA_INCLUDE="-I$raja_dir $HYPRE_RAJA_INCLUDE"
  done;
@@ -1437,20 +1435,15 @@ AS_HELP_STRING([--with-raja-include=DIR],
 )
 
 AC_ARG_WITH(raja-lib,
-AS_HELP_STRING([--with-raja-lib=LIBS],
-               [LIBS is space-separated linkable list (enclosed in quotes) of libraries
-                needed for RAJA. OK to use -L and -l flags in the list]),
+[],
 [for raja_lib in $withval; do
-       HYPRE_RAJA_LIB="$HYPRE_RAJA_LIB $raja_lib"
+        HYPRE_RAJA_LIB="$HYPRE_RAJA_LIB $raja_lib"
  done;
 hypre_user_chose_raja=yes]
 )
 
 AC_ARG_WITH(raja-libs,
-AS_HELP_STRING([--with-raja-libs=LIBS],
-               [LIBS is space-separated list (enclosed in quotes) of libraries
-                needed for RAJA (base name only). The options --with-raja-libs and
-                --with-raja-lib-dirs must be used together.]),
+[],
 [for raja_lib in $withval; do
     HYPRE_RAJA_LIB="$HYPRE_RAJA_LIB -l$raja_lib"
  done;
@@ -1458,12 +1451,7 @@ hypre_user_chose_raja=yes]
 )
 
 AC_ARG_WITH(raja-lib-dirs,
-AS_HELP_STRING([--with-raja-lib-dirs=DIRS],
-               [DIRS is space-separated list (enclosed in quotes) of
-                directories containing the libraries specified by
-                --with-raja-libs, e.g "usr/lib /usr/local/lib".
-                The  options --with-raja-libs and --raja-blas-lib-dirs
-                must be used together.]),
+[],
 [for raja_lib_dir in $withval; do
     HYPRE_RAJA_LIB_DIR="$HYPRE_RAJA_LIB_DIR -L$raja_lib_dir"
  done;
@@ -1471,10 +1459,11 @@ AS_HELP_STRING([--with-raja-lib-dirs=DIRS],
 )
 
 dnl ***** Kokkos
+dnl * Legacy developer-only option: keep support wired up, but omit it from
+dnl * configure --help since Kokkos is no longer being actively developed here.
 
 AC_ARG_WITH(kokkos,
-AS_HELP_STRING([--with-kokkos],
-               [Use Kokkos. Require kokkos package to be compiled properly(default is NO).]),
+[],
 [case "$withval" in
     yes) hypre_using_kokkos=yes ;;
     no)  hypre_using_kokkos=no ;;
@@ -1484,10 +1473,7 @@ AS_HELP_STRING([--with-kokkos],
 )
 
 AC_ARG_WITH(kokkos-include,
-AS_HELP_STRING([--with-kokkos-include=DIR],
-               [User specifies that KOKKOS headers is in DIR.  The options
-                --with-kokkos-include --with-kokkos-libs and
-                --with-kokkos-dirs must be used together.]),
+[],
 [for kokkos_dir in $withval; do
 HYPRE_KOKKOS_INCLUDE="-I$kokkos_dir $HYPRE_KOKKOS_INCLUDE"
 done;
@@ -1495,9 +1481,7 @@ hypre_user_chose_kokkos=yes]
 )
 
 AC_ARG_WITH(kokkos-lib,
-AS_HELP_STRING([--with-kokkos-lib=LIBS],
-               [LIBS is space-separated linkable list (enclosed in quotes) of libraries
-                needed for KOKKOS. OK to use -L and -l flags in the list]),
+[],
 [for kokkos_lib in $withval; do
        HYPRE_KOKKOS_LIB="$HYPRE_KOKKOS_LIB $kokkos_lib"
  done;
@@ -1505,10 +1489,7 @@ hypre_user_chose_kokkos=yes]
 )
 
 AC_ARG_WITH(kokkos-libs,
-AS_HELP_STRING([--with-kokkos-libs=LIBS],
-               [LIBS is space-separated list (enclosed in quotes) of libraries
-                needed for KOKKOS (base name only). The options --with-kokkos-libs and
-                --with-kokkos-dirs must be used together.]),
+[],
 [for kokkos_lib in $withval; do
     HYPRE_KOKKOS_LIB="$HYPRE_KOKKOS_LIB -l$kokkos_lib"
  done;
@@ -1516,12 +1497,7 @@ hypre_user_chose_kokkos=yes]
 )
 
 AC_ARG_WITH(kokkos-lib-dirs,
-AS_HELP_STRING([--with-kokkos-lib-dirs=DIRS],
-               [DIRS is space-separated list (enclosed in quotes) of
-                directories containing the libraries and
-                Makefile.kokkos is assumed to be in DIRS/../ .
-                The  options --with-kokkos-libs and --with-kokkos-dirs
-                must be used together.]),
+[],
 [for kokkos_lib_dir in $withval; do
     HYPRE_KOKKOS_LIB_DIR="$HYPRE_KOKKOS_LIB_DIR -L$kokkos_lib_dir"
  done;

--- a/src/configure
+++ b/src/configure
@@ -1734,43 +1734,7 @@ Optional Packages:
                           double+single quotes), e.g.
                           --with-sycl-target-backend="'-device
                           12.1.0,12.4.0'".
-  --with-raja             Use RAJA. Require RAJA package to be compiled
-                          properly (default is NO).
-  --with-raja-include=DIR User specifies that RAJA/*.h is in DIR. The options
-                          --with-raja-include --with-raja-libs and
-                          --with-raja-lib-dirs must be used together.
-  --with-raja-lib=LIBS    LIBS is space-separated linkable list (enclosed in
-                          quotes) of libraries needed for RAJA. OK to use -L
-                          and -l flags in the list
-  --with-raja-libs=LIBS   LIBS is space-separated list (enclosed in quotes) of
-                          libraries needed for RAJA (base name only). The
-                          options --with-raja-libs and --with-raja-lib-dirs
-                          must be used together.
-  --with-raja-lib-dirs=DIRS
-                          DIRS is space-separated list (enclosed in quotes) of
-                          directories containing the libraries specified by
-                          --with-raja-libs, e.g "usr/lib /usr/local/lib". The
-                          options --with-raja-libs and --raja-blas-lib-dirs
-                          must be used together.
-  --with-kokkos           Use Kokkos. Require kokkos package to be compiled
-                          properly(default is NO).
-  --with-kokkos-include=DIR
-                          User specifies that KOKKOS headers is in DIR. The
-                          options --with-kokkos-include --with-kokkos-libs and
-                          --with-kokkos-dirs must be used together.
-  --with-kokkos-lib=LIBS  LIBS is space-separated linkable list (enclosed in
-                          quotes) of libraries needed for KOKKOS. OK to use -L
-                          and -l flags in the list
-  --with-kokkos-libs=LIBS LIBS is space-separated list (enclosed in quotes) of
-                          libraries needed for KOKKOS (base name only). The
-                          options --with-kokkos-libs and --with-kokkos-dirs
-                          must be used together.
-  --with-kokkos-lib-dirs=DIRS
-                          DIRS is space-separated list (enclosed in quotes) of
-                          directories containing the libraries and
-                          Makefile.kokkos is assumed to be in DIRS/../ . The
-                          options --with-kokkos-libs and --with-kokkos-dirs
-                          must be used together.
+
   --with-umpire-host      Use Umpire Allocator for host memory (default is
                           NO).
   --with-umpire-device    Use Umpire Allocator for device memory (default is
@@ -4980,7 +4944,7 @@ fi
 if test ${with_raja_lib+y}
 then :
   withval=$with_raja_lib; for raja_lib in $withval; do
-       HYPRE_RAJA_LIB="$HYPRE_RAJA_LIB $raja_lib"
+        HYPRE_RAJA_LIB="$HYPRE_RAJA_LIB $raja_lib"
  done;
 hypre_user_chose_raja=yes
 


### PR DESCRIPTION
The RAJA and Kokkos backends are not actively developed (at least currently).

This PR removes information about RAJA/Kokkos support via the autotools build while still keeping it available for internal development if warranted in the future