### PR TITLE
Fix ILU destroy issues in UVM GPU mode

### DIFF
--- a/src/parcsr_ls/_hypre_parcsr_ls.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls.h
@@ -3606,7 +3606,8 @@ HYPRE_Int hypre_ILUSetupILUKSymbolic( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_In
                                       HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i,
                                       HYPRE_Int *U_diag_i, HYPRE_Int *S_diag_i,
                                       HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j,
-                                      HYPRE_Int **S_diag_j, HYPRE_Int **u_end );
+                                      HYPRE_Int **S_diag_j, HYPRE_Int **u_end,
+                                      HYPRE_MemoryLocation memory_location );
 HYPRE_Int hypre_ILUSetupILUK( hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *permp,
                               HYPRE_Int *qpermp, HYPRE_Int nLU, HYPRE_Int nI,
                               hypre_ParCSRMatrix **Lptr, HYPRE_Real **Dptr,
@@ -3628,7 +3629,8 @@ HYPRE_Int hypre_ILUSetupILUKRASSymbolic( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE
                                          HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm,
                                          HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i,
                                          HYPRE_Int *U_diag_i, HYPRE_Int **L_diag_j,
-                                         HYPRE_Int **U_diag_j );
+                                         HYPRE_Int **U_diag_j,
+                                         HYPRE_MemoryLocation memory_location );
 HYPRE_Int hypre_ILUSetupILUKRAS( hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm,
                                  HYPRE_Int nLU, hypre_ParCSRMatrix **Lptr,
                                  HYPRE_Real **Dptr, hypre_ParCSRMatrix **Uptr );

--- a/src/parcsr_ls/_hypre_parcsr_ls_mup.h
+++ b/src/parcsr_ls/_hypre_parcsr_ls_mup.h
@@ -5095,18 +5095,18 @@ HYPRE_Int
 hypre_ILUSetupILUKRAS_long_dbl( hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int nLU, hypre_ParCSRMatrix **Lptr, hypre_long_double **Dptr, hypre_ParCSRMatrix **Uptr );
 
 HYPRE_Int
-hypre_ILUSetupILUKRASSymbolic_flt( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int *A_offd_i, HYPRE_Int *A_offd_j, HYPRE_Int *E_i, HYPRE_Int *E_j, HYPRE_Int ext, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j );
+hypre_ILUSetupILUKRASSymbolic_flt( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int *A_offd_i, HYPRE_Int *A_offd_j, HYPRE_Int *E_i, HYPRE_Int *E_j, HYPRE_Int ext, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_MemoryLocation memory_location);
 HYPRE_Int
-hypre_ILUSetupILUKRASSymbolic_dbl( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int *A_offd_i, HYPRE_Int *A_offd_j, HYPRE_Int *E_i, HYPRE_Int *E_j, HYPRE_Int ext, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j );
+hypre_ILUSetupILUKRASSymbolic_dbl( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int *A_offd_i, HYPRE_Int *A_offd_j, HYPRE_Int *E_i, HYPRE_Int *E_j, HYPRE_Int ext, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_MemoryLocation memory_location);
 HYPRE_Int
-hypre_ILUSetupILUKRASSymbolic_long_dbl( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int *A_offd_i, HYPRE_Int *A_offd_j, HYPRE_Int *E_i, HYPRE_Int *E_j, HYPRE_Int ext, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j );
+hypre_ILUSetupILUKRASSymbolic_long_dbl( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int *A_offd_i, HYPRE_Int *A_offd_j, HYPRE_Int *E_i, HYPRE_Int *E_j, HYPRE_Int ext, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_MemoryLocation memory_location);
 
 HYPRE_Int
-hypre_ILUSetupILUKSymbolic_flt( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int *S_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_Int **S_diag_j, HYPRE_Int **u_end );
+hypre_ILUSetupILUKSymbolic_flt( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int *S_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_Int **S_diag_j, HYPRE_Int **u_end, HYPRE_MemoryLocation memory_location);
 HYPRE_Int
-hypre_ILUSetupILUKSymbolic_dbl( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int *S_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_Int **S_diag_j, HYPRE_Int **u_end );
+hypre_ILUSetupILUKSymbolic_dbl( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int *S_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_Int **S_diag_j, HYPRE_Int **u_end, HYPRE_MemoryLocation memory_location);
 HYPRE_Int
-hypre_ILUSetupILUKSymbolic_long_dbl( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int *S_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_Int **S_diag_j, HYPRE_Int **u_end );
+hypre_ILUSetupILUKSymbolic_long_dbl( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int *S_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_Int **S_diag_j, HYPRE_Int **u_end, HYPRE_MemoryLocation memory_location);
 
 HYPRE_Int
 hypre_ILUSetupILUT_flt( hypre_ParCSRMatrix *A, HYPRE_Int lfil, hypre_float *tol, HYPRE_Int *permp, HYPRE_Int *qpermp, HYPRE_Int nLU, HYPRE_Int nI, hypre_ParCSRMatrix **Lptr, hypre_float **Dptr, hypre_ParCSRMatrix **Uptr, hypre_ParCSRMatrix **Sptr, HYPRE_Int **u_end );

--- a/src/parcsr_ls/mup_fixed.c
+++ b/src/parcsr_ls/mup_fixed.c
@@ -5881,17 +5881,17 @@ hypre_ILUSetupILUKRAS( hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm, H
 /*--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_ILUSetupILUKRASSymbolic( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int *A_offd_i, HYPRE_Int *A_offd_j, HYPRE_Int *E_i, HYPRE_Int *E_j, HYPRE_Int ext, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j )
+hypre_ILUSetupILUKRASSymbolic( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int *A_offd_i, HYPRE_Int *A_offd_j, HYPRE_Int *E_i, HYPRE_Int *E_j, HYPRE_Int ext, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_MemoryLocation memory_location )
 {
-   return HYPRE_CURRENTPRECISION_FUNC(hypre_ILUSetupILUKRASSymbolic)( n, A_diag_i, A_diag_j, A_offd_i, A_offd_j, E_i, E_j, ext, lfil, perm, rperm, iw, nLU, L_diag_i, U_diag_i, L_diag_j, U_diag_j );
+   return HYPRE_CURRENTPRECISION_FUNC(hypre_ILUSetupILUKRASSymbolic)( n, A_diag_i, A_diag_j, A_offd_i, A_offd_j, E_i, E_j, ext, lfil, perm, rperm, iw, nLU, L_diag_i, U_diag_i, L_diag_j, U_diag_j, memory_location );
 }
 
 /*--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_ILUSetupILUKSymbolic( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int *S_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_Int **S_diag_j, HYPRE_Int **u_end )
+hypre_ILUSetupILUKSymbolic( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_Int *A_diag_j, HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm, HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i, HYPRE_Int *U_diag_i, HYPRE_Int *S_diag_i, HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j, HYPRE_Int **S_diag_j, HYPRE_Int **u_end, HYPRE_MemoryLocation memory_location )
 {
-   return HYPRE_CURRENTPRECISION_FUNC(hypre_ILUSetupILUKSymbolic)( n, A_diag_i, A_diag_j, lfil, perm, rperm, iw, nLU, L_diag_i, U_diag_i, S_diag_i, L_diag_j, U_diag_j, S_diag_j, u_end );
+   return HYPRE_CURRENTPRECISION_FUNC(hypre_ILUSetupILUKSymbolic)( n, A_diag_i, A_diag_j, lfil, perm, rperm, iw, nLU, L_diag_i, U_diag_i, S_diag_i, L_diag_j, U_diag_j, S_diag_j, u_end, memory_location );
 }
 
 /*--------------------------------------------------------------------------*/

--- a/src/parcsr_ls/par_ilu.c
+++ b/src/parcsr_ls/par_ilu.c
@@ -2618,9 +2618,9 @@ hypre_ILULocalRCM(hypre_CSRMatrix *A,
 
    /* Create matrix G on the host */
    G = hypre_CSRMatrixCreate(num_nodes, num_nodes, G_nnz);
-   hypre_CSRMatrixMemoryLocation(G) = HYPRE_MEMORY_HOST;
    hypre_CSRMatrixI(G) = G_i;
    hypre_CSRMatrixJ(G) = G_j;
+   hypre_CSRMatrixInitialize_v2(G, 0, HYPRE_MEMORY_HOST);
 
    /* Check if G is not empty (no need to do any kind of RCM) */
    if (G_nnz > 0)

--- a/src/parcsr_ls/par_ilu_setup.c
+++ b/src/parcsr_ls/par_ilu_setup.c
@@ -2794,6 +2794,8 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix  *A,
                                     0,
                                     ctrL,
                                     0 );
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(matL)) = memory_location;
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixOffd(matL)) = memory_location;
 
    L_diag = hypre_ParCSRMatrixDiag(matL);
    hypre_CSRMatrixI(L_diag) = L_diag_i;
@@ -2821,6 +2823,8 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix  *A,
                                     0,
                                     ctrU,
                                     0 );
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(matU)) = memory_location;
+   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixOffd(matU)) = memory_location;
 
    U_diag = hypre_ParCSRMatrixDiag(matU);
    hypre_CSRMatrixI(U_diag) = U_diag_i;

--- a/src/parcsr_ls/par_ilu_setup.c
+++ b/src/parcsr_ls/par_ilu_setup.c
@@ -176,8 +176,8 @@ hypre_ILUSetup( void               *ilu_vdata,
    hypre_ParCSRMatrixDestroy(matmU); matmU = NULL;
    hypre_ParCSRMatrixDestroy(matS);  matS  = NULL;
 
-   hypre_TFree(matD, HYPRE_MEMORY_DEVICE);
-   hypre_TFree(matmD, HYPRE_MEMORY_DEVICE);
+   hypre_TFree(matD, memory_location);
+   hypre_TFree(matmD, memory_location);
    hypre_TFree(CF_marker_array, HYPRE_MEMORY_HOST);
 
    /* clear old l1_norm data, if created */
@@ -239,13 +239,13 @@ hypre_ILUSetup( void               *ilu_vdata,
    Utemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(A),
                                  hypre_ParCSRMatrixGlobalNumRows(A),
                                  hypre_ParCSRMatrixRowStarts(A));
-   hypre_ParVectorInitialize(Utemp);
+   hypre_ParVectorInitialize_v2(Utemp, memory_location);
    hypre_ParILUDataUTemp(ilu_data) = Utemp;
 
    Ftemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(A),
                                  hypre_ParCSRMatrixGlobalNumRows(A),
                                  hypre_ParCSRMatrixRowStarts(A));
-   hypre_ParVectorInitialize(Ftemp);
+   hypre_ParVectorInitialize_v2(Ftemp, memory_location);
    hypre_ParILUDataFTemp(ilu_data) = Ftemp;
 
    /* set matrix, solution and rhs pointers */
@@ -474,7 +474,7 @@ hypre_ILUSetup( void               *ilu_vdata,
       Ztemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(A),
                                     hypre_ParCSRMatrixGlobalNumRows(A),
                                     hypre_ParCSRMatrixRowStarts(A));
-      hypre_ParVectorInitialize(Ztemp);
+      hypre_ParVectorInitialize_v2(Ztemp, memory_location);
    }
 
    /* setup Schur solver - TODO (VPM): merge host and device paths below */
@@ -494,24 +494,24 @@ hypre_ILUSetup( void               *ilu_vdata,
                Xtemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(matS),
                                              hypre_ParCSRMatrixGlobalNumRows(matS),
                                              hypre_ParCSRMatrixRowStarts(matS));
-               hypre_ParVectorInitialize(Xtemp);
+               hypre_ParVectorInitialize_v2(Xtemp, memory_location);
 
                Ytemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(matS),
                                              hypre_ParCSRMatrixGlobalNumRows(matS),
                                              hypre_ParCSRMatrixRowStarts(matS));
-               hypre_ParVectorInitialize(Ytemp);
+               hypre_ParVectorInitialize_v2(Ytemp, memory_location);
 
                Ftemp_upper = hypre_SeqVectorCreate(nLU);
                hypre_VectorOwnsData(Ftemp_upper)   = 0;
                hypre_VectorData(Ftemp_upper)       = hypre_VectorData(
                                                         hypre_ParVectorLocalVector(Ftemp));
-               hypre_SeqVectorInitialize(Ftemp_upper);
+               hypre_SeqVectorInitialize_v2(Ftemp_upper, memory_location);
 
                Utemp_lower = hypre_SeqVectorCreate(n - nLU);
                hypre_VectorOwnsData(Utemp_lower)   = 0;
                hypre_VectorData(Utemp_lower)       = hypre_VectorData(
                                                         hypre_ParVectorLocalVector(Utemp)) + nLU;
-               hypre_SeqVectorInitialize(Utemp_lower);
+               hypre_SeqVectorInitialize_v2(Utemp_lower, memory_location);
 
                /* create GMRES */
                //            HYPRE_ParCSRGMRESCreate(comm, &schur_solver);
@@ -575,11 +575,11 @@ hypre_ILUSetup( void               *ilu_vdata,
                rhs = hypre_ParVectorCreate(comm,
                                            hypre_ParCSRMatrixGlobalNumRows(matS),
                                            hypre_ParCSRMatrixRowStarts(matS));
-               hypre_ParVectorInitialize(rhs);
+               hypre_ParVectorInitialize_v2(rhs, memory_location);
                x = hypre_ParVectorCreate(comm,
                                          hypre_ParCSRMatrixGlobalNumRows(matS),
                                          hypre_ParCSRMatrixRowStarts(matS));
-               hypre_ParVectorInitialize(x);
+               hypre_ParVectorInitialize_v2(x, memory_location);
 
                /* setup solver */
                HYPRE_GMRESSetup(schur_solver,
@@ -650,11 +650,11 @@ hypre_ILUSetup( void               *ilu_vdata,
                rhs = hypre_ParVectorCreate(comm,
                                            hypre_ParCSRMatrixGlobalNumRows(matS),
                                            hypre_ParCSRMatrixRowStarts(matS));
-               hypre_ParVectorInitialize(rhs);
+               hypre_ParVectorInitialize_v2(rhs, memory_location);
                x = hypre_ParVectorCreate(comm,
                                          hypre_ParCSRMatrixGlobalNumRows(matS),
                                          hypre_ParCSRMatrixRowStarts(matS));
-               hypre_ParVectorInitialize(x);
+               hypre_ParVectorInitialize_v2(x, memory_location);
 
                /* setup solver */
                HYPRE_GMRESSetup(schur_solver,
@@ -697,11 +697,11 @@ hypre_ILUSetup( void               *ilu_vdata,
             rhs = hypre_ParVectorCreate(comm,
                                         hypre_ParCSRMatrixGlobalNumRows(matS),
                                         hypre_ParCSRMatrixRowStarts(matS));
-            hypre_ParVectorInitialize(rhs);
+            hypre_ParVectorInitialize_v2(rhs, memory_location);
             x = hypre_ParVectorCreate(comm,
                                       hypre_ParCSRMatrixGlobalNumRows(matS),
                                       hypre_ParCSRMatrixRowStarts(matS));
-            hypre_ParVectorInitialize(x);
+            hypre_ParVectorInitialize_v2(x, memory_location);
 
             /* setup solver */
             hypre_NSHSetup(schur_solver, matS, rhs, x);
@@ -787,11 +787,11 @@ hypre_ILUSetup( void               *ilu_vdata,
             rhs = hypre_ParVectorCreate(comm,
                                         hypre_ParCSRMatrixGlobalNumRows(matS),
                                         hypre_ParCSRMatrixRowStarts(matS));
-            hypre_ParVectorInitialize(rhs);
+            hypre_ParVectorInitialize_v2(rhs, memory_location);
             x = hypre_ParVectorCreate(comm,
                                       hypre_ParCSRMatrixGlobalNumRows(matS),
                                       hypre_ParCSRMatrixRowStarts(matS));
-            hypre_ParVectorInitialize(x);
+            hypre_ParVectorInitialize_v2(x, memory_location);
 
             /* setup solver */
             HYPRE_GMRESSetup(schur_solver,
@@ -814,23 +814,23 @@ hypre_ILUSetup( void               *ilu_vdata,
             Xtemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(matA),
                                           hypre_ParCSRMatrixGlobalNumRows(matA),
                                           hypre_ParCSRMatrixRowStarts(matA));
-            hypre_ParVectorInitialize(Xtemp);
+            hypre_ParVectorInitialize_v2(Xtemp, memory_location);
 
             Ytemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(matA),
                                           hypre_ParCSRMatrixGlobalNumRows(matA),
                                           hypre_ParCSRMatrixRowStarts(matA));
-            hypre_ParVectorInitialize(Ytemp);
+            hypre_ParVectorInitialize_v2(Ytemp, memory_location);
 
             Ftemp_upper = hypre_SeqVectorCreate(nLU);
             hypre_VectorOwnsData(Ftemp_upper) = 0;
             hypre_VectorData(Ftemp_upper) = hypre_VectorData(hypre_ParVectorLocalVector(Ftemp));
-            hypre_SeqVectorInitialize(Ftemp_upper);
+            hypre_SeqVectorInitialize_v2(Ftemp_upper, memory_location);
 
             Utemp_lower = hypre_SeqVectorCreate(n - nLU);
             hypre_VectorOwnsData(Utemp_lower) = 0;
             hypre_VectorData(Utemp_lower) = nLU +
                                             hypre_VectorData(hypre_ParVectorLocalVector(Utemp));
-            hypre_SeqVectorInitialize(Utemp_lower);
+            hypre_SeqVectorInitialize_v2(Utemp_lower, memory_location);
 
             /* create GMRES */
             //            HYPRE_ParCSRGMRESCreate(comm, &schur_solver);
@@ -897,11 +897,11 @@ hypre_ILUSetup( void               *ilu_vdata,
             rhs = hypre_ParVectorCreate(comm,
                                         hypre_ParCSRMatrixGlobalNumRows(matS),
                                         hypre_ParCSRMatrixRowStarts(matS));
-            hypre_ParVectorInitialize(rhs);
+            hypre_ParVectorInitialize_v2(rhs, memory_location);
             x = hypre_ParVectorCreate(comm,
                                       hypre_ParCSRMatrixGlobalNumRows(matS),
                                       hypre_ParCSRMatrixRowStarts(matS));
-            hypre_ParVectorInitialize(x);
+            hypre_ParVectorInitialize_v2(x, memory_location);
 
             /* setup solver */
             HYPRE_GMRESSetup(schur_solver,
@@ -935,12 +935,12 @@ hypre_ILUSetup( void               *ilu_vdata,
                Xtemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(matA),
                                              hypre_ParCSRMatrixGlobalNumRows(matA),
                                              hypre_ParCSRMatrixRowStarts(matA));
-               hypre_ParVectorInitialize(Xtemp);
+               hypre_ParVectorInitialize_v2(Xtemp, memory_location);
 
                Ytemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(matA),
                                              hypre_ParCSRMatrixGlobalNumRows(matA),
                                              hypre_ParCSRMatrixRowStarts(matA));
-               hypre_ParVectorInitialize(Ytemp);
+               hypre_ParVectorInitialize_v2(Ytemp, memory_location);
 
                hypre_MPI_Scan(&big_m, &global_start, 1, HYPRE_MPI_BIG_INT, hypre_MPI_SUM, comm);
                S_row_starts[0] = global_start - big_m;
@@ -949,12 +949,12 @@ hypre_ILUSetup( void               *ilu_vdata,
                rhs = hypre_ParVectorCreate(comm,
                                            S_total_rows,
                                            S_row_starts);
-               hypre_ParVectorInitialize(rhs);
+               hypre_ParVectorInitialize_v2(rhs, memory_location);
 
                x = hypre_ParVectorCreate(comm,
                                          S_total_rows,
                                          S_row_starts);
-               hypre_ParVectorInitialize(x);
+               hypre_ParVectorInitialize_v2(x, memory_location);
 
                /* create GMRES */
                //            HYPRE_ParCSRGMRESCreate(comm, &schur_solver);
@@ -1285,7 +1285,7 @@ hypre_ILUSetup( void               *ilu_vdata,
          hypre_ParVectorCreate(hypre_ParCSRMatrixComm(matA),
                                hypre_ParCSRMatrixGlobalNumRows(matA),
                                hypre_ParCSRMatrixRowStarts(matA) );
-      hypre_ParVectorInitialize(residual);
+      hypre_ParVectorInitialize_v2(residual, memory_location);
       hypre_ParILUDataResidual(ilu_data) = residual;
    }
    else
@@ -2020,6 +2020,8 @@ hypre_ILUSetupRAPILU0Device(hypre_ParCSRMatrix  *A,
 
       hypre_CSRMatrixDestroy(hypre_ParCSRMatrixDiag(S));
       hypre_ParCSRMatrixDiag(S) = SLU;
+      hypre_CSRMatrixInitialize_v2(hypre_ParCSRMatrixOffd(S), 0,
+                                   hypre_CSRMatrixMemoryLocation(SLU));
    }
    else
    {
@@ -2758,6 +2760,9 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix  *A,
       hypre_CSRMatrixJ(S_offd) = S_offd_j;
       hypre_CSRMatrixData(S_offd) = S_offd_data;
 
+      hypre_CSRMatrixInitialize_v2(S_diag, 0, memory_location);
+      hypre_CSRMatrixInitialize_v2(S_offd, 0, memory_location);
+
       /* now we need to update S_offd_colmap */
 
       /* get total num of send */
@@ -2794,8 +2799,6 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix  *A,
                                     0,
                                     ctrL,
                                     0 );
-   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(matL)) = memory_location;
-   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixOffd(matL)) = memory_location;
 
    L_diag = hypre_ParCSRMatrixDiag(matL);
    hypre_CSRMatrixI(L_diag) = L_diag_i;
@@ -2810,6 +2813,8 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix  *A,
       hypre_TFree(L_diag_j, memory_location);
       hypre_TFree(L_diag_data, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matL, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) ctrL;
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);
@@ -2823,8 +2828,6 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix  *A,
                                     0,
                                     ctrU,
                                     0 );
-   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(matU)) = memory_location;
-   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixOffd(matU)) = memory_location;
 
    U_diag = hypre_ParCSRMatrixDiag(matU);
    hypre_CSRMatrixI(U_diag) = U_diag_i;
@@ -2839,6 +2842,8 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix  *A,
       hypre_TFree(U_diag_j, memory_location);
       hypre_TFree(U_diag_data, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matU, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) ctrU;
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);
@@ -2889,21 +2894,22 @@ hypre_ILUSetupMILU0(hypre_ParCSRMatrix  *A,
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_ILUSetupILUKSymbolic(HYPRE_Int   n,
-                           HYPRE_Int  *A_diag_i,
-                           HYPRE_Int  *A_diag_j,
-                           HYPRE_Int   lfil,
-                           HYPRE_Int  *perm,
-                           HYPRE_Int  *rperm,
-                           HYPRE_Int  *iw,
-                           HYPRE_Int   nLU,
-                           HYPRE_Int  *L_diag_i,
-                           HYPRE_Int  *U_diag_i,
-                           HYPRE_Int  *S_diag_i,
-                           HYPRE_Int **L_diag_j,
-                           HYPRE_Int **U_diag_j,
-                           HYPRE_Int **S_diag_j,
-                           HYPRE_Int **u_end)
+hypre_ILUSetupILUKSymbolic(HYPRE_Int             n,
+                           HYPRE_Int            *A_diag_i,
+                           HYPRE_Int            *A_diag_j,
+                           HYPRE_Int             lfil,
+                           HYPRE_Int            *perm,
+                           HYPRE_Int            *rperm,
+                           HYPRE_Int            *iw,
+                           HYPRE_Int             nLU,
+                           HYPRE_Int            *L_diag_i,
+                           HYPRE_Int            *U_diag_i,
+                           HYPRE_Int            *S_diag_i,
+                           HYPRE_Int           **L_diag_j,
+                           HYPRE_Int           **U_diag_j,
+                           HYPRE_Int           **S_diag_j,
+                           HYPRE_Int           **u_end,
+                           HYPRE_MemoryLocation  memory_location)
 {
    /*
     * 1: Setup and create buffers
@@ -2932,10 +2938,6 @@ hypre_ILUSetupILUKSymbolic(HYPRE_Int   n,
    HYPRE_Int         capacity_S = 0;
    HYPRE_Int         initial_alloc = 0;
    HYPRE_Int         nnz_A;
-   HYPRE_MemoryLocation memory_location;
-
-   /* Get default memory location */
-   HYPRE_GetMemoryLocation(&memory_location);
 
    /* set iL and iLev to right place in iw array */
    iL                = iw + n;
@@ -3488,7 +3490,8 @@ hypre_ILUSetupILUK(hypre_ParCSRMatrix  *A,
 
    /* do symbolic factorization */
    hypre_ILUSetupILUKSymbolic(n, A_diag_i, A_diag_j, lfil, perm, rperm, iw,
-                              nLU, L_diag_i, U_diag_i, S_diag_i, &L_diag_j, &U_diag_j, &S_diag_j, u_end);
+                              nLU, L_diag_i, U_diag_i, S_diag_i, &L_diag_j, &U_diag_j, &S_diag_j, u_end,
+                              memory_location);
 
    /*
     * after this, we have our I,J for L, U and S ready, and L sorted
@@ -3764,6 +3767,9 @@ hypre_ILUSetupILUK(hypre_ParCSRMatrix  *A,
       hypre_CSRMatrixJ(S_offd) = S_offd_j;
       hypre_CSRMatrixData(S_offd) = S_offd_data;
 
+      hypre_CSRMatrixInitialize_v2(S_diag, 0, memory_location);
+      hypre_CSRMatrixInitialize_v2(S_offd, 0, memory_location);
+
       /* now we need to update S_offd_colmap */
 
       /* get total num of send */
@@ -3819,6 +3825,8 @@ hypre_ILUSetupILUK(hypre_ParCSRMatrix  *A,
       /* we allocated some initial length, so free them */
       hypre_TFree(L_diag_j, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matL, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) (L_diag_i[n]);
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);
@@ -3845,6 +3853,8 @@ hypre_ILUSetupILUK(hypre_ParCSRMatrix  *A,
       /* we allocated some initial length, so free them */
       hypre_TFree(U_diag_j, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matU, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) (U_diag_i[n]);
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);
@@ -4638,6 +4648,9 @@ hypre_ILUSetupILUT(hypre_ParCSRMatrix  *A,
       hypre_CSRMatrixJ(S_offd) = S_offd_j;
       hypre_CSRMatrixData(S_offd) = S_offd_data;
 
+      hypre_CSRMatrixInitialize_v2(S_diag, 0, memory_location);
+      hypre_CSRMatrixInitialize_v2(S_offd, 0, memory_location);
+
       /* now we need to update S_offd_colmap */
 
       /* get total num of send */
@@ -4682,8 +4695,6 @@ hypre_ILUSetupILUT(hypre_ParCSRMatrix  *A,
                                     0,
                                     L_diag_i[n],
                                     0 );
-   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(matL)) = memory_location;
-   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixOffd(matL)) = memory_location;
 
    L_diag = hypre_ParCSRMatrixDiag(matL);
    hypre_CSRMatrixI(L_diag) = L_diag_i;
@@ -4698,6 +4709,8 @@ hypre_ILUSetupILUT(hypre_ParCSRMatrix  *A,
       hypre_TFree(L_diag_j, memory_location);
       hypre_TFree(L_diag_data, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matL, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) (L_diag_i[n]);
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);
@@ -4711,8 +4724,6 @@ hypre_ILUSetupILUT(hypre_ParCSRMatrix  *A,
                                     0,
                                     U_diag_i[n],
                                     0 );
-   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixDiag(matU)) = memory_location;
-   hypre_CSRMatrixMemoryLocation(hypre_ParCSRMatrixOffd(matU)) = memory_location;
 
    U_diag = hypre_ParCSRMatrixDiag(matU);
    hypre_CSRMatrixI(U_diag) = U_diag_i;
@@ -4727,6 +4738,8 @@ hypre_ILUSetupILUT(hypre_ParCSRMatrix  *A,
       hypre_TFree(U_diag_j, memory_location);
       hypre_TFree(U_diag_data, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matU, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) (U_diag_i[n]);
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);
@@ -4771,7 +4784,8 @@ hypre_NSHSetup( void               *nsh_vdata,
                 hypre_ParVector    *f,
                 hypre_ParVector    *u )
 {
-   MPI_Comm             comm              = hypre_ParCSRMatrixComm(A);
+   MPI_Comm              comm             = hypre_ParCSRMatrixComm(A);
+   HYPRE_MemoryLocation  memory_location  = hypre_ParCSRMatrixMemoryLocation(A);
    hypre_ParNSHData     *nsh_data         = (hypre_ParNSHData*) nsh_vdata;
 
    /* Pointers to NSH data */
@@ -4819,13 +4833,13 @@ hypre_NSHSetup( void               *nsh_vdata,
    Utemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(A),
                                  hypre_ParCSRMatrixGlobalNumRows(A),
                                  hypre_ParCSRMatrixRowStarts(A));
-   hypre_ParVectorInitialize(Utemp);
+   hypre_ParVectorInitialize_v2(Utemp, memory_location);
    hypre_ParNSHDataUTemp(nsh_data) = Utemp;
 
    Ftemp = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(A),
                                  hypre_ParCSRMatrixGlobalNumRows(A),
                                  hypre_ParCSRMatrixRowStarts(A));
-   hypre_ParVectorInitialize(Ftemp);
+   hypre_ParVectorInitialize_v2(Ftemp, memory_location);
    hypre_ParNSHDataFTemp(nsh_data) = Ftemp;
 
    /* Set matrix, solution and rhs pointers */
@@ -4862,7 +4876,7 @@ hypre_NSHSetup( void               *nsh_vdata,
       residual = hypre_ParVectorCreate(hypre_ParCSRMatrixComm(matA),
                                        hypre_ParCSRMatrixGlobalNumRows(matA),
                                        hypre_ParCSRMatrixRowStarts(matA));
-      hypre_ParVectorInitialize(residual);
+      hypre_ParVectorInitialize_v2(residual, memory_location);
       hypre_ParNSHDataResidual(nsh_data) = residual;
    }
    else
@@ -5487,6 +5501,8 @@ hypre_ILUSetupILU0RAS(hypre_ParCSRMatrix  *A,
       hypre_TFree(L_diag_j, memory_location);
       hypre_TFree(L_diag_data, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matL, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) ctrL;
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);
@@ -5514,6 +5530,8 @@ hypre_ILUSetupILU0RAS(hypre_ParCSRMatrix  *A,
       hypre_TFree(U_diag_j, memory_location);
       hypre_TFree(U_diag_data, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matU, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) ctrU;
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);
@@ -5559,23 +5577,24 @@ hypre_ILUSetupILU0RAS(hypre_ParCSRMatrix  *A,
  *--------------------------------------------------------------------------*/
 
 HYPRE_Int
-hypre_ILUSetupILUKRASSymbolic(HYPRE_Int   n,
-                              HYPRE_Int  *A_diag_i,
-                              HYPRE_Int  *A_diag_j,
-                              HYPRE_Int  *A_offd_i,
-                              HYPRE_Int  *A_offd_j,
-                              HYPRE_Int  *E_i,
-                              HYPRE_Int  *E_j,
-                              HYPRE_Int   ext,
-                              HYPRE_Int   lfil,
-                              HYPRE_Int  *perm,
-                              HYPRE_Int  *rperm,
-                              HYPRE_Int  *iw,
-                              HYPRE_Int   nLU,
-                              HYPRE_Int  *L_diag_i,
-                              HYPRE_Int  *U_diag_i,
-                              HYPRE_Int **L_diag_j,
-                              HYPRE_Int **U_diag_j)
+hypre_ILUSetupILUKRASSymbolic(HYPRE_Int             n,
+                              HYPRE_Int            *A_diag_i,
+                              HYPRE_Int            *A_diag_j,
+                              HYPRE_Int            *A_offd_i,
+                              HYPRE_Int            *A_offd_j,
+                              HYPRE_Int            *E_i,
+                              HYPRE_Int            *E_j,
+                              HYPRE_Int             ext,
+                              HYPRE_Int             lfil,
+                              HYPRE_Int            *perm,
+                              HYPRE_Int            *rperm,
+                              HYPRE_Int            *iw,
+                              HYPRE_Int             nLU,
+                              HYPRE_Int            *L_diag_i,
+                              HYPRE_Int            *U_diag_i,
+                              HYPRE_Int           **L_diag_j,
+                              HYPRE_Int           **U_diag_j,
+                              HYPRE_MemoryLocation  memory_location)
 {
    /*
     * 1: Setup and create buffers
@@ -5602,10 +5621,6 @@ hypre_ILUSetupILUKRASSymbolic(HYPRE_Int   n,
    HYPRE_Int      capacity_U;
    HYPRE_Int      initial_alloc = 0;
    HYPRE_Int      nnz_A;
-   HYPRE_MemoryLocation memory_location;
-
-   /* Get default memory location */
-   HYPRE_GetMemoryLocation(&memory_location);
 
    /* set iL and iLev to right place in iw array */
    iL             = iw + total_rows;
@@ -6247,7 +6262,8 @@ hypre_ILUSetupILUKRAS(hypre_ParCSRMatrix  *A,
    /* do symbolic factorization */
    hypre_ILUSetupILUKRASSymbolic(n, A_diag_i, A_diag_j, A_offd_i, A_offd_j, E_i, E_j, ext, lfil, perm,
                                  rperm, iw,
-                                 nLU, L_diag_i, U_diag_i, &L_diag_j, &U_diag_j);
+                                 nLU, L_diag_i, U_diag_i, &L_diag_j, &U_diag_j,
+                                 memory_location);
 
    /*
     * after this, we have our I,J for L, U and S ready, and L sorted
@@ -6606,6 +6622,8 @@ hypre_ILUSetupILUKRAS(hypre_ParCSRMatrix  *A,
       /* we allocated some initial length, so free them */
       hypre_TFree(L_diag_j, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matL, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) (L_diag_i[total_rows]);
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);
@@ -6632,6 +6650,8 @@ hypre_ILUSetupILUKRAS(hypre_ParCSRMatrix  *A,
       /* we allocated some initial length, so free them */
       hypre_TFree(U_diag_j, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matU, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) (U_diag_i[total_rows]);
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);
@@ -7551,6 +7571,8 @@ hypre_ILUSetupILUTRAS(hypre_ParCSRMatrix  *A,
       hypre_TFree(L_diag_j, memory_location);
       hypre_TFree(L_diag_data, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matL, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) (L_diag_i[total_rows]);
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);
@@ -7578,6 +7600,8 @@ hypre_ILUSetupILUTRAS(hypre_ParCSRMatrix  *A,
       hypre_TFree(U_diag_j, memory_location);
       hypre_TFree(U_diag_data, memory_location);
    }
+   hypre_ParCSRMatrixInitialize_v2(matU, memory_location);
+
    /* store (global) total number of nonzeros */
    local_nnz = (HYPRE_Real) (U_diag_i[total_rows]);
    hypre_MPI_Allreduce(&local_nnz, &total_nnz, 1, HYPRE_MPI_REAL, hypre_MPI_SUM, comm);

--- a/src/parcsr_ls/protos.h
+++ b/src/parcsr_ls/protos.h
@@ -1874,7 +1874,8 @@ HYPRE_Int hypre_ILUSetupILUKSymbolic( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE_In
                                       HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i,
                                       HYPRE_Int *U_diag_i, HYPRE_Int *S_diag_i,
                                       HYPRE_Int **L_diag_j, HYPRE_Int **U_diag_j,
-                                      HYPRE_Int **S_diag_j, HYPRE_Int **u_end );
+                                      HYPRE_Int **S_diag_j, HYPRE_Int **u_end,
+                                      HYPRE_MemoryLocation memory_location );
 HYPRE_Int hypre_ILUSetupILUK( hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *permp,
                               HYPRE_Int *qpermp, HYPRE_Int nLU, HYPRE_Int nI,
                               hypre_ParCSRMatrix **Lptr, HYPRE_Real **Dptr,
@@ -1896,7 +1897,8 @@ HYPRE_Int hypre_ILUSetupILUKRASSymbolic( HYPRE_Int n, HYPRE_Int *A_diag_i, HYPRE
                                          HYPRE_Int lfil, HYPRE_Int *perm, HYPRE_Int *rperm,
                                          HYPRE_Int *iw, HYPRE_Int nLU, HYPRE_Int *L_diag_i,
                                          HYPRE_Int *U_diag_i, HYPRE_Int **L_diag_j,
-                                         HYPRE_Int **U_diag_j );
+                                         HYPRE_Int **U_diag_j,
+                                         HYPRE_MemoryLocation memory_location );
 HYPRE_Int hypre_ILUSetupILUKRAS( hypre_ParCSRMatrix *A, HYPRE_Int lfil, HYPRE_Int *perm,
                                  HYPRE_Int nLU, hypre_ParCSRMatrix **Lptr,
                                  HYPRE_Real **Dptr, hypre_ParCSRMatrix **Uptr );


### PR DESCRIPTION
Extends fixes proposed in #1585 to remaining ILU types.

Fixes ILU teardown crashes caused by factor matrices being tagged with the handle default memory location while their arrays lived at A’s location (often HOST after host assemble + device default switch).

Instead of retagging via `hypre_CSRMatrixMemoryLocation(...) = ...`, initialize factors/work vectors with the intended location via `initialize_v2` APIs.

Closes #1569
Closes #1336 
