### PR TITLE
Add public API for selecting the number of OpenMP threads used in hypre

### DIFF
--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -1106,6 +1106,12 @@ main( hypre_int argc,
          arg_index++;
          omp_flag = atoi(argv[arg_index++]);
       }
+      else if ( strcmp(argv[arg_index], "--threads") == 0 )
+      {
+         arg_index++;
+         ierr = HYPRE_SetNumThreads(atoi(argv[arg_index++]));
+         hypre_assert(ierr == 0);
+      }
       else if ( strcmp(argv[arg_index], "-check_constant") == 0 )
       {
          arg_index++;
@@ -2624,6 +2630,7 @@ main( hypre_int argc,
          hypre_printf("      0 = (default) No messaging.\n");
          hypre_printf("      1 = Display memory usage statistics for each MPI rank.\n");
          hypre_printf("      2 = Display aggregate memory usage statistics over MPI ranks.\n");
+         hypre_printf("  --threads <N>             : use N OpenMP threads\n");
          hypre_printf("\n");
          hypre_printf("  -fromfile <filename>       : ");
          hypre_printf("matrix read from multiple files (IJ format)\n");

--- a/src/utilities/HYPRE_utilities.h
+++ b/src/utilities/HYPRE_utilities.h
@@ -714,6 +714,19 @@ HYPRE_Int HYPRE_SetUseGpuRand( HYPRE_Int use_curand );
  **/
 HYPRE_Int HYPRE_SetGpuAwareMPI( HYPRE_Int use_gpu_aware_mpi );
 
+/**
+ * Sets the number of threads to use in OpenMP parallel regions.
+ * Must be called from outside of a parallel region.
+ *
+ * @param num_threads The number of threads to use. This must be positive and
+ * no greater than the number of processors available to the OpenMP runtime or
+ * the OpenMP thread limit, whichever is smaller.
+ *
+ * @return Returns hypre's global error code, where 0 indicates success and
+ * HYPRE_ERROR_ARG indicates that num_threads is outside the valid range.
+ **/
+HYPRE_Int HYPRE_SetNumThreads( HYPRE_Int num_threads );
+
 /**@}*/
 /**@}*/
 

--- a/src/utilities/HYPRE_utilities_mup.h
+++ b/src/utilities/HYPRE_utilities_mup.h
@@ -247,6 +247,15 @@ HYPRE_Int
 HYPRE_SetMemoryLocation( HYPRE_MemoryLocation memory_location );
 
 HYPRE_Int
+HYPRE_SetNumThreads_flt( HYPRE_Int num_threads );
+HYPRE_Int
+HYPRE_SetNumThreads_dbl( HYPRE_Int num_threads );
+HYPRE_Int
+HYPRE_SetNumThreads_long_dbl( HYPRE_Int num_threads );
+HYPRE_Int
+HYPRE_SetNumThreads( HYPRE_Int num_threads );
+
+HYPRE_Int
 HYPRE_SetPrintErrorMode_flt( HYPRE_Int mode );
 HYPRE_Int
 HYPRE_SetPrintErrorMode_dbl( HYPRE_Int mode );
@@ -421,6 +430,9 @@ HYPRE_SetLogLevel_pre( HYPRE_Precision precision, HYPRE_Int log_level );
 
 HYPRE_Int
 HYPRE_SetMemoryLocation_pre( HYPRE_Precision precision, HYPRE_MemoryLocation memory_location );
+
+HYPRE_Int
+HYPRE_SetNumThreads_pre( HYPRE_Precision precision, HYPRE_Int num_threads );
 
 HYPRE_Int
 HYPRE_SetPrintErrorMode_pre( HYPRE_Precision precision, HYPRE_Int mode );

--- a/src/utilities/_hypre_utilities_mup_def.h
+++ b/src/utilities/_hypre_utilities_mup_def.h
@@ -40,6 +40,7 @@
 #define HYPRE_SetGpuAwareMPI HYPRE_MULTIPRECISION_FUNC ( HYPRE_SetGpuAwareMPI )
 #define HYPRE_SetLogLevel HYPRE_MULTIPRECISION_FUNC ( HYPRE_SetLogLevel )
 #define HYPRE_SetMemoryLocation HYPRE_MULTIPRECISION_FUNC ( HYPRE_SetMemoryLocation )
+#define HYPRE_SetNumThreads HYPRE_MULTIPRECISION_FUNC ( HYPRE_SetNumThreads )
 #define HYPRE_SetPrintErrorMode HYPRE_MULTIPRECISION_FUNC ( HYPRE_SetPrintErrorMode )
 #define HYPRE_SetPrintErrorVerbosity HYPRE_MULTIPRECISION_FUNC ( HYPRE_SetPrintErrorVerbosity )
 #define HYPRE_SetSpGemmUseVendor HYPRE_MULTIPRECISION_FUNC ( HYPRE_SetSpGemmUseVendor )

--- a/src/utilities/_hypre_utilities_mup_undef.h
+++ b/src/utilities/_hypre_utilities_mup_undef.h
@@ -37,6 +37,7 @@
 #undef HYPRE_SetGpuAwareMPI
 #undef HYPRE_SetLogLevel
 #undef HYPRE_SetMemoryLocation
+#undef HYPRE_SetNumThreads
 #undef HYPRE_SetPrintErrorMode
 #undef HYPRE_SetPrintErrorVerbosity
 #undef HYPRE_SetSpGemmUseVendor

--- a/src/utilities/mup.functions
+++ b/src/utilities/mup.functions
@@ -23,6 +23,7 @@ HYPRE_SetExecutionPolicy
 HYPRE_SetGpuAwareMPI
 HYPRE_SetLogLevel
 HYPRE_SetMemoryLocation
+HYPRE_SetNumThreads
 HYPRE_SetPrintErrorMode
 HYPRE_SetPrintErrorVerbosity
 HYPRE_SetSpGemmUseVendor

--- a/src/utilities/mup_functions.c
+++ b/src/utilities/mup_functions.c
@@ -241,6 +241,15 @@ HYPRE_SetMemoryLocation( HYPRE_MemoryLocation memory_location )
 /*--------------------------------------------------------------------------*/
 
 HYPRE_Int
+HYPRE_SetNumThreads( HYPRE_Int num_threads )
+{
+   HYPRE_Precision precision = hypre_GlobalPrecision();
+   return HYPRE_SetNumThreads_pre( precision, num_threads );
+}
+
+/*--------------------------------------------------------------------------*/
+
+HYPRE_Int
 HYPRE_SetPrintErrorMode( HYPRE_Int mode )
 {
    HYPRE_Precision precision = hypre_GlobalPrecision();

--- a/src/utilities/mup_pre.c
+++ b/src/utilities/mup_pre.c
@@ -466,6 +466,24 @@ HYPRE_SetMemoryLocation_pre( HYPRE_Precision precision, HYPRE_MemoryLocation mem
 /*--------------------------------------------------------------------------*/
 
 HYPRE_Int
+HYPRE_SetNumThreads_pre( HYPRE_Precision precision, HYPRE_Int num_threads )
+{
+   switch (precision)
+   {
+      case HYPRE_REAL_SINGLE:
+         return HYPRE_SetNumThreads_flt( num_threads );
+      case HYPRE_REAL_DOUBLE:
+         return HYPRE_SetNumThreads_dbl( num_threads );
+      case HYPRE_REAL_LONGDOUBLE:
+         return HYPRE_SetNumThreads_long_dbl( num_threads );
+      default:
+         { HYPRE_Int value = 0; hypre_error_w_msg(HYPRE_ERROR_GENERIC, "Unknown solver precision"); return value; }
+   }
+}
+
+/*--------------------------------------------------------------------------*/
+
+HYPRE_Int
 HYPRE_SetPrintErrorMode_pre( HYPRE_Precision precision, HYPRE_Int mode )
 {
    switch (precision)

--- a/src/utilities/threading.c
+++ b/src/utilities/threading.c
@@ -66,3 +66,31 @@ hypre_GetSimpleThreadPartition( HYPRE_Int *begin, HYPRE_Int *end, HYPRE_Int n )
    *begin = hypre_min(n_per_thread * my_thread_num, n);
    *end = hypre_min(*begin + n_per_thread, n);
 }
+
+/*--------------------------------------------------------------------------
+ * HYPRE_SetNumThreads
+ *
+ * Sets the number of threads to use. Must be called from outside of a
+ * parallel region.
+ *--------------------------------------------------------------------------*/
+
+HYPRE_Int
+HYPRE_SetNumThreads( HYPRE_Int num_threads )
+{
+#ifdef HYPRE_USING_OPENMP
+   HYPRE_Int num_available_threads = hypre_min(omp_get_num_procs(), omp_get_thread_limit());
+
+   if (num_threads < 1 || num_threads > num_available_threads)
+   {
+      hypre_error_in_arg(1);
+   }
+   else
+   {
+      hypre_SetNumThreads(num_threads);
+   }
+#else
+   HYPRE_UNUSED_VAR(num_threads);
+#endif
+
+   return hypre_error_flag;
+}


### PR DESCRIPTION
This new public API allows applications to select the number of OpenMP threads used in hypre, which might differ to the global `OMP_NUM_THREADS`

Closes #1559