### PR TITLE
ij.c:  partition matrix market among procs

### DIFF
--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -741,7 +741,13 @@ main( hypre_int argc,
 
    while ( (arg_index < argc) && (!print_usage) )
    {
-      if ( strcmp(argv[arg_index], "-frombinfile") == 0 )
+      if ( strcmp(argv[arg_index], "-fromMMfile") == 0 )
+      {
+         arg_index++;
+         build_matrix_type      = -3;
+         build_matrix_arg_index = arg_index;
+      }
+      else if ( strcmp(argv[arg_index], "-frombinfile") == 0 )
       {
          arg_index++;
          build_matrix_type      = -2;
@@ -2640,6 +2646,8 @@ main( hypre_int argc,
          hypre_printf("matrix read from multiple files (ParCSR format)\n");
          hypre_printf("  -fromonecsrfile <filename> : ");
          hypre_printf("matrix read from a single file (CSR format)\n");
+         hypre_printf("  -fromMMfile <filename> : ");
+         hypre_printf("matrix read from a single file (MatrixMarket format)\n");
          hypre_printf("\n");
          hypre_printf("  -laplacian             : build 5pt 2D laplacian problem (default) \n");
          hypre_printf("  -sysL <num functions>  : build SYSTEMS laplacian 7pt operator\n");
@@ -3166,7 +3174,17 @@ main( hypre_int argc,
 
    time_index = hypre_InitializeTiming("Spatial Operator");
    hypre_BeginTiming(time_index);
-   if ( build_matrix_type == -2 )
+   if ( build_matrix_type == -3 )
+   {
+      ierr = HYPRE_IJMatrixReadMM( argv[build_matrix_arg_index], comm,
+                                   HYPRE_PARCSR, &ij_A);
+      if (ierr)
+      {
+         hypre_printf("ERROR: Problem reading in the MM matrix!\n");
+         hypre_MPI_Abort(comm, 1);
+      }
+   }
+   else if ( build_matrix_type == -2 )
    {
       ierr = HYPRE_IJMatrixReadBinary( argv[build_matrix_arg_index], comm,
                                        HYPRE_PARCSR, &ij_A );
@@ -10032,7 +10050,7 @@ final:
 
    HYPRE_ParVectorDestroy(x0_save);
 
-   if (test_ij || build_matrix_type == -1 || build_matrix_type == -2)
+   if (test_ij || build_matrix_type == -1 || build_matrix_type == -2 || build_matrix_type == -3)
    {
       if (ij_A)
       {

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -3177,7 +3177,7 @@ main( hypre_int argc,
    if ( build_matrix_type == -3 )
    {
       ierr = HYPRE_IJMatrixReadMM( argv[build_matrix_arg_index], comm,
-                                   HYPRE_PARCSR, &ij_A);
+                                   HYPRE_PARCSR, &ij_A );
       if (ierr)
       {
          hypre_printf("ERROR: Problem reading in the MM matrix!\n");

--- a/src/test/ij.c
+++ b/src/test/ij.c
@@ -64,6 +64,8 @@ HYPRE_Int BuildParDifConv (MPI_Comm comm, HYPRE_Int argc, char *argv [], HYPRE_I
                            HYPRE_ParCSRMatrix *A_ptr);
 HYPRE_Int BuildParFromOneFile (MPI_Comm comm, HYPRE_Int argc, char *argv [], HYPRE_Int arg_index,
                                HYPRE_Int num_functions, HYPRE_ParCSRMatrix *A_ptr );
+HYPRE_Int BuildParFromOneMMFile (MPI_Comm comm, HYPRE_Int argc, char *argv [], 
+                                 HYPRE_Int arg_index, HYPRE_ParCSRMatrix *A_ptr );
 HYPRE_Int BuildFuncTagsFromFiles (HYPRE_Int argc, char *argv [], HYPRE_Int arg_index,
                                   HYPRE_ParCSRMatrix A, HYPRE_Int **dof_func_ptr );
 HYPRE_Int BuildFuncTagsFromOneFile (MPI_Comm comm, HYPRE_Int argc, char *argv [],
@@ -708,7 +710,7 @@ main( hypre_int argc,
    /*-----------------------------------------------------------
     * Set defaults
     *-----------------------------------------------------------*/
-   build_matrix_type = 2;
+   build_matrix_type = 3;
    build_matrix_arg_index = argc;
    build_matrix_M = 0;
    build_matrix_M_arg_index = argc;
@@ -741,13 +743,7 @@ main( hypre_int argc,
 
    while ( (arg_index < argc) && (!print_usage) )
    {
-      if ( strcmp(argv[arg_index], "-fromMMfile") == 0 )
-      {
-         arg_index++;
-         build_matrix_type      = -3;
-         build_matrix_arg_index = arg_index;
-      }
-      else if ( strcmp(argv[arg_index], "-frombinfile") == 0 )
+      if ( strcmp(argv[arg_index], "-frombinfile") == 0 )
       {
          arg_index++;
          build_matrix_type      = -2;
@@ -993,46 +989,52 @@ main( hypre_int argc,
          build_matrix_type      = 1;
          build_matrix_arg_index = arg_index;
       }
-      else if ( strcmp(argv[arg_index], "-laplacian") == 0 )
+      else if ( strcmp(argv[arg_index], "-fromoneMMfile") == 0 )
       {
          arg_index++;
          build_matrix_type      = 2;
          build_matrix_arg_index = arg_index;
       }
-      else if ( strcmp(argv[arg_index], "-9pt") == 0 )
+      else if ( strcmp(argv[arg_index], "-laplacian") == 0 )
       {
          arg_index++;
          build_matrix_type      = 3;
          build_matrix_arg_index = arg_index;
       }
-      else if ( strcmp(argv[arg_index], "-27pt") == 0 )
+      else if ( strcmp(argv[arg_index], "-9pt") == 0 )
       {
          arg_index++;
          build_matrix_type      = 4;
          build_matrix_arg_index = arg_index;
       }
-      else if ( strcmp(argv[arg_index], "-125pt") == 0 )
+      else if ( strcmp(argv[arg_index], "-27pt") == 0 )
       {
          arg_index++;
          build_matrix_type      = 5;
          build_matrix_arg_index = arg_index;
       }
-      else if ( strcmp(argv[arg_index], "-difconv") == 0 )
+      else if ( strcmp(argv[arg_index], "-125pt") == 0 )
       {
          arg_index++;
          build_matrix_type      = 6;
          build_matrix_arg_index = arg_index;
       }
-      else if ( strcmp(argv[arg_index], "-vardifconv") == 0 )
+      else if ( strcmp(argv[arg_index], "-difconv") == 0 )
       {
          arg_index++;
          build_matrix_type      = 7;
          build_matrix_arg_index = arg_index;
       }
-      else if ( strcmp(argv[arg_index], "-rotate") == 0 )
+      else if ( strcmp(argv[arg_index], "-vardifconv") == 0 )
       {
          arg_index++;
          build_matrix_type      = 8;
+         build_matrix_arg_index = arg_index;
+      }
+      else if ( strcmp(argv[arg_index], "-rotate") == 0 )
+      {
+         arg_index++;
+         build_matrix_type      = 9;
          build_matrix_arg_index = arg_index;
       }
       else if ( strcmp(argv[arg_index], "-test_ij") == 0 )
@@ -2646,7 +2648,7 @@ main( hypre_int argc,
          hypre_printf("matrix read from multiple files (ParCSR format)\n");
          hypre_printf("  -fromonecsrfile <filename> : ");
          hypre_printf("matrix read from a single file (CSR format)\n");
-         hypre_printf("  -fromMMfile <filename> : ");
+         hypre_printf("  -fromoneMMfile <filename> : ");
          hypre_printf("matrix read from a single file (MatrixMarket format)\n");
          hypre_printf("\n");
          hypre_printf("  -laplacian             : build 5pt 2D laplacian problem (default) \n");
@@ -3174,17 +3176,7 @@ main( hypre_int argc,
 
    time_index = hypre_InitializeTiming("Spatial Operator");
    hypre_BeginTiming(time_index);
-   if ( build_matrix_type == -3 )
-   {
-      ierr = HYPRE_IJMatrixReadMM( argv[build_matrix_arg_index], comm,
-                                   HYPRE_PARCSR, &ij_A );
-      if (ierr)
-      {
-         hypre_printf("ERROR: Problem reading in the MM matrix!\n");
-         hypre_MPI_Abort(comm, 1);
-      }
-   }
-   else if ( build_matrix_type == -2 )
+   if ( build_matrix_type == -2 )
    {
       ierr = HYPRE_IJMatrixReadBinary( argv[build_matrix_arg_index], comm,
                                        HYPRE_PARCSR, &ij_A );
@@ -3215,13 +3207,17 @@ main( hypre_int argc,
    }
    else if ( build_matrix_type == 2 )
    {
-      BuildParLaplacian(comm, argc, argv, build_matrix_arg_index, &parcsr_A);
+      BuildParFromOneMMFile(comm, argc, argv, build_matrix_arg_index, &parcsr_A);
    }
    else if ( build_matrix_type == 3 )
    {
-      BuildParLaplacian9pt(comm, argc, argv, build_matrix_arg_index, &parcsr_A);
+      BuildParLaplacian(comm, argc, argv, build_matrix_arg_index, &parcsr_A);
    }
    else if ( build_matrix_type == 4 )
+   {
+      BuildParLaplacian9pt(comm, argc, argv, build_matrix_arg_index, &parcsr_A);
+   }
+   else if ( build_matrix_type == 5 )
    {
       BuildParLaplacian27pt(comm, argc, argv, build_matrix_arg_index, &parcsr_A);
 
@@ -3229,7 +3225,7 @@ main( hypre_int argc,
       hypre_CSRMatrixSpMVAnalysisDevice(hypre_ParCSRMatrixDiag(parcsr_A));
 #endif
    }
-   else if ( build_matrix_type == 5 )
+   else if ( build_matrix_type == 6 )
    {
       BuildParLaplacian125pt(comm, argc, argv, build_matrix_arg_index, &parcsr_A);
 
@@ -3237,17 +3233,17 @@ main( hypre_int argc,
       hypre_CSRMatrixSpMVAnalysisDevice(hypre_ParCSRMatrixDiag(parcsr_A));
 #endif
    }
-   else if ( build_matrix_type == 6 )
+   else if ( build_matrix_type == 7 )
    {
       BuildParDifConv(comm, argc, argv, build_matrix_arg_index, &parcsr_A);
    }
-   else if ( build_matrix_type == 7 )
+   else if ( build_matrix_type == 8 )
    {
       BuildParVarDifConv(comm, argc, argv, build_matrix_arg_index, &parcsr_A, &b);
       build_rhs_type      = 6;
       build_src_type      = 5;
    }
-   else if ( build_matrix_type == 8 )
+   else if ( build_matrix_type == 9 )
    {
       BuildParRotate7pt(comm, argc, argv, build_matrix_arg_index, &parcsr_A);
    }
@@ -3262,7 +3258,7 @@ main( hypre_int argc,
    /* BM Oct 23, 2006 */
    if (plot_grids)
    {
-      if (build_matrix_type > 1 &&  build_matrix_type < 9)
+      if (build_matrix_type > 2 &&  build_matrix_type < 10)
          BuildParCoordinates (comm, argc, argv, build_matrix_arg_index,
                               &coord_dim, &coordinates);
       else
@@ -3341,19 +3337,19 @@ main( hypre_int argc,
          size = 5;
          if (sparsity_known == 0)
          {
-            if (build_matrix_type == 2)
+            if (build_matrix_type == 3)
             {
                size = 7;
             }
-            else if (build_matrix_type == 3)
+            else if (build_matrix_type == 4)
             {
                size = 9;
             }
-            else if (build_matrix_type == 4)
+            else if (build_matrix_type == 5)
             {
                size = 27;
             }
-            else if (build_matrix_type == 5)
+            else if (build_matrix_type == 6)
             {
                size = 125;
             }
@@ -3365,19 +3361,19 @@ main( hypre_int argc,
          }
       }
       local_row = 0;
-      if (build_matrix_type == 2)
+      if (build_matrix_type == 3)
       {
          mx_size = 7;
       }
-      else if (build_matrix_type == 3)
+      else if (build_matrix_type == 4)
       {
          mx_size = 9;
       }
-      else if (build_matrix_type == 4)
+      else if (build_matrix_type == 5)
       {
          mx_size = 27;
       }
-      else if (build_matrix_type == 5)
+      else if (build_matrix_type == 6)
       {
          mx_size = 125;
       }
@@ -6402,19 +6398,19 @@ main( hypre_int argc,
             if (sparsity_known == 0) /* tries a more accurate estimate of the
                                         storage */
             {
-               if (build_matrix_type == 2)
+               if (build_matrix_type == 3)
                {
                   size = 7;
                }
-               else if (build_matrix_type == 3)
+               else if (build_matrix_type == 4)
                {
                   size = 9;
                }
-               else if (build_matrix_type == 4)
+               else if (build_matrix_type == 5)
                {
                   size = 27;
                }
-               else if (build_matrix_type == 5)
+               else if (build_matrix_type == 6)
                {
                   size = 125;
                }
@@ -10050,7 +10046,7 @@ final:
 
    HYPRE_ParVectorDestroy(x0_save);
 
-   if (test_ij || build_matrix_type == -1 || build_matrix_type == -2 || build_matrix_type == -3)
+   if (test_ij || build_matrix_type == -1 || build_matrix_type == -2)
    {
       if (ij_A)
       {
@@ -11191,6 +11187,78 @@ BuildParFromOneFile( MPI_Comm             comm,
    }
 
    return (0);
+}
+
+/*----------------------------------------------------------------------
+ * Build matrix from one Matrix Market file on Proc. 0. Distributes 
+ * matrix across processors giving each about the same number of rows.
+ * Parameters given in command line.
+ *----------------------------------------------------------------------*/
+
+HYPRE_Int BuildParFromOneMMFile( MPI_Comm comm, 
+                                 HYPRE_Int argc, 
+                                 char *argv [], 
+                                 HYPRE_Int arg_index, 
+                                 HYPRE_ParCSRMatrix *A_ptr )
+{
+   char               *filename;
+
+   hypre_CSRMatrix    *A_CSR = NULL;
+   HYPRE_IJMatrix      ij_A_self = NULL;
+
+   HYPRE_Int           myid;
+
+   /*-----------------------------------------------------------
+    * Initialize some stuff
+    *-----------------------------------------------------------*/
+
+   hypre_MPI_Comm_rank(comm, &myid);
+
+   /*-----------------------------------------------------------
+    * Parse command line
+    *-----------------------------------------------------------*/
+
+   if (arg_index < argc)
+   {
+      filename = argv[arg_index];
+   }
+   else
+   {
+      hypre_printf("Error: No filename specified \n");
+      exit(1);
+   }
+
+   /*-----------------------------------------------------------
+    * Print driver parameters
+    *-----------------------------------------------------------*/
+
+   if (myid == 0)
+   {
+      hypre_printf("  FromOneMMFile: %s\n", filename);
+
+      /*-----------------------------------------------------------
+       * Generate the matrix
+       *-----------------------------------------------------------*/
+
+      void *par_A_self;
+      
+      HYPRE_IJMatrixReadMM(filename, hypre_MPI_COMM_SELF, HYPRE_PARCSR, &ij_A_self);
+      HYPRE_IJMatrixGetObject(ij_A_self, &par_A_self);
+      A_CSR = hypre_ParCSRMatrixDiag((hypre_ParCSRMatrix *)par_A_self);
+   }
+   
+   /*-----------------------------------------------------------
+    * Partition the matrix
+    *-----------------------------------------------------------*/
+
+   HYPRE_CSRMatrixToParCSRMatrix(comm, (HYPRE_CSRMatrix)A_CSR, NULL, NULL, A_ptr);
+
+   if (myid == 0)
+   {
+      HYPRE_IJMatrixDestroy(ij_A_self);
+   }
+
+   return (0);   
 }
 
 /*----------------------------------------------------------------------


### PR DESCRIPTION
The ij executable cannot read or partition matrices in Matrix Market format.  This PR uses the existing `HYPRE_IJMatrixReadMM` function to read a Matrix Market matrix.