### PR TITLE
GPU Aware MPI use now documented in ij

### DIFF
--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -3017,6 +3017,7 @@ main( hypre_int argc,
          hypre_printf("  -fs_kap_tol <val>                : Kap. theshold (adaptive)\n");
          /* end FSAI options */
          hypre_printf("  -gpu_mpi <0/1>                   : 0: MPI communicates using host memory. 1: MPI communication using device buffers.\n");
+         hypre_printf("                                     (default 0)
          /* hypre AMG-DD options */
          hypre_printf("  -amgdd_start_level   <val>       : set AMG-DD start level = val\n");
          hypre_printf("  -amgdd_padding   <val>           : set AMG-DD padding = val\n");

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -3016,6 +3016,7 @@ main( hypre_int argc,
          hypre_printf("  -fs_eig_max_iters <val>          : Max. it. for eig calculation.\n");
          hypre_printf("  -fs_kap_tol <val>                : Kap. theshold (adaptive)\n");
          /* end FSAI options */
+         hypre_printf("  -gpu_mpi <0/1>                   : 0: MPI communicates using host memory. 1: MPI communication using device buffers.\n");
          /* hypre AMG-DD options */
          hypre_printf("  -amgdd_start_level   <val>       : set AMG-DD start level = val\n");
          hypre_printf("  -amgdd_padding   <val>           : set AMG-DD padding = val\n");


### PR DESCRIPTION
Hello.

Upon using ij for some benchmarking on AMD GPUs, I discovered that `ij` was calling `HYPRE_SetGpuAwareMPI(0)` by default; thus, GPU-aware MPI was not in use.

`ij` has an existing flag, `-gpu_mpi`, to control this behavior; however, it is not documented in `ij -help`. 

This PR adds a line to `ij`'s help printout to document this.  Please let me know if the wording needs to be changed. Thanks.