### PR TITLE
Tag ILU(0) factor matrices with A's memory location to fix teardown

### DIFF
--- a/src/parcsr_ls/par_ilu_setup.c
+++ b/src/parcsr_ls/par_ilu_setup.c
@@ -2783,6 +2783,8 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix  *A,
                                     0,
                                     ctrL,
                                     0 );
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(matL)) = memory_location;
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixOffd(matL)) = memory_location;
 
    L_diag = hypre_ParCSRMatrixDiag(matL);
    hypre_CSRMatrixI(L_diag) = L_diag_i;
@@ -2810,6 +2812,8 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix  *A,
                                     0,
                                     ctrU,
                                     0 );
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(matU)) = memory_location;
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixOffd(matU)) = memory_location;
 
    U_diag = hypre_ParCSRMatrixDiag(matU);
    hypre_CSRMatrixI(U_diag) = U_diag_i;


### PR DESCRIPTION
Based on testing, the same sort of issue addressed in PR #1111 (which did not touch ILU(0)) seems to be happening in issues #1569 (and I think #1336).  I'm using a similar reproducer to what is in #1569, but without Umpire or MPI; can share if it's helpful.

With a HYPRE debug build (which enables HYPRE's `assert(location == location_ptr)`), the reproducer aborts at the first factor free in `HYPRE_ILUDestroy` (`par_ilu.c:212` -> `csr_matrix.c:71`; v3.1.0).  The freed array is tagged `location=3` (UNIFIED) but its actual location is `0` (HOST). In a release build this accounts for the 7x `invalid argument at memory.c:524`.

Adding the 4 lines proposed here will prevent `hipFree` from being called on host memory (instead using the host-free path for host-tagged memory); this removes the crashes and leaves the residual unchanged.  (glad to modify or close this PR if the maintainers have something different in mind.)

There are some other occurrences (`hypre_ILUSetupILUK`, `hypre_ILUSetupILU0RAS`, `hypre_ILUSetupILUKRAS`) of this pattern, so this is only a partial fix targeting the error reported in issues #1569 / #1336.  Note the ILUK paths (`hypre_ILUSetupILUK` / `hypre_ILUSetupILUKRAS`) also allocate their column arrays in `hypre_ILUSetupILUKSymbolic` via `HYPRE_GetMemoryLocation()`, so those likely need additional changes beyond the sort of retag proposed here.