### PR TITLE
Fix rocm-7 build

### DIFF
--- a/src/seq_mv/csr_spgemm_device_symbl.h
+++ b/src/seq_mv/csr_spgemm_device_symbl.h
@@ -245,20 +245,20 @@ hypre_spgemm_symbolic( hypre_DeviceItem             &item,
 {
    /* number of groups in the grid */
 #if defined(HYPRE_USING_SYCL)
-   volatile const HYPRE_Int grid_num_groups = get_num_groups(item) * item.get_group_range(2);
+   const HYPRE_Int grid_num_groups = get_num_groups(item) * item.get_group_range(2);
 #else
-   volatile const HYPRE_Int grid_num_groups = get_num_groups(item) * gridDim.x;
+   const HYPRE_Int grid_num_groups = get_num_groups(item) * gridDim.x;
 #endif
    /* group id inside the block */
-   volatile const HYPRE_Int group_id = get_group_id(item);
+   const HYPRE_Int group_id = get_group_id(item);
    /* group id in the grid */
 #if defined(HYPRE_USING_SYCL)
-   volatile const HYPRE_Int grid_group_id = item.get_group(2) * get_num_groups(item) + group_id;
+   const HYPRE_Int grid_group_id = item.get_group(2) * get_num_groups(item) + group_id;
 #else
-   volatile const HYPRE_Int grid_group_id = blockIdx.x * get_num_groups(item) + group_id;
+   const HYPRE_Int grid_group_id = blockIdx.x * get_num_groups(item) + group_id;
 #endif
    /* lane id inside the group */
-   volatile const HYPRE_Int lane_id = get_group_lane_id(item);
+   const HYPRE_Int lane_id = get_group_lane_id(item);
 #if defined(HYPRE_USING_SYCL)
    /* shared memory hash table */
    HYPRE_Int *s_HashKeys = (HYPRE_Int*) shmem_ptr;


### PR DESCRIPTION
Fix the following compilation issue seen in the SpGEMM symbolic kernels compiled with rocm-7 and O3 compiler flag:

```bash
   error: Illegal instruction detected: Operand has incorrect register class.
   V_CMP_NE_U32_e32 0, $src_shared_base, implicit-def $vcc, implicit $exec
```

This PR removes `volatile` from a few variables that are already declared as `const` and initialized once at kernel entry while living in thread-private space (so no other thread can observe or modify them and `volatile` does not make sense). 

The `volatile` qualifiers that are relevant (the shared-memory hash table `s_HashKeys` and the volatile hash-table pointers used for warp-synchronous access) are unchanged.

Closes #1595 
