### PR TITLE
Document IJ driver options

### DIFF
--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -2620,10 +2620,11 @@ main( hypre_int argc,
          hypre_printf("\n");
          hypre_printf("Usage: %s [<options>]\n", argv[0]);
          hypre_printf("\n");
-         hypre_printf("  -ll                        : hypre's log level. \n");
+         hypre_printf("  -ll <val>                  : hypre's log level. \n");
          hypre_printf("      0 = (default) No messaging.\n");
          hypre_printf("      1 = Display memory usage statistics for each MPI rank.\n");
          hypre_printf("      2 = Display aggregate memory usage statistics over MPI ranks.\n");
+         hypre_printf("\n");
          hypre_printf("  -fromfile <filename>       : ");
          hypre_printf("matrix read from multiple files (IJ format)\n");
          hypre_printf("  -frombinfile <filename>    : ");
@@ -3034,14 +3035,37 @@ main( hypre_int argc,
          hypre_printf("       2=W-cycle  \n");
          hypre_printf("       3=F-cycle  \n");
          /* end AMG-DD options */
+#if defined(HYPRE_USING_GPU)
+         /* GPU options */
+         hypre_printf("GPU options:\n");
+         hypre_printf("  -lazy_device_init <0/1>    : delay device initialization until first use (default 0)\n");
+         hypre_printf("  -device_id <val>           : bind this MPI rank to a specific GPU device (default auto)\n");
+         hypre_printf("  -memory_host               : use host memory for IJ matrix/vector data\n");
+         hypre_printf("  -memory_device             : use device memory for IJ matrix/vector data\n");
+         hypre_printf("  -exec_host                 : use host execution policy\n");
+         hypre_printf("  -exec_device               : use device execution policy\n");
+         hypre_printf("  -exec2_host                : use host execution policy for the second setup/solve\n");
+         hypre_printf("  -exec2_device              : use device execution policy for the second setup/solve\n");
+         hypre_printf("  -gpu_mpi <0/1>             : use GPU-aware MPI with device buffers (default 0)\n");
+         hypre_printf("  -mv_vendor <0/1>           : use vendor SpMV implementation\n");
+         hypre_printf("  -mm_vendor <0/1>           : use vendor SpGEMM implementation\n");
+         hypre_printf("  -spgemm_alg <val>          : set SpGEMM algorithm (1-3)\n");
+         hypre_printf("  -spgemm_binned <0/1>       : use binned SpGEMM kernels\n");
+         hypre_printf("  -spgemm_rowest <val>       : set SpGEMM row-nnz estimate method (1-3)\n");
+         hypre_printf("  -spgemm_rowestmult <val>   : set SpGEMM row-nnz estimate multiplier\n");
+         hypre_printf("  -spgemm_rowestnsamples <val> : set SpGEMM row-nnz estimate sample count\n");
+         hypre_printf("  -use_curand <0/1>          : use GPU random number generation\n");
+         /* end GPU options */
+#endif
 #if defined (HYPRE_USING_UMPIRE)
-         /* hypre umpire options */
+         /* UMPIRE options */
          hypre_printf("  -umpire_dev_pool_size <val>      : device memory pool size (GiB)\n");
          hypre_printf("  -umpire_uvm_pool_size <val>      : device unified virtual memory pool size (GiB)\n");
          hypre_printf("  -umpire_pinned_pool_size <val>   : pinned memory pool size (GiB)\n");
          hypre_printf("  -umpire_host_pool_size <val>     : host memory pool size (GiB)\n");
-         /* end umpire options */
+         /* end UMPIRE options */
 #endif
+
       }
 
       goto final;

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -3017,6 +3017,7 @@ main( hypre_int argc,
          hypre_printf("  -fs_kap_tol <val>                : Kap. theshold (adaptive)\n");
          /* end FSAI options */
          hypre_printf("  -gpu_mpi <0/1>                   : 0: MPI communicates using host memory. 1: MPI communication using device buffers.\n");
+         hypre_printf("                                     (default 0)
          /* hypre AMG-DD options */
          hypre_printf("  -amgdd_start_level   <val>       : set AMG-DD start level = val\n");
          hypre_printf("  -amgdd_padding   <val>           : set AMG-DD padding = val\n");

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -3017,8 +3017,6 @@ main( hypre_int argc,
          hypre_printf("  -fs_eig_max_iters <val>          : Max. it. for eig calculation.\n");
          hypre_printf("  -fs_kap_tol <val>                : Kap. theshold (adaptive)\n");
          /* end FSAI options */
-         hypre_printf("  -gpu_mpi <0/1>                   : 0: MPI communicates using host memory. 1: MPI communication using device buffers.\n");
-         hypre_printf("                                     (default 0)
          /* hypre AMG-DD options */
          hypre_printf("  -amgdd_start_level   <val>       : set AMG-DD start level = val\n");
          hypre_printf("  -amgdd_padding   <val>           : set AMG-DD padding = val\n");

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -3016,6 +3016,7 @@ main( hypre_int argc,
          hypre_printf("  -fs_eig_max_iters <val>          : Max. it. for eig calculation.\n");
          hypre_printf("  -fs_kap_tol <val>                : Kap. theshold (adaptive)\n");
          /* end FSAI options */
+         hypre_printf("  -gpu_mpi <0/1>                   : 0: MPI communicates using host memory. 1: MPI communication using device buffers.\n");
          /* hypre AMG-DD options */
          hypre_printf("  -amgdd_start_level   <val>       : set AMG-DD start level = val\n");
          hypre_printf("  -amgdd_padding   <val>           : set AMG-DD padding = val\n");


### PR DESCRIPTION
Extends #1550 

Several GPU options were undocumented (not appearing in `./ij -help`). This PR addresses this issue 