### PR TITLE
Fix several OpenMP issues

### DIFF
--- a/src/parcsr_ls/par_gsmg.c
+++ b/src/parcsr_ls/par_gsmg.c
@@ -1625,7 +1625,7 @@ hypre_BoomerAMGBuildInterpGSMG( hypre_ParCSRMatrix   *A,
     *-----------------------------------------------------------------------*/
 
 #ifdef HYPRE_USING_OPENMP
-   #pragma omp parallel for private(i,j,jl,i1,i2,jj,jj1,ns,ne,size,rest,sum,distribute,P_marker,P_marker_offd,strong_f_marker,jj_counter,jj_counter_offd,c_num,jj_begin_row,jj_end_row,jj_begin_row_offd,jj_end_row_offd) HYPRE_SMP_SCHEDULE
+   #pragma omp parallel for private(i,j,jl,i1,i2,jj,jj1,ns,ne,size,rest,sum,distribute,P_marker,P_marker_offd,strong_f_marker,jj_counter,jj_counter_offd,c_num,jj_begin_row,jj_end_row,jj_begin_row_offd,jj_end_row_offd,big_i2) HYPRE_SMP_SCHEDULE
 #endif
    for (jl = 0; jl < num_threads; jl++)
    {

--- a/src/parcsr_ls/par_mod_lr_interp.c
+++ b/src/parcsr_ls/par_mod_lr_interp.c
@@ -1403,7 +1403,7 @@ hypre_BoomerAMGBuildModExtPEInterpHost(hypre_ParCSRMatrix   *A,
    startf_array = hypre_CTAlloc(HYPRE_Int, num_threads + 1, HYPRE_MEMORY_HOST);
 
 #ifdef HYPRE_USING_OPENMP
-   #pragma omp parallel private(i,j,start,stop,startf,stopf,row,theta,value)
+   #pragma omp parallel private(i,j,start,stop,startf,stopf,row,theta,value,index)
 #endif
    {
       HYPRE_Int my_thread_num = hypre_GetThreadNum();

--- a/src/parcsr_ls/par_multi_interp.c
+++ b/src/parcsr_ls/par_multi_interp.c
@@ -1188,7 +1188,7 @@ hypre_BoomerAMGBuildMultipassHost( hypre_ParCSRMatrix  *A,
           * up evenly amongst the threads. */
 
          alfa = beta = 1.0;
-         P_marker_offd = C_array_offd = NULL;
+         P_marker_offd = NULL;
          P_marker = hypre_CTAlloc(HYPRE_Int, n_fine, HYPRE_MEMORY_HOST);
          for (i = 0; i < n_fine; i++)
          {   P_marker[i] = -1; }
@@ -1787,7 +1787,7 @@ hypre_BoomerAMGBuildMultipassHost( hypre_ParCSRMatrix  *A,
 
          pass_length = pass_pointer[pass + 1] - pass_pointer[pass];
 #ifdef HYPRE_USING_OPENMP
-         #pragma omp parallel private(thread_start,thread_stop,my_thread_num,num_threads,k,k1,i,i1,j,j1,sum_C,sum_N,j_start,j_end,cnt,tmp_marker,tmp_marker_offd,cnt_offd,diagonal,alfa,tmp_array,tmp_array_offd)
+         #pragma omp parallel private(thread_start,thread_stop,my_thread_num,num_threads,k,k1,i,i1,j,j1,sum_C,sum_N,j_start,j_end,cnt,tmp_marker,tmp_marker_offd,cnt_offd,diagonal,alfa,beta,tmp_array,tmp_array_offd)
 #endif
          {
             /* Sparsity structure is now finished.  Next, calculate interpolation

--- a/src/parcsr_ls/par_strength.c
+++ b/src/parcsr_ls/par_strength.c
@@ -758,7 +758,7 @@ hypre_BoomerAMGCreateSFromCFMarker(hypre_ParCSRMatrix   *A,
 
    /* give S same nonzero structure as A */
 #ifdef HYPRE_USING_OPENMP
-   #pragma omp parallel private(i,diag,row_scale,row_sum,jA,jS,start,stop)
+   #pragma omp parallel private(i,jj,diag,row_scale,row_sum,jA,jS,start,stop)
 #endif
    {
       hypre_GetSimpleThreadPartition(&start, &stop, num_variables);

--- a/src/parcsr_mv/par_csr_matrix_stats.c
+++ b/src/parcsr_mv/par_csr_matrix_stats.c
@@ -244,7 +244,7 @@ hypre_ParCSRMatrixStatsComputePassTwoLocalHost(hypre_ParCSRMatrix  *A,
    }
 
 #ifdef HYPRE_USING_OPENMP
-   #pragma omp parallel private(i, j)
+   #pragma omp parallel private(i, j, nnzrow)
 #endif
    {
       HYPRE_Int   ns, ne;

--- a/src/seq_mv/csr_matop.c
+++ b/src/seq_mv/csr_matop.c
@@ -607,7 +607,7 @@ hypre_CSRMatrixBigAdd( hypre_CSRMatrix *A,
          jj = twspace[0];
          for (ic = 1; ic < ii; ic++)
          {
-            jj += twspace[ia];
+            jj += twspace[ic];
          }
 
          for (ic = ns; ic < ne; ic++)
@@ -629,6 +629,10 @@ hypre_CSRMatrixBigAdd( hypre_CSRMatrix *A,
          C_j = hypre_CSRMatrixBigJ(C);
          C_data = hypre_CSRMatrixData(C);
       }
+
+#ifdef HYPRE_USING_OPENMP
+      #pragma omp barrier
+#endif
 
       /* Second pass */
       for (ia = 0; ia < ncols_A; ia++)
@@ -2388,7 +2392,7 @@ hypre_CSRMatrixSetConstantValues( hypre_CSRMatrix *A,
 #endif
    {
 #ifdef HYPRE_USING_OPENMP
-      #pragma omp parallel
+      #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
 #endif
       for (i = 0; i < nnz; i++)
       {

--- a/src/seq_mv/csr_matvec.c
+++ b/src/seq_mv/csr_matvec.c
@@ -1272,7 +1272,7 @@ hypre_CSRMatrixMatvec_FF( HYPRE_Complex    alpha,
     *-----------------------------------------------------------------*/
 
 #ifdef HYPRE_USING_OPENMP
-   #pragma omp parallel for private(i,jj) HYPRE_SMP_SCHEDULE
+   #pragma omp parallel for private(i,jj,temp) HYPRE_SMP_SCHEDULE
 #endif
 
    for (i = 0; i < num_rows; i++)

--- a/src/seq_mv/vector.c
+++ b/src/seq_mv/vector.c
@@ -1131,7 +1131,7 @@ hypre_SeqVectorPointwiseDivpyHost( hypre_Vector *x,
          if (marker)
          {
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+            #pragma omp parallel for private(i, val) HYPRE_SMP_SCHEDULE
 #endif
             for (i = 0; i < size; i++)
             {
@@ -1146,7 +1146,7 @@ hypre_SeqVectorPointwiseDivpyHost( hypre_Vector *x,
          else
          {
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i) HYPRE_SMP_SCHEDULE
+            #pragma omp parallel for private(i, val) HYPRE_SMP_SCHEDULE
 #endif
             for (i = 0; i < size; i++)
             {
@@ -1162,7 +1162,7 @@ hypre_SeqVectorPointwiseDivpyHost( hypre_Vector *x,
          if (marker)
          {
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i, j) HYPRE_SMP_SCHEDULE
+            #pragma omp parallel for private(i, j, val) HYPRE_SMP_SCHEDULE
 #endif
             for (i = 0; i < size; i++)
             {
@@ -1179,7 +1179,7 @@ hypre_SeqVectorPointwiseDivpyHost( hypre_Vector *x,
          else
          {
 #ifdef HYPRE_USING_OPENMP
-            #pragma omp parallel for private(i, j) HYPRE_SMP_SCHEDULE
+            #pragma omp parallel for private(i, j, val) HYPRE_SMP_SCHEDULE
 #endif
             for (i = 0; i < size; i++)
             {


### PR DESCRIPTION
Adds missing private clauses to OpenMP regions that write variables from all threads, which could lead to corrupt results.

Closes #1596 