### PR TITLE
Skip iterative weight interpolation on coarse levels with additional interpolation vectors

### DIFF
--- a/src/parcsr_ls/par_amg_setup.c
+++ b/src/parcsr_ls/par_amg_setup.c
@@ -2556,7 +2556,9 @@ hypre_BoomerAMGSetup( void               *amg_vdata,
        * Build prolongation matrix, P, and place in P_array[level]
        *--------------------------------------------------------------*/
 
-      if (interp_refine > 0)
+      if (interp_refine > 0 &&
+          !(interp_vec_variant > 1 && num_interp_vectors > 0 &&
+            level > interp_vec_first_level))
       {
          for (k = 0; k < interp_refine; k++)
             hypre_BoomerAMGRefineInterp(A_array[level],


### PR DESCRIPTION
The additional vectors (e.g. rigid body motions for elasticity) lead to near-zero diagonal entries, that cause division by near-zeros in hypre_BoomerAMGRefineInterp. For coarse levels when additional interpolation vectors are provided, skip the iterative weight interpolation.

Resolves #1560.