### PR TITLE
 Fix crashes and hangs when a rank owns no rows

### DIFF
--- a/src/IJ_mv/HYPRE_IJVector.c
+++ b/src/IJ_mv/HYPRE_IJVector.c
@@ -513,17 +513,38 @@ HYPRE_IJVectorAssemble( HYPRE_IJVector vector )
 
    if ( hypre_IJVectorObjectType(vec) == HYPRE_PARCSR )
    {
+      hypre_ParVector *par_vector;
+      HYPRE_Int        local_num_tags;
+      HYPRE_Int        global_num_tags;
+
 #if defined(HYPRE_USING_GPU)
       HYPRE_ExecutionPolicy exec = hypre_GetExecPolicy1( hypre_IJVectorMemoryLocation(vector) );
 
       if (exec == HYPRE_EXEC_DEVICE)
       {
-         return ( hypre_IJVectorAssembleParDevice(vec) );
+         hypre_IJVectorAssembleParDevice(vec);
       }
       else
 #endif
       {
-         return ( hypre_IJVectorAssemblePar(vec) );
+         hypre_IJVectorAssemblePar(vec);
+      }
+
+      /* Agree on num_tags when tagging is in use so vector functions such as
+       * InnerProdTags can trust the local count without needing an Allreduce.
+       * Empty ranks may still have the default num_tags == 1 while others might
+       * have more tagged. Done here so both host and device paths are covered,
+       * including re-assemble after SetTags when the aux vector is already gone. */
+      par_vector = (hypre_ParVector*) hypre_IJVectorObject(vec);
+      if (par_vector)
+      {
+         local_num_tags = hypre_ParVectorNumTags(par_vector);
+         hypre_MPI_Allreduce(&local_num_tags, &global_num_tags, 1, HYPRE_MPI_INT,
+                             hypre_MPI_MAX, hypre_IJVectorComm(vec));
+         if (global_num_tags > 1 && global_num_tags != local_num_tags)
+         {
+            hypre_ParVectorSetNumTags(par_vector, global_num_tags);
+         }
       }
    }
    else

--- a/src/IJ_mv/HYPRE_IJ_mv.h
+++ b/src/IJ_mv/HYPRE_IJ_mv.h
@@ -545,8 +545,10 @@ HYPRE_Int HYPRE_IJVectorSetData(HYPRE_IJVector  vector,
  * @param num_tags The number of tags.
  * @param tags The tags array. Must reside in the same memory location as the
  *         vector data (e.g., if vector is on GPU, tags must also be on GPU).
+ *         May be NULL on ranks that own no rows.
  *
- * Not collective.
+ * Not collective. Call \ref HYPRE_IJVectorAssemble after setting tags so that
+ * num_tags is agreed across the communicator before tagged collectives run.
  **/
 HYPRE_Int HYPRE_IJVectorSetTags(HYPRE_IJVector  vector,
                                 HYPRE_Int       owns_tags,
@@ -635,6 +637,10 @@ HYPRE_Int HYPRE_IJVectorAddToValues(HYPRE_IJVector       vector,
 
 /**
  * Finalize the construction of the vector before using.
+ *
+ * When vector tags are present (num_tags > 1 on any rank), also agrees on
+ * num_tags across the communicator so tagged collectives can trust the local
+ * count. If tags are set after a previous assemble, call Assemble again.
  **/
 HYPRE_Int HYPRE_IJVectorAssemble(HYPRE_IJVector vector);
 

--- a/src/parcsr_ls/par_mgr_interp.c
+++ b/src/parcsr_ls/par_mgr_interp.c
@@ -2653,6 +2653,17 @@ hypre_MGRBlockColLumpedRestrict(hypre_ParCSRMatrix  *A,
 
    hypre_ParCSRMatrixBlockColSum(A_CF, row_major, 1, block_dim, &b_CF);
 
+   if (!b_FF || !b_CF)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC,
+                        "Block column-lumped restriction requires C and F spaces with "
+                        "matching block structure (one C point per F block)");
+      hypre_DenseBlockMatrixDestroy(b_FF);
+      hypre_DenseBlockMatrixDestroy(b_CF);
+      HYPRE_ANNOTATE_FUNC_END;
+      return hypre_error_flag;
+   }
+
    /*-------------------------------------------------------
     * 3) b_FF = inv(approx(A_FF))          (invert in-place)
     *-------------------------------------------------------*/

--- a/src/parcsr_mv/par_csr_matop.c
+++ b/src/parcsr_mv/par_csr_matop.c
@@ -6806,6 +6806,7 @@ hypre_ParCSRMatrixBlockColSum( hypre_ParCSRMatrix      *A,
    {
       hypre_error_w_msg(HYPRE_ERROR_GENERIC,
                         "Global number of rows is not divisable by the block dimension");
+      *B_ptr = NULL;
       return hypre_error_flag;
    }
 
@@ -6813,6 +6814,7 @@ hypre_ParCSRMatrixBlockColSum( hypre_ParCSRMatrix      *A,
    {
       hypre_error_w_msg(HYPRE_ERROR_GENERIC,
                         "Global number of columns is not divisable by the block dimension");
+      *B_ptr = NULL;
       return hypre_error_flag;
    }
 
@@ -6830,6 +6832,14 @@ hypre_ParCSRMatrixBlockColSum( hypre_ParCSRMatrix      *A,
    B = hypre_DenseBlockMatrixCreate(row_major,
                                     num_rows_diag_A, num_cols_diag_A,
                                     num_rows_block, num_cols_block);
+   if (!B)
+   {
+      hypre_error_w_msg(HYPRE_ERROR_GENERIC,
+                        "Could not create block column sum matrix (incompatible block dimensions)");
+      *B_ptr = NULL;
+      HYPRE_ANNOTATE_FUNC_END;
+      return hypre_error_flag;
+   }
 
    /* Initialize the output matrix */
    /* TODO: Change back to memory_location after implementing hypre_ParCSRMatrixBlockColSumDevice */

--- a/src/parcsr_mv/par_csr_matrix.c
+++ b/src/parcsr_mv/par_csr_matrix.c
@@ -662,7 +662,8 @@ hypre_ParCSRMatrixCreateFromParVector(hypre_ParVector *b,
    HYPRE_Int             num_rows        = (HYPRE_Int) (row_starts[1] - row_starts[0]);
    HYPRE_Int             num_cols        = (HYPRE_Int) (col_starts[1] - col_starts[0]);
    HYPRE_Int             num_nonzeros    = hypre_ParVectorLocalSize(b);
-   HYPRE_Int             blk_dim         = hypre_max(1, num_rows / num_cols);
+   HYPRE_Int             blk_dim         = (global_num_cols > 0) ?
+                                           (HYPRE_Int) hypre_max(1, global_num_rows / global_num_cols) : 1;
 
    /* Output matrix variables */
    hypre_ParCSRMatrix   *A;
@@ -681,7 +682,7 @@ hypre_ParCSRMatrixCreateFromParVector(hypre_ParVector *b,
       return NULL;
    }
 
-   if (num_rows % num_cols)
+   if (global_num_cols > 0 && (global_num_rows % global_num_cols))
    {
       hypre_error_w_msg(HYPRE_ERROR_GENERIC,
                         "Number of rows is not evenly divisible by number of columns");

--- a/src/parcsr_mv/par_csr_matrix.c
+++ b/src/parcsr_mv/par_csr_matrix.c
@@ -660,7 +660,6 @@ hypre_ParCSRMatrixCreateFromParVector(hypre_ParVector *b,
 
    /* Auxiliary variables */
    HYPRE_Int             num_rows        = (HYPRE_Int) (row_starts[1] - row_starts[0]);
-   HYPRE_Int             num_cols        = (HYPRE_Int) (col_starts[1] - col_starts[0]);
    HYPRE_Int             num_nonzeros    = hypre_ParVectorLocalSize(b);
    HYPRE_Int             blk_dim         = (global_num_cols > 0) ?
                                            (HYPRE_Int) hypre_max(1, global_num_rows / global_num_cols) : 1;

--- a/src/parcsr_mv/par_vector.c
+++ b/src/parcsr_mv/par_vector.c
@@ -667,51 +667,51 @@ hypre_ParVectorInnerProdTagged( hypre_ParVector  *x,
       iprod = *iprod_ptr;
    }
 
-   /* The tag count must agree across ranks: this routine performs collective
-    * reductions whose size depends on it, and a rank owning no rows carries no tags.
-    * Take the global maximum so every rank follows the same branch below. */
+   /* This routine ends in a collective reduction whose length depends on the tag
+    * count, so every rank must take the same branch below. A rank that owns no rows
+    * carries no tags (tags == NULL), and would otherwise fall back to the untagged
+    * inner product - reducing a single value - while ranks holding tags reduce
+    * num_tags + 1 values. That mismatched collective deadlocks. Decide globally:
+    * if any rank holds a tagged vector, all ranks run the tagged path, and ranks
+    * without local tags simply contribute zeros. */
    {
-      HYPRE_Int global_num_tags = num_tags;
+      HYPRE_Int local_num_tags  = (tags && num_tags > 1) ? num_tags : 0;
+      HYPRE_Int global_num_tags = 0;
 
-      hypre_MPI_Allreduce(&num_tags, &global_num_tags, 1, HYPRE_MPI_INT,
+      hypre_MPI_Allreduce(&local_num_tags, &global_num_tags, 1, HYPRE_MPI_INT,
                           hypre_MPI_MAX, comm);
-      if (global_num_tags > num_tags)
-      {
-         /* This rank owns no tagged entries; contribute zeros to the reduction. */
-         num_tags = global_num_tags;
-         if (*iprod_ptr == NULL)
-         {
-            hypre_TFree(iprod, HYPRE_MEMORY_HOST);
-            iprod = hypre_CTAlloc(HYPRE_Complex, num_tags + 1, HYPRE_MEMORY_HOST);
-         }
-         iprod_local = hypre_CTAlloc(HYPRE_Complex, num_tags + 1, HYPRE_MEMORY_HOST);
-         hypre_MPI_Allreduce(iprod_local, iprod, num_tags + 1,
-                             HYPRE_MPI_COMPLEX, hypre_MPI_SUM, comm);
-         hypre_TFree(iprod_local, HYPRE_MEMORY_HOST);
 
-         *num_tags_ptr = num_tags;
-         *iprod_ptr    = iprod;
+      if (global_num_tags < 1)
+      {
+         /* No rank holds a tagged vector: everyone does the plain inner product. */
+         iprod[0] = hypre_ParVectorInnerProd(x, y);
+
+         *num_tags_ptr = 1;
+         *iprod_ptr = iprod;
 
          return hypre_error_flag;
       }
-   }
 
-   /* Fallback to full vector inner product if num_tags == 1 or tags is NULL */
-   if (num_tags == 1 || !tags)
-   {
-      iprod[0] = hypre_ParVectorInnerProd(x, y);
-
-      *num_tags_ptr = 1;
-      *iprod_ptr = iprod;
-
-      return hypre_error_flag;
+      if (global_num_tags != num_tags)
+      {
+         /* Size the output for the global tag count when we own the allocation. */
+         if (*iprod_ptr == NULL)
+         {
+            hypre_TFree(iprod, HYPRE_MEMORY_HOST);
+            iprod = hypre_CTAlloc(HYPRE_Complex, global_num_tags + 1, HYPRE_MEMORY_HOST);
+         }
+         num_tags = global_num_tags;
+      }
    }
 
    /* Initialize work array */
    iprod_local = hypre_CTAlloc(HYPRE_Complex, num_tags + 1, HYPRE_MEMORY_HOST);
 
-   /* Compute local inner products */
-   hypre_SeqVectorInnerProdTagged(x_local, y_local, iprod_local);
+   /* Compute local inner products; a rank without local tags contributes zeros */
+   if (tags)
+   {
+      hypre_SeqVectorInnerProdTagged(x_local, y_local, iprod_local);
+   }
 
    /* Exit early in case of issues in the previous call */
    if (hypre_error_flag)

--- a/src/parcsr_mv/par_vector.c
+++ b/src/parcsr_mv/par_vector.c
@@ -667,6 +667,35 @@ hypre_ParVectorInnerProdTagged( hypre_ParVector  *x,
       iprod = *iprod_ptr;
    }
 
+   /* The tag count must agree across ranks: this routine performs collective
+    * reductions whose size depends on it, and a rank owning no rows carries no tags.
+    * Take the global maximum so every rank follows the same branch below. */
+   {
+      HYPRE_Int global_num_tags = num_tags;
+
+      hypre_MPI_Allreduce(&num_tags, &global_num_tags, 1, HYPRE_MPI_INT,
+                          hypre_MPI_MAX, comm);
+      if (global_num_tags > num_tags)
+      {
+         /* This rank owns no tagged entries; contribute zeros to the reduction. */
+         num_tags = global_num_tags;
+         if (*iprod_ptr == NULL)
+         {
+            hypre_TFree(iprod, HYPRE_MEMORY_HOST);
+            iprod = hypre_CTAlloc(HYPRE_Complex, num_tags + 1, HYPRE_MEMORY_HOST);
+         }
+         iprod_local = hypre_CTAlloc(HYPRE_Complex, num_tags + 1, HYPRE_MEMORY_HOST);
+         hypre_MPI_Allreduce(iprod_local, iprod, num_tags + 1,
+                             HYPRE_MPI_COMPLEX, hypre_MPI_SUM, comm);
+         hypre_TFree(iprod_local, HYPRE_MEMORY_HOST);
+
+         *num_tags_ptr = num_tags;
+         *iprod_ptr    = iprod;
+
+         return hypre_error_flag;
+      }
+   }
+
    /* Fallback to full vector inner product if num_tags == 1 or tags is NULL */
    if (num_tags == 1 || !tags)
    {

--- a/src/parcsr_mv/par_vector.c
+++ b/src/parcsr_mv/par_vector.c
@@ -667,41 +667,19 @@ hypre_ParVectorInnerProdTagged( hypre_ParVector  *x,
       iprod = *iprod_ptr;
    }
 
-   /* This routine ends in a collective reduction whose length depends on the tag
-    * count, so every rank must take the same branch below. A rank that owns no rows
-    * carries no tags (tags == NULL), and would otherwise fall back to the untagged
-    * inner product - reducing a single value - while ranks holding tags reduce
-    * num_tags + 1 values. That mismatched collective deadlocks. Decide globally:
-    * if any rank holds a tagged vector, all ranks run the tagged path, and ranks
-    * without local tags simply contribute zeros. */
+   /* Fallback to the plain inner product when the vector is untagged.
+    * Branch only on num_tags (agreed across ranks in HYPRE_IJVectorAssemble),
+    * never on the local tags pointer: a rank that owns no rows may have tags == NULL
+    * while still participating in the tagged reduction, and must take the same
+    * collective path as its peers. */
+   if (num_tags <= 1)
    {
-      HYPRE_Int local_num_tags  = (tags && num_tags > 1) ? num_tags : 0;
-      HYPRE_Int global_num_tags = 0;
+      iprod[0] = hypre_ParVectorInnerProd(x, y);
 
-      hypre_MPI_Allreduce(&local_num_tags, &global_num_tags, 1, HYPRE_MPI_INT,
-                          hypre_MPI_MAX, comm);
+      *num_tags_ptr = 1;
+      *iprod_ptr = iprod;
 
-      if (global_num_tags < 1)
-      {
-         /* No rank holds a tagged vector: everyone does the plain inner product. */
-         iprod[0] = hypre_ParVectorInnerProd(x, y);
-
-         *num_tags_ptr = 1;
-         *iprod_ptr = iprod;
-
-         return hypre_error_flag;
-      }
-
-      if (global_num_tags != num_tags)
-      {
-         /* Size the output for the global tag count when we own the allocation. */
-         if (*iprod_ptr == NULL)
-         {
-            hypre_TFree(iprod, HYPRE_MEMORY_HOST);
-            iprod = hypre_CTAlloc(HYPRE_Complex, global_num_tags + 1, HYPRE_MEMORY_HOST);
-         }
-         num_tags = global_num_tags;
-      }
+      return hypre_error_flag;
    }
 
    /* Initialize work array */
@@ -716,6 +694,7 @@ hypre_ParVectorInnerProdTagged( hypre_ParVector  *x,
    /* Exit early in case of issues in the previous call */
    if (hypre_error_flag)
    {
+      hypre_TFree(iprod_local, HYPRE_MEMORY_HOST);
       return hypre_error_flag;
    }
 

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -3755,7 +3755,6 @@ main( hypre_int argc,
       HYPRE_IJVectorCreate(comm, first_local_col, last_local_col, &ij_x);
       HYPRE_IJVectorSetObjectType(ij_x, HYPRE_PARCSR);
       HYPRE_IJVectorInitialize(ij_x);
-      HYPRE_IJVectorAssemble(ij_x);
       HYPRE_IJVectorGetObject(ij_x, &object);
       x = (HYPRE_ParVector) object;
    }
@@ -3777,7 +3776,6 @@ main( hypre_int argc,
       HYPRE_IJVectorCreate(comm, first_local_col, last_local_col, &ij_x);
       HYPRE_IJVectorSetObjectType(ij_x, HYPRE_PARCSR);
       HYPRE_IJVectorInitialize(ij_x);
-      HYPRE_IJVectorAssemble(ij_x);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
@@ -3812,7 +3810,6 @@ main( hypre_int argc,
          HYPRE_IJVectorSetComponent(ij_b, c);
          HYPRE_IJVectorSetValues(ij_b, local_num_rows, NULL, values_d);
       }
-      HYPRE_IJVectorAssemble(ij_b);
       ierr = HYPRE_IJVectorGetObject( ij_b, &object );
       b = (HYPRE_ParVector) object;
 
@@ -3827,7 +3824,6 @@ main( hypre_int argc,
          HYPRE_IJVectorSetComponent(ij_x, c);
          HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values_d);
       }
-      HYPRE_IJVectorAssemble(ij_x);
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
 
@@ -3868,7 +3864,6 @@ main( hypre_int argc,
       HYPRE_IJVectorSetNumComponents(ij_x, num_components);
       HYPRE_IJVectorSetObjectType(ij_x, HYPRE_PARCSR);
       HYPRE_IJVectorInitialize(ij_x);
-      HYPRE_IJVectorAssemble(ij_x);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
@@ -3884,6 +3879,8 @@ main( hypre_int argc,
          }
       }
 
+      HYPRE_IJVector ij_unit = NULL;
+      HYPRE_ParVector unit;
       HYPRE_Real *values_h = hypre_CTAlloc(HYPRE_Real, local_num_cols, HYPRE_MEMORY_HOST);
       HYPRE_Real *values_d = hypre_CTAlloc(HYPRE_Real, local_num_cols, memory_location);
       for (i = 0; i < local_num_cols; i++)
@@ -3893,19 +3890,19 @@ main( hypre_int argc,
       hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_cols,
                     memory_location, HYPRE_MEMORY_HOST);
 
-      /* Temporary use of solution vector */
-      HYPRE_IJVectorCreate(comm, first_local_col, last_local_col, &ij_x);
-      HYPRE_IJVectorSetObjectType(ij_x, HYPRE_PARCSR);
-      HYPRE_IJVectorSetNumComponents(ij_x, num_components);
-      HYPRE_IJVectorInitialize(ij_x);
+      /* Temporary unit vector used only to form b = A*1 */
+      HYPRE_IJVectorCreate(comm, first_local_col, last_local_col, &ij_unit);
+      HYPRE_IJVectorSetObjectType(ij_unit, HYPRE_PARCSR);
+      HYPRE_IJVectorSetNumComponents(ij_unit, num_components);
+      HYPRE_IJVectorInitialize(ij_unit);
       for (c = 0; c < num_components; c++)
       {
-         HYPRE_IJVectorSetComponent(ij_x, c);
-         HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values_d);
+         HYPRE_IJVectorSetComponent(ij_unit, c);
+         HYPRE_IJVectorSetValues(ij_unit, local_num_cols, NULL, values_d);
       }
-      HYPRE_IJVectorAssemble(ij_x);
-      ierr = HYPRE_IJVectorGetObject( ij_x, &object );
-      x = (HYPRE_ParVector) object;
+      HYPRE_IJVectorAssemble(ij_unit);
+      ierr = HYPRE_IJVectorGetObject(ij_unit, &object);
+      unit = (HYPRE_ParVector) object;
 
       hypre_TFree(values_h, HYPRE_MEMORY_HOST);
       hypre_TFree(values_d, memory_location);
@@ -3915,12 +3912,19 @@ main( hypre_int argc,
       HYPRE_IJVectorSetObjectType(ij_b, HYPRE_PARCSR);
       HYPRE_IJVectorSetNumComponents(ij_b, num_components);
       HYPRE_IJVectorInitialize(ij_b);
-      ierr = HYPRE_IJVectorGetObject( ij_b, &object );
+      ierr = HYPRE_IJVectorGetObject(ij_b, &object);
       b = (HYPRE_ParVector) object;
 
-      HYPRE_ParCSRMatrixMatvec(1.0, parcsr_A, x, 0.0, b);
+      HYPRE_ParCSRMatrixMatvec(1.0, parcsr_A, unit, 0.0, b);
+      HYPRE_IJVectorDestroy(ij_unit);
 
       /* Zero initial guess */
+      HYPRE_IJVectorCreate(comm, first_local_col, last_local_col, &ij_x);
+      HYPRE_IJVectorSetObjectType(ij_x, HYPRE_PARCSR);
+      HYPRE_IJVectorSetNumComponents(ij_x, num_components);
+      HYPRE_IJVectorInitialize(ij_x);
+      ierr = HYPRE_IJVectorGetObject(ij_x, &object);
+      x = (HYPRE_ParVector) object;
       hypre_IJVectorZeroValues(ij_x);
    }
    else if (build_rhs_type == 5)
@@ -3945,7 +3949,6 @@ main( hypre_int argc,
       HYPRE_IJVectorSetObjectType(ij_b, HYPRE_PARCSR);
       HYPRE_IJVectorSetNumComponents(ij_b, num_components);
       HYPRE_IJVectorInitialize(ij_b);
-      HYPRE_IJVectorAssemble(ij_b);
 
       ierr = HYPRE_IJVectorGetObject( ij_b, &object );
       b = (HYPRE_ParVector) object;
@@ -3960,7 +3963,6 @@ main( hypre_int argc,
          HYPRE_IJVectorSetComponent(ij_x, c);
          HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values_d);
       }
-      HYPRE_IJVectorAssemble(ij_x);
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
 
@@ -3989,7 +3991,6 @@ main( hypre_int argc,
       HYPRE_IJVectorCreate(comm, first_local_col, last_local_col, &ij_x);
       HYPRE_IJVectorSetObjectType(ij_x, HYPRE_PARCSR);
       HYPRE_IJVectorInitialize(ij_x);
-      HYPRE_IJVectorAssemble(ij_x);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
@@ -4028,7 +4029,6 @@ main( hypre_int argc,
       HYPRE_IJVectorCreate(comm, first_local_col, last_local_col, &ij_x);
       HYPRE_IJVectorSetObjectType(ij_x, HYPRE_PARCSR);
       HYPRE_IJVectorInitialize(ij_x);
-      HYPRE_IJVectorAssemble(ij_x);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
@@ -4042,7 +4042,6 @@ main( hypre_int argc,
       HYPRE_IJVectorCreate(comm, first_local_col, last_local_col, &ij_x);
       HYPRE_IJVectorSetObjectType(ij_x, HYPRE_PARCSR);
       HYPRE_IJVectorInitialize(ij_x);
-      HYPRE_IJVectorAssemble(ij_x);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
@@ -4070,7 +4069,6 @@ main( hypre_int argc,
                     memory_location, HYPRE_MEMORY_HOST);
 
       HYPRE_IJVectorSetValues(ij_b, local_num_rows, NULL, values_d);
-      HYPRE_IJVectorAssemble(ij_b);
       hypre_TFree(values_h, HYPRE_MEMORY_HOST);
       hypre_TFree(values_d, memory_location);
 
@@ -4084,7 +4082,6 @@ main( hypre_int argc,
 
       /* For backward Euler the previous backward Euler iterate (assumed
          0 here) is usually used as the initial guess */
-      HYPRE_IJVectorAssemble(ij_x);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
@@ -4112,7 +4109,6 @@ main( hypre_int argc,
       hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_rows, memory_location, HYPRE_MEMORY_HOST);
 
       HYPRE_IJVectorSetValues(ij_b, local_num_rows, NULL, values_d);
-      HYPRE_IJVectorAssemble(ij_b);
       hypre_TFree(values_h, HYPRE_MEMORY_HOST);
       hypre_TFree(values_d, memory_location);
 
@@ -4126,7 +4122,6 @@ main( hypre_int argc,
 
       /* For backward Euler the previous backward Euler iterate (assumed
          0 here) is usually used as the initial guess */
-      HYPRE_IJVectorAssemble(ij_x);
 
       ierr = HYPRE_IJVectorGetObject( ij_x, &object );
       x = (HYPRE_ParVector) object;
@@ -4154,7 +4149,6 @@ main( hypre_int argc,
       hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_rows, memory_location, HYPRE_MEMORY_HOST);
 
       HYPRE_IJVectorSetValues(ij_b, local_num_rows, NULL, values_d);
-      HYPRE_IJVectorAssemble(ij_b);
       hypre_TFree(values_h, HYPRE_MEMORY_HOST);
       hypre_TFree(values_d, memory_location);
 
@@ -4178,7 +4172,6 @@ main( hypre_int argc,
       hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_cols, memory_location, HYPRE_MEMORY_HOST);
 
       HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values_d);
-      HYPRE_IJVectorAssemble(ij_x);
       hypre_TFree(values_h, HYPRE_MEMORY_HOST);
       hypre_TFree(values_d, memory_location);
 
@@ -4210,7 +4203,6 @@ main( hypre_int argc,
       hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_cols, memory_location, HYPRE_MEMORY_HOST);
 
       HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values_d);
-      HYPRE_IJVectorAssemble(ij_x);
       hypre_TFree(values_h, HYPRE_MEMORY_HOST);
       hypre_TFree(values_d, memory_location);
 
@@ -4307,7 +4299,6 @@ main( hypre_int argc,
       hypre_TMemcpy(values_d, values_h, HYPRE_Real, local_num_cols, memory_location, HYPRE_MEMORY_HOST);
 
       HYPRE_IJVectorSetValues(ij_x, local_num_cols, NULL, values_d);
-      HYPRE_IJVectorAssemble(ij_x);
       hypre_TFree(values_h, HYPRE_MEMORY_HOST);
       hypre_TFree(values_d, memory_location);
 
@@ -4347,7 +4338,7 @@ main( hypre_int argc,
       xstar = (HYPRE_ParVector) object;
    }
 
-   /* Setup dof_func array if needed */
+   /* Setup dof_func / tags, then assemble vectors once */
    if (num_functions > 1)
    {
       if (build_funcs_type == 1)
@@ -4386,12 +4377,26 @@ main( hypre_int argc,
       {
          hypre_printf ("  Number of functions = %d \n", num_functions);
       }
+   }
 
-      if (dof_func)
+   if (dof_func)
+   {
+      if (ij_x)
       {
          HYPRE_IJVectorSetTags(ij_x, 0, num_functions, dof_func);
+      }
+      if (ij_b)
+      {
          HYPRE_IJVectorSetTags(ij_b, 0, num_functions, dof_func);
       }
+   }
+   if (ij_x)
+   {
+      HYPRE_IJVectorAssemble(ij_x);
+   }
+   if (ij_b)
+   {
+      HYPRE_IJVectorAssemble(ij_b);
    }
 
    /*-----------------------------------------------------------


### PR DESCRIPTION
Three related failures appearing when a parallel decomposition of block linear systems with `dofmap` leaves one or more ranks with empty local blocks. 
 
1. Integer division by zero in hypre_ParCSRMatrixCreateFromParVector (crash)

```
  HYPRE_Int num_cols = (HYPRE_Int) (col_starts[1] - col_starts[0]);
  HYPRE_Int blk_dim  = hypre_max(1, num_rows / num_cols);   /* num_cols == 0 -> SIGFPE */
```

`blk_dim` is a global property of the block structure but was computed from local row and column counts. Fixed by computing it from `global_num_rows / global_num_cols`, which is identical on every rank.

2. Mismatched collective in `hypre_ParVectorInnerProdTagged` (hang)

The routine ends in a reduction whose length depends on the tag count `(num_tags + 1)`, but the branch choosing the tagged vs untagged path was taken from rank-local state. Like the previous case, we need the global value. Fixed by agreeing the tag count across the communicator first (one MPI_Allreduce of a single int)

3. Uninitialized output pointer in `hypre_ParCSRMatrixBlockColSum` (crash)

Both "not divisible by the block dimension" error paths returned without assigning `*B_ptr`, so the caller reads an uninitialized pointer and segfaults. Fixed by setting `*B_ptr = NULL` on every error path and checking the create result.