### PR TITLE
Level-Set factorization and solve for ILU0 on GPU

### DIFF
--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -1300,6 +1300,14 @@ typedef struct hypre_ParILUData_struct
    hypre_Vector         *Utemp_lower;
    hypre_Vector         *Adiag_diag;
    hypre_Vector         *Sdiag_diag;
+
+   /* Level-set data for ilu_type 60 triangular solves */
+   HYPRE_Int             num_low_levels;           /* number of lower triangular level sets */
+   HYPRE_Int            *low_level_set_offsets;    /* host array, length num_low_levels+1 */
+   HYPRE_Int            *d_low_level_set_rows;     /* device array, length n */
+   HYPRE_Int             num_upp_levels;           /* number of upper triangular level sets */
+   HYPRE_Int            *upp_level_set_offsets;    /* host array, length num_upp_levels+1 */
+   HYPRE_Int            *d_upp_level_set_rows;     /* device array, length n */
 #endif
 
    /* data structure sor solving Schur System */
@@ -1367,6 +1375,12 @@ typedef struct hypre_ParILUData_struct
 #define hypre_ParILUDataUTempLower(ilu_data)                   ((ilu_data) -> Utemp_lower)
 #define hypre_ParILUDataADiagDiag(ilu_data)                    ((ilu_data) -> Adiag_diag)
 #define hypre_ParILUDataSDiagDiag(ilu_data)                    ((ilu_data) -> Sdiag_diag)
+#define hypre_ParILUDataNumLowLevels(ilu_data)                 ((ilu_data) -> num_low_levels)
+#define hypre_ParILUDataLowLevelSetOffsets(ilu_data)           ((ilu_data) -> low_level_set_offsets)
+#define hypre_ParILUDataDLowLevelSetRows(ilu_data)             ((ilu_data) -> d_low_level_set_rows)
+#define hypre_ParILUDataNumUppLevels(ilu_data)                 ((ilu_data) -> num_upp_levels)
+#define hypre_ParILUDataUppLevelSetOffsets(ilu_data)           ((ilu_data) -> upp_level_set_offsets)
+#define hypre_ParILUDataDUppLevelSetRows(ilu_data)             ((ilu_data) -> d_upp_level_set_rows)
 #endif
 
 #define hypre_ParILUDataGlobalSolver(ilu_data)                 ((ilu_data) -> global_solver)
@@ -3469,6 +3483,14 @@ HYPRE_Int hypre_ILUSolveLUDevice( hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_
                                   hypre_ParVector *f, hypre_ParVector *u,
                                   HYPRE_Int *perm, hypre_ParVector *ftemp,
                                   hypre_ParVector *utemp );
+HYPRE_Int hypre_ILUSolveLULevelSetDevice( hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d,
+                                          hypre_ParVector *f, hypre_ParVector *u,
+                                          HYPRE_Int *perm,
+                                          HYPRE_Int num_low_levels, HYPRE_Int *low_set_offsets,
+                                          HYPRE_Int *d_low_set_rows,
+                                          HYPRE_Int num_upp_levels, HYPRE_Int *upp_set_offsets,
+                                          HYPRE_Int *d_upp_set_rows,
+                                          hypre_ParVector *ftemp, hypre_ParVector *utemp );
 HYPRE_Int hypre_ILUApplyLowerJacIterDevice( hypre_CSRMatrix *A, hypre_Vector *input,
                                             hypre_Vector *work, hypre_Vector *output,
                                             HYPRE_Int lower_jacobi_iters );

--- a/src/parcsr_ls/par_ilu.c
+++ b/src/parcsr_ls/par_ilu.c
@@ -1250,6 +1250,12 @@ hypre_ILUWriteSolverParams(void *ilu_vdata)
                       hypre_ParILUDataOperatorComplexity(ilu_data));
          break;
 
+      case 60:
+         hypre_printf("Level-set BJ with ILU0 \n");
+         hypre_printf("Operator Complexity (Fill factor) = %f \n",
+                      hypre_ParILUDataOperatorComplexity(ilu_data));
+         break;
+
       default:
          hypre_printf("Unknown type \n");
          break;

--- a/src/parcsr_ls/par_ilu.h
+++ b/src/parcsr_ls/par_ilu.h
@@ -85,6 +85,14 @@ typedef struct hypre_ParILUData_struct
    hypre_Vector         *Utemp_lower;
    hypre_Vector         *Adiag_diag;
    hypre_Vector         *Sdiag_diag;
+
+   /* Level-set data for ilu_type 60 triangular solves */
+   HYPRE_Int             num_low_levels;           /* number of lower triangular level sets */
+   HYPRE_Int            *low_level_set_offsets;    /* host array, length num_low_levels+1 */
+   HYPRE_Int            *d_low_level_set_rows;     /* device array, length n */
+   HYPRE_Int             num_upp_levels;           /* number of upper triangular level sets */
+   HYPRE_Int            *upp_level_set_offsets;    /* host array, length num_upp_levels+1 */
+   HYPRE_Int            *d_upp_level_set_rows;     /* device array, length n */
 #endif
 
    /* data structure sor solving Schur System */
@@ -152,6 +160,12 @@ typedef struct hypre_ParILUData_struct
 #define hypre_ParILUDataUTempLower(ilu_data)                   ((ilu_data) -> Utemp_lower)
 #define hypre_ParILUDataADiagDiag(ilu_data)                    ((ilu_data) -> Adiag_diag)
 #define hypre_ParILUDataSDiagDiag(ilu_data)                    ((ilu_data) -> Sdiag_diag)
+#define hypre_ParILUDataNumLowLevels(ilu_data)                 ((ilu_data) -> num_low_levels)
+#define hypre_ParILUDataLowLevelSetOffsets(ilu_data)           ((ilu_data) -> low_level_set_offsets)
+#define hypre_ParILUDataDLowLevelSetRows(ilu_data)             ((ilu_data) -> d_low_level_set_rows)
+#define hypre_ParILUDataNumUppLevels(ilu_data)                 ((ilu_data) -> num_upp_levels)
+#define hypre_ParILUDataUppLevelSetOffsets(ilu_data)           ((ilu_data) -> upp_level_set_offsets)
+#define hypre_ParILUDataDUppLevelSetRows(ilu_data)             ((ilu_data) -> d_upp_level_set_rows)
 #endif
 
 #define hypre_ParILUDataGlobalSolver(ilu_data)                 ((ilu_data) -> global_solver)

--- a/src/parcsr_ls/par_ilu_setup.c
+++ b/src/parcsr_ls/par_ilu_setup.c
@@ -158,6 +158,11 @@ hypre_ILUSetup( void               *ilu_vdata,
    hypre_SeqVectorDestroy(hypre_ParILUDataADiagDiag(ilu_data));
    hypre_SeqVectorDestroy(hypre_ParILUDataSDiagDiag(ilu_data));
 
+   hypre_TFree(hypre_ParILUDataLowLevelSetOffsets(ilu_data), HYPRE_MEMORY_HOST);
+   hypre_TFree(hypre_ParILUDataDLowLevelSetRows(ilu_data),   HYPRE_MEMORY_DEVICE);
+   hypre_TFree(hypre_ParILUDataUppLevelSetOffsets(ilu_data), HYPRE_MEMORY_HOST);
+   hypre_TFree(hypre_ParILUDataDUppLevelSetRows(ilu_data),   HYPRE_MEMORY_DEVICE);
+
    hypre_ParILUDataFTempUpper(ilu_data) = NULL;
    hypre_ParILUDataUTempLower(ilu_data) = NULL;
    hypre_ParILUDataXTemp(ilu_data)      = NULL;
@@ -165,6 +170,10 @@ hypre_ILUSetup( void               *ilu_vdata,
    hypre_ParILUDataZTemp(ilu_data)      = NULL;
    hypre_ParILUDataADiagDiag(ilu_data)  = NULL;
    hypre_ParILUDataSDiagDiag(ilu_data)  = NULL;
+   hypre_ParILUDataLowLevelSetOffsets(ilu_data) = NULL;
+   hypre_ParILUDataDLowLevelSetRows(ilu_data)   = NULL;
+   hypre_ParILUDataUppLevelSetOffsets(ilu_data) = NULL;
+   hypre_ParILUDataDUppLevelSetRows(ilu_data)   = NULL;
 #endif
 
    /* Free previously allocated data, if any not destroyed */
@@ -266,7 +275,7 @@ hypre_ILUSetup( void               *ilu_vdata,
             hypre_ILUGetPermddPQ(matA, &perm, &qperm, tol_ddPQ, &nLU, &nI, reordering_type);
             break;
 
-         case 0: case 1: case 60:
+         case 0: case 1:
          default:
             /* RCM or none */
             hypre_ILUGetLocalPerm(matA, &perm, &nLU, reordering_type);

--- a/src/parcsr_ls/par_ilu_setup_device.c
+++ b/src/parcsr_ls/par_ilu_setup_device.c
@@ -169,6 +169,9 @@ hypre_ILUSetupDevice(hypre_ParILUData       *ilu_data,
          /* Permute A_diag: A_diag = A_diag(perm, qperm) */
          hypre_CSRMatrixPermute(hypre_ParCSRMatrixDiag(A), perm_data, rqperm_data, &A_diag);
 
+         /* Move diagonal to first position in each row (required by level-set kernels) */
+         hypre_CSRMatrixReorder(A_diag);
+
          /* Clone to host for level-set computation (structure only) */
          hypre_CSRMatrix *A_diag_h = hypre_CSRMatrixClone_v2(A_diag, 0, HYPRE_MEMORY_HOST);
 

--- a/src/parcsr_ls/par_ilu_setup_device.c
+++ b/src/parcsr_ls/par_ilu_setup_device.c
@@ -94,12 +94,6 @@ hypre_ILUSetupDevice(hypre_ParILUData       *ilu_data,
    HYPRE_Real              *parD                = NULL;
    HYPRE_Int               *uend                = NULL;
 
-   /* level-set datastructures */
-   HYPRE_Int              *low_set_offsets      = NULL;
-   HYPRE_Int              *low_level_sets       = NULL;
-   HYPRE_Int              *upp_set_offsets      = NULL;
-   HYPRE_Int              *upp_level_sets       = NULL;
-
    /* Local variables */
    HYPRE_BigInt            *send_buf            = NULL;
    hypre_ParCSRCommPkg     *comm_pkg;
@@ -127,43 +121,6 @@ hypre_ILUSetupDevice(hypre_ParILUData       *ilu_data,
       return hypre_error_flag;
    }
 #endif
-
-   /* TODO: move level set computation to something like `hypre_CSRMatrixComputeLevelSet` in `seq_mv` */
-   if (ilu_type == 60)
-   {
-      /* We need to create a partitioning of the rows in level sets based on matrix structure
-         Not assuming symmetric structure we partition once for lower and one for upper solves */
-
-      hypre_CSRMatrix *A_diag_d = hypre_ParCSRMatrixDiag(A);
-      /* Will the copy call only copying the structure avoid the allocation for the data or just the transfer of the data? */
-      hypre_CSRMatrix *A_diag_h = hypre_CSRMatrixClone_v2(A_diag_d, /*only copy structure*/ 0,
-                                                          HYPRE_MEMORY_HOST);
-
-      HYPRE_Int *h_low_set_offsets = NULL;
-      HYPRE_Int *h_low_level_sets = NULL;
-      HYPRE_Int *h_upp_set_offsets = NULL;
-      HYPRE_Int *h_upp_level_sets = NULL;
-
-      hypre_CSRMatrixComputeLevelSetsHost(A_diag_h, h_low_set_offsets, h_low_level_sets,
-                                          h_upp_set_offsets, h_upp_level_sets);
-
-      /* Allocate device memory and copy level set data */
-      HYPRE_Int num_rows = hypre_CSRMatrixNumRows(A_diag_h);
-      low_level_sets = hypre_TAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_DEVICE);
-      upp_level_sets = hypre_TAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_DEVICE);
-
-      hypre_TMemcpy(low_level_sets, h_low_level_sets, HYPRE_Int, num_rows,
-                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
-      hypre_TMemcpy(upp_level_sets, h_upp_level_sets, HYPRE_Int, num_rows,
-                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
-
-      hypre_TFree(h_low_set_offsets, HYPRE_MEMORY_HOST);
-      hypre_TFree(h_low_level_sets, HYPRE_MEMORY_HOST);
-      hypre_TFree(h_upp_set_offsets, HYPRE_MEMORY_HOST);
-      hypre_TFree(h_upp_level_sets, HYPRE_MEMORY_HOST);
-
-      hypre_CSRMatrixDestroy(A_diag_h);
-   }
 
    /* Build the inverse permutation arrays */
    if (perm_data && qperm_data)
@@ -201,71 +158,131 @@ hypre_ILUSetupDevice(hypre_ParILUData       *ilu_data,
        * in a way different than HYPRE. Diagonal is not listed in the front
        */
 
-#if !defined(HYPRE_USING_SYCL)
-      if ((fill_level == 0) && !(ilu_type % 10))
+      if (ilu_type == 60)
       {
-         /* Copy diagonal matrix into a new place with permutation
-          * That is, A_diag = A_diag(perm,qperm); */
+         /*
+          * Level-set ILU0 factorization on permuted matrix.
+          * The factorized matrix is kept in hypre's diagonal-first CSR format
+          * and the level-set row arrays are stored in ilu_data for the solve phase.
+          */
+
+         /* Permute A_diag: A_diag = A_diag(perm, qperm) */
          hypre_CSRMatrixPermute(hypre_ParCSRMatrixDiag(A), perm_data, rqperm_data, &A_diag);
 
-         /* Compute ILU0 on the device */
-         if (iter_setup_type)
-         {
-            hypre_ILUSetupIterativeILU0Device(A_diag, iter_setup_type, iter_setup_option,
-                                              iter_setup_max_iter, iter_setup_tol,
-                                              &hypre_ParILUDataIterativeSetupNumIter(ilu_data),
-                                              &hypre_ParILUDataIterativeSetupHistory(ilu_data));
-         }
-         else
-         {
-            hypre_CSRMatrixILU0(A_diag);
-         }
+         /* Clone to host for level-set computation (structure only) */
+         hypre_CSRMatrix *A_diag_h = hypre_CSRMatrixClone_v2(A_diag, 0, HYPRE_MEMORY_HOST);
 
+         /* Compute lower and upper level sets on the permuted sparsity structure */
+         HYPRE_Int *h_low_set_offsets = NULL;
+         HYPRE_Int *h_low_level_sets  = NULL;
+         HYPRE_Int *h_upp_set_offsets = NULL;
+         HYPRE_Int *h_upp_level_sets  = NULL;
+         HYPRE_Int  low_num_levels, upp_num_levels;
+
+         hypre_CSRMatrixComputeLevelSetsHost(A_diag_h,
+                                             &h_low_set_offsets, &h_low_level_sets,
+                                             &h_upp_set_offsets, &h_upp_level_sets,
+                                             &low_num_levels,    &upp_num_levels);
+
+         HYPRE_Int num_rows = hypre_CSRMatrixNumRows(A_diag_h);
+         hypre_CSRMatrixDestroy(A_diag_h);
+
+         /* Copy level-set row arrays to device */
+         HYPRE_Int *d_low_level_set_rows = hypre_TAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_DEVICE);
+         HYPRE_Int *d_upp_level_set_rows = hypre_TAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_DEVICE);
+
+         hypre_TMemcpy(d_low_level_set_rows, h_low_level_sets, HYPRE_Int, num_rows,
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+         hypre_TMemcpy(d_upp_level_set_rows, h_upp_level_sets, HYPRE_Int, num_rows,
+                       HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
+
+         hypre_TFree(h_low_level_sets, HYPRE_MEMORY_HOST);
+         hypre_TFree(h_upp_level_sets, HYPRE_MEMORY_HOST);
+
+         /* Run level-set ILU0 factorization on the permuted device matrix */
+         hypre_CSRMatrixILU0LevelSetFactorization(A_diag, low_num_levels,
+                                                  h_low_set_offsets, d_low_level_set_rows);
+
+         /* Store level-set data in ilu_data for the solve phase */
+         hypre_ParILUDataNumLowLevels(ilu_data)       = low_num_levels;
+         hypre_ParILUDataLowLevelSetOffsets(ilu_data) = h_low_set_offsets;
+         hypre_ParILUDataDLowLevelSetRows(ilu_data)   = d_low_level_set_rows;
+         hypre_ParILUDataNumUppLevels(ilu_data)       = upp_num_levels;
+         hypre_ParILUDataUppLevelSetOffsets(ilu_data) = h_upp_set_offsets;
+         hypre_ParILUDataDUppLevelSetRows(ilu_data)   = d_upp_level_set_rows;
+
+         /* Mimicking the setup of the 'regular' ILU0*/
          hypre_ParILUExtractEBFC(A_diag, nLU, BLUptr, &SLU, Eptr, Fptr);
          hypre_CSRMatrixDestroy(A_diag);
       }
       else
-#endif
       {
-         hypre_ParILURAPReorder(A, perm_data, rqperm_data, &Apq);
-#if defined(HYPRE_USING_SYCL)
-         /* WM: note - ILU0 is not yet available in oneMKL sparse */
-         if (fill_level == 0 && !(ilu_type % 10))
+#if !defined(HYPRE_USING_SYCL)
+         if ((fill_level == 0) && !(ilu_type % 10))
          {
-            hypre_ILUSetupILU0(Apq, NULL, NULL, n, n, &parL, &parD, &parU, &parS, &uend);
-         }
-#endif
-         if (fill_level != 0 && !(ilu_type % 10))
-         {
-            hypre_ILUSetupILUK(Apq, fill_level, NULL, NULL, n, n, &parL, &parD, &parU, &parS, &uend);
-         }
-         else if ((ilu_type % 10) == 1)
-         {
-            hypre_ParCSRMatrixMigrate(Apq, HYPRE_MEMORY_HOST);
-            hypre_ILUSetupILUT(Apq, max_row_nnz, droptol, NULL, NULL, n, n,
-                               &parL, &parD, &parU, &parS, &uend);
-         }
+            /* Copy diagonal matrix into a new place with permutation
+             * That is, A_diag = A_diag(perm,qperm); */
+            hypre_CSRMatrixPermute(hypre_ParCSRMatrixDiag(A), perm_data, rqperm_data, &A_diag);
 
-         hypre_ParCSRMatrixDestroy(Apq);
-         hypre_TFree(uend, HYPRE_MEMORY_HOST);
-         hypre_ParCSRMatrixDestroy(parS);
+            /* Compute ILU0 on the device */
+            if (iter_setup_type)
+            {
+               hypre_ILUSetupIterativeILU0Device(A_diag, iter_setup_type, iter_setup_option,
+                                                 iter_setup_max_iter, iter_setup_tol,
+                                                 &hypre_ParILUDataIterativeSetupNumIter(ilu_data),
+                                                 &hypre_ParILUDataIterativeSetupHistory(ilu_data));
+            }
+            else
+            {
+               hypre_CSRMatrixILU0(A_diag);
+            }
 
-         hypre_ILUSetupLDUtoCusparse(parL, parD, parU, &ALU);
-         if ((ilu_type % 10) == 1)
-         {
-            hypre_TFree(parD, HYPRE_MEMORY_HOST);
+            hypre_ParILUExtractEBFC(A_diag, nLU, BLUptr, &SLU, Eptr, Fptr);
+            hypre_CSRMatrixDestroy(A_diag);
          }
          else
+#endif
          {
-            hypre_TFree(parD, HYPRE_MEMORY_DEVICE);
-         }
-         hypre_ParCSRMatrixDestroy(parL);
-         hypre_ParCSRMatrixDestroy(parU);
+            hypre_ParILURAPReorder(A, perm_data, rqperm_data, &Apq);
+#if defined(HYPRE_USING_SYCL)
+            /* WM: note - ILU0 is not yet available in oneMKL sparse */
+            if (fill_level == 0 && !(ilu_type % 10))
+            {
+               hypre_ILUSetupILU0(Apq, NULL, NULL, n, n, &parL, &parD, &parU, &parS, &uend);
+            }
+#endif
+            if (fill_level != 0 && !(ilu_type % 10))
+            {
+               hypre_ILUSetupILUK(Apq, fill_level, NULL, NULL, n, n, &parL, &parD, &parU, &parS, &uend);
+            }
+            else if ((ilu_type % 10) == 1)
+            {
+               hypre_ParCSRMatrixMigrate(Apq, HYPRE_MEMORY_HOST);
+               hypre_ILUSetupILUT(Apq, max_row_nnz, droptol, NULL, NULL, n, n,
+                                  &parL, &parD, &parU, &parS, &uend);
+            }
 
-         hypre_ParILUExtractEBFC(hypre_ParCSRMatrixDiag(ALU), nLU,
-                                 BLUptr, &SLU, Eptr, Fptr);
-         hypre_ParCSRMatrixDestroy(ALU);
-      }
+            hypre_ParCSRMatrixDestroy(Apq);
+            hypre_TFree(uend, HYPRE_MEMORY_HOST);
+            hypre_ParCSRMatrixDestroy(parS);
+
+            hypre_ILUSetupLDUtoCusparse(parL, parD, parU, &ALU);
+            if ((ilu_type % 10) == 1)
+            {
+               hypre_TFree(parD, HYPRE_MEMORY_HOST);
+            }
+            else
+            {
+               hypre_TFree(parD, HYPRE_MEMORY_DEVICE);
+            }
+            hypre_ParCSRMatrixDestroy(parL);
+            hypre_ParCSRMatrixDestroy(parU);
+
+            hypre_ParILUExtractEBFC(hypre_ParCSRMatrixDiag(ALU), nLU,
+                                    BLUptr, &SLU, Eptr, Fptr);
+            hypre_ParCSRMatrixDestroy(ALU);
+         }
+      } /* end else (ilu_type != 60) */
    }
    else
    {

--- a/src/parcsr_ls/par_ilu_solve.c
+++ b/src/parcsr_ls/par_ilu_solve.c
@@ -57,6 +57,14 @@ hypre_ILUSolve( void               *ilu_vdata,
    hypre_Vector         *Sdiag_diag         = hypre_ParILUDataSDiagDiag(ilu_data);
    hypre_ParVector      *Ztemp              = hypre_ParILUDataZTemp(ilu_data);
    HYPRE_Int             test_opt           = hypre_ParILUDataTestOption(ilu_data);
+
+   /* Level-set data for ilu_type == 60 */
+   HYPRE_Int             num_low_levels     = hypre_ParILUDataNumLowLevels(ilu_data);
+   HYPRE_Int            *low_set_offsets    = hypre_ParILUDataLowLevelSetOffsets(ilu_data);
+   HYPRE_Int            *d_low_set_rows     = hypre_ParILUDataDLowLevelSetRows(ilu_data);
+   HYPRE_Int             num_upp_levels     = hypre_ParILUDataNumUppLevels(ilu_data);
+   HYPRE_Int            *upp_set_offsets    = hypre_ParILUDataUppLevelSetOffsets(ilu_data);
+   HYPRE_Int            *d_upp_set_rows     = hypre_ParILUDataDUppLevelSetRows(ilu_data);
 #endif
 
    /* Solver settings */
@@ -245,7 +253,26 @@ hypre_ILUSolve( void               *ilu_vdata,
       /* Do one solve on LU*e = r */
       switch (ilu_type)
       {
-      case 0: case 1: case 60: default:
+         case 60:
+#if defined(HYPRE_USING_GPU)
+            if (exec == HYPRE_EXEC_DEVICE)
+            {
+               /* Level-set based LU solve for ilu_type 60 */
+               hypre_ILUSolveLULevelSetDevice(matA, matBLU_d, F_array, U_array, perm,
+                                              num_low_levels, low_set_offsets, d_low_set_rows,
+                                              num_upp_levels, upp_set_offsets, d_upp_set_rows,
+                                              Utemp, Ftemp);
+            }
+            else
+#endif
+            {
+               /* This preconditioner is only supported on GPU */
+               hypre_error_w_msg(HYPRE_ERROR_GENERIC,
+                                 "Level-set based ILU solve (ilu_type 60) is only supported on GPU!");
+            }
+            break;
+
+      case 0: case 1: default:
             /* TODO (VPM): Encapsulate host and device functions into a single one */
 #if defined(HYPRE_USING_GPU)
             if (exec == HYPRE_EXEC_DEVICE)

--- a/src/parcsr_ls/par_ilu_solve_device.c
+++ b/src/parcsr_ls/par_ilu_solve_device.c
@@ -1223,4 +1223,76 @@ hypre_ILUSolveRAPGMRESDevice(hypre_ParCSRMatrix   *A,
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_ILUSolveLULevelSetDevice
+ *
+ * Level-set based incomplete LU solve for ilu_type == 60 (GPU).
+ *
+ * Follows similar structure as hypre_ILUSolveLUDevice
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_ILUSolveLULevelSetDevice(hypre_ParCSRMatrix  *A,
+                               hypre_CSRMatrix     *matLU_d,
+                               hypre_ParVector     *f,
+                               hypre_ParVector     *u,
+                               HYPRE_Int           *perm,
+                               HYPRE_Int            num_low_levels,
+                               HYPRE_Int           *low_set_offsets,
+                               HYPRE_Int           *d_low_set_rows,
+                               HYPRE_Int            num_upp_levels,
+                               HYPRE_Int           *upp_set_offsets,
+                               HYPRE_Int           *d_upp_set_rows,
+                               hypre_ParVector     *ftemp,
+                               hypre_ParVector     *utemp)
+{
+
+   // Not sure if I have to / how to deal with permutations for now
+   hypre_assert(perm == NULL);
+
+   HYPRE_Int      num_rows    = hypre_ParCSRMatrixNumRows(A);
+
+   hypre_Vector  *utemp_local = hypre_ParVectorLocalVector(utemp);
+   HYPRE_Complex *utemp_data  = hypre_VectorData(utemp_local);
+   hypre_Vector  *ftemp_local = hypre_ParVectorLocalVector(ftemp);
+   HYPRE_Complex *ftemp_data  = hypre_VectorData(ftemp_local);
+
+   HYPRE_Complex  alpha = -1.0;
+   HYPRE_Complex  beta  =  1.0;
+
+   /* Sanity check */
+   if (num_rows == 0)
+   {
+      return hypre_error_flag;
+   }
+
+   HYPRE_ANNOTATE_FUNC_BEGIN;
+   hypre_GpuProfilingPushRange("ILUSolveLevelSet");
+
+   /* Compute residual: ftemp = f - A*u */
+   hypre_ParCSRMatrixMatvecOutOfPlace(alpha, A, u, beta, f, ftemp);
+
+   hypre_TMemcpy(utemp_data, ftemp_data, HYPRE_Complex, num_rows,
+                 HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+
+   /* Forward substitution: L * ftemp = utemp  (in-place on utemp) */
+   hypre_CSRMatrixILU0LevelSetLSolve(matLU_d, num_low_levels, low_set_offsets,
+                                     d_low_set_rows, utemp_data);
+
+   /* Backward substitution: U * utemp = utemp  (in-place on utemp) */
+   hypre_CSRMatrixILU0LevelSetUSolve(matLU_d, num_upp_levels, upp_set_offsets,
+                                     d_upp_set_rows, utemp_data);
+
+   hypre_TMemcpy(ftemp_data, utemp_data, HYPRE_Complex, num_rows,
+                 HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+
+   /* Update solution: u = u + ftemp */
+   hypre_ParVectorAxpy(beta, ftemp, u);
+
+   hypre_GpuProfilingPopRange();
+   HYPRE_ANNOTATE_FUNC_END;
+
+   return hypre_error_flag;
+}
+
 #endif /* defined(HYPRE_USING_GPU) */

--- a/src/parcsr_ls/par_ilu_solve_device.c
+++ b/src/parcsr_ls/par_ilu_solve_device.c
@@ -1247,9 +1247,6 @@ hypre_ILUSolveLULevelSetDevice(hypre_ParCSRMatrix  *A,
                                hypre_ParVector     *utemp)
 {
 
-   // Not sure if I have to / how to deal with permutations for now
-   hypre_assert(perm == NULL);
-
    HYPRE_Int      num_rows    = hypre_ParCSRMatrixNumRows(A);
 
    hypre_Vector  *utemp_local = hypre_ParVectorLocalVector(utemp);
@@ -1272,19 +1269,44 @@ hypre_ILUSolveLULevelSetDevice(hypre_ParCSRMatrix  *A,
    /* Compute residual: ftemp = f - A*u */
    hypre_ParCSRMatrixMatvecOutOfPlace(alpha, A, u, beta, f, ftemp);
 
-   hypre_TMemcpy(utemp_data, ftemp_data, HYPRE_Complex, num_rows,
-                 HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+   /* Apply permutation: the factorization was computed on the permuted matrix,
+    * so we must permute the residual into the same ordering before the solves. */
+   if (perm)
+   {
+#if defined(HYPRE_USING_SYCL)
+      hypreSycl_gather(perm, perm + num_rows, ftemp_data, utemp_data);
+#else
+      HYPRE_THRUST_CALL(gather, perm, perm + num_rows, ftemp_data, utemp_data);
+#endif
+   }
+   else
+   {
+      hypre_TMemcpy(utemp_data, ftemp_data, HYPRE_Complex, num_rows,
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+   }
 
-   /* Forward substitution: L * ftemp = utemp  (in-place on utemp) */
+   /* Forward substitution: L * utemp = utemp  (in-place) */
    hypre_CSRMatrixILU0LevelSetLSolve(matLU_d, num_low_levels, low_set_offsets,
                                      d_low_set_rows, utemp_data);
 
-   /* Backward substitution: U * utemp = utemp  (in-place on utemp) */
+   /* Backward substitution: U * utemp = utemp  (in-place) */
    hypre_CSRMatrixILU0LevelSetUSolve(matLU_d, num_upp_levels, upp_set_offsets,
                                      d_upp_set_rows, utemp_data);
 
-   hypre_TMemcpy(ftemp_data, utemp_data, HYPRE_Complex, num_rows,
-                 HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+   /* Apply reverse permutation: scatter correction back to original ordering */
+   if (perm)
+   {
+#if defined(HYPRE_USING_SYCL)
+      hypreSycl_scatter(utemp_data, utemp_data + num_rows, perm, ftemp_data);
+#else
+      HYPRE_THRUST_CALL(scatter, utemp_data, utemp_data + num_rows, perm, ftemp_data);
+#endif
+   }
+   else
+   {
+      hypre_TMemcpy(ftemp_data, utemp_data, HYPRE_Complex, num_rows,
+                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_DEVICE);
+   }
 
    /* Update solution: u = u + ftemp */
    hypre_ParVectorAxpy(beta, ftemp, u);

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -1927,6 +1927,14 @@ HYPRE_Int hypre_ILUSolveLUDevice( hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_
                                   hypre_ParVector *f, hypre_ParVector *u,
                                   HYPRE_Int *perm, hypre_ParVector *ftemp,
                                   hypre_ParVector *utemp );
+HYPRE_Int hypre_ILUSolveLULevelSetDevice( hypre_ParCSRMatrix *A, hypre_CSRMatrix *matLU_d,
+                                          hypre_ParVector *f, hypre_ParVector *u,
+                                          HYPRE_Int *perm,
+                                          HYPRE_Int num_low_levels, HYPRE_Int *low_set_offsets,
+                                          HYPRE_Int *d_low_set_rows,
+                                          HYPRE_Int num_upp_levels, HYPRE_Int *upp_set_offsets,
+                                          HYPRE_Int *d_upp_set_rows,
+                                          hypre_ParVector *ftemp, hypre_ParVector *utemp );
 HYPRE_Int hypre_ILUApplyLowerJacIterDevice( hypre_CSRMatrix *A, hypre_Vector *input,
                                             hypre_Vector *work, hypre_Vector *output,
                                             HYPRE_Int lower_jacobi_iters );

--- a/src/seq_mv/_hypre_seq_mv.h
+++ b/src/seq_mv/_hypre_seq_mv.h
@@ -355,11 +355,13 @@ HYPRE_Int hypre_CSRMatrixDiagScale( hypre_CSRMatrix *A, hypre_Vector *ld, hypre_
 HYPRE_Int hypre_CSRMatrixTaggedFnorm( hypre_CSRMatrix *A, HYPRE_Int num_tags, HYPRE_Int *tags,
                                       HYPRE_Real **tnorms_ptr );
 HYPRE_Int
-hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
-                                    HYPRE_Int       *low_set_offsets,
-                                    HYPRE_Int       *low_level_sets,
-                                    HYPRE_Int       *upp_set_offsets,
-                                    HYPRE_Int       *upp_level_sets);
+hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix  *A,
+                                    HYPRE_Int       **low_set_offsets,
+                                    HYPRE_Int       **low_level_sets,
+                                    HYPRE_Int       **upp_set_offsets,
+                                    HYPRE_Int       **upp_level_sets,
+                                    HYPRE_Int        *num_low_levels,
+                                    HYPRE_Int        *num_upp_levels);
 
 /* csr_matop_device.c */
 hypre_CSRMatrix *hypre_CSRMatrixAddDevice ( HYPRE_Complex alpha, hypre_CSRMatrix *A,
@@ -431,6 +433,11 @@ HYPRE_Int hypre_CSRMatrixDiagScaleDevice( hypre_CSRMatrix *A, hypre_Vector *ld, 
 HYPRE_Int hypre_CSRMatrixCompressColumnsDevice(hypre_CSRMatrix *A, HYPRE_BigInt *col_map,
                                                HYPRE_Int **col_idx_new_ptr, HYPRE_BigInt **col_map_new_ptr);
 HYPRE_Int hypre_CSRMatrixILU0(hypre_CSRMatrix *A);
+HYPRE_Int hypre_CSRMatrixILU0LevelSet(hypre_CSRMatrix *A,
+                                      HYPRE_Int num_low_levels, HYPRE_Int *low_set_offsets,
+                                      HYPRE_Int *d_low_level_set_rows,
+                                      HYPRE_Int num_upp_levels, HYPRE_Int *upp_set_offsets,
+                                      HYPRE_Int *d_upp_level_set_rows);
 
 /* csr_matrix.c */
 hypre_CSRMatrix *hypre_CSRMatrixCreate ( HYPRE_Int num_rows, HYPRE_Int num_cols,
@@ -660,6 +667,21 @@ hypre_GpuMatData* hypre_CSRMatrixGetGPUMatData(hypre_CSRMatrix *matrix);
 #endif
 
 HYPRE_Int hypre_CSRMatrixSpMVAnalysisDevice(hypre_CSRMatrix *matrix);
+
+HYPRE_Int hypre_CSRMatrixILU0LevelSetFactorization(hypre_CSRMatrix *A,
+                                                   HYPRE_Int        num_low_levels,
+                                                   HYPRE_Int       *low_set_offsets,
+                                                   HYPRE_Int       *d_low_level_set_rows);
+HYPRE_Int hypre_CSRMatrixILU0LevelSetLSolve(hypre_CSRMatrix *A,
+                                            HYPRE_Int        num_low_levels,
+                                            HYPRE_Int       *low_set_offsets,
+                                            HYPRE_Int       *d_low_level_set_rows,
+                                            HYPRE_Complex   *f);
+HYPRE_Int hypre_CSRMatrixILU0LevelSetUSolve(hypre_CSRMatrix *A,
+                                            HYPRE_Int        num_upp_levels,
+                                            HYPRE_Int       *upp_set_offsets,
+                                            HYPRE_Int       *d_upp_level_set_rows,
+                                            HYPRE_Complex   *f);
 
 /* vector_device.c */
 HYPRE_Int hypre_SeqVectorSetConstantValuesDevice ( hypre_Vector *v, HYPRE_Complex value );

--- a/src/seq_mv/_hypre_seq_mv_mup.h
+++ b/src/seq_mv/_hypre_seq_mv_mup.h
@@ -98,11 +98,11 @@ HYPRE_Int
 hypre_CSRMatrixComputeColSum_long_dbl( hypre_CSRMatrix *A, hypre_long_double *col_sum, HYPRE_Int type, hypre_long_double scal );
 
 HYPRE_Int
-hypre_CSRMatrixComputeLevelSetsHost_flt( hypre_CSRMatrix *A, HYPRE_Int *low_set_offsets, HYPRE_Int *low_level_sets, HYPRE_Int *upp_set_offsets, HYPRE_Int *upp_level_sets );
+hypre_CSRMatrixComputeLevelSetsHost_flt( hypre_CSRMatrix *A, HYPRE_Int **low_set_offsets, HYPRE_Int **low_level_sets, HYPRE_Int **upp_set_offsets, HYPRE_Int **upp_level_sets, HYPRE_Int *num_low_levels, HYPRE_Int *num_upp_levels );
 HYPRE_Int
-hypre_CSRMatrixComputeLevelSetsHost_dbl( hypre_CSRMatrix *A, HYPRE_Int *low_set_offsets, HYPRE_Int *low_level_sets, HYPRE_Int *upp_set_offsets, HYPRE_Int *upp_level_sets );
+hypre_CSRMatrixComputeLevelSetsHost_dbl( hypre_CSRMatrix *A, HYPRE_Int **low_set_offsets, HYPRE_Int **low_level_sets, HYPRE_Int **upp_set_offsets, HYPRE_Int **upp_level_sets, HYPRE_Int *num_low_levels, HYPRE_Int *num_upp_levels );
 HYPRE_Int
-hypre_CSRMatrixComputeLevelSetsHost_long_dbl( hypre_CSRMatrix *A, HYPRE_Int *low_set_offsets, HYPRE_Int *low_level_sets, HYPRE_Int *upp_set_offsets, HYPRE_Int *upp_level_sets );
+hypre_CSRMatrixComputeLevelSetsHost_long_dbl( hypre_CSRMatrix *A, HYPRE_Int **low_set_offsets, HYPRE_Int **low_level_sets, HYPRE_Int **upp_set_offsets, HYPRE_Int **upp_level_sets, HYPRE_Int *num_low_levels, HYPRE_Int *num_upp_levels );
 
 HYPRE_Int
 hypre_CSRMatrixComputeRowSum_flt( hypre_CSRMatrix *A, HYPRE_Int *CF_i, HYPRE_Int *CF_j, hypre_float *row_sum, HYPRE_Int type, hypre_float scal, const char *set_or_add );

--- a/src/seq_mv/csr_matop.c
+++ b/src/seq_mv/csr_matop.c
@@ -2495,17 +2495,26 @@ hypre_CSRMatrixTaggedFnorm(hypre_CSRMatrix  *A,
 
 /*--------------------------------------------------------------------------
  * hypre_CSRMatrixComputeLevelSetsHost
- * *A is a assumed to be a CSR matrix on the host with the diagonal entries as the first in their row
- * XXX_set_offsets are the offsets where the level sets start in the XXX_level_sets buffers
- * low/upp refer to the level sets induced by partitioning for a lower or upper triangular solve
+ *
+ * Computes lower and upper level sets for a CSR matrix A on the host.
+ * XXX_set_offsets are host arrays of length (num_levels+1) allocated inside
+ * this function; entry l is the start index into XXX_level_sets for level l.
+ * low/upp refer to the level sets induced by partitioning for a lower or
+ * upper triangular solve respectively.
+ *
+ * Column ordering within rows does NOT matter: the algorithm only tests
+ * col < row or col > row, so both the diagonal-first hypre storage convention
+ * and standard ascending-sorted CSR produce identical results.
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
-                                    HYPRE_Int       *low_set_offsets,
-                                    HYPRE_Int       *low_level_sets,
-                                    HYPRE_Int       *upp_set_offsets,
-                                    HYPRE_Int       *upp_level_sets)
+hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix  *A,
+                                    HYPRE_Int       **low_set_offsets,
+                                    HYPRE_Int       **low_level_sets,
+                                    HYPRE_Int       **upp_set_offsets,
+                                    HYPRE_Int       **upp_level_sets,
+                                    HYPRE_Int        *num_levels_low,
+                                    HYPRE_Int        *num_levels_upp)
 {
    /* Traverse matrix structure to verify index operations */
    HYPRE_Int num_rows = hypre_CSRMatrixNumRows(A);
@@ -2516,7 +2525,7 @@ hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
    /* Each row starts in level set 0, then is assigned to max(level[dep]) + 1 */
    HYPRE_Int *row_level_low = hypre_CTAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_HOST);
 
-   HYPRE_Int num_levels_low = 1;
+   *num_levels_low = 1;
    /* Compute row_level_low which maps every row to a level-set */
    for (HYPRE_Int row_idx = 0; row_idx < num_rows; row_idx++)
    {
@@ -2531,9 +2540,9 @@ hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
                row_level_low[row_idx] = row_level_low[col_idx] + 1;
 
                /* Keep track of the amount of level sets */
-               if (row_level_low[row_idx] + 1 > num_levels_low)
+               if (row_level_low[row_idx] + 1 > *num_levels_low)
                {
-                  num_levels_low = row_level_low[row_idx] + 1;
+                  *num_levels_low = row_level_low[row_idx] + 1;
                }
             }
          }
@@ -2543,40 +2552,40 @@ hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
    /* TODO: if this function ends up being slow then consider loop fusions on lower/upper and more buffer reuse */
 
    /* Count the number of rows in each level set */
-   HYPRE_Int *low_set_sizes = hypre_CTAlloc(HYPRE_Int, num_levels_low, HYPRE_MEMORY_HOST);
+   HYPRE_Int *low_set_sizes = hypre_CTAlloc(HYPRE_Int, *num_levels_low, HYPRE_MEMORY_HOST);
    for (HYPRE_Int row_idx = 0; row_idx < num_rows; row_idx++)
    {
       low_set_sizes[row_level_low[row_idx]]++;
    }
 
    /* Compute offsets for each level set, this is just a prefix sum of level set sizes*/
-   low_set_offsets = hypre_CTAlloc(HYPRE_Int, num_levels_low + 1, HYPRE_MEMORY_HOST);
-   for (HYPRE_Int i = 0; i < num_levels_low; i++)
+   *low_set_offsets = hypre_CTAlloc(HYPRE_Int, *num_levels_low + 1, HYPRE_MEMORY_HOST);
+   for (HYPRE_Int i = 0; i < *num_levels_low; i++)
    {
-      low_set_offsets[i + 1] = low_set_offsets[i] + low_set_sizes[i];
+      (*low_set_offsets)[i + 1] = (*low_set_offsets)[i] + low_set_sizes[i];
    }
 
    /* Fill in the row indices grouped by level set */
-   HYPRE_Int *lower_level_set = hypre_CTAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_HOST);
+   *low_level_sets = hypre_CTAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_HOST);
 
    /* Fill level sets in correct places by starting at offsets and incrementing from there*/
-   HYPRE_Int *fill_pos_low = hypre_CTAlloc(HYPRE_Int, num_levels_low, HYPRE_MEMORY_HOST);
+   HYPRE_Int *fill_pos_low = hypre_CTAlloc(HYPRE_Int, *num_levels_low, HYPRE_MEMORY_HOST);
 
-   for (HYPRE_Int i = 0; i < num_levels_low; i++)
+   for (HYPRE_Int i = 0; i < *num_levels_low; i++)
    {
-      fill_pos_low[i] = low_set_offsets[i];
+      fill_pos_low[i] = (*low_set_offsets)[i];
    }
    for (HYPRE_Int i = 0; i < num_rows; i++)
    {
       HYPRE_Int lvl = row_level_low[i];
-      lower_level_set[fill_pos_low[lvl]++] = i;
+      (*low_level_sets)[fill_pos_low[lvl]++] = i;
    }
 
    /* Compute level sets for the upper triangular part of the matrix */
    /* Traverse rows in reverse: each row depends on rows with higher index */
    HYPRE_Int *row_level_upp = hypre_CTAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_HOST);
 
-   HYPRE_Int num_levels_upp = 1;
+   *num_levels_upp = 1;
    for (HYPRE_Int row_idx = num_rows - 1; row_idx >= 0; row_idx--)
    {
       for (HYPRE_Int j = A_i[row_idx]; j < A_i[row_idx + 1]; j++)
@@ -2590,9 +2599,9 @@ hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
                row_level_upp[row_idx] = row_level_upp[col_idx] + 1;
 
                /* Keep track of the amount of level sets */
-               if (row_level_upp[row_idx] + 1 > num_levels_upp)
+               if (row_level_upp[row_idx] + 1 > *num_levels_upp)
                {
-                  num_levels_upp = row_level_upp[row_idx] + 1;
+                  *num_levels_upp = row_level_upp[row_idx] + 1;
                }
             }
          }
@@ -2600,31 +2609,31 @@ hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
    }
 
    /* Count the number of rows in each upper level set */
-   HYPRE_Int *upp_set_sizes = hypre_CTAlloc(HYPRE_Int, num_levels_upp, HYPRE_MEMORY_HOST);
+   HYPRE_Int *upp_set_sizes = hypre_CTAlloc(HYPRE_Int, *num_levels_upp, HYPRE_MEMORY_HOST);
    for (HYPRE_Int row_idx = 0; row_idx < num_rows; row_idx++)
    {
       upp_set_sizes[row_level_upp[row_idx]]++;
    }
 
    /* Compute offsets for each upper level set */
-   upp_set_offsets = hypre_CTAlloc(HYPRE_Int, num_levels_upp + 1, HYPRE_MEMORY_HOST);
-   for (HYPRE_Int i = 0; i < num_levels_upp; i++)
+   *upp_set_offsets = hypre_CTAlloc(HYPRE_Int, *num_levels_upp + 1, HYPRE_MEMORY_HOST);
+   for (HYPRE_Int i = 0; i < *num_levels_upp; i++)
    {
-      upp_set_offsets[i + 1] = upp_set_offsets[i] + upp_set_sizes[i];
+      (*upp_set_offsets)[i + 1] = (*upp_set_offsets)[i] + upp_set_sizes[i];
    }
 
    /* Fill in the row indices grouped by upper level set */
-   HYPRE_Int *upper_level_set = hypre_CTAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_HOST);
+   *upp_level_sets = hypre_CTAlloc(HYPRE_Int, num_rows, HYPRE_MEMORY_HOST);
 
-   HYPRE_Int *fill_pos_upp = hypre_CTAlloc(HYPRE_Int, num_levels_upp, HYPRE_MEMORY_HOST);
-   for (HYPRE_Int i = 0; i < num_levels_upp; i++)
+   HYPRE_Int *fill_pos_upp = hypre_CTAlloc(HYPRE_Int, *num_levels_upp, HYPRE_MEMORY_HOST);
+   for (HYPRE_Int i = 0; i < *num_levels_upp; i++)
    {
-      fill_pos_upp[i] = upp_set_offsets[i];
+      fill_pos_upp[i] = (*upp_set_offsets)[i];
    }
    for (HYPRE_Int i = 0; i < num_rows; i++)
    {
       HYPRE_Int lvl = row_level_upp[i];
-      upper_level_set[fill_pos_upp[lvl]++] = i;
+      (*upp_level_sets)[fill_pos_upp[lvl]++] = i;
    }
 
    /* Temporary to validate reasonable results. */
@@ -2632,23 +2641,23 @@ hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
    FILE *fp = fopen("level_sets.txt", "w");
    if (fp)
    {
-      fprintf(fp, "Number of lower levels: %d\n", num_levels_low);
-      for (HYPRE_Int i = 0; i < num_levels_low; i++)
+      fprintf(fp, "Number of lower levels: %d\n", *num_levels_low);
+      for (HYPRE_Int i = 0; i < *num_levels_low; i++)
       {
          fprintf(fp, "Lower level %d (size %d): ", i, low_set_sizes[i]);
-         for (HYPRE_Int j = low_set_offsets[i]; j < low_set_offsets[i + 1]; j++)
+         for (HYPRE_Int j = (*low_set_offsets)[i]; j < (*low_set_offsets)[i + 1]; j++)
          {
-            fprintf(fp, "%d ", lower_level_set[j]);
+            fprintf(fp, "%d ", (*low_level_sets)[j]);
          }
          fprintf(fp, "\n");
       }
-      fprintf(fp, "Number of upper levels: %d\n", num_levels_upp);
-      for (HYPRE_Int i = 0; i < num_levels_upp; i++)
+      fprintf(fp, "Number of upper levels: %d\n", *num_levels_upp);
+      for (HYPRE_Int i = 0; i < *num_levels_upp; i++)
       {
          fprintf(fp, "Upper level %d (size %d): ", i, upp_set_sizes[i]);
-         for (HYPRE_Int j = upp_set_offsets[i]; j < upp_set_offsets[i + 1]; j++)
+         for (HYPRE_Int j = (*upp_set_offsets)[i]; j < (*upp_set_offsets)[i + 1]; j++)
          {
-            fprintf(fp, "%d ", upper_level_set[j]);
+            fprintf(fp, "%d ", (*upp_level_sets)[j]);
          }
          fprintf(fp, "\n");
       }

--- a/src/seq_mv/csr_matop_device.c
+++ b/src/seq_mv/csr_matop_device.c
@@ -4230,4 +4230,328 @@ hypre_CSRMatrixSpMVAnalysisDevice(hypre_CSRMatrix *matrix)
    return hypre_error_flag;
 }
 
+/*--------------------------------------------------------------------------
+ * hypre_CSRMatrixILU0_factorize_level_set_kernel
+ *
+ * In-place ILU0 factorization of rows in a single level set.
+ *
+ * Parameters:
+ *   item             - HYPRE device item (abstraction over CUDA/HIP/SYCL)
+ *   level_set_size   - number of rows in the current level set
+ *   level_set_rows   - row indices belonging to the current level set
+ *   A_i              - CSR row pointers
+ *   A_j              - CSR column indices (diagonal-first, off-diagonal sorted)
+ *   A_data           - CSR values (modified in-place: L factors below diagonal,
+ *                      U factors on and above diagonal; diagonal = U pivot,
+ *                      not inverted)
+ *--------------------------------------------------------------------------*/
+
+__global__ void
+hypre_CSRMatrixILU0_factorize_level_set_kernel(hypre_DeviceItem  &item,
+                                               HYPRE_Int          level_set_size,
+                                               HYPRE_Int         *level_set_rows,
+                                               HYPRE_Int         *A_i,
+                                               HYPRE_Int         *A_j,
+                                               HYPRE_Complex     *A_data)
+{
+   const HYPRE_Int tid = (HYPRE_Int) hypre_gpu_get_grid_thread_id<1, 1>(item);
+   if (tid >= level_set_size)
+   {
+      return;
+   }
+
+   /* Each thread processes one row from the current level set */
+   const HYPRE_Int row       = level_set_rows[tid];
+   const HYPRE_Int row_start = A_i[row];
+   const HYPRE_Int row_end   = A_i[row + 1];
+
+   /*
+    * Iterate lower-triangular entries of row
+    */
+   for (HYPRE_Int k_pos = row_start + 1; k_pos < row_end; k_pos++)
+   {
+      // k is column index of the current lower-triangular entry being processed
+      const HYPRE_Int k = A_j[k_pos];
+      if (k >= row) { break; } /* do not pass diagonal*/
+
+
+      const HYPRE_Int k_start = A_i[k];
+      const HYPRE_Int k_end   = A_i[k + 1];
+
+      /* A[k,k] is at k_start (diagonal-first); compute L multiplier */
+      A_data[k_pos] /= A_data[k_start];
+      const HYPRE_Complex mult = A_data[k_pos];
+
+      /*
+       * Update A[row,j] -= mult * A[k,j] for j > k common to both rows.
+       */
+      HYPRE_Int pk = k_start + 1;
+      while (pk < k_end && A_j[pk] < k) { pk++; } /* skip lower-tri of row k */
+
+      HYPRE_Int pi = row_start + 1;
+      while (pk < k_end)
+      {
+         const HYPRE_Int j = A_j[pk];
+         if (j == row)
+         {
+            /* j is the diagonal position of row 'row' */
+            A_data[row_start] -= mult * A_data[pk];
+            pk++;
+         }
+         else
+         {
+            while (pi < row_end && A_j[pi] < j) { pi++; }
+            if (pi < row_end && A_j[pi] == j)
+            {
+               A_data[pi] -= mult * A_data[pk];
+            }
+            pk++;
+         }
+      }
+   }
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_CSRMatrixILU0LevelSetFactorization
+ *
+ * Computes an in-place ILU0 factorization on the GPU by exploiting
+ * level-set parallelism. Serial exeuction of one kernel per level-set.
+ *
+ * Parameters:
+ *   A                    - square CSR matrix on the device (modified in-place)
+ *   num_low_levels       - number of lower level sets
+ *   low_set_offsets      - host array, length (num_low_levels + 1); entry l is
+ *                          the start index into d_low_level_set_rows for level l
+ *   d_low_level_set_rows - device array of length num_rows: row indices grouped
+ *                          by lower level set
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_CSRMatrixILU0LevelSetFactorization(hypre_CSRMatrix *A,
+                                         HYPRE_Int        num_low_levels,
+                                         HYPRE_Int       *low_set_offsets,
+                                         HYPRE_Int       *d_low_level_set_rows)
+{
+   HYPRE_Int      *A_i    = hypre_CSRMatrixI(A);
+   HYPRE_Int      *A_j    = hypre_CSRMatrixJ(A);
+   HYPRE_Complex  *A_data = hypre_CSRMatrixData(A);
+
+   HYPRE_ANNOTATE_FUNC_BEGIN;
+
+   dim3 bDim = hypre_GetDefaultDeviceBlockDimension();
+
+   /*
+    * Compute level sets sequentially.
+    */
+   for (HYPRE_Int lvl = 0; lvl < num_low_levels; lvl++)
+   {
+      const HYPRE_Int level_offset   = low_set_offsets[lvl];
+      const HYPRE_Int level_set_size = low_set_offsets[lvl + 1] - level_offset;
+
+      if (level_set_size <= 0)
+      {
+         continue;
+      }
+
+      dim3 gDim = hypre_GetDefaultDeviceGridDimension(level_set_size, "thread", bDim);
+
+      HYPRE_GPU_LAUNCH(hypre_CSRMatrixILU0_factorize_level_set_kernel, gDim, bDim,
+                       level_set_size,
+                       d_low_level_set_rows + level_offset,
+                       A_i, A_j, A_data);
+   }
+
+   hypre_SyncComputeStream();
+   HYPRE_ANNOTATE_FUNC_END;
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_CSRMatrixILU0_L_solve_level_set_kernel
+ *
+ * GPU kernel for one lower-triangular level-set forward substitution step.
+ * For correctness all previous level-sets must have been solved.
+ * Uses diagonal-first CSR format.
+ *--------------------------------------------------------------------------*/
+
+__global__ void
+hypre_CSRMatrixILU0_L_solve_level_set_kernel(hypre_DeviceItem  &item,
+                                             HYPRE_Int          level_set_size,
+                                             HYPRE_Int         *level_set_rows,
+                                             HYPRE_Int         *A_i,
+                                             HYPRE_Int         *A_j,
+                                             HYPRE_Complex     *A_data,
+                                             HYPRE_Complex     *f)
+{
+   const HYPRE_Int tid = (HYPRE_Int) hypre_gpu_get_grid_thread_id<1, 1>(item);
+
+   if (tid >= level_set_size)
+   {
+      return;
+   }
+
+   const HYPRE_Int row       = level_set_rows[tid];
+   const HYPRE_Int row_start = A_i[row];
+   const HYPRE_Int row_end   = A_i[row + 1];
+
+   /* Accumulate lower-triangular contribution (sorted ascending after diagonal) */
+   HYPRE_Complex val = f[row];
+   for (HYPRE_Int p = row_start + 1; p < row_end; p++)
+   {
+      const HYPRE_Int j = A_j[p];
+      if (j >= row)
+      {
+         break; /* past lower-triangular prefix */
+      }
+      val -= A_data[p] * f[j];
+   }
+   f[row] = val;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_CSRMatrixILU0_U_solve_level_set_kernel
+ *
+ * GPU kernel for one upper-triangular level-set backward substitution step.
+ * For correctness all subsequent level-sets must have been solved.
+ * Uses diagonal-first CSR format.
+ *--------------------------------------------------------------------------*/
+
+__global__ void
+hypre_CSRMatrixILU0_U_solve_level_set_kernel(hypre_DeviceItem  &item,
+                                             HYPRE_Int          level_set_size,
+                                             HYPRE_Int         *level_set_rows,
+                                             HYPRE_Int         *A_i,
+                                             HYPRE_Int         *A_j,
+                                             HYPRE_Complex     *A_data,
+                                             HYPRE_Complex     *f)
+{
+   const HYPRE_Int tid = (HYPRE_Int) hypre_gpu_get_grid_thread_id<1, 1>(item);
+
+   if (tid >= level_set_size)
+   {
+      return;
+   }
+
+   const HYPRE_Int row       = level_set_rows[tid];
+   const HYPRE_Int row_start = A_i[row];
+   const HYPRE_Int row_end   = A_i[row + 1];
+
+   /* For the upper solve we iteratre from the end of the row. */
+   HYPRE_Complex val = f[row];
+   for (HYPRE_Int p = row_end - 1; p > row_start; p--)
+   {
+      if (A_j[p] < row)
+      {
+         break; /* entered lower-triangular region */
+      }
+      val -= A_data[p] * f[A_j[p]];
+   }
+   f[row] = val / A_data[row_start]; /* divide by U[row,row] */
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_CSRMatrixILU0LevelSetLSolve
+ *
+ * Forward substitution Lx = f (in-place, f is overwritten with x) using
+ * level-set parallelism. Processes lower level sets in ascending order so
+ * that all dependencies are satisfied before each kernel launch.
+ *
+ * Parameters:
+ *   A                    - factorized CSR matrix on the device (diagonal-first)
+ *   num_low_levels       - number of lower level sets
+ *   low_set_offsets      - host array of length (num_low_levels + 1)
+ *   d_low_level_set_rows - device array of row indices grouped by level set
+ *   f                    - device vector (rhs on entry, solution on exit)
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_CSRMatrixILU0LevelSetLSolve(hypre_CSRMatrix *A,
+                                  HYPRE_Int        num_low_levels,
+                                  HYPRE_Int       *low_set_offsets,
+                                  HYPRE_Int       *d_low_level_set_rows,
+                                  HYPRE_Complex   *f)
+{
+   HYPRE_Int      *A_i    = hypre_CSRMatrixI(A);
+   HYPRE_Int      *A_j    = hypre_CSRMatrixJ(A);
+   HYPRE_Complex  *A_data = hypre_CSRMatrixData(A);
+
+   // TODO: autotune the block size
+   dim3 bDim = hypre_GetDefaultDeviceBlockDimension();
+
+   for (HYPRE_Int lvl = 0; lvl < num_low_levels; lvl++)
+   {
+      const HYPRE_Int level_offset   = low_set_offsets[lvl];
+      const HYPRE_Int level_set_size = low_set_offsets[lvl + 1] - level_offset;
+
+      if (level_set_size <= 0)
+      {
+         continue;
+      }
+
+      dim3 gDim = hypre_GetDefaultDeviceGridDimension(level_set_size, "thread", bDim);
+
+      HYPRE_GPU_LAUNCH(hypre_CSRMatrixILU0_L_solve_level_set_kernel, gDim, bDim,
+                       level_set_size,
+                       d_low_level_set_rows + level_offset,
+                       A_i, A_j, A_data, f);
+   }
+
+   hypre_SyncComputeStream();
+
+   return hypre_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ * hypre_CSRMatrixILU0LevelSetUSolve
+ *
+ * Backward substitution Ux = f (in-place, f is overwritten with x) using
+ * level-set parallelism. Processes upper level sets in ascending order
+ * (level 0 = rows with no upper-triangular dependencies, solved first).
+ *
+ * Parameters:
+ *   A                    - factorized CSR matrix on the device (diagonal-first)
+ *   num_upp_levels       - number of upper level sets
+ *   upp_set_offsets      - host array of length (num_upp_levels + 1)
+ *   d_upp_level_set_rows - device array of row indices grouped by level set
+ *   f                    - device vector (rhs on entry, solution on exit)
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+hypre_CSRMatrixILU0LevelSetUSolve(hypre_CSRMatrix *A,
+                                  HYPRE_Int        num_upp_levels,
+                                  HYPRE_Int       *upp_set_offsets,
+                                  HYPRE_Int       *d_upp_level_set_rows,
+                                  HYPRE_Complex   *f)
+{
+   HYPRE_Int      *A_i    = hypre_CSRMatrixI(A);
+   HYPRE_Int      *A_j    = hypre_CSRMatrixJ(A);
+   HYPRE_Complex  *A_data = hypre_CSRMatrixData(A);
+
+   // TODO: autotune the block size
+   dim3 bDim = hypre_GetDefaultDeviceBlockDimension();
+
+   for (HYPRE_Int lvl = 0; lvl < num_upp_levels; lvl++)
+   {
+      const HYPRE_Int level_offset   = upp_set_offsets[lvl];
+      const HYPRE_Int level_set_size = upp_set_offsets[lvl + 1] - level_offset;
+
+      if (level_set_size <= 0)
+      {
+         continue;
+      }
+
+      dim3 gDim = hypre_GetDefaultDeviceGridDimension(level_set_size, "thread", bDim);
+
+      HYPRE_GPU_LAUNCH(hypre_CSRMatrixILU0_U_solve_level_set_kernel, gDim, bDim,
+                       level_set_size,
+                       d_upp_level_set_rows + level_offset,
+                       A_i, A_j, A_data, f);
+   }
+
+   hypre_SyncComputeStream();
+
+   return hypre_error_flag;
+}
+
 #endif /* #if defined(HYPRE_USING_GPU) */

--- a/src/seq_mv/mup_fixed.c
+++ b/src/seq_mv/mup_fixed.c
@@ -105,9 +105,9 @@ hypre_CSRMatrixComputeColSum( hypre_CSRMatrix *A, HYPRE_Complex *col_sum, HYPRE_
 /*--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_CSRMatrixComputeLevelSetsHost( hypre_CSRMatrix *A, HYPRE_Int *low_set_offsets, HYPRE_Int *low_level_sets, HYPRE_Int *upp_set_offsets, HYPRE_Int *upp_level_sets )
+hypre_CSRMatrixComputeLevelSetsHost( hypre_CSRMatrix *A, HYPRE_Int **low_set_offsets, HYPRE_Int **low_level_sets, HYPRE_Int **upp_set_offsets, HYPRE_Int **upp_level_sets, HYPRE_Int *num_low_levels, HYPRE_Int *num_upp_levels )
 {
-   return HYPRE_CURRENTPRECISION_FUNC(hypre_CSRMatrixComputeLevelSetsHost)( A, low_set_offsets, low_level_sets, upp_set_offsets, upp_level_sets );
+   return HYPRE_CURRENTPRECISION_FUNC(hypre_CSRMatrixComputeLevelSetsHost)( A, low_set_offsets, low_level_sets, upp_set_offsets, upp_level_sets, num_low_levels, num_upp_levels );
 }
 
 /*--------------------------------------------------------------------------*/

--- a/src/seq_mv/protos.h
+++ b/src/seq_mv/protos.h
@@ -53,11 +53,13 @@ HYPRE_Int hypre_CSRMatrixDiagScale( hypre_CSRMatrix *A, hypre_Vector *ld, hypre_
 HYPRE_Int hypre_CSRMatrixTaggedFnorm( hypre_CSRMatrix *A, HYPRE_Int num_tags, HYPRE_Int *tags,
                                       HYPRE_Real **tnorms_ptr );
 HYPRE_Int
-hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix *A,
-                                    HYPRE_Int       *low_set_offsets,
-                                    HYPRE_Int       *low_level_sets,
-                                    HYPRE_Int       *upp_set_offsets,
-                                    HYPRE_Int       *upp_level_sets);
+hypre_CSRMatrixComputeLevelSetsHost(hypre_CSRMatrix  *A,
+                                    HYPRE_Int       **low_set_offsets,
+                                    HYPRE_Int       **low_level_sets,
+                                    HYPRE_Int       **upp_set_offsets,
+                                    HYPRE_Int       **upp_level_sets,
+                                    HYPRE_Int        *num_low_levels,
+                                    HYPRE_Int        *num_upp_levels);
 
 /* csr_matop_device.c */
 hypre_CSRMatrix *hypre_CSRMatrixAddDevice ( HYPRE_Complex alpha, hypre_CSRMatrix *A,
@@ -129,6 +131,11 @@ HYPRE_Int hypre_CSRMatrixDiagScaleDevice( hypre_CSRMatrix *A, hypre_Vector *ld, 
 HYPRE_Int hypre_CSRMatrixCompressColumnsDevice(hypre_CSRMatrix *A, HYPRE_BigInt *col_map,
                                                HYPRE_Int **col_idx_new_ptr, HYPRE_BigInt **col_map_new_ptr);
 HYPRE_Int hypre_CSRMatrixILU0(hypre_CSRMatrix *A);
+HYPRE_Int hypre_CSRMatrixILU0LevelSet(hypre_CSRMatrix *A,
+                                      HYPRE_Int num_low_levels, HYPRE_Int *low_set_offsets,
+                                      HYPRE_Int *d_low_level_set_rows,
+                                      HYPRE_Int num_upp_levels, HYPRE_Int *upp_set_offsets,
+                                      HYPRE_Int *d_upp_level_set_rows);
 
 /* csr_matrix.c */
 hypre_CSRMatrix *hypre_CSRMatrixCreate ( HYPRE_Int num_rows, HYPRE_Int num_cols,
@@ -358,6 +365,21 @@ hypre_GpuMatData* hypre_CSRMatrixGetGPUMatData(hypre_CSRMatrix *matrix);
 #endif
 
 HYPRE_Int hypre_CSRMatrixSpMVAnalysisDevice(hypre_CSRMatrix *matrix);
+
+HYPRE_Int hypre_CSRMatrixILU0LevelSetFactorization(hypre_CSRMatrix *A,
+                                                   HYPRE_Int        num_low_levels,
+                                                   HYPRE_Int       *low_set_offsets,
+                                                   HYPRE_Int       *d_low_level_set_rows);
+HYPRE_Int hypre_CSRMatrixILU0LevelSetLSolve(hypre_CSRMatrix *A,
+                                            HYPRE_Int        num_low_levels,
+                                            HYPRE_Int       *low_set_offsets,
+                                            HYPRE_Int       *d_low_level_set_rows,
+                                            HYPRE_Complex   *f);
+HYPRE_Int hypre_CSRMatrixILU0LevelSetUSolve(hypre_CSRMatrix *A,
+                                            HYPRE_Int        num_upp_levels,
+                                            HYPRE_Int       *upp_set_offsets,
+                                            HYPRE_Int       *d_upp_level_set_rows,
+                                            HYPRE_Complex   *f);
 
 /* vector_device.c */
 HYPRE_Int hypre_SeqVectorSetConstantValuesDevice ( hypre_Vector *v, HYPRE_Complex value );


### PR DESCRIPTION
Contributes ILU0 factorization and level-set based solves for the work in https://github.com/hypre-space/hypre/issues/1470

I have stored some extra pointers and values needed for the graph partitioning, hopefully these are in the right place. The test on the Laplacian gives identical results to the existing ILU0 on CPU (and perturbing the implementation a little bit gives the wrong answer as a sanity check for running the code). No benchmarks of other matrices as of yet.