### PR TITLE
#include <thrust/tuple.h>

### DIFF
--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -454,6 +454,7 @@ using hypre_DeviceItem = void*;
 #include <thrust/remove.h>
 #include <thrust/version.h>
 #include <thrust/pair.h>
+#include <thrust/tuple.h>
 
 /* VPM: this is needed to support cuda 10. not_fn is the correct replacement going forward. */
 #define THRUST_VERSION_NOTFN 200600

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -221,6 +221,7 @@ using hypre_DeviceItem = void*;
 #include <thrust/remove.h>
 #include <thrust/version.h>
 #include <thrust/pair.h>
+#include <thrust/tuple.h>
 
 /* VPM: this is needed to support cuda 10. not_fn is the correct replacement going forward. */
 #define THRUST_VERSION_NOTFN 200600


### PR DESCRIPTION
`#include <thrust/tuple.h>`

before, this was included transitively from other thrust headers, in more recent versions it must be included explicitly