### PR TITLE
Fix communication exchanges for multicomponent vectors

### DIFF
--- a/AUTOTEST/check-license.filters
+++ b/AUTOTEST/check-license.filters
@@ -9,6 +9,11 @@
 ./src/test/ij
 ./src/test/struct
 ./src/test/sstruct
+./src/test/test_csr_overlap
+./src/test/test_matrix_stats
+./src/test/test_mp_pcg
+./src/test/test_mp_pcg_3d
+./AUTOTEST/machine-.*[.]dir/
 ./src/zerr
 ./src/config.log
 ./src/config.status

--- a/AUTOTEST/check-license.sh
+++ b/AUTOTEST/check-license.sh
@@ -44,6 +44,7 @@ egrep -LR "$LicStr" . | egrep -v '[.](o|obj|a|filters|pdf|svg|gif|png)$' |
   egrep -v '[.]/src/(blas|lapack)/.*[.]c' |
   egrep -v '[.]/src/.*functions[.]saved$' |
   egrep -v '[.]/src/.*mup[.](exclude|fixed|functions|methods)(_gpu)?$' |
+  egrep -v '[.]/src/.*/mup_check[.](old|new|err)$' |
   egrep -v '[.]/src/examples/docs' |
   egrep -v '[.]/src/docs/wiki-dev' |
   egrep -v '[.]/src/test/TEST_.*'    > check-license.files

--- a/AUTOTEST/cmake.filters
+++ b/AUTOTEST/cmake.filters
@@ -9,3 +9,10 @@ Enable it with -DHYPRE_ENABLE_UMPIRE=ON.
 Call Stack
 CMakeLists.txt:
 ^$
+In function .hypre_matinv.:
+warning: iteration .* invokes undefined behavior \[-Waggressive-loop-optimizations\]
+note: within this loop
+\|          x\[i \+ j \+ k \* i\] = 0;
+\|            ~~\^~~
+\|       for \(j = 1; j < k - i; j\+\+\)
+\|                   ~~\^~~~~~~

--- a/src/parcsr_ls/par_schwarz.c
+++ b/src/parcsr_ls/par_schwarz.c
@@ -585,6 +585,7 @@ hypre_SchwarzOverlapSetup(hypre_SchwarzData       *schwarz_data,
          hypre_SchwarzDataLocalSolverDestroy(schwarz_data) = (HYPRE_PtrToDestroyFcn)
                                                              hypre_SLUDistDestroy;
          hypre_SchwarzDataLocalSolverOwner(schwarz_data) = 1;
+         break;
 #else
          if (my_id == 0)
          {
@@ -595,7 +596,6 @@ hypre_SchwarzOverlapSetup(hypre_SchwarzData       *schwarz_data,
          hypre_SchwarzOverlapDataDestroy(schwarz_data);
          return hypre_error_flag;
 #endif
-         break;
       }
 
       default:

--- a/src/parcsr_mv/par_csr_communication.c
+++ b/src/parcsr_mv/par_csr_communication.c
@@ -1089,18 +1089,24 @@ hypre_ParCSRCommPkgUpdateVecStarts( hypre_ParCSRCommPkg *comm_pkg,
 
    HYPRE_Int    *send_map_elmts_new;
 
+   HYPRE_Int     num_send_elmts;
+
    HYPRE_Int     i, j;
 
    hypre_assert(num_components > 0);
 
    if (num_components_in != num_components)
    {
+      /* Number of scalar send elements. This is computed from the current
+         (not-yet-rescaled) extents, which hold num_send_elmts * num_components. */
+      num_send_elmts = send_map_starts[num_sends] / num_components;
+
       /* Update number of components in the communication package */
       hypre_ParCSRCommPkgNumComponents(comm_pkg) = num_components_in;
 
       /* Allocate send_maps_elmts */
       send_map_elmts_new = hypre_CTAlloc(HYPRE_Int,
-                                         send_map_starts[num_sends] * num_components_in,
+                                         num_send_elmts * num_components_in,
                                          HYPRE_MEMORY_HOST);
 
       /* Update send_maps_elmts */
@@ -1108,7 +1114,7 @@ hypre_ParCSRCommPkgUpdateVecStarts( hypre_ParCSRCommPkg *comm_pkg,
       {
          if (num_components == 1)
          {
-            for (i = 0; i < send_map_starts[num_sends]; i++)
+            for (i = 0; i < num_send_elmts; i++)
             {
                for (j = 0; j < num_components_in; j++)
                {
@@ -1119,7 +1125,7 @@ hypre_ParCSRCommPkgUpdateVecStarts( hypre_ParCSRCommPkg *comm_pkg,
          }
          else
          {
-            for (i = 0; i < send_map_starts[num_sends]; i++)
+            for (i = 0; i < num_send_elmts; i++)
             {
                for (j = 0; j < num_components_in; j++)
                {
@@ -1134,14 +1140,14 @@ hypre_ParCSRCommPkgUpdateVecStarts( hypre_ParCSRCommPkg *comm_pkg,
          /* num_components_in < num_components */
          if (num_components_in == 1)
          {
-            for (i = 0; i < send_map_starts[num_sends]; i++)
+            for (i = 0; i < num_send_elmts; i++)
             {
                send_map_elmts_new[i] = send_map_elmts[i * num_components];
             }
          }
          else
          {
-            for (i = 0; i < send_map_starts[num_sends]; i++)
+            for (i = 0; i < num_send_elmts; i++)
             {
                for (j = 0; j < num_components_in; j++)
                {
@@ -1161,16 +1167,19 @@ hypre_ParCSRCommPkgUpdateVecStarts( hypre_ParCSRCommPkg *comm_pkg,
       hypre_ParCSRCommPkgMatrixE(comm_pkg) = NULL;
 #endif
 
-      /* Update send_map_starts */
+      /* Update send_map_starts. Divide first to recover the scalar extent
+         (exact, since the extent is a multiple of num_components), then scale
+         by num_components_in. A direct multiply by the ratio num_components_in /
+         num_components would truncate to zero on a decreasing transition. */
       for (i = 0; i < num_sends + 1; i++)
       {
-         send_map_starts[i] *= num_components_in / num_components;
+         send_map_starts[i] = (send_map_starts[i] / num_components) * num_components_in;
       }
 
       /* Update recv_vec_starts */
       for (i = 0; i < num_recvs + 1; i++)
       {
-         recv_vec_starts[i] *= num_components_in / num_components;
+         recv_vec_starts[i] = (recv_vec_starts[i] / num_components) * num_components_in;
       }
    }
 

--- a/src/seq_mv/csr_spgemm_device_symbl.c
+++ b/src/seq_mv/csr_spgemm_device_symbl.c
@@ -36,14 +36,10 @@ hypreDevice_CSRSpGemmRownnzUpperboundNoBin( HYPRE_Int  m,
                                             HYPRE_Int *d_rc,
                                             char      *d_rf )
 {
-   static constexpr HYPRE_Int SHMEM_HASH_SIZE = SYMBL_HASH_SIZE[5];
-   static constexpr HYPRE_Int GROUP_SIZE = T_GROUP_SIZE[5];
-   static constexpr HYPRE_Int BIN = 5;
-
    const bool need_ghash = in_rc > 0;
    const bool can_fail = in_rc < 2;
 
-   hypre_spgemm_symbolic_rownnz<BIN, SHMEM_HASH_SIZE, GROUP_SIZE, false>
+   hypre_spgemm_symbolic_rownnz<5, SYMBL_HASH_SIZE[5], T_GROUP_SIZE[5], false>
    (m, NULL, k, n, need_ghash, d_ia, d_ja, d_ib, d_jb, d_rc, can_fail, d_rf);
 
    return hypre_error_flag;
@@ -181,16 +177,12 @@ hypreDevice_CSRSpGemmRownnzNoBin( HYPRE_Int  m,
                                   HYPRE_Int  in_rc,
                                   HYPRE_Int *d_rc )
 {
-   static constexpr HYPRE_Int SHMEM_HASH_SIZE = SYMBL_HASH_SIZE[5];
-   static constexpr HYPRE_Int GROUP_SIZE = T_GROUP_SIZE[5];
-   static constexpr HYPRE_Int BIN = 5;
-
    const bool need_ghash = in_rc > 0;
    const bool can_fail = in_rc < 2;
 
    char *d_rf = can_fail ? hypre_TAlloc(char, m, HYPRE_MEMORY_DEVICE) : NULL;
 
-   hypre_spgemm_symbolic_rownnz<BIN, SHMEM_HASH_SIZE, GROUP_SIZE, false>
+   hypre_spgemm_symbolic_rownnz<5, SYMBL_HASH_SIZE[5], T_GROUP_SIZE[5], false>
    (m, NULL, k, n, need_ghash, d_ia, d_ja, d_ib, d_jb, d_rc, can_fail, d_rf);
 
    if (can_fail)
@@ -236,7 +228,7 @@ hypreDevice_CSRSpGemmRownnzNoBin( HYPRE_Int  m,
 
          hypre_assert(new_end - d_rind == num_failed_rows);
 
-         hypre_spgemm_symbolic_rownnz < BIN + 1, 2 * SHMEM_HASH_SIZE, 2 * GROUP_SIZE, true >
+         hypre_spgemm_symbolic_rownnz < 6, 2 * SYMBL_HASH_SIZE[5], 2 * T_GROUP_SIZE[5], true >
          (num_failed_rows, d_rind, k, n, true, d_ia, d_ja, d_ib, d_jb, d_rc, false, NULL);
 
          hypre_TFree(d_rind, HYPRE_MEMORY_DEVICE);

--- a/src/struct_mv/_hypre_struct_mv.h
+++ b/src/struct_mv/_hypre_struct_mv.h
@@ -226,6 +226,7 @@ HYPRE_Int  hypre__sk##k[HYPRE_MAXDIM], hypre__ikinc##k[HYPRE_MAXDIM+1]
 hypre__ndim = ndim;\
 hypre__n[0] = loop_size[0];\
 hypre__tot = 1;\
+hypre__ik = 0;\
 HYPRE_UNUSED_VAR(hypre__ik);\
 for (hypre__d = 1; hypre__d < hypre__ndim; hypre__d++)\
 {\

--- a/src/struct_mv/_hypre_struct_mv.h
+++ b/src/struct_mv/_hypre_struct_mv.h
@@ -214,7 +214,7 @@ for (i = 0; i < hypre_BoxArrayArraySize(box_array_array); i++)
 #define zypre_BoxLoopDeclare() \
 HYPRE_Int  hypre__tot, hypre__div, hypre__mod;\
 HYPRE_Int  hypre__block, hypre__num_blocks;\
-HYPRE_Int  hypre__d, hypre__ndim, hypre__ik;\
+HYPRE_Int  hypre__d, hypre__ndim;\
 HYPRE_Int  hypre__I, hypre__J, hypre__IN, hypre__JN;\
 HYPRE_Int  hypre__i[HYPRE_MAXDIM+1], hypre__n[HYPRE_MAXDIM+1]
 
@@ -226,8 +226,6 @@ HYPRE_Int  hypre__sk##k[HYPRE_MAXDIM], hypre__ikinc##k[HYPRE_MAXDIM+1]
 hypre__ndim = ndim;\
 hypre__n[0] = loop_size[0];\
 hypre__tot = 1;\
-hypre__ik = 0;\
-HYPRE_UNUSED_VAR(hypre__ik);\
 for (hypre__d = 1; hypre__d < hypre__ndim; hypre__d++)\
 {\
    hypre__n[hypre__d] = loop_size[hypre__d];\
@@ -251,6 +249,8 @@ else\
 }
 
 #define zypre_BoxLoopInitK(k, dboxk, startk, stridek) \
+{\
+HYPRE_Int  hypre__ik;\
 hypre__sk##k[0] = stridek[0];\
 hypre__ikinc##k[0] = 0;\
 hypre__ik = hypre_BoxSizeD(dboxk, 0);\
@@ -263,7 +263,8 @@ for (hypre__d = 1; hypre__d < hypre__ndim; hypre__d++)\
 }\
 hypre__i0inc##k = hypre__sk##k[0];\
 hypre__ikinc##k[hypre__ndim] = 0;\
-hypre__ikstart##k = hypre_BoxIndexRank(dboxk, startk)
+hypre__ikstart##k = hypre_BoxIndexRank(dboxk, startk);\
+}
 
 #define zypre_BoxLoopSet() \
 hypre__IN = hypre__n[0];\

--- a/src/struct_mv/box.h
+++ b/src/struct_mv/box.h
@@ -193,7 +193,7 @@ for (i = 0; i < hypre_BoxArrayArraySize(box_array_array); i++)
 #define zypre_BoxLoopDeclare() \
 HYPRE_Int  hypre__tot, hypre__div, hypre__mod;\
 HYPRE_Int  hypre__block, hypre__num_blocks;\
-HYPRE_Int  hypre__d, hypre__ndim, hypre__ik;\
+HYPRE_Int  hypre__d, hypre__ndim;\
 HYPRE_Int  hypre__I, hypre__J, hypre__IN, hypre__JN;\
 HYPRE_Int  hypre__i[HYPRE_MAXDIM+1], hypre__n[HYPRE_MAXDIM+1]
 
@@ -205,8 +205,6 @@ HYPRE_Int  hypre__sk##k[HYPRE_MAXDIM], hypre__ikinc##k[HYPRE_MAXDIM+1]
 hypre__ndim = ndim;\
 hypre__n[0] = loop_size[0];\
 hypre__tot = 1;\
-hypre__ik = 0;\
-HYPRE_UNUSED_VAR(hypre__ik);\
 for (hypre__d = 1; hypre__d < hypre__ndim; hypre__d++)\
 {\
    hypre__n[hypre__d] = loop_size[hypre__d];\
@@ -230,6 +228,8 @@ else\
 }
 
 #define zypre_BoxLoopInitK(k, dboxk, startk, stridek) \
+{\
+HYPRE_Int  hypre__ik;\
 hypre__sk##k[0] = stridek[0];\
 hypre__ikinc##k[0] = 0;\
 hypre__ik = hypre_BoxSizeD(dboxk, 0);\
@@ -242,7 +242,8 @@ for (hypre__d = 1; hypre__d < hypre__ndim; hypre__d++)\
 }\
 hypre__i0inc##k = hypre__sk##k[0];\
 hypre__ikinc##k[hypre__ndim] = 0;\
-hypre__ikstart##k = hypre_BoxIndexRank(dboxk, startk)
+hypre__ikstart##k = hypre_BoxIndexRank(dboxk, startk);\
+}
 
 #define zypre_BoxLoopSet() \
 hypre__IN = hypre__n[0];\

--- a/src/struct_mv/box.h
+++ b/src/struct_mv/box.h
@@ -205,6 +205,7 @@ HYPRE_Int  hypre__sk##k[HYPRE_MAXDIM], hypre__ikinc##k[HYPRE_MAXDIM+1]
 hypre__ndim = ndim;\
 hypre__n[0] = loop_size[0];\
 hypre__tot = 1;\
+hypre__ik = 0;\
 HYPRE_UNUSED_VAR(hypre__ik);\
 for (hypre__d = 1; hypre__d < hypre__ndim; hypre__d++)\
 {\


### PR DESCRIPTION
Closes #1586 

When `hypre_ParCSRCommPkg` is reused for multi-component vectors with a varying number of components such as `1, 2, 1`, the arrays `send_map_starts` and `recv_vec_starts` were zeroed out incorrectly. This happened because the extents were rescaled by the integer ratio `num_components_in / num_components`, which truncates to 0 when transitioning down (e.g. 1/2). With zeroed extents, matvec would pack/receive the wrong data and produce incorrect results.

The fix in this PR computes the scalar element count once and uses it for the allocation size and all `send_map_elmts` reconstruction loop bounds, and rescales the extents via `send_map_starts[i] = (send_map_starts[i] / num_components) * num_components_in` to avoid getting a zero result