### PR TITLE
avoid reconfiguring CMAKE_HIP_STANDARD_REQUIRED or CMAKE_HIP_COMPILER

### DIFF
--- a/src/config/cmake/HYPRE_SetupHIPToolkit.cmake
+++ b/src/config/cmake/HYPRE_SetupHIPToolkit.cmake
@@ -26,16 +26,20 @@ list(APPEND CMAKE_PREFIX_PATH "${HIP_PATH};${HIP_PATH}/lib/cmake;${HIP_PATH}/llv
 if(NOT DEFINED CMAKE_HIP_STANDARD)
   set(CMAKE_HIP_STANDARD ${CMAKE_CXX_STANDARD} CACHE STRING "C++ standard for HIP" FORCE)
 endif()
-set(CMAKE_HIP_STANDARD_REQUIRED ON CACHE BOOL "Require C++ standard for HIP" FORCE)
+if(NOT DEFINED CMAKE_HIP_STANDARD_REQUIRED)
+  set(CMAKE_HIP_STANDARD_REQUIRED ON CACHE BOOL "Require C++ standard for HIP" FORCE)
+endif()
 
-# Check if HIP is available and enable it if found
-set(CMAKE_HIP_COMPILER "${HIP_PATH}/llvm/bin/clang++" CACHE FILEPATH "Path to HIP compiler")
-include(CheckLanguage)
-check_language(HIP)
-if(CMAKE_HIP_COMPILER)
-  enable_language(HIP)
-else()
-  message(FATAL_ERROR "HIP language not found. Please check your HIP/ROCm installation.")
+if(NOT CMAKE_HIP_COMPILER)
+  # Check if HIP is available and enable it if found
+  set(CMAKE_HIP_COMPILER "${HIP_PATH}/llvm/bin/clang++" CACHE FILEPATH "Path to HIP compiler")
+  include(CheckLanguage)
+  check_language(HIP)
+  if(CMAKE_HIP_COMPILER)
+    enable_language(HIP)
+  else()
+    message(FATAL_ERROR "HIP language not found. Please check your HIP/ROCm installation.")
+  endif()
 endif()
 
 # Find HIP package


### PR DESCRIPTION
This PR changes HIP detection to avoid setting/configuring `CMAKE_HIP_STANDARD_REQUIRED` or `CMAKE_HIP_COMPILER` if they're already defined.  The rationale is to better support adding HYPRE to a code via `add_subdirectory`.  For my code, it already configures HIP so these variables are initialized by the time HYPRE cmake configuration is run.  Without this PR, I was hitting the error below.   With this PR, the error is eliminated and presumably won't affect standalone HYPRE builds.

```
-- Configuring incomplete, errors occurred!
You have changed variables that require your cache to be deleted.
Configure will be re-run and you may have to reset some variables.
The following variables have changed:
CMAKE_HIP_COMPILER= /opt/rocm-6.1.1/include/llvm/bin/clang++
```