### PR TITLE
Add CUDA/HIP device graph utilities

### DIFF
--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -731,6 +731,58 @@ typedef sycl::queue* hypre_DeviceStream;
 #endif
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ *  GPU Graph capture type and macros (CUDA and HIP only)
+ *
+ *  Graph capture is a feature that can reduce overhead associated with
+ *  launching a known pattern of GPU kernels. If a sequence of kernels
+ *  is known to repeat, then capturing it the first time and subsequently
+ *  only launching the graph can improve performance.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+
+struct hypre_GPUGraphHandler
+{
+#if defined(HYPRE_USING_CUDA)
+   cudaGraph_t     graph;
+   cudaGraphExec_t graph_exec;
+#else  /* HIP */
+   hipGraph_t      graph;
+   hipGraphExec_t  graph_exec;
+#endif
+   HYPRE_Int       is_ready; /* 0 = not yet captured, 1 = ready for graph launch */
+};
+
+#if defined(HYPRE_USING_CUDA)
+#define hypre_GraphStreamBeginCapture(stream) \
+   HYPRE_CUDA_CALL( cudaStreamBeginCapture((stream), cudaStreamCaptureModeThreadLocal) )
+#define hypre_GraphStreamEndCapture(stream, graph) \
+   HYPRE_CUDA_CALL( cudaStreamEndCapture((stream), (graph)) )
+#define hypre_GraphInstantiate(graph_exec, graph) \
+   HYPRE_CUDA_CALL( cudaGraphInstantiate((graph_exec), (graph), 0) )
+#define hypre_GraphLaunch(graph_exec, stream) \
+   HYPRE_CUDA_CALL( cudaGraphLaunch((graph_exec), (stream)) )
+#define hypre_GraphDestroy(graph) \
+   HYPRE_CUDA_CALL( cudaGraphDestroy(graph) )
+#define hypre_GraphExecDestroy(graph_exec) \
+   HYPRE_CUDA_CALL( cudaGraphExecDestroy(graph_exec) )
+#else  /* HIP */
+#define hypre_GraphStreamBeginCapture(stream) \
+   HYPRE_HIP_CALL( hipStreamBeginCapture((stream), hipStreamCaptureModeThreadLocal) )
+#define hypre_GraphStreamEndCapture(stream, graph) \
+   HYPRE_HIP_CALL( hipStreamEndCapture((stream), (graph)) )
+#define hypre_GraphInstantiate(graph_exec, graph) \
+   HYPRE_HIP_CALL( hipGraphInstantiate((graph_exec), (graph), NULL, NULL, 0) )
+#define hypre_GraphLaunch(graph_exec, stream) \
+   HYPRE_HIP_CALL( hipGraphLaunch((graph_exec), (stream)) )
+#define hypre_GraphDestroy(graph) \
+   HYPRE_HIP_CALL( hipGraphDestroy(graph) )
+#define hypre_GraphExecDestroy(graph_exec) \
+   HYPRE_HIP_CALL( hipGraphExecDestroy(graph_exec) )
+#endif  /* CUDA vs HIP */
+
+#endif  /* HYPRE_USING_CUDA || HYPRE_USING_HIP */
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  *      macros for wrapping vendor library calls for error reporting
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 

--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -740,7 +740,7 @@ typedef sycl::queue* hypre_DeviceStream;
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
-struct hypre_GPUGraphHandler
+struct hypre_DeviceGraphData
 {
 #if defined(HYPRE_USING_CUDA)
    cudaGraph_t     graph;
@@ -753,30 +753,30 @@ struct hypre_GPUGraphHandler
 };
 
 #if defined(HYPRE_USING_CUDA)
-#define hypre_GraphStreamBeginCapture(stream) \
+#define hypre_DeviceGraphStreamBeginCapture(stream) \
    HYPRE_CUDA_CALL( cudaStreamBeginCapture((stream), cudaStreamCaptureModeThreadLocal) )
-#define hypre_GraphStreamEndCapture(stream, graph) \
+#define hypre_DeviceGraphStreamEndCapture(stream, graph) \
    HYPRE_CUDA_CALL( cudaStreamEndCapture((stream), (graph)) )
-#define hypre_GraphInstantiate(graph_exec, graph) \
+#define hypre_DeviceGraphInstantiate(graph_exec, graph) \
    HYPRE_CUDA_CALL( cudaGraphInstantiate((graph_exec), (graph), 0) )
-#define hypre_GraphLaunch(graph_exec, stream) \
+#define hypre_DeviceGraphLaunch(graph_exec, stream) \
    HYPRE_CUDA_CALL( cudaGraphLaunch((graph_exec), (stream)) )
-#define hypre_GraphDestroy(graph) \
+#define hypre_DeviceGraphDestroy(graph) \
    HYPRE_CUDA_CALL( cudaGraphDestroy(graph) )
-#define hypre_GraphExecDestroy(graph_exec) \
+#define hypre_DeviceGraphExecDestroy(graph_exec) \
    HYPRE_CUDA_CALL( cudaGraphExecDestroy(graph_exec) )
 #else  /* HIP */
-#define hypre_GraphStreamBeginCapture(stream) \
+#define hypre_DeviceGraphStreamBeginCapture(stream) \
    HYPRE_HIP_CALL( hipStreamBeginCapture((stream), hipStreamCaptureModeThreadLocal) )
-#define hypre_GraphStreamEndCapture(stream, graph) \
+#define hypre_DeviceGraphStreamEndCapture(stream, graph) \
    HYPRE_HIP_CALL( hipStreamEndCapture((stream), (graph)) )
-#define hypre_GraphInstantiate(graph_exec, graph) \
+#define hypre_DeviceGraphInstantiate(graph_exec, graph) \
    HYPRE_HIP_CALL( hipGraphInstantiate((graph_exec), (graph), NULL, NULL, 0) )
-#define hypre_GraphLaunch(graph_exec, stream) \
+#define hypre_DeviceGraphLaunch(graph_exec, stream) \
    HYPRE_HIP_CALL( hipGraphLaunch((graph_exec), (stream)) )
-#define hypre_GraphDestroy(graph) \
+#define hypre_DeviceGraphDestroy(graph) \
    HYPRE_HIP_CALL( hipGraphDestroy(graph) )
-#define hypre_GraphExecDestroy(graph_exec) \
+#define hypre_DeviceGraphExecDestroy(graph_exec) \
    HYPRE_HIP_CALL( hipGraphExecDestroy(graph_exec) )
 #endif  /* CUDA vs HIP */
 

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -507,7 +507,7 @@ typedef sycl::queue* hypre_DeviceStream;
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 #if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
 
-struct hypre_GPUGraphHandler
+struct hypre_DeviceGraphData
 {
 #if defined(HYPRE_USING_CUDA)
    cudaGraph_t     graph;
@@ -520,30 +520,30 @@ struct hypre_GPUGraphHandler
 };
 
 #if defined(HYPRE_USING_CUDA)
-#define hypre_GraphStreamBeginCapture(stream) \
+#define hypre_DeviceGraphStreamBeginCapture(stream) \
    HYPRE_CUDA_CALL( cudaStreamBeginCapture((stream), cudaStreamCaptureModeThreadLocal) )
-#define hypre_GraphStreamEndCapture(stream, graph) \
+#define hypre_DeviceGraphStreamEndCapture(stream, graph) \
    HYPRE_CUDA_CALL( cudaStreamEndCapture((stream), (graph)) )
-#define hypre_GraphInstantiate(graph_exec, graph) \
+#define hypre_DeviceGraphInstantiate(graph_exec, graph) \
    HYPRE_CUDA_CALL( cudaGraphInstantiate((graph_exec), (graph), 0) )
-#define hypre_GraphLaunch(graph_exec, stream) \
+#define hypre_DeviceGraphLaunch(graph_exec, stream) \
    HYPRE_CUDA_CALL( cudaGraphLaunch((graph_exec), (stream)) )
-#define hypre_GraphDestroy(graph) \
+#define hypre_DeviceGraphDestroy(graph) \
    HYPRE_CUDA_CALL( cudaGraphDestroy(graph) )
-#define hypre_GraphExecDestroy(graph_exec) \
+#define hypre_DeviceGraphExecDestroy(graph_exec) \
    HYPRE_CUDA_CALL( cudaGraphExecDestroy(graph_exec) )
 #else  /* HIP */
-#define hypre_GraphStreamBeginCapture(stream) \
+#define hypre_DeviceGraphStreamBeginCapture(stream) \
    HYPRE_HIP_CALL( hipStreamBeginCapture((stream), hipStreamCaptureModeThreadLocal) )
-#define hypre_GraphStreamEndCapture(stream, graph) \
+#define hypre_DeviceGraphStreamEndCapture(stream, graph) \
    HYPRE_HIP_CALL( hipStreamEndCapture((stream), (graph)) )
-#define hypre_GraphInstantiate(graph_exec, graph) \
+#define hypre_DeviceGraphInstantiate(graph_exec, graph) \
    HYPRE_HIP_CALL( hipGraphInstantiate((graph_exec), (graph), NULL, NULL, 0) )
-#define hypre_GraphLaunch(graph_exec, stream) \
+#define hypre_DeviceGraphLaunch(graph_exec, stream) \
    HYPRE_HIP_CALL( hipGraphLaunch((graph_exec), (stream)) )
-#define hypre_GraphDestroy(graph) \
+#define hypre_DeviceGraphDestroy(graph) \
    HYPRE_HIP_CALL( hipGraphDestroy(graph) )
-#define hypre_GraphExecDestroy(graph_exec) \
+#define hypre_DeviceGraphExecDestroy(graph_exec) \
    HYPRE_HIP_CALL( hipGraphExecDestroy(graph_exec) )
 #endif  /* CUDA vs HIP */
 

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -498,6 +498,58 @@ typedef sycl::queue* hypre_DeviceStream;
 #endif
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ *  GPU Graph capture type and macros (CUDA and HIP only)
+ *
+ *  Graph capture is a feature that can reduce overhead associated with
+ *  launching a known pattern of GPU kernels. If a sequence of kernels
+ *  is known to repeat, then capturing it the first time and subsequently
+ *  only launching the graph can improve performance.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP)
+
+struct hypre_GPUGraphHandler
+{
+#if defined(HYPRE_USING_CUDA)
+   cudaGraph_t     graph;
+   cudaGraphExec_t graph_exec;
+#else  /* HIP */
+   hipGraph_t      graph;
+   hipGraphExec_t  graph_exec;
+#endif
+   HYPRE_Int       is_ready; /* 0 = not yet captured, 1 = ready for graph launch */
+};
+
+#if defined(HYPRE_USING_CUDA)
+#define hypre_GraphStreamBeginCapture(stream) \
+   HYPRE_CUDA_CALL( cudaStreamBeginCapture((stream), cudaStreamCaptureModeThreadLocal) )
+#define hypre_GraphStreamEndCapture(stream, graph) \
+   HYPRE_CUDA_CALL( cudaStreamEndCapture((stream), (graph)) )
+#define hypre_GraphInstantiate(graph_exec, graph) \
+   HYPRE_CUDA_CALL( cudaGraphInstantiate((graph_exec), (graph), 0) )
+#define hypre_GraphLaunch(graph_exec, stream) \
+   HYPRE_CUDA_CALL( cudaGraphLaunch((graph_exec), (stream)) )
+#define hypre_GraphDestroy(graph) \
+   HYPRE_CUDA_CALL( cudaGraphDestroy(graph) )
+#define hypre_GraphExecDestroy(graph_exec) \
+   HYPRE_CUDA_CALL( cudaGraphExecDestroy(graph_exec) )
+#else  /* HIP */
+#define hypre_GraphStreamBeginCapture(stream) \
+   HYPRE_HIP_CALL( hipStreamBeginCapture((stream), hipStreamCaptureModeThreadLocal) )
+#define hypre_GraphStreamEndCapture(stream, graph) \
+   HYPRE_HIP_CALL( hipStreamEndCapture((stream), (graph)) )
+#define hypre_GraphInstantiate(graph_exec, graph) \
+   HYPRE_HIP_CALL( hipGraphInstantiate((graph_exec), (graph), NULL, NULL, 0) )
+#define hypre_GraphLaunch(graph_exec, stream) \
+   HYPRE_HIP_CALL( hipGraphLaunch((graph_exec), (stream)) )
+#define hypre_GraphDestroy(graph) \
+   HYPRE_HIP_CALL( hipGraphDestroy(graph) )
+#define hypre_GraphExecDestroy(graph_exec) \
+   HYPRE_HIP_CALL( hipGraphExecDestroy(graph_exec) )
+#endif  /* CUDA vs HIP */
+
+#endif  /* HYPRE_USING_CUDA || HYPRE_USING_HIP */
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  *      macros for wrapping vendor library calls for error reporting
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 


### PR DESCRIPTION
Extends #1576 by @multitalentloes 

Adds a backend-independent device graph abstraction for CUDA and HIP

  - Introduces `hypre_DeviceGraphData` to store the graph, executable graph, and capture state.
  - Adds `hypre_DeviceGraph*` macros for capture, instantiation, launch, and destruction.
  - Regenerates `_hypre_utilities.hpp`.

GPU graphs reduce launch overhead when the same sequence of kernels is executed repeatedly. These will be used by the device level-set ILU implementation
