### PR TITLE
Fix issue with MGR restriction calculation

### DIFF
--- a/src/parcsr_ls/par_mgr_device.c
+++ b/src/parcsr_ls/par_mgr_device.c
@@ -32,6 +32,17 @@ struct functor
    }
 };
 
+/* Safeguarded reciprocal: returns 1.0 for zero input (matches hypre_MGRBuildPHost) */
+template<typename T>
+struct safe_reciprocal
+{
+   __host__ __device__
+   T operator()(const T &x) const
+   {
+      return (x != T(0.0)) ? (T(1.0) / x) : T(1.0);
+   }
+};
+
 /*--------------------------------------------------------------------------
  * hypre_MGRBuildPFromWpDevice
  *--------------------------------------------------------------------------*/
@@ -186,7 +197,7 @@ hypre_MGRBuildPDevice(hypre_ParCSRMatrix  *A,
                            diag,
                            diag + nfpoints,
                            diag,
-         [] (auto x) { return 1.0 / x; });
+                           safe_reciprocal<HYPRE_Complex>());
 #else
          HYPRE_THRUST_CALL(transform,
                            diag,
@@ -199,7 +210,7 @@ hypre_MGRBuildPDevice(hypre_ParCSRMatrix  *A,
                            diag,
                            diag + nfpoints,
                            diag,
-                           1.0 / _1);
+                           safe_reciprocal<HYPRE_Complex>());
 #endif
 
          hypre_TFree(diag1, HYPRE_MEMORY_DEVICE);

--- a/src/parcsr_ls/par_mgr_interp.c
+++ b/src/parcsr_ls/par_mgr_interp.c
@@ -995,6 +995,7 @@ hypre_MGRBuildP( hypre_ParCSRMatrix   *A,
    HYPRE_Int        start;
 
    HYPRE_Real       one  = 1.0;
+   HYPRE_Real       zero = 0.0;
 
    HYPRE_Int        my_id;
    HYPRE_Int        num_procs;
@@ -1272,7 +1273,7 @@ hypre_MGRBuildP( hypre_ParCSRMatrix   *A,
          for (jj = A_diag_i[i]; jj < A_diag_i[i + 1]; jj++)
          {
             i1 = A_diag_j[jj];
-            if ( i == i1 ) /* diagonal of A only */
+            if (i == i1 && hypre_cabs(A_diag_data[jj]) > zero) /* diagonal of A only */
             {
                a_diag[i] = 1.0 / A_diag_data[jj];
             }
@@ -1562,6 +1563,7 @@ hypre_MGRBuildPDRS( hypre_ParCSRMatrix   *A,
    HYPRE_Int                j, jl, jj;
    HYPRE_Int                start;
    HYPRE_Real               one  = 1.0;
+   HYPRE_Real               zero = 0.0;
    HYPRE_Int                my_id, num_procs;
    HYPRE_Int                num_threads;
    HYPRE_Int                num_sends;
@@ -1839,7 +1841,7 @@ hypre_MGRBuildPDRS( hypre_ParCSRMatrix   *A,
       for (jj = A_diag_i[i]; jj < A_diag_i[i + 1]; jj++)
       {
          i1 = A_diag_j[jj];
-         if ( i == i1 ) /* diagonal of A only */
+         if (i == i1 && hypre_cabs(A_diag_data[jj]) > zero) /* diagonal of A only */
          {
             a_diag[i] = 1.0 / A_diag_data[jj];
          }


### PR DESCRIPTION
Fix an issue in the calculation of the restriction operator in MGR that happens when matrix A has zero diagonal. This fix avoids a division by zero