### PR TITLE
Fix SSAMG coarsened grid boundary handling

### DIFF
--- a/src/sstruct_ls/ssamg.c
+++ b/src/sstruct_ls/ssamg.c
@@ -30,7 +30,7 @@ hypre_SSAMGCreate( hypre_MPI_Comm comm )
    (ssamg_data -> zero_guess)       = 0;
    (ssamg_data -> max_levels)       = 0;
    (ssamg_data -> relax_type)       = 1;
-   (ssamg_data -> interp_type)      = 0;
+   (ssamg_data -> interp_type)      = -1;
    (ssamg_data -> skip_relax)       = 0;
    (ssamg_data -> usr_relax_weight) = 1.0;
    (ssamg_data -> usr_set_rweight)  = 0;

--- a/src/sstruct_mv/sstruct_matrix.c
+++ b/src/sstruct_mv/sstruct_matrix.c
@@ -2973,6 +2973,7 @@ hypre_SStructMatrixHaloToUMatrix( hypre_SStructMatrix   *A,
    hypre_BoxArray        *convert_boxa;
    hypre_BoxArray        *pbnd_boxa;
    hypre_BoxArray        *grid_boxes;
+   HYPRE_Int             *grid_box_ids;
    hypre_Box             *box;
    hypre_Box             *grow_box;
    hypre_Box             *grid_box;
@@ -2984,7 +2985,6 @@ hypre_SStructMatrixHaloToUMatrix( hypre_SStructMatrix   *A,
    HYPRE_Int              num_boxes;
    HYPRE_Int              pbnd_boxaa_size;
    HYPRE_Int              convert_boxaa_size;
-   HYPRE_Int              grid_box_id;
    HYPRE_Int              convert_box_id;
 
    HYPRE_ANNOTATE_FUNC_BEGIN;
@@ -3008,6 +3008,7 @@ hypre_SStructMatrixHaloToUMatrix( hypre_SStructMatrix   *A,
          sgrid = hypre_SStructPGridSGrid(pgrid, var);
          num_boxes  = hypre_StructGridNumBoxes(sgrid);
          grid_boxes = hypre_StructGridBoxes(sgrid);
+         grid_box_ids = hypre_BoxArrayIDs(grid_boxes);
 
          /* Exit this loop if there are no grid boxes */
          if (!num_boxes)
@@ -3022,20 +3023,19 @@ hypre_SStructMatrixHaloToUMatrix( hypre_SStructMatrix   *A,
          convert_boxaa_size = hypre_min(num_boxes, pbnd_boxaa_size) + 1;
          convert_boxaa[part][var] = hypre_BoxArrayArrayCreate(convert_boxaa_size, ndim);
 
-         k = kk = 0;
+         kk = 0;
          hypre_ForBoxArrayI(i, pbnd_boxaa)
          {
             pbnd_boxa      = hypre_BoxArrayArrayBoxArray(pbnd_boxaa, i);
             convert_box_id = hypre_BoxArrayArrayID(pbnd_boxaa, i);
-            grid_box_id    = hypre_StructGridID(sgrid, k);
             convert_boxa   = hypre_BoxArrayArrayBoxArray(convert_boxaa[part][var], kk);
 
-            /* Find matching box id */
-            while (convert_box_id != grid_box_id)
+            /* Find matching box id. Some boxes may have been pruned by coarsening,
+             * so part-boundary entries are not guaranteed to exist on this grid. */
+            k = hypre_BinarySearch(grid_box_ids, convert_box_id, num_boxes);
+            if (k < 0)
             {
-               k++;
-               //hypre_assert(k < hypre_StructGridNumBoxes(sgrid));
-               grid_box_id = hypre_StructGridID(sgrid, k);
+               continue;
             }
             grid_box = hypre_BoxArrayBox(grid_boxes, k);
 


### PR DESCRIPTION
## Summary

Fix two SSAMG issues triggered by coarsened semi-structured grids with pruned boxes.

- Initialize SSAMG `interp_type` to `-1`, matching the public API documentation that describes structured interpolation as the default.
- Make `hypre_SStructMatrixHaloToUMatrix` look up part-boundary box IDs in the current structured grid ID list instead of assuming every part-boundary ID is present and ordered contiguously. Boundary entries whose source boxes were pruned by coarsening are skipped.

## Root Cause

Bug 1: The SSAMG default interpolation type was documented as `-1`, but the solver data object initialized it to `0`, enabling the unstructured interpolation path by default.

Bug 2: In the structured interpolation path, RAP setup calls `hypre_SStructMatrixHaloToUMatrix`; after coarsening/pruning, the current `StructGrid` can contain IDs like `0,2,4,...` while the part-boundary metadata still contains IDs such as `1`. The old linear scan walked past the end of the grid boxes in that case.

## Validation

Validated in an AMReX SStruct SSAMG reproducer against this HYPRE build:

- `make -j8` in `hypre/src`
- `make -B -j8 main3d.gnu.DEBUG.MPI.ex`
- `./main3d.gnu.DEBUG.MPI.ex inputs-mlhypre-ssamg-works`
- `./main3d.gnu.DEBUG.MPI.ex inputs-mlhypre-ssamg-works max_grid_size=64`
- `./main3d.gnu.DEBUG.MPI.ex inputs-mlhypre-ssamg-works max_grid_size=8`

The original reproducer now completes with 27 SSAMG iterations and relative residual `5.649857648e-11`.
