### PR TITLE
Fix CUDA 13.3 compilation warnings

### DIFF
--- a/src/utilities/_hypre_utilities.hpp
+++ b/src/utilities/_hypre_utilities.hpp
@@ -457,10 +457,13 @@ using hypre_DeviceItem = void*;
 #include <thrust/pair.h>
 #include <thrust/tuple.h>
 
-/* VPM: this is needed to support cuda 10. not_fn is the correct replacement going forward. */
+/* VPM: this is needed to support cuda 10. not_fn is the correct replacement going forward.
+ *      CUDA 13 / CCCL 3 deprecates thrust::not_fn in favor of cuda::std::not_fn. */
 #define THRUST_VERSION_NOTFN 200600
 #if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 #define HYPRE_THRUST_NOT(pred) thrust::not1(pred)
+#elif defined(HYPRE_USING_CUDA) && (defined(THRUST_VERSION) && THRUST_VERSION >= 300000)
+#define HYPRE_THRUST_NOT(pred) cuda::std::not_fn(pred)
 #else
 #define HYPRE_THRUST_NOT(pred) thrust::not_fn(pred)
 #endif
@@ -472,6 +475,19 @@ using hypre_DeviceItem = void*;
 #define HYPRE_THRUST_IDENTITY(type) cuda::std::identity()
 #elif defined(HYPRE_USING_HIP)
 #define HYPRE_THRUST_IDENTITY(type) ::internal::identity()
+#endif
+
+/* Resolve deprecated warnings about thrust::plus / equal_to (CCCL 3.0 / CUDA 13).
+ * Variadic so types with commas (e.g. thrust::tuple<T1, T2>) work. */
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 300000)
+#define HYPRE_THRUST_PLUS(...)     thrust::plus<__VA_ARGS__>()
+#define HYPRE_THRUST_EQUAL_TO(...) thrust::equal_to<__VA_ARGS__>()
+#elif defined(HYPRE_USING_CUDA)
+#define HYPRE_THRUST_PLUS(...)     cuda::std::plus<__VA_ARGS__>()
+#define HYPRE_THRUST_EQUAL_TO(...) cuda::std::equal_to<__VA_ARGS__>()
+#else
+#define HYPRE_THRUST_PLUS(...)     thrust::plus<__VA_ARGS__>()
+#define HYPRE_THRUST_EQUAL_TO(...) thrust::equal_to<__VA_ARGS__>()
 #endif
 
 using namespace thrust::placeholders;

--- a/src/utilities/device_utils.c
+++ b/src/utilities/device_utils.c
@@ -1333,8 +1333,8 @@ hypreDevice_ReduceByTupleKey( HYPRE_Int N,
    auto begin_keys_in  = thrust::make_zip_iterator(thrust::make_tuple(keys1_in,     keys2_in    ));
    auto end_keys_in    = thrust::make_zip_iterator(thrust::make_tuple(keys1_in + N, keys2_in + N));
    auto begin_keys_out = thrust::make_zip_iterator(thrust::make_tuple(keys1_out,    keys2_out   ));
-   thrust::equal_to< thrust::tuple<T1, T2> > pred;
-   thrust::plus<T3> func;
+   auto pred = HYPRE_THRUST_EQUAL_TO(thrust::tuple<T1, T2>);
+   auto func = HYPRE_THRUST_PLUS(T3);
 
    auto new_end = HYPRE_THRUST_CALL(reduce_by_key,
                                     begin_keys_in,

--- a/src/utilities/device_utils.h
+++ b/src/utilities/device_utils.h
@@ -224,10 +224,13 @@ using hypre_DeviceItem = void*;
 #include <thrust/pair.h>
 #include <thrust/tuple.h>
 
-/* VPM: this is needed to support cuda 10. not_fn is the correct replacement going forward. */
+/* VPM: this is needed to support cuda 10. not_fn is the correct replacement going forward.
+ *      CUDA 13 / CCCL 3 deprecates thrust::not_fn in favor of cuda::std::not_fn. */
 #define THRUST_VERSION_NOTFN 200600
 #if (defined(THRUST_VERSION) && THRUST_VERSION < THRUST_VERSION_NOTFN)
 #define HYPRE_THRUST_NOT(pred) thrust::not1(pred)
+#elif defined(HYPRE_USING_CUDA) && (defined(THRUST_VERSION) && THRUST_VERSION >= 300000)
+#define HYPRE_THRUST_NOT(pred) cuda::std::not_fn(pred)
 #else
 #define HYPRE_THRUST_NOT(pred) thrust::not_fn(pred)
 #endif
@@ -239,6 +242,19 @@ using hypre_DeviceItem = void*;
 #define HYPRE_THRUST_IDENTITY(type) cuda::std::identity()
 #elif defined(HYPRE_USING_HIP)
 #define HYPRE_THRUST_IDENTITY(type) ::internal::identity()
+#endif
+
+/* Resolve deprecated warnings about thrust::plus / equal_to (CCCL 3.0 / CUDA 13).
+ * Variadic so types with commas (e.g. thrust::tuple<T1, T2>) work. */
+#if (defined(THRUST_VERSION) && THRUST_VERSION < 300000)
+#define HYPRE_THRUST_PLUS(...)     thrust::plus<__VA_ARGS__>()
+#define HYPRE_THRUST_EQUAL_TO(...) thrust::equal_to<__VA_ARGS__>()
+#elif defined(HYPRE_USING_CUDA)
+#define HYPRE_THRUST_PLUS(...)     cuda::std::plus<__VA_ARGS__>()
+#define HYPRE_THRUST_EQUAL_TO(...) cuda::std::equal_to<__VA_ARGS__>()
+#else
+#define HYPRE_THRUST_PLUS(...)     thrust::plus<__VA_ARGS__>()
+#define HYPRE_THRUST_EQUAL_TO(...) thrust::equal_to<__VA_ARGS__>()
 #endif
 
 using namespace thrust::placeholders;


### PR DESCRIPTION
Fix three CUDA compilation warnings:

1. Deprecated `thrust:not_fn`
```
hypre/src/parcsr_ls/ams.c:697:196: warning: ‘constexpr auto thrust::_V_300304_SM_1200::not_fn(_Fn&&) [with _Fn = cuda::std::__4::identity; bool __cccl_true_ = true; typename __cccl_select<(is_constructible_v<typename cuda::std::__4::decay<_Tp>::type, _Fn> && __cccl_true_)>::type<int> <anonymous> = 0; typename __cccl_select<(is_move_constructible_v<typename cuda::std::__4::decay<_Tp>::type> && __cccl_true_)>::type<int> <anonymous> = 0]’ is deprecated: Use cuda::std::not_fn instead [-Wdeprecated-declarations]
  697 |          HYPRE_THRUST_CALL(replace_if, l1_norm, l1_norm + num_rows,
```

2. Deprecated `thrust:equal_to`
```
hypre/src/utilities/device_utils.c: In function ‘HYPRE_Int hypreDevice_ReduceByTupleKey(HYPRE_Int, T1*, T2*, T3*, T1*, T2*, T3*)’:
hypre/utilities/device_utils.c:1336:45: warning: ‘using thrust::_V_300304_SM_1200::equal_to = struct cuda::std::__4::equal_to<cuda::std::__4::tuple<_Tp1, _Tp2> >’ is deprecated: Use cuda::std::equal_to instead [-Wdeprecated-declarations]
 1336 |    thrust::equal_to< thrust::tuple<T1, T2> > pred;
```

3. Deprecated `thrust:plus`

```
hypre/src/utilities/device_utils.c:1337:20: warning: ‘using thrust::_V_300304_SM_1200::plus = struct cuda::std::__4::plus<T>’ is deprecated: Use cuda::std::plus instead [-Wdeprecated-declarations]
 1337 |    thrust::plus<T3> func;
      |                    ^~~~
```