### PR TITLE
Fix "CMake + mixed precision + shared" build

### DIFF
--- a/src/distributed_matrix/CMakeLists.txt
+++ b/src/distributed_matrix/CMakeLists.txt
@@ -22,8 +22,14 @@ set(REGULAR_SRCS
 )
 
 if(HYPRE_ENABLE_MIXED_PRECISION)
+  set(MUP_SRCS
+    mup_fixed.c
+    mup_functions.c
+    mup_pre.c
+  )
+
   setup_mixed_precision_compilation("distributed_matrix" SRCS "${REGULAR_SRCS}")
-  target_sources(${PROJECT_NAME} PRIVATE ${HDRS})
+  target_sources(${PROJECT_NAME} PRIVATE ${MUP_SRCS} ${HDRS})
 else()
   target_sources(${PROJECT_NAME} PRIVATE ${REGULAR_SRCS} ${HDRS})
 endif()

--- a/src/distributed_matrix/Makefile
+++ b/src/distributed_matrix/Makefile
@@ -30,6 +30,12 @@ FILES =\
  distributed_matrix_PETSc.c\
  distributed_matrix_parcsr.c
 
+# Mixed precision files
+MP_FILES =\
+ mup_fixed.c\
+ mup_functions.c\
+ mup_pre.c
+
 OBJS = ${FILES:.c=.o}
 
 ifeq (${MP_BUILD}, 1) 
@@ -37,8 +43,9 @@ ifeq (${MP_BUILD}, 1)
 COBJS_single      = ${FILES:.c=.o_flt}
 COBJS_double      = ${FILES:.c=.o_dbl}
 COBJS_longdouble  = ${FILES:.c=.o_ldbl}
+MP_COBJS          = ${MP_FILES:.c=.o}
 
-OBJS = ${COBJS_single} ${COBJS_double} ${COBJS_longdouble}
+OBJS = ${COBJS_single} ${COBJS_double} ${COBJS_longdouble} ${MP_COBJS}
 
 endif
 

--- a/src/distributed_matrix/distributed_matrix.h
+++ b/src/distributed_matrix/distributed_matrix.h
@@ -17,7 +17,6 @@
 
 #include "_hypre_utilities.h"
 
-
 /*--------------------------------------------------------------------------
  * hypre_DistributedMatrix:
  *--------------------------------------------------------------------------*/
@@ -58,5 +57,10 @@ typedef struct
  *--------------------------------------------------------------------------*/
 #include "HYPRE_distributed_matrix_mv.h"
 #include "internal_protos.h"
+
+#ifdef HYPRE_MIXED_PRECISION
+#include "HYPRE_distributed_matrix_mv_mup.h"
+#include "internal_protos_mup.h"
+#endif
 
 #endif


### PR DESCRIPTION
This PR fixes compilation and linking errors that occur when building shared libraries with mixed precision enabled.

- Header order: Fixed `distributed_matrix.h` to declare the base type before including mixed-precision headers, resolving "unknown type" errors.
- Build parity: Added missing `mup_*.c` dispatch wrappers to the autotools and CMake. Resolves missing symbol errors (like GetDims and GetRow) that were previously masked during static builds.