### PR TITLE
Fix HMIS issue with device execution policy

### DIFF
--- a/src/parcsr_ls/par_coarsen_device.c
+++ b/src/parcsr_ls/par_coarsen_device.c
@@ -371,14 +371,6 @@ hypreGPUKernel_PMISCoarseningInit(hypre_DeviceItem &item,
    if (CF_marker_i == 0 && measure_diag[i] < 1.0)
    {
       CF_marker_i = F_PT;
-   }
-
-   /* Keep points selected by the initial HMIS pass out of subsequent
-    * independent sets.  These points are not included in graph_diag, so a
-    * nonzero measure would allow a neighboring graph point to reset their
-    * marker to zero without adding them back to the graph. */
-   if (CF_marker_i != 0)
-   {
       measure_diag[i] = 0.0;
    }
 

--- a/src/parcsr_ls/par_coarsen_device.c
+++ b/src/parcsr_ls/par_coarsen_device.c
@@ -364,6 +364,14 @@ hypreGPUKernel_PMISCoarseningInit(hypre_DeviceItem &item,
    if (CF_marker_i == 0 && measure_diag[i] < 1.0)
    {
       CF_marker_i = F_PT;
+   }
+
+   /* Keep points selected by the initial HMIS pass out of subsequent
+    * independent sets.  These points are not included in graph_diag, so a
+    * nonzero measure would allow a neighboring graph point to reset their
+    * marker to zero without adding them back to the graph. */
+   if (CF_marker_i != 0)
+   {
       measure_diag[i] = 0.0;
    }
 

--- a/src/parcsr_ls/par_coarsen_device.c
+++ b/src/parcsr_ls/par_coarsen_device.c
@@ -343,13 +343,6 @@ hypreGPUKernel_PMISCoarseningInit(hypre_DeviceItem &item,
       {
          measure_diag[i] = 0.0;
       }
-
-      /* Retained HMIS C-points are excluded from graph_diag.  Clear their
-       * measures so subsequent independent sets cannot reset their markers. */
-      if (CF_marker_i > 0)
-      {
-         measure_diag[i] = 0.0;
-      }
    }
    else
    {
@@ -435,21 +428,47 @@ hypre_PMISCoarseningInitDevice( hypre_ParCSRMatrix  *S,               /* in */
 
    hypre_ParCSRCommHandleDestroy(comm_handle);
 
-   /* graph_diag consists points with CF_marker_diag == 0 */
+   /* graph_diag consists of points with CF_marker_diag == 0.
+    * For CF_init == 1 (HMIS), C-points retained from the first coarsening pass
+    * are also kept in the initial graph, as in the host code, so that the first
+    * C/F update pass clears their measures */
 #if defined(HYPRE_USING_SYCL)
    oneapi::dpl::counting_iterator<HYPRE_Int> count(0);
-   new_end = hypre_RemoveCopyIfSycl( count,
-                                     count + num_rows_diag,
-                                     CF_marker_diag,
-                                     graph_diag,
-   [] (const auto & x) {return x;} );
+   if (CF_init == 1)
+   {
+      new_end = hypre_RemoveCopyIfSycl( count,
+                                        count + num_rows_diag,
+                                        CF_marker_diag,
+                                        graph_diag,
+                                        is_negative<HYPRE_Int>() );
+   }
+   else
+   {
+      new_end = hypre_RemoveCopyIfSycl( count,
+                                        count + num_rows_diag,
+                                        CF_marker_diag,
+                                        graph_diag,
+      [] (const auto & x) {return x;} );
+   }
 #else
-   new_end = HYPRE_THRUST_CALL( remove_copy_if,
-                                thrust::make_counting_iterator(0),
-                                thrust::make_counting_iterator(num_rows_diag),
-                                CF_marker_diag,
-                                graph_diag,
-                                HYPRE_THRUST_IDENTITY(HYPRE_Int));
+   if (CF_init == 1)
+   {
+      new_end = HYPRE_THRUST_CALL( remove_copy_if,
+                                   thrust::make_counting_iterator(0),
+                                   thrust::make_counting_iterator(num_rows_diag),
+                                   CF_marker_diag,
+                                   graph_diag,
+                                   is_negative<HYPRE_Int>());
+   }
+   else
+   {
+      new_end = HYPRE_THRUST_CALL( remove_copy_if,
+                                   thrust::make_counting_iterator(0),
+                                   thrust::make_counting_iterator(num_rows_diag),
+                                   CF_marker_diag,
+                                   graph_diag,
+                                   HYPRE_THRUST_IDENTITY(HYPRE_Int));
+   }
 #endif
 
    *graph_diag_size = new_end - graph_diag;

--- a/src/parcsr_ls/par_coarsen_device.c
+++ b/src/parcsr_ls/par_coarsen_device.c
@@ -343,6 +343,13 @@ hypreGPUKernel_PMISCoarseningInit(hypre_DeviceItem &item,
       {
          measure_diag[i] = 0.0;
       }
+
+      /* Retained HMIS C-points are excluded from graph_diag.  Clear their
+       * measures so subsequent independent sets cannot reset their markers. */
+      if (CF_marker_i > 0)
+      {
+         measure_diag[i] = 0.0;
+      }
    }
    else
    {


### PR DESCRIPTION
Closes #1573

This PR fixes a device HMIS coarsening bug that could leave some CF markers undecided and later cause interpolation setup to abort.